### PR TITLE
refactor: split CLAUDE.md into module-specific files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,48 +3,6 @@ opslane/verify — automated acceptance criteria verification for Claude Code ch
 
 Also contains `server/` — a SaaS backend (Hono + TypeScript + Postgres) for GitHub OAuth sign-in, GitHub App installation tracking, and PR webhook handling.
 
-## Stack
-
-### Pipeline (pipeline/)
-- TypeScript 5, Node 22 ESM, tsx
-- `claude -p` — non-interactive Claude CLI (OAuth, no API key needed)
-- gstack browse — headless browser for each AC check
-- vitest for unit + integration tests
-
-### Pipeline legacy (scripts/)
-- Bash (3-compatible — macOS + Linux) — being replaced by `pipeline/`
-
-### Server (server/)
-- Hono + TypeScript, running on `@hono/node-server`
-- postgres.js for DB access (no ORM)
-- hono/jwt for HS256 JWT session cookies
-- vitest for unit + integration tests
-- Docker for production packaging
-
-## Structure
-- `pipeline/` — TypeScript pipeline v2
-  - `src/lib/` — shared types, config, app-index, prisma-parser, seed-extractor
-  - `src/stages/` — ac-generator, planner, setup-writer, browse-agent, judge, learner
-  - `src/prompts/` — Claude prompt templates for each stage
-  - `src/cli.ts` — CLI entry point (`run`, `index-app`, `run-stage`)
-  - `src/orchestrator.ts` — full pipeline orchestration
-  - `test/` — vitest tests
-- `scripts/` — legacy bash pipeline (being replaced by `pipeline/`)
-- `server/` — SaaS backend
-  - `src/routes/auth.ts` — GitHub OAuth routes (CSRF state, JWT session cookie)
-  - `src/routes/webhooks.ts` — GitHub App webhook handler (HMAC verification)
-  - `src/db.ts` — postgres.js helpers (upsertOrg, upsertUser, upsertInstallation, findUserByLogin)
-  - `src/migrate.ts` — runs SQL migrations at startup
-  - `src/index.ts` — app entry point, caches landing HTML, graceful shutdown
-  - `migrations/` — SQL migration files
-- `skills/verify/SKILL.md` — the `/verify` Claude Code skill (**source of truth**)
-- `skills/verify-setup/SKILL.md` — the `/verify-setup` skill (**source of truth**)
-- `.verify/` — runtime output (gitignored): `config.json`, `plan.json`, `evidence/`, `auth.json`
-- `docs/evals/` — eval sets for prompt quality testing
-
-## Skill sync
-The skills in `skills/` are the source of truth. A `PostToolUse` hook (`.claude/hooks/sync-skill.sh`) automatically copies them to `~/.claude/skills/` after every Write or Edit. It also syncs `pipeline/` to `~/.claude/tools/verify/pipeline/` when pipeline files change. Never edit `~/.claude/skills/verify/SKILL.md` directly — edit the project copy instead.
-
 ## Architecture
 
 ### Pipeline
