### PR TITLE
docs: split AGENTS.md into lean root + per-package guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,85 +2,25 @@
 
 Opslane is an AI-powered production error-resolution engine. It ingests browser errors, investigates root causes, and either opens a verified fix PR or creates an actionable `needs_human` incident.
 
-## Stack
+## Areas
 
-| Area | Runtime and tools |
+| Path | Runtime and responsibility |
 | --- | --- |
-| `packages/ingestion` | Go 1.24, chi, pgx, Postgres 16, S3-compatible storage |
-| `packages/worker` | TypeScript, Node 22, Anthropic SDK, Octokit, Vitest |
-| `packages/dashboard` | Vue 3, Vite, Tailwind CSS |
-| `packages/sdk` | Browser TypeScript SDK, React/Vue integrations, Vite source-map plugin |
-| `shared` | Shared TypeScript contracts with no runtime dependencies |
+| `packages/ingestion` | Go 1.24, chi, pgx; API, grouping, migrations, and storage |
+| `packages/worker` | Node 22, TypeScript; investigation, fix verification, and PR creation |
+| `packages/dashboard` | Vue 3, Vite, Tailwind CSS; ingestion-served UI |
+| `packages/sdk` | Browser TypeScript SDK, React/Vue integrations, Vite source maps |
+| `shared` | Runtime-free shared TypeScript contracts |
 | `cli` | Node 22, Commander, Inquirer, Chalk |
-| `eval` | Evaluation runner and framework fixtures |
-| `test-e2e` | Vitest end-to-end contracts |
+| `eval`, `test-e2e`, `test-fixtures` | Evaluations, end-to-end contracts, and browser fixtures |
 
-The server, worker, dashboard, eval, and test code are AGPL-3.0-only. The SDK, CLI, and shared types are MIT licensed.
-
-## Repository structure
-
-```text
-packages/
-  ingestion/          Go API, database access, migrations, grouping, masking
-  worker/             Job poller, investigation/fix pipeline, PR creation
-  dashboard/          Vue application served by ingestion
-  sdk/                Browser SDK and framework/build-tool integrations
-shared/               Shared TypeScript contracts
-cli/                  Opslane CLI and framework codemods
-eval/                 Evaluation runner, cases, and standalone apps
-test-e2e/             End-to-end contract tests
-test-fixtures/         Local applications used by browser/E2E tests
-docs/                 Install, privacy, agent, and public contract docs
-scripts/              Development, migration, and seed scripts
-```
-
-## Commands
-
-```bash
-pnpm install
-pnpm -r build
-pnpm test
-
-cd packages/ingestion
-go build ./...
-go test ./...
-cd ../..
-
-docker compose config --quiet
-docker compose up -d
-docker compose ps
-pnpm db:migrate
-```
-
-Useful focused checks:
-
-```bash
-pnpm --filter @opslane/worker test
-pnpm --filter @opslane/sdk test
-pnpm --filter @opslane/cli test
-pnpm --filter @opslane/dashboard build
-cd packages/ingestion && go test ./db ./handler
-```
-
-`docker compose down -v` and `./scripts/restart-services.sh --wipe-db` destroy local data. Use them only when the task explicitly requires a clean database.
+Server, worker, dashboard, eval, and test code is AGPL-3.0-only. SDK, CLI, and shared types are MIT licensed.
 
 ## Verification
 
-Verify the smallest relevant surface while iterating, then run every check needed to prove the final claim. Do not report completion from an unverified edit.
+Verify the smallest relevant surface while iterating, then every check needed to prove the final claim. Focused package checks live in each package's `AGENTS.md`.
 
-| Change | Required verification |
-| --- | --- |
-| Shared types or workspace metadata | `pnpm -r build` and affected tests |
-| Worker or pipeline | worker build/tests; Docker E2E smoke for flow changes |
-| SDK or integrations | SDK build/tests, including browser contract tests |
-| CLI | CLI build/tests |
-| Dashboard | dashboard build/tests |
-| Ingestion | `go build ./...` and `go test ./...` |
-| Migration SQL | apply to a clean DB and an existing DB; verify idempotency |
-| Compose or health checks | `docker compose config --quiet`, start services, inspect health |
-| Dockerfiles | build the affected Compose image |
-
-For a full repository gate:
+Full repository gate:
 
 ```bash
 pnpm install --frozen-lockfile
@@ -90,57 +30,41 @@ pnpm test
 docker compose config --quiet
 ```
 
