### PR TITLE
docs: rewrite README with QA framing + add CHANGELOG

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,13 +1,13 @@
 {
   "name": "opslane-verify-marketplace",
-  "description": "Browser-based AC verification for frontend PRs",
+  "description": "Self-serve QA for your PR — browser-based verification before you push.",
   "owner": {
     "name": "opslane"
   },
   "plugins": [
     {
       "name": "opslane-verify",
-      "description": "Browser-based acceptance criteria verification for frontend PRs using Claude + Playwright",
+      "description": "Self-serve QA for your PR — browser-based verification of ticket requirements before you push.",
       "version": "1.1.0",
       "source": "./",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,7 +12,7 @@
   "mcp_servers": {
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@latest", "--storage-state", ".verify/auth.json", "--isolated"],
+      "args": ["@playwright/mcp@next", "--storage-state", ".verify/auth.json", "--isolated", "--caps=devtools", "--output-dir", ".verify/mcp-output"],
       "description": "Browser automation for verification"
     }
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "opslane",
     "url": "https://github.com/opslane"
   },
-  "homepage": "https://github.com/opslane/opslane-v3",
-  "repository": "https://github.com/opslane/opslane-v3",
+  "homepage": "https://github.com/opslane/verify",
+  "repository": "https://github.com/opslane/verify",
   "license": "MIT",
   "mcp_servers": {
     "playwright": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "opslane-verify",
-  "description": "Browser-based acceptance criteria verification for frontend PRs using Claude + Playwright",
+  "description": "Self-serve QA for your PR — browser-based verification of ticket requirements before you push.",
   "version": "1.1.0",
   "author": {
     "name": "opslane",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 - `/verify-setup` cookie import flow, `auth.json` export path, and browse-binary download fallback. (#9)
 
-[Unreleased]: https://github.com/opslane/opslane-v3/compare/v1.1.0...HEAD
-[1.1.0]: https://github.com/opslane/opslane-v3/releases/tag/v1.1.0
+[Unreleased]: https://github.com/opslane/verify/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/opslane/verify/releases/tag/v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to opslane/verify are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0] — 2026-04-23
+
+### Added
+- Per-AC video + trace evidence on non-pass verdicts. Each failing AC's directory now contains a Playwright video and trace alongside screenshots, making it easy to diff what the agent saw vs. expected. (#12)
+- Inline `/verify-setup` skill — auto-detects dev server port, indexes routes and selectors from your codebase, writes `.verify/config.json` and `.verify/app.json`. No `npm install` needed. (#11)
+- Playwright MCP-based `/verify` skill — drives the browser via Playwright MCP directly from Claude Code, no CLI binary required. (#7)
+
+### Changed
+- `/verify` skill now uses Playwright MCP directly instead of an external browse binary, simplifying the install path to one `claude mcp add` command. (#7)
+- Cookie-based auth replaces credential-based auth — log in once via your normal browser, `/verify-setup` reads the cookie. (#5)
+
+### Removed
+- Server directory and SaaS backend — opslane/verify is now a pure Claude Code plugin with no server dependency. Auth state lives in `.verify/auth.json` locally. (#10)
+- Standalone CLI package (`@opslane/verify`) — replaced by inline Claude Code skills. (#11)
+- Browse binary and v1 pipeline code — superseded by Playwright MCP. (#8)
+
+### Fixed
+- `/verify-setup` cookie import flow, `auth.json` export path, and browse-binary download fallback. (#9)
+
+[Unreleased]: https://github.com/opslane/opslane-v3/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/opslane/opslane-v3/releases/tag/v1.1.0

--- a/README.md
+++ b/README.md
@@ -1,40 +1,79 @@
 # Verify
 
-**Self-serve QA for your PR, before you push.**
+Verify is self-serve QA for your PR. You paste the ticket; Verify drives a real browser against your local dev server, checks each acceptance criterion, and reports pass/fail with screenshots — inline in Claude Code, before you push.
 
-Paste the ticket. Verify drives a browser against your local dev server and checks each requirement. Pass/fail + screenshots, inline in Claude Code. No CI. No tests to write. No infrastructure.
+## How it works
+
+When you finish a feature and run `/verify`, it doesn't just lint the code. It reads the ticket, extracts the concrete acceptance criteria, and asks you about anything ambiguous. Then it drives the actual app via Playwright MCP — clicking, typing, navigating like a person would — and checks each AC against what it sees. You get a per-AC verdict with screenshots, and a Playwright video + trace on anything that didn't pass.
+
+This is the sanity pass you'd otherwise do manually with the PM ticket open in one tab and your dev server in another. It runs locally, against your real app, with no test code to write and no CI to wire up.
+
+## Demo
+
+<!-- DEMO_PLACEHOLDER: drop a 30s screencast (mp4 or gif + poster.png) here once recorded. -->
+
+*30-second screencast coming soon.* For now, here's what a finished run looks like:
 
 ![Verify report screenshot](docs/report-screenshot.png)
 
-## Install (90 seconds)
+## Installation
 
 **Prerequisites:** Claude Code with OAuth login (`claude login`).
 
-Three commands, in order:
-
-**1. Add Playwright MCP** (one-time per machine)
+In Claude Code, register the marketplace first:
 
 ```bash
-claude mcp add playwright -- npx @playwright/mcp@latest --storage-state .verify/auth.json --isolated
+/plugin marketplace add opslane/verify
 ```
 
-Restart Claude Code after this command.
-
-**2. Set up the project** (one-time per project, run from your repo root)
+Then install the plugin:
 
 ```bash
+/plugin install opslane-verify@opslane-verify-marketplace
+```
+
+That's it. The plugin registers two slash commands — `/verify-setup` and `/verify` — and wires up the Playwright MCP server automatically. No separate `claude mcp add` step.
+
+## Setup: `/verify-setup`
+
+Run this **once per repo** from your repo root, with your dev server running:
+
+```
 /verify-setup
 ```
 
-Auto-detects your dev server port, indexes routes and selectors from your codebase, and writes `.verify/config.json` + `.verify/app.json`.
+It does the following inline (no `npm install`, no CLI binary):
 
-**3. Verify a PR** (run anytime)
+1. **Scaffolds `.verify/`** in your repo and adds it to `.gitignore` if missing.
+2. **Detects your dev server port** by reading `package.json` scripts (`dev`/`start`/`serve` flags), then `.env*` files, then framework configs (`vite.config.*`, `next.config.*`). Falls back to `3000` and tells you. If it picks the wrong one, you can correct it (e.g. "my dev server runs on 5173").
+3. **Pings the dev server** at the detected port. If it can't reach it, it stops here and tells you to start the server first.
+4. **Writes `.verify/config.json`** with the resolved `baseUrl`.
+5. **Indexes your routes.** Walks your codebase looking for user-facing pages — works for Next.js (`app/`, `pages/`), Remix (`routes/`), React Router (`<Route>` / `createBrowserRouter`), SvelteKit (`routes/`), Nuxt (`pages/`), and Express/Hono/Fastify route definitions. Skips `/api/*`. Handles monorepos.
+6. **Indexes your selectors** by reading any existing Playwright (`*.spec.ts`) or Cypress (`*.cy.ts`) tests and extracting the URLs they navigate to and the selectors they use. Prefers `data-testid` and role-based selectors.
+7. **Writes `.verify/app.json`** — a single JSON map of routes + per-page selectors that `/verify` reads later for grounded AC extraction.
+8. **Confirms Playwright MCP is registered** and prints a setup summary.
 
-```bash
-/verify
+Re-run `/verify-setup` any time your routes change or you've added new tests — the index gets refreshed.
+
+## Running: `/verify`
+
+Once setup is done, verify any change with:
+
+```
+/verify                          # auto-discovers a likely spec file
+/verify path/to/spec.md          # or point it at a specific spec
 ```
 
-Paste the ticket. Verify reviews it for ambiguities, drives the browser through each requirement via Playwright MCP, and reports pass/fail with screenshots — all inline.
+Here's what happens, turn by turn:
+
+1. **Spec intake.** If you didn't pass a path, it greps your repo for files matching `*spec*`, `*plan*`, `*requirements*`, `*acceptance*` and either suggests one or asks you to pick. You can also paste the ticket inline.
+2. **Pre-flight.** Confirms Playwright MCP is responding and your dev server is up. Then navigates to the app and checks whether you're logged in. If not, it tries a `credentials` field in `.verify/config.json` (path must live under `.verify/`), then asks you to paste creds inline. Logs you in via the browser; the session persists in `.verify/auth.json` for next time.
+3. **Spec interpretation.** Reads each AC and flags anything ambiguous — vague reveal actions ("shown" without saying how), missing preconditions, unclear targets, no clear pass/fail. Asks one clarifying question at a time. If nothing is ambiguous, it skips this turn.
+4. **AC extraction.** Pulls concrete, testable ACs grounded in your `.verify/app.json` routes and any seed data you've stashed in `.verify/seed-data.txt`. Splits multi-behavior ACs apart. Skips ACs that need external services (Stripe, email, OAuth).
+5. **Browser verification.** For each AC: navigate → start video + trace recording → snapshot the page → interact (click, type, hover, wait) → screenshot → judge the verdict (`pass`, `fail`, `blocked`, `unclear`, `error`, `timeout`, `auth_expired`, `spec_unclear`) → write `result.json`. Recordings get **deleted on pass** (no clutter) and **kept on every non-pass verdict** (so you can replay exactly what happened).
+6. **Report.** Writes `verdicts.json` (machine-readable) + `report.html` (single-file, embeds verdict cards, screenshots, and inline video) to `.verify/runs/<run_id>/`, and prints an inline pass/fail summary in Claude Code with `npx playwright show-trace` commands for any failures.
+
+Hard limits keep runs tight: ~12 Playwright commands per AC, bail after 3 nav attempts, one retry per failed command, no source-code reads, no data mutation.
 
 ## Example
 
@@ -64,21 +103,17 @@ You see the failing AC inline with the screenshot — before you push.
 After a run, evidence lives in `.verify/runs/<run_id>/`:
 
 ```bash
-# Browse raw evidence for a specific AC
+# Open the HTML report in a browser
+open .verify/runs/*/report.html
+
+# Or browse raw evidence for a specific AC
 ls .verify/runs/*/evidence/<ac_id>/
 ```
 
 Each AC's evidence directory contains:
-- `result.json` — verdict, confidence, reasoning, steps taken
+- `result.json` — verdict, confidence, reasoning, steps taken, screenshot filenames
 - `*.png` — screenshots captured during execution
-
-## How it works
-
-`/verify` runs as a Claude Code skill using Playwright MCP for browser interaction. Three stages:
-
-1. **Spec interpretation** — reads your ticket, extracts concrete acceptance criteria, asks clarifying questions when something is ambiguous
-2. **Browser verification** — drives the app via Playwright MCP, checks each AC, captures screenshots / video / trace
-3. **Report** — writes per-AC `result.json` and a combined `verdicts.json` to `.verify/runs/<run_id>/`
+- On non-pass verdicts: `{run_id}-{ac_id}.webm` (video) + `trace.zip` (Playwright trace) — replay the run with `npx playwright show-trace .verify/runs/<run_id>/evidence/<ac_id>/trace.zip`
 
 ## Why this exists
 
@@ -91,19 +126,23 @@ See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 **Latest (v1.1.0 — 2026-04-23):**
 - Per-AC video + trace evidence on non-pass verdicts
 - Inline `/verify-setup` skill (no CLI binary)
-- Playwright MCP-based `/verify` (one-command install)
+- Playwright MCP-based `/verify` (one-command install via `/plugin install`)
 
 ## FAQ
 
 **How is this different from Playwright alone?**
-Playwright is a browser library — you still write tests, run them, maintain them. Verify takes a PM ticket and executes intent-level checks via Claude + Playwright. No test code to write, no selectors to maintain, no CI to wire up.
+Playwright is a browser library — you still write tests, run them, maintain them. Verify takes a PM ticket and executes intent-level checks via Claude + Playwright MCP. No test code to write, no selectors to maintain, no CI to wire up.
 
 **What about auth?**
-`/verify-setup` initializes Playwright with `--storage-state .verify/auth.json --isolated`. On first `/verify` run, the skill walks you through logging in once and re-uses the session for every subsequent run.
+The plugin launches Playwright with `--storage-state .verify/auth.json --isolated`. On first `/verify` run, the skill walks you through logging in once and re-uses the session for every subsequent run.
 
 **What about flaky selectors?**
-The browser agent does intent-based navigation (clicks "the submit button"), not brittle CSS selectors. If something does break, `.verify/runs/<run_id>/evidence/<ac_id>/` has the video + trace so you can see exactly what happened.
+The browser agent navigates by intent (clicks "the submit button" via the accessibility tree), not brittle CSS selectors. If something does break, `.verify/runs/<run_id>/evidence/<ac_id>/` has the video + trace so you can see exactly what happened.
 
 ## Dev setup
 
 See [CLAUDE.md](./CLAUDE.md) for dev commands, conventions, and test instructions.
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,37 +1,40 @@
 # Verify
 
-A verification layer for Claude Code. Reads your spec, runs a browser agent against your local dev server for each acceptance criterion, and returns pass/fail with screenshots — before you push. No CI. No infrastructure.
+**Self-serve QA for your PR, before you push.**
 
-## Install
+Paste the ticket. Verify drives a browser against your local dev server and checks each requirement. Pass/fail + screenshots, inline in Claude Code. No CI. No tests to write. No infrastructure.
 
-### Prerequisites
+![Verify report screenshot](docs/report-screenshot.png)
 
-- Claude Code with OAuth login (`claude login`)
-- Playwright MCP configured (see below)
+## Install (90 seconds)
 
-## Usage
+**Prerequisites:** Claude Code with OAuth login (`claude login`).
 
-### Claude Code Skills
+Three commands, in order:
 
-```bash
-# One-time setup — auto-detects dev server, indexes app
-/verify-setup
-
-# Run verification against a spec
-/verify
-```
-
-`/verify-setup` auto-detects your dev server port, indexes routes and selectors from your codebase, and writes `.verify/config.json` + `.verify/app.json`. No npm install needed.
-
-`/verify` asks for your spec, reviews it for ambiguities, then verifies each acceptance criterion using Playwright MCP. Results appear inline with screenshots.
-
-### Playwright MCP Setup
+**1. Add Playwright MCP** (one-time per machine)
 
 ```bash
 claude mcp add playwright -- npx @playwright/mcp@latest --storage-state .verify/auth.json --isolated
 ```
 
-Restart Claude Code after adding the MCP server.
+Restart Claude Code after this command.
+
+**2. Set up the project** (one-time per project, run from your repo root)
+
+```bash
+/verify-setup
+```
+
+Auto-detects your dev server port, indexes routes and selectors from your codebase, and writes `.verify/config.json` + `.verify/app.json`.
+
+**3. Verify a PR** (run anytime)
+
+```bash
+/verify
+```
+
+Paste the ticket. Verify reviews it for ambiguities, drives the browser through each requirement via Playwright MCP, and reports pass/fail with screenshots — all inline.
 
 ## Debugging failures
 

--- a/README.md
+++ b/README.md
@@ -72,15 +72,27 @@ Each AC's evidence directory contains:
 - `result.json` — verdict, confidence, reasoning, steps taken
 - `*.png` — screenshots captured during execution
 
-## Architecture
+## How it works
 
-`/verify` runs as a Claude Code skill using Playwright MCP for browser interaction:
+`/verify` runs as a Claude Code skill using Playwright MCP for browser interaction. Three stages:
 
-1. **Spec Interpreter** — reviews acceptance criteria for ambiguities, asks clarifying questions
-2. **AC Extractor** — parses the spec into concrete, testable acceptance criteria using seed data and known routes
-3. **Browser Verification** — navigates the app via Playwright MCP, checks each AC, collects screenshots
-4. **Report** — writes per-AC `result.json` and a combined `verdicts.json`
+1. **Spec interpretation** — reads your ticket, extracts concrete acceptance criteria, asks clarifying questions when something is ambiguous
+2. **Browser verification** — drives the app via Playwright MCP, checks each AC, captures screenshots / video / trace
+3. **Report** — writes per-AC `result.json` and a combined `verdicts.json` to `.verify/runs/<run_id>/`
 
-### Dev setup
+## Why this exists
 
-See [CLAUDE.md](./CLAUDE.md) for full dev commands, conventions, and test instructions.
+Built this because I kept shipping PRs that passed my eyeball check but failed the PM's check. Verify is the sanity pass I always did manually, automated against a real browser — not a mock, not a unit test, the actual app.
+
+## Recently shipped
+
+See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+
+**Latest (v1.1.0 — 2026-04-23):**
+- Per-AC video + trace evidence on non-pass verdicts
+- Inline `/verify-setup` skill (no CLI binary)
+- Playwright MCP-based `/verify` (one-command install)
+
+## Dev setup
+
+See [CLAUDE.md](./CLAUDE.md) for dev commands, conventions, and test instructions.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,29 @@ Auto-detects your dev server port, indexes routes and selectors from your codeba
 
 Paste the ticket. Verify reviews it for ambiguities, drives the browser through each requirement via Playwright MCP, and reports pass/fail with screenshots — all inline.
 
+## Example
+
+You paste a ticket like this:
+
+> **As a user, I want to save a draft of my document.**
+>
+> Acceptance criteria:
+> 1. The "Save Draft" button appears on the document edit page
+> 2. Clicking it persists the document state without publishing
+> 3. A confirmation toast appears with text "Draft saved"
+
+Verify drives the browser through each AC and produces a verdict for every one:
+
+```json
+{
+  "ac_1": { "verdict": "pass", "confidence": 0.95, "evidence": "save_draft_button.png" },
+  "ac_2": { "verdict": "pass", "confidence": 0.91, "evidence": "draft_persisted.png" },
+  "ac_3": { "verdict": "fail", "confidence": 0.88, "reasoning": "Toast text was 'Saved' not 'Draft saved'", "evidence": "toast_mismatch.png" }
+}
+```
+
+You see the failing AC inline with the screenshot — before you push.
+
 ## Debugging failures
 
 After a run, evidence lives in `.verify/runs/<run_id>/`:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 - Inline `/verify-setup` skill (no CLI binary)
 - Playwright MCP-based `/verify` (one-command install)
 
+## FAQ
+
+**How is this different from Playwright alone?**
+Playwright is a browser library — you still write tests, run them, maintain them. Verify takes a PM ticket and executes intent-level checks via Claude + Playwright. No test code to write, no selectors to maintain, no CI to wire up.
+
+**What about auth?**
+`/verify-setup` initializes Playwright with `--storage-state .verify/auth.json --isolated`. On first `/verify` run, the skill walks you through logging in once and re-uses the session for every subsequent run.
+
+**What about flaky selectors?**
+The browser agent does intent-based navigation (clicks "the submit button"), not brittle CSS selectors. If something does break, `.verify/runs/<run_id>/evidence/<ac_id>/` has the video + trace so you can see exactly what happened.
+
 ## Dev setup
 
 See [CLAUDE.md](./CLAUDE.md) for dev commands, conventions, and test instructions.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Verify drives the browser through each AC and produces a verdict for every one:
 
 ```json
 {
-  "ac_1": { "verdict": "pass", "confidence": 0.95, "evidence": "save_draft_button.png" },
-  "ac_2": { "verdict": "pass", "confidence": 0.91, "evidence": "draft_persisted.png" },
-  "ac_3": { "verdict": "fail", "confidence": 0.88, "reasoning": "Toast text was 'Saved' not 'Draft saved'", "evidence": "toast_mismatch.png" }
+  "ac_1": { "verdict": "pass", "confidence": "high", "reasoning": "Save Draft button visible on /docs/edit", "screenshots": ["save_draft_button.png"] },
+  "ac_2": { "verdict": "pass", "confidence": "high", "reasoning": "Draft persisted; reload shows the saved state", "screenshots": ["draft_persisted.png"] },
+  "ac_3": { "verdict": "fail", "confidence": "high", "reasoning": "Toast text was 'Saved' not 'Draft saved'", "screenshots": ["toast_mismatch.png"] }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Rewrite README hero and install flow around the "self-serve QA for your PR" framing; add 90-second three-command install, concrete ticket→verdict example, debugging guide, and FAQ (Playwright vs Verify, auth, flaky selectors)
- Add `CHANGELOG.md` (Keep a Changelog + SemVer) backfilled with v1.1.0 entries citing the merged PRs
- Align `.claude-plugin/plugin.json` and `marketplace.json` descriptions to the QA framing; fix dead `opslane/opslane-v3` URLs to `opslane/verify`
- Align example verdict JSON in README with the actual skill schema (`confidence` enum, `screenshots` array)

## Test Plan
- [ ] Render README on GitHub and confirm `docs/report-screenshot.png` displays
- [ ] Verify CHANGELOG compare links resolve to `opslane/verify`
- [ ] Confirm marketplace.json description renders correctly when the plugin is browsed via Claude Code marketplace