### PR TITLE
fix: replace unwrap() and expect() with proper error handling

### DIFF
--- a/src-tauri/src/commands/messages.rs
+++ b/src-tauri/src/commands/messages.rs
@@ -165,7 +165,7 @@ async fn save_base64_to_temp_file(session_id: &str, data: &str) -> Result<String
     // Generate unique filename with timestamp for cleanup
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
+        .map_err(|e| format!("System time error for session {session_id}: {e}"))?
         .as_secs();
     let uuid = uuid::Uuid::new_v4();
     let filename = format!("{TEMP_IMAGE_PREFIX}{timestamp}-{uuid}.{extension}");
@@ -217,7 +217,7 @@ async fn cleanup_old_temp_images(session_id: &str) -> Result<(), String> {
     let max_age_secs = 300; // 5 minutes
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
+        .map_err(|e| format!("System time error for session {session_id}: {e}"))?
         .as_secs();
 
     let dir = match std::fs::read_dir(&images_dir) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -141,5 +141,9 @@ pub fn run() {
             })
         })
         .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .map_err(|e| {
+            log::error!("Fatal error while running Tauri application: {e}");
+            e
+        })
+        .ok(); // Allow graceful exit instead of panicking
 }


### PR DESCRIPTION
- Replace unwrap() calls on SystemTime in messages.rs (lines 168, 220)
- Replace expect() with graceful error handling in lib.rs (line 144)
- Improves error resilience and prevents potential panics
- Follows Rust best practices for error handling