-Pipeline changes require a live smoke test: apply migrations, run `scripts/seed-e2e.sql`, rebuild ingestion and worker, send an event to `http://localhost:8082/api/v1/events`, and confirm the resulting job reaches its expected terminal state. Use the repository-local `test-fixtures/vue-app` when an E2E test needs a browser fixture.
+- Shared types or workspace metadata: run `pnpm -r build` and affected tests.
+- CLI: run `pnpm --filter @opslane/cli build` and `pnpm --filter @opslane/cli test`.
+- Compose or health checks: validate config, start services, and inspect health. Build any affected Compose image after Dockerfile changes.
+- Pipeline changes require a live smoke: apply migrations, run `scripts/seed-e2e.sql`, rebuild ingestion and worker, send an event to `http://localhost:8082/api/v1/events`, and confirm the job reaches its expected terminal state. Use `test-fixtures/vue-app` for browser fixtures.
 
-## Engineering conventions
+## Cross-cutting conventions
 
-### Go and database
-
-- Keep HTTP handlers in `handler/` and database operations in `db/`.
-- Every database helper must take and enforce the required project or organization scope.
-- Postgres is both the system of record and the job queue. Claim work with `FOR UPDATE SKIP LOCKED` and preserve lease ownership semantics.
-- `001_baseline.sql` is the consolidated baseline. New schema changes are append-only migrations starting at `002`.
-- Every migration must be safe to reapply. Prefer `IF NOT EXISTS` and equivalent guarded operations.
-- Every terminal `needs_human` result must include `reason_code`, `reason_message`, and `remediation`.
-
-### TypeScript and Vue
-
-- Use ESM, strict TypeScript, and `unknown` plus narrowing instead of `any`.
-- Keep tests colocated in `__tests__` and use Vitest.
-- Use Vue 3 Composition API with `<script setup>`.
-- Keep dashboard API calls in `packages/dashboard/src/api.ts` and API contracts in `types/api.ts`.
-- Sanitize untrusted error text and model output before rendering it or interpolating it into HTML/Markdown.
-
-### Naming and licensing
-
+- Use ESM and strict TypeScript. Use `unknown` plus narrowing instead of `any`.
+- Keep Vitest tests colocated in `__tests__`.
 - Use the `@opslane/` package scope and the `opslane` CLI name.
 - Local Postgres user/database names are `opslane`; Compose services are `ingestion`, `worker`, `postgres`, and `minio`.
-- New server-side packages default to `AGPL-3.0-only`. Add code to the MIT SDK/CLI/shared boundary only when that distribution choice is intentional.
+- New server-side packages default to `AGPL-3.0-only`. Put code in the MIT SDK/CLI/shared boundary only when that distribution choice is intentional.
 
 ## Guardrails
 
-- Do not introduce Redis, BullMQ, or another queue without an explicit architectural decision.
-- Do not write unscoped tenant queries.
-- Do not store production API keys in plaintext; use the existing envelope-encryption path.
-- Do not add legacy compatibility shims unless a documented public contract requires them.
-- Do not broaden the current issue into unrelated product expansion.
-- Do not add a dependency without checking for an existing utility and reviewing its license.
-- Do not weaken terminal-status or lease contracts to make a test pass.
-- Do not run destructive database commands unless the task explicitly calls for them.
+- Do not introduce Redis, BullMQ, or another queue without an architectural decision; use the existing Postgres job queue.
+- Do not persist production credentials in plaintext; use deployment environment variables or GitHub App credentials until encrypted storage is implemented.
+- Do not add legacy shims by default; preserve documented public contracts or change them explicitly.
+- Keep the change inside the current issue instead of expanding the product scope.
+- Reuse existing utilities before adding a dependency, and review any new dependency's license.
+- Preserve terminal-status and lease contracts; fix the implementation or test setup instead of weakening them.
+- Do not run destructive database commands on retained data. Use a disposable database when clean-state verification is required.
 
 ## Agent workflow
 
-- Work directly when a task is clear; ask only when a decision is destructive, externally side-effectful, or materially ambiguous.
+- Work directly when the task is clear; ask only for destructive, externally side-effectful, or materially ambiguous decisions.
 - Preserve unrelated worktree changes and keep diffs small and reviewable.
 - Prefer deletion and existing patterns over new abstractions.
-- Read current code and tests before changing behavior.
-- Use the repository's GitHub tracker from the repository root so `gh` infers the current remote.
+- Read current code and tests before changing behavior; verify before reporting completion.
+- Run `gh` from the repository root so it infers the current remote.
 
-Progressive references:
+## References
 
-- Issue operations: `docs/agents/issue-tracker.md`
-- Triage vocabulary: `docs/agents/triage-labels.md`
+- Package specifics: `packages/<name>/AGENTS.md` (loads when working in that package)
+- Issue operations and triage: `docs/agents/issue-tracker.md`, `docs/agents/triage-labels.md`
 - Domain and ADR discovery: `docs/agents/domain.md`