@@ -53,6 +11,7 @@ The skills in `skills/` are the source of truth. A `PostToolUse` hook (`.claude/
 /verify → ac-generator → planner → setup-writer + browse-agents (parallel) → judge → learner → report
 ```
 Config lives in `.verify/config.json`. App index lives in `.verify/app.json`. Env vars always override config.
+`.verify/` is runtime output (gitignored) — config, plans, evidence, auth. `scripts/` is the legacy bash pipeline, being replaced by `pipeline/`.
 
 ### Server
 ```
@@ -60,82 +19,15 @@ Config lives in `.verify/config.json`. App index lives in `.verify/app.json`. En
 GitHub App webhook → /webhooks/github → HMAC verify → installation.created handler
 ```
 
-## Commands
+## Skill sync
+The skills in `skills/` are the source of truth. A `PostToolUse` hook (`.claude/hooks/sync-skill.sh`) automatically copies them to `~/.claude/skills/` after every Write or Edit. It also syncs `pipeline/` to `~/.claude/tools/verify/pipeline/` when pipeline files change. Never edit `~/.claude/skills/verify/SKILL.md` directly — edit the project copy instead.
 
-### Pipeline
-- Typecheck: `cd pipeline && npx tsc --noEmit`
-- Tests: `cd pipeline && npx vitest run`
-- Single test: `cd pipeline && npx vitest run test/prisma-parser.test.ts`
-- Run a stage: `cd pipeline && npx tsx src/cli.ts run-stage <stage> --verify-dir .verify`
-- Full run: `cd pipeline && npx tsx src/cli.ts run --spec .verify/spec.md`
-- Index app: `cd pipeline && npx tsx src/cli.ts index-app --project-dir /path/to/project`
-
-### Server
-- Dev: `cd server && npm run dev` (loads `.env` via `--env-file`)
-- Tests (all, with .env): `cd server && node --env-file=.env ./node_modules/.bin/vitest run`
-- Docker smoke test: `bash scripts/test-docker.sh`
-- Required DB setup: `createdb verify_dev && createdb verify_test`
-
-## Verification (run in this order before every commit)
-For pipeline changes:
-1. `cd pipeline && npx tsc --noEmit` — fix all type errors
-2. `cd pipeline && npx vitest run` — fix all failing tests
-
-For server changes:
-1. `cd server && npx tsc --noEmit` — fix all type errors
-2. `cd server && node --env-file=.env ./node_modules/.bin/vitest run` — fix all failing tests (loads .env for DB + secrets)
-3. Check no `any` escapes or eslint-disable without justification
-
-**Important:** Always run tests with `.env` loaded. `npm test` alone does NOT load `.env`, so DB integration and webhook tests will fail with misleading errors (skipped tests, missing secrets). Use `node --env-file=.env` as shown above.
-
-## Conventions
-
-### Pipeline
-- **TypeScript strict**: no `any`, use `unknown` and narrow
-- **Node 22 ESM**: use `import`, not `require`
-- **Non-interactive Claude**: always use `claude -p`, never interactive mode
-- **Stage permissions**: each stage gets minimal tool access via `STAGE_PERMISSIONS` in types.ts
-- **Deterministic > LLM**: Prisma column mappings and seed IDs are parsed deterministically, not by LLM
-
-### Server
-- **CSRF protection**: every OAuth callback must validate the `state` cookie — no exceptions, no bypass paths
-- **Cookie security**: use `isSecure(c)` which trusts `x-forwarded-proto` from proxies; assumes server always runs behind a trusted reverse proxy (ngrok, ALB) — never exposed directly
-- **Webhook auth**: always verify `X-Hub-Signature-256` with `timingSafeEqual` before processing any webhook payload
-- **Error responses**: never return internal state (cookie values, param values) in error response bodies — log server-side, return generic message to client
-- **DB helpers**: use `ON CONFLICT ... DO UPDATE` for all upserts — all writes must be idempotent
-- **Env vars at startup**: throw at module load time if required env vars are missing (fail fast on deploy)
-- **Tests**: DB integration tests require `TEST_DATABASE_URL`; unit tests mock `../db.js` at the top of the file before any imports
-- **vitest config**: `singleThread: true` — DB tests must run sequentially to prevent migrate.test.ts from dropping tables while db.test.ts uses them
-
-## Don't
-
-### Pipeline
-- Don't use `any` in TypeScript — use `unknown` and narrow
-- Don't hardcode URLs — use config or env vars
-- Don't call `claude` interactively — always `claude -p`
-- Don't commit `.verify/` contents — auth, evidence, and plans are gitignored
-- Don't use Prisma field names in SQL — always look up the Postgres column name from `app.json`
-
-### Server
-- Don't add bypass paths that skip CSRF state validation — session fixation attacks are real (an attacker can craft a callback URL with their own valid code to log a victim into the attacker's account)
-- Don't use `any` in TypeScript — use `unknown` and narrow, or use the correct vitest type (`MockInstance`)
-- Don't leak diagnostic info in HTTP error responses — log with `console.error`, return generic message
-- Don't run DB tests in parallel — vitest `singleThread: true` is mandatory
-- Don't set `secure: process.env.NODE_ENV === 'production'` directly on cookies — use `isSecure(c)` so ngrok/staging environments work correctly
-- Don't use `tsx watch` directly in dev scripts — use `node --env-file=.env --import tsx/esm --watch` for reliable `.env` loading
-- Don't commit `server/.env` — use `server/.env.example` as the template
-- Don't skip webhook HMAC verification even in tests — mock the signature, don't disable the check
-
-## GitHub App setup
-- "Request user authorization (OAuth) during installation" must be **unchecked** — users sign in via `/auth/github` first, then install the app; the `installation.created` webhook handles the rest
-- Callback URL must match the server's public URL (ngrok in dev, production domain in prod)
-- Webhook URL: `<base>/webhooks/github`
+## Module-specific instructions
+Pipeline and server have their own conventions, commands, and verification steps:
+- For pipeline work, see `pipeline/CLAUDE.md`
+- For server work, see `server/CLAUDE.md`
 
 ## References
