### PR TITLE
fix(plugin): remove invalid 'skills' array from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,6 +16,5 @@
       "description": "Browser automation for verification"
     }
   },
-  "skills": ["verify", "verify-setup"],
   "keywords": ["verify", "playwright", "frontend", "acceptance-criteria", "qa"]
 }


### PR DESCRIPTION
## Summary
- The Claude Code plugin schema doesn't accept a `skills` field — skills are auto-discovered from `skills/*/SKILL.md` based on directory layout
- Declaring `"skills": ["verify", "verify-setup"]` was triggering a manifest validation error (`skills: Invalid input`) on `/plugin install`, causing the GitHub install to fail entirely
- Confirmed against `obra/superpowers` plugin.json which omits this field

## Test Plan
- [ ] `/plugin marketplace add opslane/verify` resolves
- [ ] `/plugin install opslane-verify@opslane-verify-marketplace` succeeds (no `skills: Invalid input` error)
- [ ] After install, `/verify` and `/verify-setup` are available as slash commands
- [ ] After install, the `playwright` MCP server is registered with the args declared in `plugin.json`