### PR TITLE
feat(verify): adversarial variant generation and two-bucket reporting

### DIFF
--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -166,10 +166,10 @@ Present the AC list to the user: "I've extracted N acceptance criteria. Here's t
 
 For each extracted AC, dispatch a variant-generator subagent. This is a generation-only step; variants are verified in Phase 2.
 
-**Invocation:** Use the `Agent` tool with:
+**Invocation:** Use the `Task` tool with:
 - `subagent_type`: `"general-purpose"`
 - `description`: `"Adversarial variant generation"`
-- Timeout: 60 seconds (enforced at skill level — if subagent takes longer, treat as failure per constraint #13)
+- On Task-tool default timeout, record `[]` for this AC and continue (constraint #13)
 
 **Prompt:**
 
@@ -298,24 +298,24 @@ Skip this step if:
 **Re-read variants for this AC** (skill is stateless across ACs):
 
 ```bash
-VARIANTS=$(jq --arg ac "$AC_ID" '.[$ac] // []' .verify/runs/$RUN_ID/variants.json)
+VARIANTS=$(jq --arg ac "{ac_id}" '.[$ac] // []' .verify/runs/$RUN_ID/variants.json)
 ```
 
 If `$VARIANTS` is `[]` or empty, skip to step 8.
 
 For each variant `v` in `$VARIANTS`:
 
-a. **Execute variant** using Playwright MCP primitives with a **6-command budget** (constraint #9). Stop and write best-guess verdict at command 6.
+a. **Execute variant** — read `steps` and `expected` from the variant object; execute `steps` in order using Playwright MCP primitives within a **6-command budget** (constraint #9). At command 6, write best-guess verdict and stop. Judge the final observed state against `expected`.
 
 b. **Judge result** using the same vocabulary: `pass`, `fail`, `blocked`, `unclear`, `error`, `timeout`, `skipped`. A variant's `error`/`timeout` verdict does not cascade (constraint #13).
 
 c. **Write variant result:**
 
    ```bash
-   mkdir -p .verify/runs/$RUN_ID/evidence/$AC_ID/adversarial/$VARIANT_ID
+   mkdir -p .verify/runs/$RUN_ID/evidence/{ac_id}/adversarial/{variant_id}
    ```
 
-   Use the Write tool to create `.verify/runs/$RUN_ID/evidence/$AC_ID/adversarial/$VARIANT_ID/result.json`:
+   Use the Write tool to create `.verify/runs/$RUN_ID/evidence/{ac_id}/adversarial/{variant_id}/result.json`:
 
    ```json
    {
@@ -398,7 +398,7 @@ These rules are battle-tested from 15+ real verification runs:
 
 8. **ALWAYS WRITE RESULT:** Before moving to the next AC, you MUST write the result JSON. A partial result is better than no result.
 
-9. **ADVERSARIAL BUDGET:** 6 Playwright commands per variant max. If 5 commands used and result unresolved, write best-guess verdict and move on.
+9. **ADVERSARIAL BUDGET:** 6 Playwright commands per variant max. At command 6, write best-guess verdict and stop.
 
 10. **ADVERSARIAL IS READ-ONLY (extends #6):** Variants must not submit forms or click Save/Submit/Delete/Create/Remove/Publish/Confirm buttons. The generator prompt enforces this.
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -289,6 +289,53 @@ For EACH acceptance criterion, follow this sequence:
    }
    ```
 
+7b. **Verify adversarial variants (if `adversarial_enabled` and happy-path verdict == `pass`)**
+
+Skip this step if:
+- `adversarial_enabled` is false
+- Happy-path verdict for this AC is not `pass` (constraint #12)
+
+**Re-read variants for this AC** (skill is stateless across ACs):
+
+```bash
+VARIANTS=$(jq --arg ac "$AC_ID" '.[$ac] // []' .verify/runs/$RUN_ID/variants.json)
+```
+
+If `$VARIANTS` is `[]` or empty, skip to step 8.
+
+For each variant `v` in `$VARIANTS`:
+
+a. **Execute variant** using Playwright MCP primitives with a **6-command budget** (constraint #9). Stop and write best-guess verdict at command 6.
+
+b. **Judge result** using the same vocabulary: `pass`, `fail`, `blocked`, `unclear`, `error`, `timeout`, `skipped`. A variant's `error`/`timeout` verdict does not cascade (constraint #13).
+
+c. **Write variant result:**
+
+   ```bash
+   mkdir -p .verify/runs/$RUN_ID/evidence/$AC_ID/adversarial/$VARIANT_ID
+   ```
+
+   Use the Write tool to create `.verify/runs/$RUN_ID/evidence/$AC_ID/adversarial/$VARIANT_ID/result.json`:
+
+   ```json
+   {
+     "variant_id": "ac1_adv1",
+     "parent": "ac1",
+     "type": "adversarial",
+     "category": "input_boundary",
+     "verdict": "pass",
+     "confidence": "high",
+     "reasoning": "What you observed and why",
+     "observed": "Exact text/state on the page",
+     "steps_taken": ["..."],
+     "screenshots": ["screenshot-filename.png"]
+   }
+   ```
+
+   Constraint #8 (ALWAYS WRITE RESULT) applies — write before moving on.
+
+d. **Move to next variant.** Do NOT reset the browser.
+
 8. **Move to next AC.** Do NOT close or reset the browser between ACs.
 
 ### Phase 3: Report Results

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -134,6 +134,16 @@ Read the spec content and any clarifications. Also read context files if they ex
 - `.verify/seed-data.txt` — actual database records, use for specific data references (limit: first 8000 chars)
 - `.verify/learnings.md` — corrections from past verification runs
 
+**Read adversarial flag** — parse `.verify/config.json` and set `adversarial_enabled`:
+
+Default: `true` (adversarial runs always-on unless explicitly disabled).
+
+```bash
+ADVERSARIAL=$(cat .verify/config.json 2>/dev/null | grep -o '"adversarial"[[:space:]]*:[[:space:]]*[a-z]*' | grep -oE '(true|false)' || echo "true")
+```
+
+If `$ADVERSARIAL` is `false`, skip Phase 1b and all adversarial steps in Phase 2 and 3. Happy-path flow is unchanged.
+
 Extract testable ACs. Each AC must be concrete enough for browser verification:
 
 **AC quality standard — this is critical:**
@@ -151,6 +161,64 @@ USE THE ROUTES. If app routes show `/t/personal_xyz/settings/document`, referenc
 - NEVER use template variables like {envId}, {orgId} — resolve to actual values from routes or seed data
 
 Present the AC list to the user: "I've extracted N acceptance criteria. Here's the plan: [list ACs]. Starting verification now."
+
+### Phase 1b: Generate Adversarial Variants (if `adversarial_enabled`)
+
+For each extracted AC, dispatch a variant-generator subagent. This is a generation-only step; variants are verified in Phase 2.
+
+**Invocation:** Use the `Agent` tool with:
+- `subagent_type`: `"general-purpose"`
+- `description`: `"Adversarial variant generation"`
+- Timeout: 60 seconds (enforced at skill level — if subagent takes longer, treat as failure per constraint #13)
+
+**Prompt:**
+
+> You are an adversarial test-case generator for a web app acceptance criterion. You generate test steps only — you do NOT execute them.
+>
+> Input:
+> - AC description: {ac_description}
+> - Current page snapshot (accessibility tree): {snapshot}
+> - Seed data (real DB records): {seed_data}
+> - Known app routes: {routes}
+>
+> Task: Generate exactly 3 **READ-ONLY** edge-case variants of this AC. Pick from these categories:
+> - `input_boundary`: empty, very long (10k chars), unicode, whitespace-only, special chars — ONLY on filter/search/read-side inputs (no submit that creates or modifies records).
+> - `navigation_recovery`: back-button out of a form or modal; rapid-click on non-mutating controls (sort, filter, pagination); deep-link to a page then navigate away and return.
+>
+> HARD RULES:
+> - Variants MUST NOT create, update, or delete any app data.
+> - Variants MUST NOT click "Save", "Submit", "Delete", "Create", "Remove", "Publish", or "Confirm" buttons.
+> - Variants MUST be executable with exactly these Playwright MCP primitives: `mcp__playwright__browser_navigate`, `browser_navigate_back`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_hover`, `browser_press_key`, `browser_wait_for`, `browser_take_screenshot`. There is no refresh primitive.
+>
+> Output: a JSON array of exactly 3 objects. No prose before or after. Schema:
+> ```json
+> [
+>   {
+>     "variant_id": "ac1_adv1",
+>     "category": "input_boundary",
+>     "description": "Human-readable edge case description",
+>     "steps": ["navigate /path", "click ref_search", "type 10000 chars", "snapshot"],
+>     "expected": "Falsifiable observation"
+>   }
+> ]
+> ```
+
+**Handling generator output per AC:**
+- If response parses as a JSON array of length 3 → use it
+- If length > 3 → truncate to first 3
+- If length 0–2 → accept as-is
+- If malformed JSON, empty response, timeout, or error → store `[]` for this AC, continue (constraint #13)
+
+**Persist variants to disk** — the skill is stateless prose; Phase 2 must re-read per AC. After all ACs processed, write `.verify/runs/$RUN_ID/variants.json`:
+
+```json
+{
+  "ac1": [{"variant_id": "ac1_adv1", "category": "input_boundary", "description": "...", "steps": [...], "expected": "..."}],
+  "ac2": []
+}
+```
+
+Present variant count to user alongside the AC list: "Generated M adversarial variants across N ACs. Starting verification now."
 
 ### Phase 2: Verify Each AC with Playwright MCP
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -340,27 +340,41 @@ d. **Move to next variant.** Do NOT reset the browser.
 
 ### Phase 3: Report Results
 
-After all ACs are verified:
+After all ACs and variants are verified:
 
-1. Read each `result.json` from the evidence subdirectories and show inline summary:
+1. **Read all result.json files** from `.verify/runs/$RUN_ID/evidence/` recursively. Classify each as `happy_path` (direct child of `evidence/{ac_id}/`) or `adversarial` (under `evidence/{ac_id}/adversarial/{variant_id}/`).
 
-   For each AC:
-   - `pass` → "✓ ac1: pass"
-   - anything else → "✗ ac2: fail — [first 100 chars of reasoning]"
+2. **Print two-bucket summary to the user:**
 
-2. Write combined `verdicts.json` using the Write tool to `.verify/runs/$RUN_ID/verdicts.json`:
+   ```
+   HAPPY PATH (gating)
+   ✓ ac1: pass
+   ✗ ac2: fail — [first 100 chars of reasoning]
+
+   ADVERSARIAL WARNINGS (informational, does not block push)
+   ⚠ ac1_adv2 (input_boundary): fail — [first 100 chars]
+   ⚠ ac1_adv3 (navigation_recovery): fail — [first 100 chars]
+
+   Summary: X/Y happy-path passed. Z adversarial warnings.
+   ```
+
+   If no adversarial variants ran (disabled or all empty), omit the ADVERSARIAL WARNINGS section entirely.
+
+3. **Write combined `verdicts.json`** to `.verify/runs/$RUN_ID/verdicts.json`:
 
    ```json
    {
      "run_id": "{RUN_ID}",
+     "adversarial_enabled": true,
      "verdicts": [
-       {"ac_id": "ac1", "verdict": "pass", "confidence": "high", "reasoning": "..."},
-       {"ac_id": "ac2", "verdict": "fail", "confidence": "high", "reasoning": "..."}
+       {"ac_id": "ac1", "type": "happy_path", "verdict": "pass", "reasoning": "..."},
+       {"ac_id": "ac1_adv1", "type": "adversarial", "parent": "ac1", "category": "input_boundary", "verdict": "pass", "reasoning": "..."},
+       {"ac_id": "ac2", "type": "happy_path", "verdict": "fail", "reasoning": "..."}
      ]
    }
    ```
 
-3. Show pass/fail summary counts.
+   Every verdict entry MUST have a `type` field. Adversarial entries MUST have `parent` and `category`.
 
 ---
 
@@ -406,6 +420,8 @@ These rules are battle-tested from 15+ real verification runs:
 | Auth redirect on all ACs | "Auth cookies expired. Re-run `/verify-setup` to import fresh cookies." |
 | Playwright command timeout | Write `timeout` for current AC, continue to next |
 | All ACs blocked | "Check dev server and auth. Run `/verify-setup` to reconfigure." |
+| Generator subagent failure | Log, set variants[ac_id] = [], continue (constraint #13) |
+| Variant timeout | Write timeout verdict, continue to next variant (constraint #13) |
 
 ---
 
@@ -417,4 +433,5 @@ These rules are battle-tested from 15+ real verification runs:
 /verify path/to/spec.md             # run with specific spec
 cat .verify/runs/*/verdicts.json    # check verdicts
 ls .verify/runs/*/evidence/         # browse evidence (each AC has a subdirectory)
+jq '.verdicts[] | select(.type=="adversarial" and .verdict=="fail")' .verify/runs/*/verdicts.json  # adversarial warnings only
 ```

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -269,6 +269,16 @@ These rules are battle-tested from 15+ real verification runs:
 
 8. **ALWAYS WRITE RESULT:** Before moving to the next AC, you MUST write the result JSON. A partial result is better than no result.
 
+9. **ADVERSARIAL BUDGET:** 6 Playwright commands per variant max. If 5 commands used and result unresolved, write best-guess verdict and move on.
+
+10. **ADVERSARIAL IS READ-ONLY (extends #6):** Variants must not submit forms or click Save/Submit/Delete/Create/Remove/Publish/Confirm buttons. The generator prompt enforces this.
+
+11. **ADVERSARIAL NEVER BLOCKS:** Adversarial failures are informational warnings. The summary must clearly mark them as informational. Never tell the user to "fix this before pushing" for an adversarial verdict.
+
+12. **SKIP ADVERSARIAL ON NON-PASS:** If a happy-path AC verdict is not `pass`, do not run its variants. Adversarial is only meaningful after the happy path succeeds.
+
+13. **ADVERSARIAL FAILURES ARE ISOLATED:** Generator subagent errors, timeouts, or malformed output set `variants[ac_id] = []` and continue. A variant's `error`, `timeout`, or `blocked` verdict never cascades to sibling variants or to the parent AC.
+
 ---
 
 ## Error Handling


### PR DESCRIPTION
## Summary
- Add 5 hard constraints (#9-13) scoping adversarial variants: 6-cmd budget, read-only, skip-on-non-pass happy-path, etc.
- Generate + persist adversarial variants in Phase 1b; verify them in Phase 2 after happy-path pass
- Two-bucket report: `happy_path` (gating) + `adversarial` (informational warnings); error handling docs
- Review-fix pass addresses blockers 1-4 and should-fix 6 from code review

All changes in `skills/verify/SKILL.md` (+151/-9).

## Test plan
- [x] Documenso sanity smoke: 1 happy-path + 3 adversarial variants (input_boundary x2, navigation_recovery), all 4 jq assertions green
- [ ] Full 15-spec × 3-repo HITL eval (separate Claude Code sessions)