-- Pipeline v2 design: `docs/plans/2026-03-18-pipeline-v2-implementation.md`
-- WS6 integration plan: `docs/plans/2026-03-18-ws6-integration.md`
-- Pipeline v1 design: `docs/plans/2026-03-08-verify-implementation.md`
-- Server design: `docs/plans/2026-03-12-saas-auth-design.md`
-- Server implementation plan: `docs/plans/2026-03-12-saas-auth-implementation.md`
-- Eval sets: `docs/evals/eval-set-v1.json`
+- Design docs and implementation plans: `docs/plans/`
+- Eval sets: `docs/evals/`
 - Prompt templates: `pipeline/src/prompts/`

--- a/pipeline/CLAUDE.md
+++ b/pipeline/CLAUDE.md
@@ -1,0 +1,26 @@
+## Stack
+- TypeScript 5, Node 22 ESM, tsx
+- `claude -p` — non-interactive Claude CLI (OAuth, no API key needed)
+- gstack browse — headless browser for each AC check
+- vitest for unit + integration tests
+
+## Commands
+- Run a stage: `npx tsx src/cli.ts run-stage <stage> --verify-dir .verify`
+- Full run: `npx tsx src/cli.ts run --spec .verify/spec.md`
+- Index app: `npx tsx src/cli.ts index-app --project-dir /path/to/project`
+
+## Verification (run before every commit)
+1. `npx tsc --noEmit` — fix all type errors
+2. `npx vitest run` — fix all failing tests
+
+## Conventions
+- **TypeScript strict**: no `any` — use `unknown` and narrow
+- **Node 22 ESM**: use `import`, not `require`
+- **Non-interactive Claude**: always use `claude -p`, never interactive mode
+- **Stage permissions**: each stage gets minimal tool access via `STAGE_PERMISSIONS` in types.ts
+- **Deterministic > LLM**: Prisma column mappings and seed IDs are parsed deterministically, not by LLM
+
+## Don't
+- Don't hardcode URLs — use config or env vars
+- Don't commit `.verify/` contents — auth, evidence, and plans are gitignored
+- Don't use Prisma field names in SQL — always look up the Postgres column name from `app.json`

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -1,202 +1,37 @@
-<!-- TRIGGER.DEV basic START -->
-# Trigger.dev Basic Tasks (v4)
+## Stack
+- Hono + TypeScript, running on `@hono/node-server`
+- postgres.js for DB access (no ORM)
+- hono/jwt for HS256 JWT session cookies
+- vitest for unit + integration tests
+- Docker for production packaging
 
-**MUST use `@trigger.dev/sdk`, NEVER `client.defineJob`**
+## Commands
+- Dev: `npm run dev` (loads `.env` via `--env-file`)
+- Docker smoke test: `bash ../scripts/test-docker.sh`
+- Required DB setup: `createdb verify_dev && createdb verify_test`
 
-## Basic Task
+## Verification (run before every commit)
+1. `npx tsc --noEmit` — fix all type errors
+2. `node --env-file=.env ./node_modules/.bin/vitest run` — fix all failing tests (`npm test` alone does NOT load `.env`)
+3. Check no `any` escapes or eslint-disable without justification
 