-- Installation: `docs/install.md`
-- Replay privacy: `docs/replay-privacy.md`
+- Installation and replay privacy: `docs/install.md`, `docs/replay-privacy.md`
 - Public contracts: `docs/contracts/`

--- a/packages/dashboard/AGENTS.md
+++ b/packages/dashboard/AGENTS.md
@@ -1,0 +1,13 @@
+# Dashboard guidance
+
+The dashboard is a Vue 3 application served by ingestion.
+
+## Conventions
+
+- Use the Composition API with `<script setup>`.
+- Keep API calls in `src/api.ts` and API contracts in `src/types/api.ts`.
+- Treat error text and model output as untrusted. Sanitize them before rendering or interpolating them into HTML or Markdown.
+
+## Verification
+
+- Run `pnpm --filter @opslane/dashboard build` and `pnpm --filter @opslane/dashboard test`.

--- a/packages/dashboard/CLAUDE.md
+++ b/packages/dashboard/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/ingestion/AGENTS.md
+++ b/packages/ingestion/AGENTS.md
@@ -1,0 +1,17 @@
+# Ingestion guidance
+
+The ingestion service is the Go API and owns grouping, persistence, migrations, and S3-compatible storage.
+
+## Boundaries
+
+- Keep HTTP handlers in `handler/` and database operations in `db/`.
+- Scope every database helper to the required project or organization, and enforce that scope in its query.
+- Treat `001_baseline.sql` as the consolidated baseline. Add schema changes as append-only migrations starting at `002`.
+- Make migrations safe to reapply with guarded operations such as `IF NOT EXISTS`.
+
+## Verification
+
+- Run `go build ./...` and `go test ./...` from `packages/ingestion`.
+- For focused database or handler work, run `go test ./db ./handler` while iterating.
+- Apply migration SQL to a disposable clean database and a representative existing database, then reapply it to verify idempotency.
+- Build the ingestion Compose image after Dockerfile changes.

--- a/packages/ingestion/CLAUDE.md
+++ b/packages/ingestion/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -1,0 +1,9 @@
+# SDK guidance
+
+The MIT-licensed browser SDK includes React and Vue integrations plus the Vite source-map plugin.
+
+## Verification
+
+- Run `pnpm --filter @opslane/sdk build` and `pnpm --filter @opslane/sdk test`.
+- Confirm the real-browser contract tests execute rather than skip when changing browser capture or replay behavior.
+- Run `pnpm --filter @opslane/sdk check:package` when changing exports or package contents.

--- a/packages/sdk/CLAUDE.md
+++ b/packages/sdk/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/worker/AGENTS.md
+++ b/packages/worker/AGENTS.md
@@ -1,0 +1,17 @@
+# Worker guidance
+
+The worker polls Postgres and owns investigation, fix verification, lease handling, and PR delivery.
+
+## Contracts
+
+- Use Postgres as the job queue. Claim work with `FOR UPDATE SKIP LOCKED` and preserve worker ownership on every lease mutation.
+- Scope database operations to the required project or organization.
+- Every terminal `needs_human` result must include a non-empty `reason_code`, `reason_message`, and `remediation`.
+- Keep terminal-state and lease behavior intact when fixing failures; correct the implementation or test setup instead of weakening those contracts.
+- Fence untrusted error text and repository content before including it in model prompts.
+
+## Verification
+
+- Run `pnpm --filter @opslane/worker build` and `pnpm --filter @opslane/worker test`.
+- For worker pipeline behavior, also run the live smoke described in the root `AGENTS.md` and confirm the expected terminal state.
+- Build the worker Compose image after Dockerfile changes.

--- a/packages/worker/CLAUDE.md
+++ b/packages/worker/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## What

Splits the monolithic root `AGENTS.md` into a lean root plus per-package guidance.

- Root `AGENTS.md` trimmed to the cross-cutting essentials (areas, full-repo verification gate, conventions, guardrails, agent workflow, references).
- Package-specific conventions and verification steps moved into per-package `AGENTS.md` for `ingestion`, `worker`, `dashboard`, and `sdk`.
- Each package gets a `CLAUDE.md` (`@AGENTS.md` pointer) so Claude Code loads the right guidance when working in that package.

## Why

The single root file had grown to ~146 lines mixing repo-wide rules with package detail. Shorter, scoped files get followed more uniformly and load only the relevant guidance per package.

## Notes

- Corrected the dashboard API-contract path from `types/api.ts` to the accurate `src/types/api.ts`.
- `scripts/check-docs-drift.mjs` passes: 47 routes, 36 env vars, 12 SDK options, 22 reason codes all consistent.
- No code changes — docs only.