-```ts
-import { task } from "@trigger.dev/sdk";
+## Conventions
+- **Webhook auth**: always verify `X-Hub-Signature-256` with `timingSafeEqual` before processing any webhook payload
+- **DB helpers**: use `ON CONFLICT ... DO UPDATE` for all upserts — all writes must be idempotent
+- **Env vars at startup**: throw at module load time if required env vars are missing (fail fast)
+- **TypeScript strict**: no `any` — use `unknown` and narrow, or use vitest `MockInstance`
+- **Tests**: DB integration tests require `TEST_DATABASE_URL`; unit tests mock `../db.js` before imports
+- **vitest config**: `singleThread: true` — DB tests must run sequentially to prevent migrate.test.ts from dropping tables while db.test.ts uses them
 
-export const processData = task({
-  id: "process-data",
-  retry: {
-    maxAttempts: 10,
-    factor: 1.8,
-    minTimeoutInMs: 500,
-    maxTimeoutInMs: 30_000,
-    randomize: false,
-  },
-  run: async (payload: { userId: string; data: any[] }) => {
-    // Task logic - runs for long time, no timeouts
-    console.log(`Processing ${payload.data.length} items for user ${payload.userId}`);
-    return { processed: payload.data.length };
-  },
-});
-```
+## Don't
+- Don't add bypass paths that skip CSRF state validation — session fixation attacks are real; use the `state` cookie on every OAuth callback
+- Don't return internal state in HTTP error responses — log with `console.error`, return generic message
+- Don't set `secure: process.env.NODE_ENV === 'production'` on cookies — use `isSecure(c)` for ngrok/staging
+- Don't use `tsx watch` directly — use `node --env-file=.env --import tsx/esm --watch`
+- Don't commit `server/.env` — use `.env.example` as the template
+- Don't skip webhook HMAC verification even in tests — mock the signature, don't disable the check
 
-## Schema Task (with validation)
-
-```ts
-import { schemaTask } from "@trigger.dev/sdk";
-import { z } from "zod";
-
-export const validatedTask = schemaTask({
-  id: "validated-task",
-  schema: z.object({
-    name: z.string(),
-    age: z.number(),
-    email: z.string().email(),
-  }),
-  run: async (payload) => {
-    // Payload is automatically validated and typed
-    return { message: `Hello ${payload.name}, age ${payload.age}` };
-  },
-});
-```
-
-## Triggering Tasks
-
-### From Backend Code
-
-```ts
-import { tasks } from "@trigger.dev/sdk";
-import type { processData } from "./trigger/tasks";
-
-// Single trigger
-const handle = await tasks.trigger<typeof processData>("process-data", {
-  userId: "123",
-  data: [{ id: 1 }, { id: 2 }],
-});
-
-// Batch trigger (up to 1,000 items, 3MB per payload)
-const batchHandle = await tasks.batchTrigger<typeof processData>("process-data", [
-  { payload: { userId: "123", data: [{ id: 1 }] } },
-  { payload: { userId: "456", data: [{ id: 2 }] } },
-]);
-```
-
-### Debounced Triggering
-
-Consolidate multiple triggers into a single execution:
-
-```ts
-// Multiple rapid triggers with same key = single execution
-await myTask.trigger(
-  { userId: "123" },
-  {
-    debounce: {
-      key: "user-123-update",  // Unique key for debounce group
-      delay: "5s",              // Wait before executing
-    },
-  }
-);
-
-// Trailing mode: use payload from LAST trigger
-await myTask.trigger(
-  { data: "latest-value" },
-  {
-    debounce: {
-      key: "trailing-example",
-      delay: "10s",
-      mode: "trailing",  // Default is "leading" (first payload)
-    },
-  }
-);
-```
-
-**Debounce modes:**
-- `leading` (default): Uses payload from first trigger, subsequent triggers only reschedule
-- `trailing`: Uses payload from most recent trigger
-
-### From Inside Tasks (with Result handling)
-
-```ts
-export const parentTask = task({
-  id: "parent-task",
-  run: async (payload) => {
-    // Trigger and continue
-    const handle = await childTask.trigger({ data: "value" });
-
-    // Trigger and wait - returns Result object, NOT task output
-    const result = await childTask.triggerAndWait({ data: "value" });
-    if (result.ok) {
-      console.log("Task output:", result.output); // Actual task return value
-    } else {
-      console.error("Task failed:", result.error);
-    }
-
-    // Quick unwrap (throws on error)
-    const output = await childTask.triggerAndWait({ data: "value" }).unwrap();
-
-    // Batch trigger and wait
-    const results = await childTask.batchTriggerAndWait([
-      { payload: { data: "item1" } },
-      { payload: { data: "item2" } },
-    ]);
-
-    for (const run of results) {
-      if (run.ok) {
-        console.log("Success:", run.output);
-      } else {
-        console.log("Failed:", run.error);
-      }
-    }
-  },
-});
-
-export const childTask = task({
-  id: "child-task",
-  run: async (payload: { data: string }) => {
-    return { processed: payload.data };
-  },
-});
-```
-
-> Never wrap triggerAndWait or batchTriggerAndWait calls in a Promise.all or Promise.allSettled as this is not supported in Trigger.dev tasks.
-
-## Waits
-
-```ts
-import { task, wait } from "@trigger.dev/sdk";
-
-export const taskWithWaits = task({
-  id: "task-with-waits",
-  run: async (payload) => {
-    console.log("Starting task");
-
-    // Wait for specific duration
-    await wait.for({ seconds: 30 });
-    await wait.for({ minutes: 5 });
-    await wait.for({ hours: 1 });
-    await wait.for({ days: 1 });
-
-    // Wait until specific date
-    await wait.until({ date: new Date("2024-12-25") });
-
-    // Wait for token (from external system)
-    await wait.forToken({
-      token: "user-approval-token",
-      timeoutInSeconds: 3600, // 1 hour timeout
-    });
-
-    console.log("All waits completed");
-    return { status: "completed" };
-  },
-});
-```
-
-> Never wrap wait calls in a Promise.all or Promise.allSettled as this is not supported in Trigger.dev tasks.
-
-## Key Points
-
-- **Result vs Output**: `triggerAndWait()` returns a `Result` object with `ok`, `output`, `error` properties - NOT the direct task output
-- **Type safety**: Use `import type` for task references when triggering from backend
-- **Waits > 5 seconds**: Automatically checkpointed, don't count toward compute usage
-- **Debounce + idempotency**: Idempotency keys take precedence over debounce settings
-
-## NEVER Use (v2 deprecated)
-
-```ts
-// BREAKS APPLICATION
-client.defineJob({
-  id: "job-id",
-  run: async (payload, io) => {
-    /* ... */
-  },
-});
-```
-
-Use SDK (`@trigger.dev/sdk`), check `result.ok` before accessing `result.output`
-
-<!-- TRIGGER.DEV basic END -->
+## GitHub App setup
+- "Request user authorization (OAuth) during installation" must be **unchecked**
+- Callback URL must match the server's public URL (ngrok in dev, production domain in prod)
+- Webhook URL: `<base>/webhooks/github`


### PR DESCRIPTION
## Summary
- Split 141-line root CLAUDE.md into 3 lean, directory-scoped files (96 lines total)
- Root keeps project overview, architecture diagrams, skill sync, and references
- `pipeline/CLAUDE.md` (new) — pipeline-specific commands, conventions, and don'ts
- `server/CLAUDE.md` — replaced 202 lines of irrelevant Trigger.dev boilerplate with actual server conventions

## Why
Models start ignoring CLAUDE.md instructions uniformly past ~80 lines. Module-specific files are loaded on-demand by Claude Code, so each file gets full attention when relevant.

## Test plan
- [ ] Verify Claude Code loads `pipeline/CLAUDE.md` when working in `pipeline/`
- [ ] Verify Claude Code loads `server/CLAUDE.md` when working in `server/`
- [ ] Confirm no critical conventions were lost (Node 22 ESM, CSRF, `.verify/` gitignored, etc.)