### PR TITLE
CI and releases: pipeline implementation (epic #1)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": [],
+  "privatePackages": {
+    "version": false,
+    "tag": false
+  }
+}

--- a/.changeset/tidy-pugs-shave.md
+++ b/.changeset/tidy-pugs-shave.md
@@ -1,0 +1,6 @@
+---
+'@opslane/sdk': patch
+'@opslane/cli': patch
+---
+
+Publish readiness. SDK type declarations are now bundled into flat per-entry files, inlining types from the private `@opslane/shared` package — previously the published tarball's types were unresolvable for npm consumers. CLI tarball now ships only `dist` and carries repository metadata required for npm provenance.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: gomod
+    directory: '/packages/ingestion'
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directories:
+      - '/packages/ingestion'
+      - '/packages/worker'
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     services:
       postgres:
-        image: postgres:16
+        image: postgres:16@sha256:ab47a724d0e37131ac950b98ff2beeb3fdb3bfcc592d73c6cc4b4e7626649671
         env:
           POSTGRES_USER: opslane
           POSTGRES_PASSWORD: opslane_dev
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 20
     services:
       postgres:
-        image: postgres:16
+        image: postgres:16@sha256:ab47a724d0e37131ac950b98ff2beeb3fdb3bfcc592d73c6cc4b4e7626649671
         env:
           POSTGRES_USER: opslane
           POSTGRES_PASSWORD: opslane_dev
@@ -86,6 +86,8 @@ jobs:
         run: pnpm --filter @opslane/sdk exec playwright install --with-deps chromium
       - run: pnpm -r build
       - run: pnpm test
+      - name: License-boundary check (MIT-published packages)
+        run: node scripts/check-licenses.mjs
 
   compose:
     name: Compose validation
@@ -179,11 +181,27 @@ jobs:
         if: always()
         run: docker compose down -v
 
+  security:
+    name: Secret scan and action pinning
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Gitleaks secret scan
+        run: >
+          docker run --rm -v "$PWD:/repo:ro"
+          ghcr.io/gitleaks/gitleaks@sha256:e1b35e12a8c6fa8901f060459cfb6b2fc4c484d3afbe3b029733a3bbfab07055
+          dir /repo --config /repo/.gitleaks.toml --no-banner --redact
+      - name: Enforce SHA-pinned actions
+        run: node scripts/check-action-pins.mjs
+
   ci-ok:
     name: ci-ok
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [go, js, compose, docker, e2e-keyless]
+    needs: [go, js, compose, docker, e2e-keyless, security]
     if: always()
     steps:
       - name: Report job results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,11 +111,79 @@ jobs:
           persist-credentials: false
       - run: docker build -f packages/${{ matrix.image }}/Dockerfile .
 
+  e2e-keyless:
+    name: Keyless smoke E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Deterministic canaries planted where real secrets would live; the leak
+      # scan below fails the job if they surface in logs or HTTP responses.
+      GITHUB_APP_CLIENT_SECRET: OPSLANE-E2E-CANARY-ingestion-2f9c41d7
+      E2B_API_KEY: OPSLANE-E2E-CANARY-worker-8b1e63aa
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Assert the LLM key is absent
+        run: |
+          if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "ANTHROPIC_API_KEY must not be set in the keyless lane."
+            exit 1
+          fi
+      - name: Boot the stack without an LLM key
+        run: |
+          docker compose up -d postgres minio minio-setup
+          docker compose run --rm migrate
+          docker compose up -d --build --wait ingestion worker
+      - name: Assert the worker container is keyless
+        run: docker compose exec -T worker sh -c '[ -z "$ANTHROPIC_API_KEY" ]'
+      - name: Run E2E contracts with hard assertions
+        env:
+          DATABASE_URL: postgres://opslane:opslane_dev@localhost:5434/opslane
+          INGESTION_URL: http://localhost:8082
+          E2E_WORKER_NO_KEY: "1"
+        run: >
+          pnpm --filter @opslane/test-e2e exec vitest run
+          --reporter=default --reporter=json
+          --outputFile=${{ runner.temp }}/e2e-results.json
+      - name: Enforce zero unexpected skips
+        env:
+          # The with-secrets PR pipeline suite is the only allowed skip here.
+          E2E_ALLOWED_SKIP_PATTERN: '^pr_created pipeline \(full flow\)'
+          E2E_MIN_TESTS: "15"
+        run: node scripts/check-e2e-results.mjs "${{ runner.temp }}/e2e-results.json"
+      - name: Token-leak scan over logs and public HTTP surfaces
+        run: |
+          docker compose logs --no-color > "${{ runner.temp }}/stack-logs.txt"
+          curl -fsS http://localhost:8082/health > "${{ runner.temp }}/responses.txt" || true
+          curl -fsS http://localhost:8082/ >> "${{ runner.temp }}/responses.txt" || true
+          leak=0
+          for canary in "OPSLANE-E2E-CANARY-ingestion-2f9c41d7" "OPSLANE-E2E-CANARY-worker-8b1e63aa"; do
+            if grep -qF "$canary" "${{ runner.temp }}/stack-logs.txt" "${{ runner.temp }}/responses.txt"; then
+              echo "Token leak detected: $canary appeared in scanned surfaces."
+              leak=1
+            fi
+          done
+          [ "$leak" -eq 0 ] && echo "Leak scan clean."
+          exit "$leak"
+      - name: Dump stack logs on failure
+        if: failure()
+        run: docker compose logs --no-color | tail -300
+      - name: Teardown
+        if: always()
+        run: docker compose down -v
+
   ci-ok:
     name: ci-ok
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [go, js, compose, docker]
+    needs: [go, js, compose, docker, e2e-keyless]
     if: always()
     steps:
       - name: Report job results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  go:
+    name: Go build and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: opslane
+          POSTGRES_PASSWORD: opslane_dev
+          POSTGRES_DB: opslane
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U opslane"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://opslane:opslane_dev@localhost:5432/opslane?sslmode=disable
+    defaults:
+      run:
+        working-directory: packages/ingestion
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: packages/ingestion/go.mod
+          cache-dependency-path: packages/ingestion/go.sum
+      - name: Apply migrations
+        run: MIGRATION_DIR=db/migrations ../../scripts/run-migrations.sh
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test ./...
+
+  js:
+    name: JS build and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: opslane
+          POSTGRES_PASSWORD: opslane_dev
+          POSTGRES_DB: opslane
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U opslane"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://opslane:opslane_dev@localhost:5432/opslane?sslmode=disable
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - name: Apply migrations
+        run: MIGRATION_DIR=packages/ingestion/db/migrations ./scripts/run-migrations.sh
+      - run: pnpm install --frozen-lockfile
+      - name: Install Playwright chromium (SDK browser tests)
+        run: pnpm --filter @opslane/sdk exec playwright install --with-deps chromium
+      - run: pnpm -r build
+      - run: pnpm test
+
+  compose:
+    name: Compose validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - run: docker compose config --quiet
+
+  docker:
+    name: Docker build (${{ matrix.image }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [ingestion, worker]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - run: docker build -f packages/${{ matrix.image }}/Dockerfile .
+
+  ci-ok:
+    name: ci-ok
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [go, js, compose, docker]
+    if: always()
+    steps:
+      - name: Report job results
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: echo "$RESULTS"
+      - name: Fail on any failed, cancelled, or skipped required job
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,3 +193,46 @@ jobs:
       - name: Fail on any failed, cancelled, or skipped required job
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
         run: exit 1
+
+  # Candidate images: only on push to main, only after ci-ok. The unique tag
+  # main-<sha>-<run-id>-<attempt> IS the candidate's identity (no stored
+  # manifest); the release workflow resolves digests from it at promotion.
+  candidate-images:
+    name: Publish candidate images
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [ci-ok]
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [ingestion, worker]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Log in to GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GH_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Build and push candidate
+        id: push
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/opslane-${{ matrix.image }}
+          TAG: main-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          docker build -f "packages/${{ matrix.image }}/Dockerfile" -t "$IMAGE:$TAG" .
+          docker push "$IMAGE:$TAG"
+          digest=$(docker inspect --format '{{index .RepoDigests 0}}' "$IMAGE:$TAG")
+          echo "Candidate pushed: $IMAGE:$TAG"
+          echo "Digest: $digest"
+          {
+            echo "### Candidate: \`${{ matrix.image }}\`"
+            echo '```'
+            echo "tag:    $IMAGE:$TAG"
+            echo "digest: $digest"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,78 @@
+name: npm release
+
+# Changesets is the sole npm publishing authority. On every push to main this
+# either (a) opens/refreshes the "Version Packages" PR when changesets are
+# pending, or (b) publishes to npm when the Version Packages PR was just
+# merged. Publishing uses npm Trusted Publishing (OIDC) — no npm token exists
+# anywhere. Platform v* tags never trigger this workflow, and package tags
+# never trigger the platform release.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Credential-free verification. This job installs freshly-resolved
+  # third-party dependency code (the clean-consumer checks), so it must never
+  # hold publish credentials.
+  verify:
+    name: Clean-consumer tarball checks
+    if: github.repository == 'opslane/opslane-oss'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+      - name: Install (lifecycle scripts blocked)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build publishable packages
+        run: pnpm --filter @opslane/sdk... --filter @opslane/cli... build
+      - name: Clean-consumer tarball checks
+        run: node scripts/check-packed-packages.mjs
+
+  # Credentialed publish. Runs only trusted code: frozen-lockfile install with
+  # lifecycle scripts blocked, our own builds, and changesets. No consumer
+  # installs happen here.
+  release:
+    name: Version PR or publish
+    if: github.repository == 'opslane/opslane-oss'
+    needs: [verify]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: write # changesets action pushes the version branch
+      pull-requests: write # and opens/updates the Version Packages PR
+      id-token: write # npm Trusted Publishing (OIDC) + provenance
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+      - name: Update npm (trusted publishing requires >= 11.5.1)
+        run: npm install -g npm@latest && npm --version
+      - name: Install (lifecycle scripts blocked)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build publishable packages
+        run: pnpm --filter @opslane/sdk... --filter @opslane/cli... build
+      - name: Version PR or publish
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        with:
+          publish: pnpm changeset publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/.github/workflows/release-platform.yml
+++ b/.github/workflows/release-platform.yml
@@ -1,0 +1,176 @@
+name: Platform release
+
+# Manual-dispatch-only promotion of a soaked candidate. The maintainer names a
+# CalVer version and the candidate CI run; the workflow validates everything,
+# creates the tag AFTER validation (v* tags are immutable with no bypass — a
+# premature tag would be stranded forever), re-tags the existing candidate
+# digests without rebuilding, and publishes a GitHub Release with the digest
+# manifest. Nothing anywhere triggers on tag push: a stray hand-pushed v* tag
+# is inert. No `latest` tag is ever created.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'CalVer version to release (e.g. v26.7.0)'
+        required: true
+      candidate_run_id:
+        description: 'Run ID of the main-branch CI run that published the candidate images'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: platform-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Validate, tag, promote, publish
+    if: github.repository == 'opslane/opslane-oss'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write # create the version tag + the GitHub Release
+      packages: write # re-tag the candidate images
+      actions: read # inspect the candidate workflow run
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ inputs.version }}
+      RUN_ID: ${{ inputs.candidate_run_id }}
+      REPO: ${{ github.repository }}
+      OWNER: ${{ github.repository_owner }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Validate version syntax and release uniqueness
+        run: |
+          if ! printf '%s' "$VERSION" | grep -qE '^v[0-9]{2}\.(1[0-2]|[1-9])\.(0|[1-9][0-9]*)$'; then
+            echo "Version '$VERSION' is not exact CalVer (vYY.M.PATCH, e.g. v26.7.0)."
+            exit 1
+          fi
+          if gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists."
+            exit 1
+          fi
+
+      - name: Verify the candidate came from a successful main CI run
+        id: run
+        run: |
+          run_json=$(gh api "repos/$REPO/actions/runs/$RUN_ID")
+          conclusion=$(echo "$run_json" | jq -r .conclusion)
+          path=$(echo "$run_json" | jq -r .path)
+          branch=$(echo "$run_json" | jq -r .head_branch)
+          event=$(echo "$run_json" | jq -r .event)
+          sha=$(echo "$run_json" | jq -r .head_sha)
+          attempt=$(echo "$run_json" | jq -r .run_attempt)
+          echo "run: path=$path branch=$branch event=$event conclusion=$conclusion sha=$sha attempt=$attempt"
+          [ "$conclusion" = "success" ] || { echo "Candidate run did not succeed."; exit 1; }
+          [ "$path" = ".github/workflows/ci.yml" ] || { echo "Run is not the CI workflow."; exit 1; }
+          [ "$branch" = "main" ] || { echo "Run is not a main-branch run."; exit 1; }
+          [ "$event" = "push" ] || { echo "Run is not a push run."; exit 1; }
+          git merge-base --is-ancestor "$sha" origin/main || { echo "SHA is not an ancestor of main."; exit 1; }
+          # Immutable-tag handling: a pre-existing version tag is fatal unless
+          # it already points at this exact SHA (then this run is a resume of a
+          # partially-failed promotion).
+          existing=$(git ls-remote --tags origin "refs/tags/$VERSION" | cut -f1)
+          if [ -n "$existing" ] && [ "$existing" != "$sha" ]; then
+            echo "Tag $VERSION already exists at $existing (not $sha) — immutable tags are never reused."
+            exit 1
+          fi
+          [ -n "$existing" ] && echo "Tag $VERSION already points at $sha — resuming promotion."
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "attempt=$attempt" >> "$GITHUB_OUTPUT"
+          echo "tag_exists=${existing:+yes}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        run: echo "$GH_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Resolve candidate digests
+        id: digests
+        env:
+          SHA: ${{ steps.run.outputs.sha }}
+          ATTEMPT: ${{ steps.run.outputs.attempt }}
+        run: |
+          # A partially re-run candidate build (rerun-failed-jobs) can leave
+          # each image published under a different run attempt, so resolve
+          # per image, trying the aggregate attempt down to 1.
+          cand_tag=""
+          for image in ingestion worker; do
+            digest=""
+            for attempt in $(seq "$ATTEMPT" -1 1); do
+              ref="ghcr.io/$OWNER/opslane-$image:main-$SHA-$RUN_ID-$attempt"
+              if d=$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest}}' 2>/dev/null | jq -r .digest) \
+                 && [ -n "$d" ] && [ "$d" != "null" ]; then
+                digest="$d"
+                cand_tag="main-$SHA-$RUN_ID-$attempt"
+                echo "$image: $ref -> $digest"
+                break
+              fi
+            done
+            [ -n "$digest" ] || { echo "No candidate image found for $image (run $RUN_ID, attempts $ATTEMPT..1)."; exit 1; }
+            echo "$image=$digest" >> "$GITHUB_OUTPUT"
+          done
+          echo "cand_tag=$cand_tag" >> "$GITHUB_OUTPUT"
+
+      # Registry promotion happens BEFORE the immutable git tag: retagging is
+      # idempotent and repeatable, while a stranded v* tag can never be
+      # removed. The tag is only created once both images are verified.
+      - name: Re-tag candidate digests as the version (no rebuild)
+        env:
+          INGESTION_DIGEST: ${{ steps.digests.outputs.ingestion }}
+          WORKER_DIGEST: ${{ steps.digests.outputs.worker }}
+        run: |
+          for image in ingestion worker; do
+            digest_var=$(echo "$image" | tr '[:lower:]' '[:upper:]')_DIGEST
+            digest=$(eval "echo \$$digest_var")
+            src="ghcr.io/$OWNER/opslane-$image@$digest"
+            dst="ghcr.io/$OWNER/opslane-$image:$VERSION"
+            docker buildx imagetools create --tag "$dst" "$src"
+            promoted=$(docker buildx imagetools inspect "$dst" --format '{{json .Manifest}}' | jq -r .digest)
+            [ "$promoted" = "$digest" ] || { echo "Digest mismatch after retag: $promoted != $digest"; exit 1; }
+            echo "$dst -> $digest (verified)"
+          done
+
+      - name: Create the version tag (after successful registry promotion)
+        if: steps.run.outputs.tag_exists != 'yes'
+        env:
+          SHA: ${{ steps.run.outputs.sha }}
+        run: gh api "repos/$REPO/git/refs" -f ref="refs/tags/$VERSION" -f sha="$SHA"
+
+      - name: Publish the GitHub Release with the digest manifest
+        env:
+          SHA: ${{ steps.run.outputs.sha }}
+          CAND_TAG: ${{ steps.digests.outputs.cand_tag }}
+          INGESTION_DIGEST: ${{ steps.digests.outputs.ingestion }}
+          WORKER_DIGEST: ${{ steps.digests.outputs.worker }}
+        run: |
+          cat > "release-manifest-$VERSION.json" <<MANIFEST
+          {
+            "version": "$VERSION",
+            "source_sha": "$SHA",
+            "candidate_run": "https://github.com/$REPO/actions/runs/$RUN_ID",
+            "candidate_tag": "$CAND_TAG",
+            "platforms": ["linux/amd64"],
+            "images": {
+              "ingestion": {
+                "ref": "ghcr.io/$OWNER/opslane-ingestion:$VERSION",
+                "digest": "$INGESTION_DIGEST"
+              },
+              "worker": {
+                "ref": "ghcr.io/$OWNER/opslane-worker:$VERSION",
+                "digest": "$WORKER_DIGEST"
+              }
+            },
+            "released_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          MANIFEST
+          gh release create "$VERSION" "release-manifest-$VERSION.json" \
+            --repo "$REPO" \
+            --title "$VERSION" \
+            --notes "$(printf 'Promoted from candidate run %s (commit %s).\n\nImage digests:\n- ghcr.io/%s/opslane-ingestion@%s\n- ghcr.io/%s/opslane-worker@%s\n\nPin images by digest or by the %s tag. There is no latest tag.' \
+              "https://github.com/$REPO/actions/runs/$RUN_ID" "$SHA" "$OWNER" "$INGESTION_DIGEST" "$OWNER" "$WORKER_DIGEST" "$VERSION")"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -17,4 +17,6 @@ regexes = [
   # Deterministic canary values planted by the keyless E2E lane's token-leak
   # scan (.github/workflows/ci.yml). Not secrets by construction.
   '''OPSLANE-E2E-CANARY-[a-z]+-[0-9a-f]+''',
+  # Documentation placeholder API key used in README/docs curl examples.
+  '''e2e-test-key-plaintext''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,7 +1,10 @@
 [extend]
 useDefault = true
 
-[[allowlists]]
+# NOTE: this must stay the singular [allowlist] table. The plural
+# [[allowlists]] form is silently ignored as a global allowlist by the
+# gitleaks version pinned in CI, which un-suppresses every entry below.
+[allowlist]
 description = "Synthetic credentials used to verify secret masking and authentication failures"
 paths = [
   '''packages/ingestion/db/agent_session_test\.go''',
@@ -9,4 +12,9 @@ paths = [
   '''packages/sdk/src/__tests__/scrub\.test\.ts''',
   '''test-e2e/error-to-pr\.test\.ts''',
   '''test-e2e/replay-contract\.test\.ts''',
+]
+regexes = [
+  # Deterministic canary values planted by the keyless E2E lane's token-leak
+  # scan (.github/workflows/ci.yml). Not secrets by construction.
+  '''OPSLANE-E2E-CANARY-[a-z]+-[0-9a-f]+''',
 ]

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,10 +1,19 @@
 {
   "name": "@opslane/cli",
   "version": "0.0.1",
+  "description": "CLI for installing and configuring the Opslane SDK",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opslane/opslane-oss.git",
+    "directory": "cli"
+  },
   "bin": {
     "opslane": "dist/index.js"
   },
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { readFileSync } from 'node:fs';
 import { Command } from 'commander';
 import { login } from './login.js';
 import { init } from './init.js';
@@ -10,12 +11,18 @@ import { verify } from './verify.js';
 import { status } from './status.js';
 import { listErrors, getError } from './errors.js';
 
+// Derive the version from package.json so Changesets bumps propagate to
+// `opslane --version` without a hand edit (dist/index.js -> ../package.json).
+const pkg = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+) as { version: string };
+
 const program = new Command();
 
 program
   .name('opslane')
   .description('Opslane CLI - AI-powered production error resolution')
-  .version('0.0.1');
+  .version(pkg.version);
 
 program
   .command('login')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,14 +115,12 @@ services:
       postgres:
         condition: service_healthy
     volumes:
-      - ./packages/ingestion/db/migrations:/migrations
-    entrypoint: >
-      sh -c "for f in /migrations/*.sql; do
-        echo \"Applying $$f...\";
-        PGPASSWORD=opslane_dev psql -h postgres -U opslane -d opslane -f $$f;
-      done"
+      - ./packages/ingestion/db/migrations:/migrations:ro
+      - ./scripts/run-migrations.sh:/run-migrations.sh:ro
+    entrypoint: ["/run-migrations.sh"]
     environment:
-      PGPASSWORD: opslane_dev
+      MIGRATION_DIR: /migrations
+      DATABASE_URL: postgres://opslane:opslane_dev@postgres:5432/opslane
 
 volumes:
   pgdata:

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "test": "pnpm -r --filter '!@opslane/test-e2e' test",
     "test:unit": "pnpm -r --filter '!@opslane/test-e2e' test",
     "test:e2e": "pnpm --filter @opslane/test-e2e test"
+  },
+  "devDependencies": {
+    "@changesets/cli": "^2.31.0"
   }
 }

--- a/packages/ingestion/Dockerfile
+++ b/packages/ingestion/Dockerfile
@@ -1,10 +1,11 @@
-# Stage 1: Build dashboard
+# Stage 1: Build dashboard (workspace lockfile, reproducible)
 FROM node:22-alpine AS dashboard-builder
 WORKDIR /app
-COPY packages/dashboard/package.json ./
-RUN npm install
-COPY packages/dashboard/ .
-RUN npx vue-tsc && npx vite build
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
+COPY packages/dashboard/package.json packages/dashboard/
+RUN corepack enable pnpm && pnpm install --frozen-lockfile
+COPY packages/dashboard/ packages/dashboard/
+RUN pnpm --filter @opslane/dashboard build
 
 # Stage 2: Build Go service
 FROM golang:1.24-alpine AS builder
@@ -23,7 +24,7 @@ RUN addgroup -S ingestion && adduser -S ingestion -G ingestion
 COPY --from=builder /ingestion /usr/local/bin/ingestion
 COPY --from=builder /app/db/migrations /app/db/migrations
 COPY scripts/run-migrations.sh /app/run-migrations.sh
-COPY --from=dashboard-builder /app/dist /app/dashboard
+COPY --from=dashboard-builder /app/packages/dashboard/dist /app/dashboard
 ENV DASHBOARD_DIR=/app/dashboard
 ENV PORT=8080
 WORKDIR /app

--- a/packages/ingestion/handler/cookies_test.go
+++ b/packages/ingestion/handler/cookies_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/opslane/opslane/packages/ingestion/auth"
 	"github.com/opslane/opslane/packages/ingestion/handler"
 )
@@ -109,7 +110,7 @@ func TestRefresh_CookieModeRotates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("gen refresh: %v", err)
 	}
-	if err := deps.Queries.StoreRefreshToken(ctx, user.ID, hashRefresh, "fam-1", time.Now().Add(time.Hour)); err != nil {
+	if err := deps.Queries.StoreRefreshToken(ctx, user.ID, hashRefresh, uuid.NewString(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("store refresh: %v", err)
 	}
 

--- a/packages/ingestion/handler/error_event_test.go
+++ b/packages/ingestion/handler/error_event_test.go
@@ -200,7 +200,7 @@ func TestIngestStacklessEvent_AcceptedAndDefaultsType(t *testing.T) {
 	// ordering bug — defaulting after fingerprinting would fragment groups).
 	var errorType string
 	err = pool.QueryRow(context.Background(),
-		`SELECT error_type FROM error_groups WHERE project_id = $1 ORDER BY created_at DESC LIMIT 1`,
+		`SELECT error_type FROM error_events WHERE project_id = $1 ORDER BY created_at DESC LIMIT 1`,
 		projectID).Scan(&errorType)
 	if err != nil {
 		t.Fatalf("query group: %v", err)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,19 +11,19 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "types": "dist/src/index.d.ts",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./react": {
-      "import": "./dist/react.js",
-      "types": "./dist/src/react.d.ts"
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js"
     },
     "./vite-plugin": {
-      "import": "./dist/vite-plugin.js",
-      "types": "./dist/vite-plugin/index.d.ts"
+      "types": "./dist/vite-plugin.d.ts",
+      "import": "./dist/vite-plugin.js"
     }
   },
   "files": [

--- a/packages/sdk/vite.config.ts
+++ b/packages/sdk/vite.config.ts
@@ -29,6 +29,11 @@ export default defineConfig({
   plugins: [
     dts({
       include: ['src/**/*.ts', 'src/**/*.tsx', 'vite-plugin/**/*.ts'],
+      // Bundle types into flat per-entry .d.ts files so type-only imports
+      // from the private @opslane/shared package are inlined — without this,
+      // the published tarball's types are unresolvable for npm consumers.
+      rollupTypes: true,
+      bundledPackages: ['@opslane/shared'],
     }),
   ],
   test: {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -189,6 +189,23 @@ export async function processInvestigateJob(job: ClaimedJob & { errorGroupId: st
 
   checkAbort(signal);
 
+  // The LLM key is the pipeline's most fundamental prerequisite. Check it
+  // before token resolution and the repo clone so the terminal reason names
+  // the real blocker instead of a downstream clone failure.
+  const apiKey = process.env['ANTHROPIC_API_KEY'];
+  if (!apiKey) {
+    await updateGroupInvestigation(job.errorGroupId, job.projectId, 'needs_human', {
+      reason: {
+        reason_code: 'missing_llm_key',
+        reason_message: 'ANTHROPIC_API_KEY environment variable is not set',
+        remediation: 'Set the ANTHROPIC_API_KEY environment variable with a valid Anthropic API key',
+      },
+    });
+    jobsFailed++;
+    lastJobAt = new Date().toISOString();
+    return;
+  }
+
   // Resolve GitHub token
   let githubToken: string | undefined;
   const installInfo = await db.getProjectGitHubInstallation(job.projectId);
@@ -266,20 +283,6 @@ export async function processInvestigateJob(job: ClaimedJob & { errorGroupId: st
     checkAbort(signal);
 
     // Run codebase-aware investigation
-    const apiKey = process.env['ANTHROPIC_API_KEY'];
-    if (!apiKey) {
-      await updateGroupInvestigation(job.errorGroupId, job.projectId, 'needs_human', {
-        reason: {
-          reason_code: 'missing_llm_key',
-          reason_message: 'ANTHROPIC_API_KEY environment variable is not set',
-          remediation: 'Set the ANTHROPIC_API_KEY environment variable with a valid Anthropic API key',
-        },
-      });
-      jobsFailed++;
-      lastJobAt = new Date().toISOString();
-      return;
-    }
-
     const triage = await investigateError(apiKey, {
       errorType: event?.error_type ?? 'Unknown',
       title: group.title,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@changesets/cli':
+        specifier: ^2.31.0
+        version: 2.31.0(@types/node@25.3.0)
 
   cli:
     dependencies:
@@ -465,6 +469,61 @@ packages:
 
   '@bufbuild/protobuf@2.11.0':
     resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+
+  '@changesets/apply-release-plan@7.1.1':
+    resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
+
+  '@changesets/assemble-release-plan@6.0.10':
+    resolution: {integrity: sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==}
+
+  '@changesets/changelog-git@0.2.1':
+    resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
+
+  '@changesets/cli@2.31.0':
+    resolution: {integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==}
+    hasBin: true
+
+  '@changesets/config@3.1.4':
+    resolution: {integrity: sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==}
+
+  '@changesets/errors@0.2.0':
+    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+
+  '@changesets/get-dependents-graph@2.1.4':
+    resolution: {integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==}
+
+  '@changesets/get-release-plan@4.0.16':
+    resolution: {integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==}
+
+  '@changesets/get-version-range-type@0.4.0':
+    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
+
+  '@changesets/git@3.0.4':
+    resolution: {integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==}
+
+  '@changesets/logger@0.1.1':
+    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
+
+  '@changesets/parse@0.4.3':
+    resolution: {integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==}
+
+  '@changesets/pre@2.0.2':
+    resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
+
+  '@changesets/read@0.6.7':
+    resolution: {integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==}
+
+  '@changesets/should-skip-package@0.1.2':
+    resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
+
+  '@changesets/types@4.1.0':
+    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+
+  '@changesets/types@6.1.0':
+    resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
+
+  '@changesets/write@0.4.0':
+    resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
   '@connectrpc/connect-web@2.0.0-rc.3':
     resolution: {integrity: sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==}
@@ -1147,6 +1206,12 @@ packages:
       '@opentelemetry/core': ^2.0.1
       '@opentelemetry/exporter-trace-otlp-http': '>=0.202.0 <1.0.0'
       '@opentelemetry/sdk-trace-base': ^2.0.1
+
+  '@manypkg/find-root@1.1.0':
+    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+
+  '@manypkg/get-packages@1.1.3':
+    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
   '@microsoft/api-extractor-model@7.33.1':
     resolution: {integrity: sha512-KX0LI6xzI0gcBOXXmr5mnnbdhsK2W93pqvJo8OgJgWvRRh+wMEp0Ccj38h1XKeJ29E1tuAZKSUOfHUQ1WA8fZg==}
@@ -1918,6 +1983,9 @@ packages:
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
@@ -2125,6 +2193,10 @@ packages:
   alien-signals@1.0.13:
     resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
 
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2150,8 +2222,15 @@ packages:
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -2185,6 +2264,10 @@ packages:
 
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
+
+  better-path-resolve@1.0.0:
+    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
+    engines: {node: '>=4'}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -2346,12 +2429,20 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-indent@6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
+
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -2375,6 +2466,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -2422,6 +2517,11 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -2438,6 +2538,9 @@ packages:
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  extendable-error@0.1.7:
+    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
   fast-content-type-parse@2.0.1:
     resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
@@ -2472,6 +2575,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -2493,6 +2600,14 @@ packages:
   fs-extra@11.3.3:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
+
+  fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -2536,6 +2651,10 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -2575,12 +2694,20 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  human-id@4.2.0:
+    resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
+    hasBin: true
+
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
 
   import-in-the-middle@1.7.1:
     resolution: {integrity: sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==}
@@ -2628,6 +2755,14 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-subdir@1.2.0:
+    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
+    engines: {node: '>=4'}
+
+  is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2648,6 +2783,14 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+    hasBin: true
+
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+    hasBin: true
+
   jsdom@28.1.0:
     resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -2662,6 +2805,9 @@ packages:
 
   json-with-bigint@3.5.3:
     resolution: {integrity: sha512-QObKu6nxy7NsxqR0VK4rkXnsNr5L9ElJaGEg+ucJ6J7/suoKZ0n+p76cu9aCqowytxEbwYNzvrMerfMkXneF5A==}
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
@@ -2680,8 +2826,15 @@ packages:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.startcase@4.4.0:
+    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
@@ -2763,6 +2916,10 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2816,14 +2973,44 @@ packages:
   openapi-typescript-helpers@0.0.15:
     resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
 
+  outdent@0.5.0:
+    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  p-filter@2.1.0:
+    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
+    engines: {node: '>=8'}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-map@2.1.0:
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
+    engines: {node: '>=6'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@0.2.11:
+    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2835,6 +3022,10 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -2894,6 +3085,10 @@ packages:
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
+
+  pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
 
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -2981,6 +3176,11 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -3018,6 +3218,10 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
+  read-yaml-file@1.1.0:
+    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
+    engines: {node: '>=6'}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -3037,6 +3241,10 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -3107,6 +3315,10 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3114,6 +3326,9 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  spawndamnit@3.0.1:
+    resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -3139,6 +3354,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -3174,6 +3393,10 @@ packages:
   tar@7.5.9:
     resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
     engines: {node: '>=18'}
+
+  term-size@2.2.1:
+    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
+    engines: {node: '>=8'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -3277,6 +3500,10 @@ packages:
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -4116,6 +4343,149 @@ snapshots:
 
   '@bufbuild/protobuf@2.11.0': {}
 
+  '@changesets/apply-release-plan@7.1.1':
+    dependencies:
+      '@changesets/config': 3.1.4
+      '@changesets/get-version-range-type': 0.4.0
+      '@changesets/git': 3.0.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      detect-indent: 6.1.0
+      fs-extra: 7.0.1
+      lodash.startcase: 4.4.0
+      outdent: 0.5.0
+      prettier: 2.8.8
+      resolve-from: 5.0.0
+      semver: 7.5.4
+
+  '@changesets/assemble-release-plan@6.0.10':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      semver: 7.5.4
+
+  '@changesets/changelog-git@0.2.1':
+    dependencies:
+      '@changesets/types': 6.1.0
+
+  '@changesets/cli@2.31.0(@types/node@25.3.0)':
+    dependencies:
+      '@changesets/apply-release-plan': 7.1.1
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/changelog-git': 0.2.1
+      '@changesets/config': 3.1.4
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/get-release-plan': 4.0.16
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.7
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@changesets/write': 0.4.0
+      '@inquirer/external-editor': 1.0.3(@types/node@25.3.0)
+      '@manypkg/get-packages': 1.1.3
+      ansi-colors: 4.1.3
+      enquirer: 2.4.1
+      fs-extra: 7.0.1
+      mri: 1.2.0
+      package-manager-detector: 0.2.11
+      picocolors: 1.1.1
+      resolve-from: 5.0.0
+      semver: 7.5.4
+      spawndamnit: 3.0.1
+      term-size: 2.2.1
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@changesets/config@3.1.4':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/logger': 0.1.1
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+      micromatch: 4.0.8
+
+  '@changesets/errors@0.2.0':
+    dependencies:
+      extendable-error: 0.1.7
+
+  '@changesets/get-dependents-graph@2.1.4':
+    dependencies:
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      picocolors: 1.1.1
+      semver: 7.5.4
+
+  '@changesets/get-release-plan@4.0.16':
+    dependencies:
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/config': 3.1.4
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.7
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/get-version-range-type@0.4.0': {}
+
+  '@changesets/git@3.0.4':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@manypkg/get-packages': 1.1.3
+      is-subdir: 1.2.0
+      micromatch: 4.0.8
+      spawndamnit: 3.0.1
+
+  '@changesets/logger@0.1.1':
+    dependencies:
+      picocolors: 1.1.1
+
+  '@changesets/parse@0.4.3':
+    dependencies:
+      '@changesets/types': 6.1.0
+      js-yaml: 4.3.0
+
+  '@changesets/pre@2.0.2':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+
+  '@changesets/read@0.6.7':
+    dependencies:
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/parse': 0.4.3
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      p-filter: 2.1.0
+      picocolors: 1.1.1
+
+  '@changesets/should-skip-package@0.1.2':
+    dependencies:
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/types@4.1.0': {}
+
+  '@changesets/types@6.1.0': {}
+
+  '@changesets/write@0.4.0':
+    dependencies:
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      human-id: 4.2.0
+      prettier: 2.8.8
+
   '@connectrpc/connect-web@2.0.0-rc.3(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.11.0))':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
@@ -4544,6 +4914,22 @@ snapshots:
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@manypkg/find-root@1.1.0':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/node': 12.20.55
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+
+  '@manypkg/get-packages@1.1.3':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@changesets/types': 4.1.0
+      '@manypkg/find-root': 1.1.0
+      fs-extra: 8.1.0
+      globby: 11.1.0
+      read-yaml-file: 1.1.0
 
   '@microsoft/api-extractor-model@7.33.1(@types/node@25.3.0)':
     dependencies:
@@ -5514,6 +5900,8 @@ snapshots:
       '@types/node': 25.3.0
       form-data: 4.0.5
 
+  '@types/node@12.20.55': {}
+
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
@@ -5775,6 +6163,8 @@ snapshots:
 
   alien-signals@1.0.13: {}
 
+  ansi-colors@4.1.3: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -5796,9 +6186,13 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
+  argparse@2.0.1: {}
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
+
+  array-union@2.1.0: {}
 
   assertion-error@2.0.1: {}
 
@@ -5822,6 +6216,10 @@ snapshots:
   baseline-browser-mapping@2.10.0: {}
 
   before-after-hook@3.0.2: {}
+
+  better-path-resolve@1.0.0:
+    dependencies:
+      is-windows: 1.0.2
 
   bidi-js@1.0.3:
     dependencies:
@@ -5967,9 +6365,15 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  detect-indent@6.1.0: {}
+
   didyoumean@1.2.2: {}
 
   diff@8.0.3: {}
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
 
   dlv@1.1.3: {}
 
@@ -6002,6 +6406,11 @@ snapshots:
   electron-to-chromium@1.5.286: {}
 
   emoji-regex@8.0.0: {}
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
 
   entities@6.0.1: {}
 
@@ -6110,6 +6519,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  esprima@4.0.1: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -6121,6 +6532,8 @@ snapshots:
   expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
+
+  extendable-error@0.1.7: {}
 
   fast-content-type-parse@2.0.1: {}
 
@@ -6152,6 +6565,11 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -6179,6 +6597,18 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+
+  fs-extra@7.0.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
 
   fsevents@2.3.2:
     optional: true
@@ -6229,6 +6659,15 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -6267,6 +6706,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-id@4.2.0: {}
+
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
@@ -6274,6 +6715,8 @@ snapshots:
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  ignore@5.3.2: {}
 
   import-in-the-middle@1.7.1:
     dependencies:
@@ -6323,6 +6766,12 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-subdir@1.2.0:
+    dependencies:
+      better-path-resolve: 1.0.0
+
+  is-windows@1.0.2: {}
+
   isexe@2.0.0: {}
 
   jackspeak@4.2.3:
@@ -6336,6 +6785,15 @@ snapshots:
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
+
+  js-yaml@3.15.0:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
 
   jsdom@28.1.0:
     dependencies:
@@ -6368,6 +6826,10 @@ snapshots:
 
   json-with-bigint@3.5.3: {}
 
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsonfile@6.2.0:
     dependencies:
       universalify: 2.0.1
@@ -6386,7 +6848,13 @@ snapshots:
       pkg-types: 2.3.0
       quansync: 0.2.11
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   lodash.camelcase@4.3.0: {}
+
+  lodash.startcase@4.4.0: {}
 
   lodash@4.17.23: {}
 
@@ -6456,6 +6924,8 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
+  mri@1.2.0: {}
+
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
@@ -6490,13 +6960,37 @@ snapshots:
 
   openapi-typescript-helpers@0.0.15: {}
 
+  outdent@0.5.0: {}
+
+  p-filter@2.1.0:
+    dependencies:
+      p-map: 2.1.0
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-map@2.1.0: {}
+
+  p-try@2.2.0: {}
+
   package-json-from-dist@1.0.1: {}
+
+  package-manager-detector@0.2.11:
+    dependencies:
+      quansync: 0.2.11
 
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
 
   path-browserify@1.0.1: {}
+
+  path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
@@ -6506,6 +7000,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.6
       minipass: 7.1.3
+
+  path-type@4.0.0: {}
 
   pathe@1.1.2: {}
 
@@ -6555,6 +7051,8 @@ snapshots:
   picomatch@4.0.3: {}
 
   pify@2.3.0: {}
+
+  pify@4.0.1: {}
 
   pirates@4.0.7: {}
 
@@ -6629,6 +7127,8 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  prettier@2.8.8: {}
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -6687,6 +7187,13 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
+  read-yaml-file@1.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      js-yaml: 3.15.0
+      pify: 4.0.1
+      strip-bom: 3.0.0
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
@@ -6709,6 +7216,8 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
+
+  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -6806,9 +7315,16 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  slash@3.0.0: {}
+
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
+
+  spawndamnit@3.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
 
   split2@4.2.0: {}
 
@@ -6829,6 +7345,8 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -6891,6 +7409,8 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  term-size@2.2.1: {}
 
   thenify-all@1.6.0:
     dependencies:
@@ -6967,6 +7487,8 @@ snapshots:
   universal-github-app-jwt@2.2.2: {}
 
   universal-user-agent@7.0.3: {}
+
+  universalify@0.1.2: {}
 
   universalify@2.0.1: {}
 

--- a/scripts/check-action-pins.mjs
+++ b/scripts/check-action-pins.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Enforce that every third-party GitHub Action and container image used in
+ * workflows is pinned to an immutable reference:
+ *   - `uses: owner/repo@<40-hex-sha>` for actions
+ *   - `docker://...@sha256:<64-hex>` for container actions
+ *   - `image: ...@sha256:<64-hex>` for job/service containers
+ * Local actions (`./...`) are exempt. Tag or branch refs fail.
+ *
+ * Usage: node scripts/check-action-pins.mjs
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dir = '.github/workflows';
+let files = [];
+try {
+  files = readdirSync(dir).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+} catch {
+  console.error(`No ${dir} directory found.`);
+  process.exit(1);
+}
+
+const problems = [];
+let checked = 0;
+
+for (const file of files) {
+  const lines = readFileSync(join(dir, file), 'utf8').split('\n');
+  lines.forEach((line, i) => {
+    const uses = line.match(/^\s*(?:-\s+)?uses:\s*(\S+)/);
+    if (uses) {
+      const ref = uses[1].replace(/^["']|["']$/g, '');
+      if (ref.startsWith('./')) return; // local composite action
+      checked += 1;
+      if (ref.startsWith('docker://')) {
+        if (!/@sha256:[0-9a-f]{64}$/.test(ref)) {
+          problems.push(`${file}:${i + 1} container image not digest-pinned: ${ref}`);
+        }
+        return;
+      }
+      if (!/@[0-9a-f]{40}$/.test(ref)) {
+        problems.push(`${file}:${i + 1} action not pinned to a full commit SHA: ${ref}`);
+      }
+      return;
+    }
+    // Job containers and service containers: `image: <ref>`
+    const image = line.match(/^\s*image:\s*(\S+)/);
+    if (image) {
+      const ref = image[1].replace(/^["']|["']$/g, '');
+      // A YAML flow sequence (e.g. a matrix axis named "image") is not a
+      // container reference.
+      if (ref.startsWith('[')) return;
+      checked += 1;
+      if (!/@sha256:[0-9a-f]{64}$/.test(ref)) {
+        problems.push(`${file}:${i + 1} service/job container image not digest-pinned: ${ref}`);
+      }
+    }
+  });
+}
+
+if (checked === 0) {
+  console.error('Action-pin check inspected zero `uses:` references — something is wrong.');
+  process.exit(1);
+}
+if (problems.length > 0) {
+  console.error('Action-pin check FAILED:');
+  for (const p of problems) console.error(`  - ${p}`);
+  process.exit(1);
+}
+console.log(`Action-pin check OK: ${checked} references are SHA-pinned.`);

--- a/scripts/check-e2e-results.mjs
+++ b/scripts/check-e2e-results.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Enforce hard E2E results from a vitest JSON report:
+ *   - no failed tests
+ *   - no skipped/todo tests except those matching an explicit allowlist
+ *   - a minimum total test count (guards against filtering everything out)
+ *
+ * Usage: node scripts/check-e2e-results.mjs <vitest-results.json>
+ * Env:
+ *   E2E_ALLOWED_SKIP_PATTERN  regex of fully-qualified test names allowed to
+ *                             skip (default: none)
+ *   E2E_MIN_TESTS             minimum numTotalTests (default: 10)
+ */
+import { readFileSync } from 'node:fs';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: check-e2e-results.mjs <vitest-results.json>');
+  process.exit(2);
+}
+
+const report = JSON.parse(readFileSync(file, 'utf8'));
+const allowedPattern = process.env.E2E_ALLOWED_SKIP_PATTERN;
+const allowed = allowedPattern ? new RegExp(allowedPattern) : null;
+const minTests = Number(process.env.E2E_MIN_TESTS ?? '10');
+
+const problems = [];
+let passed = 0;
+let allowedSkips = 0;
+
+for (const tf of report.testResults ?? []) {
+  for (const t of tf.assertionResults ?? []) {
+    const name = [...(t.ancestorTitles ?? []), t.title].join(' > ');
+    if (t.status === 'passed') {
+      passed += 1;
+    } else if (t.status === 'failed') {
+      problems.push(`FAILED: ${name}`);
+    } else if (allowed && allowed.test(name)) {
+      allowedSkips += 1;
+    } else {
+      problems.push(`UNEXPECTED ${String(t.status).toUpperCase()}: ${name}`);
+    }
+  }
+}
+
+const total = report.numTotalTests ?? 0;
+if (total < minTests) {
+  problems.push(`Only ${total} tests were collected; expected at least ${minTests}`);
+}
+if (report.success === false && problems.length === 0) {
+  problems.push('vitest reported overall failure');
+}
+
+if (problems.length > 0) {
+  console.error('E2E result check FAILED:');
+  for (const p of problems) console.error(`  - ${p}`);
+  process.exit(1);
+}
+
+console.log(
+  `E2E OK: ${passed}/${total} passed, ${allowedSkips} allowlisted skip(s), no failures, no unexpected skips.`
+);

--- a/scripts/check-licenses.mjs
+++ b/scripts/check-licenses.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * License-boundary check for the MIT-published packages.
+ *
+ * @opslane/sdk and @opslane/cli ship under MIT, so every production
+ * dependency in their tarballs must carry an MIT-compatible permissive
+ * license. Copyleft (GPL/AGPL/LGPL) or unlicensed dependencies fail the
+ * build. The AGPL server packages can consume anything permissive plus
+ * AGPL itself, so they are not checked here.
+ *
+ * Usage: node scripts/check-licenses.mjs
+ * (expects `pnpm install` to have run; reads the workspace via `pnpm list`)
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const MIT_PACKAGES = ['@opslane/sdk', '@opslane/cli'];
+
+const ALLOWED = new Set([
+  'MIT',
+  'ISC',
+  'BSD-2-Clause',
+  'BSD-3-Clause',
+  'Apache-2.0',
+  '0BSD',
+  'BlueOak-1.0.0',
+  'CC0-1.0',
+  'CC-BY-4.0',
+  'Unlicense',
+  'Python-2.0',
+  'MIT OR Apache-2.0',
+  'Apache-2.0 OR MIT',
+  '(MIT OR CC0-1.0)',
+]);
+
+const listJson = execFileSync(
+  'pnpm',
+  [
+    'list',
+    '--prod',
+    '--depth',
+    'Infinity',
+    '--json',
+    ...MIT_PACKAGES.flatMap((p) => ['--filter', p]),
+  ],
+  { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+);
+
+const projects = JSON.parse(listJson);
+const seen = new Map(); // "name@version" -> path
+function walk(deps) {
+  for (const [name, info] of Object.entries(deps ?? {})) {
+    const key = `${name}@${info.version}`;
+    if (seen.has(key)) continue;
+    seen.set(key, info.path);
+    walk(info.dependencies);
+  }
+}
+for (const project of projects) walk(project.dependencies);
+
+const problems = [];
+let checked = 0;
+for (const [key, pkgPath] of seen) {
+  // Workspace packages are NOT exempt: an MIT package depending on an AGPL
+  // workspace package (e.g. @opslane/worker) violates the boundary just as
+  // hard as a third-party copyleft dependency would.
+  let license;
+  try {
+    const pkg = JSON.parse(readFileSync(join(pkgPath, 'package.json'), 'utf8'));
+    license = typeof pkg.license === 'string' ? pkg.license : pkg.license?.type;
+  } catch {
+    problems.push(`${key}: cannot read package.json at ${pkgPath}`);
+    continue;
+  }
+  checked += 1;
+  if (!license) {
+    problems.push(`${key}: no license declared`);
+  } else if (!ALLOWED.has(license)) {
+    problems.push(`${key}: license "${license}" is not on the MIT-boundary allowlist`);
+  }
+}
+
+if (checked === 0) {
+  console.error('License check inspected zero dependencies — something is wrong.');
+  process.exit(1);
+}
+if (problems.length > 0) {
+  console.error('License-boundary check FAILED:');
+  for (const p of problems) console.error(`  - ${p}`);
+  process.exit(1);
+}
+console.log(
+  `License check OK: ${checked} production dependencies of ${MIT_PACKAGES.join(', ')} are MIT-compatible.`
+);

--- a/scripts/check-packed-packages.mjs
+++ b/scripts/check-packed-packages.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Prove the published npm tarballs work for a real consumer.
+ *
+ * For each publishable package (@opslane/sdk, @opslane/cli):
+ *   1. `pnpm pack` the exact tarball npm would ship
+ *   2. Assert the tarball contains ONLY allowlisted paths (dist/, package.json,
+ *      README*, LICENSE*) — no stray env files, sources, or maps
+ *   3. Install the tarball into a fresh, empty consumer project (no workspace)
+ *   4. SDK: typecheck real imports with tsc — catches unresolvable type-only
+ *      imports from the private @opslane/shared package
+ *      CLI: execute the installed bin (--help must exit 0)
+ *   5. `npm audit signatures` over the consumer's installed tree
+ *
+ * Usage: node scripts/check-packed-packages.mjs
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const ALLOWED_TARBALL_PATH = /^package\/(dist\/|package\.json$|README[^/]*$|LICENSE[^/]*$)/;
+
+const TARGETS = [
+  {
+    name: '@opslane/sdk',
+    dir: 'packages/sdk',
+    verify: (consumerDir) => {
+      writeFileSync(
+        join(consumerDir, 'probe.ts'),
+        [
+          "import { init, captureException, OpslaneSDK } from '@opslane/sdk';",
+          "import type { SdkInitOptions } from '@opslane/sdk';",
+          'const opts: SdkInitOptions = { apiKey: "k", endpoint: "https://example.com" };',
+          'void opts; void init; void captureException; void OpslaneSDK;',
+        ].join('\n')
+      );
+      writeFileSync(
+        join(consumerDir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            strict: true,
+            noEmit: true,
+            module: 'esnext',
+            moduleResolution: 'bundler',
+            target: 'es2022',
+            lib: ['es2022', 'dom'],
+            // Standard consumer default; without it, transitive @types
+            // packages (rrweb's css-font-loading-module) conflict with the
+            // built-in DOM lib. The SDK's own exported types are still fully
+            // checked via the probe imports.
+            skipLibCheck: true,
+          },
+          include: ['probe.ts'],
+        })
+      );
+      execFileSync(
+        'npm',
+        ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--save-dev', 'typescript@5'],
+        { cwd: consumerDir, stdio: 'inherit' }
+      );
+      execFileSync('npx', ['tsc', '--noEmit', '-p', consumerDir], {
+        cwd: consumerDir,
+        stdio: 'inherit',
+      });
+      console.log(`  ✓ consumer typecheck passed`);
+    },
+  },
+  {
+    name: '@opslane/cli',
+    dir: 'cli',
+    verify: (consumerDir) => {
+      const out = execFileSync(join(consumerDir, 'node_modules', '.bin', 'opslane'), ['--help'], {
+        cwd: consumerDir,
+        encoding: 'utf8',
+      });
+      if (!out.toLowerCase().includes('usage')) {
+        throw new Error(`opslane --help produced unexpected output:\n${out}`);
+      }
+      console.log(`  ✓ installed bin runs (--help)`);
+    },
+  },
+];
+
+let failed = false;
+
+for (const target of TARGETS) {
+  console.log(`\n== ${target.name} ==`);
+  const pkgDir = resolve(target.dir);
+
+  // 1. Pack
+  const packOut = execFileSync('pnpm', ['pack'], { cwd: pkgDir, encoding: 'utf8' }).trim();
+  const tarball = resolve(pkgDir, packOut.split('\n').pop());
+  console.log(`  packed: ${tarball}`);
+
+  try {
+    // 2. Tarball contents allowlist
+    const listing = execFileSync('tar', ['-tzf', tarball], { encoding: 'utf8' })
+      .trim()
+      .split('\n');
+    const offenders = listing.filter((p) => !ALLOWED_TARBALL_PATH.test(p));
+    if (offenders.length > 0) {
+      console.error(`  ✗ tarball contains non-allowlisted paths:`);
+      for (const o of offenders) console.error(`      ${o}`);
+      failed = true;
+      continue;
+    }
+    console.log(`  ✓ tarball contents clean (${listing.length} files, all allowlisted)`);
+
+    // 3. Clean consumer install
+    const consumerDir = mkdtempSync(join(tmpdir(), 'opslane-consumer-'));
+    try {
+      writeFileSync(
+        join(consumerDir, 'package.json'),
+        JSON.stringify({ name: 'consumer', private: true, type: 'module' })
+      );
+      execFileSync('npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund', tarball], {
+        cwd: consumerDir,
+        stdio: 'inherit',
+      });
+      console.log(`  ✓ clean-room install succeeded`);
+
+      // 4. Package-specific verification
+      target.verify(consumerDir);
+
+      // 5. Registry signature/attestation verification of the installed tree
+      execFileSync('npm', ['audit', 'signatures'], { cwd: consumerDir, stdio: 'inherit' });
+      console.log(`  ✓ npm audit signatures passed`);
+    } finally {
+      rmSync(consumerDir, { recursive: true, force: true });
+    }
+  } finally {
+    rmSync(tarball, { force: true });
+  }
+}
+
+if (failed) {
+  console.error('\nPacked-package check FAILED.');
+  process.exit(1);
+}
+console.log('\nPacked-package check OK.');

--- a/test-e2e/needs-human-contract.test.ts
+++ b/test-e2e/needs-human-contract.test.ts
@@ -12,6 +12,7 @@
  *   INGESTION_URL      — Base URL for ingestion API (default: http://localhost:8082)
  */
 
+import crypto from 'node:crypto';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import {
   seedTenant,
@@ -23,6 +24,7 @@ import {
   cleanupTenant,
   closePool,
   type TestTenant,
+  type Incident,
 } from './helpers.js';
 
 // All reason codes from shared/src/types.ts
@@ -165,49 +167,61 @@ describe.skipIf(hasLLMKey || !keylessWorkerRunning)(
       await closePool();
     });
 
-    it('worker produces needs_human with missing_llm_key reason', async () => {
-      const eventPayload = {
-        timestamp: new Date().toISOString(),
-        error: {
-          type: 'ReferenceError',
-          message: 'foo is not defined',
-          stack: 'ReferenceError: foo is not defined\n  at bar.js:10:5',
-        },
-        breadcrumbs: [],
-        context: {
-          url: 'https://app.example.com/test',
-          user_agent: 'Mozilla/5.0 (E2E Test)',
-        },
-        sdk_version: '0.0.1-e2e',
-      };
+    it(
+      'worker produces needs_human with missing_llm_key reason',
+      async () => {
+        // Unique marker so we can assert on the EXACT event we submit —
+        // an empty incident list is a failure, never a silent pass.
+        const marker = `e2e-keyless-${crypto.randomUUID()}`;
+        const eventPayload = {
+          timestamp: new Date().toISOString(),
+          error: {
+            type: 'ReferenceError',
+            message: `${marker} is not defined`,
+            stack: `ReferenceError: ${marker} is not defined\n  at bar.js:10:5`,
+          },
+          breadcrumbs: [],
+          context: {
+            url: 'https://app.example.com/test',
+            user_agent: 'Mozilla/5.0 (E2E Test)',
+          },
+          sdk_version: '0.0.1-e2e',
+        };
 
-      const postRes = await postEvent(tenant.apiKey, eventPayload);
-      expect(postRes.status).toBe(202);
+        const postRes = await postEvent(tenant.apiKey, eventPayload);
+        expect(postRes.status).toBe(202);
 
-      // Wait for the worker to pick it up (may take a few seconds)
-      // Then poll for terminal status
-      const incidents = await listIncidents(tenant.apiKey, tenant.projectId);
-      if (incidents.length === 0) {
-        // Event may not have created a group yet (ingest handler is a stub)
-        // Skip the poll in that case — this is expected for the current state
-        return;
-      }
+        // The submitted event must surface as an incident. Poll — grouping is
+        // synchronous but the worker claim is not — and fail hard on timeout.
+        const deadline = Date.now() + 60_000;
+        let incident: Incident | undefined;
+        while (Date.now() < deadline && !incident) {
+          const incidents = await listIncidents(tenant.apiKey, tenant.projectId);
+          incident = incidents.find((i) => i.title.includes(marker));
+          if (!incident) await new Promise((r) => setTimeout(r, 2_000));
+        }
+        if (!incident) {
+          throw new Error(
+            `Submitted event (marker ${marker}) never appeared as an incident — ingestion or grouping is broken`
+          );
+        }
 
-      const incident = incidents[0]!;
-      const terminal = await pollUntilTerminal(
-        tenant.apiKey,
-        tenant.projectId,
-        incident.id,
-        ['needs_human'],
-        45_000
-      );
+        const terminal = await pollUntilTerminal(
+          tenant.apiKey,
+          tenant.projectId,
+          incident.id,
+          ['needs_human'],
+          90_000
+        );
 
-      expect(terminal.status).toBe('needs_human');
-      expect(terminal.reason).toBeDefined();
-      expect(terminal.reason!.reason_code).toBe('missing_llm_key');
-      expect(terminal.reason!.reason_message).toBeTruthy();
-      expect(terminal.reason!.remediation).toBeTruthy();
-    });
+        expect(terminal.status).toBe('needs_human');
+        expect(terminal.reason).toBeDefined();
+        expect(terminal.reason!.reason_code).toBe('missing_llm_key');
+        expect(terminal.reason!.reason_message).toBeTruthy();
+        expect(terminal.reason!.remediation).toBeTruthy();
+      },
+      180_000
+    );
   }
 );
 


### PR DESCRIPTION
Implements the CI/release epic #1, one issue per commit. Each commit was codex-reviewed before landing.

- Closes #4 — single CI workflow with always-reporting `ci-ok` aggregate (DB-backed tests run against a real migrated Postgres)
- Closes #5 — compose migrate service now fails fast via `scripts/run-migrations.sh`
- Closes #7 — keyless smoke E2E lane with hard assertions, zero-unexpected-skip enforcement, and a token-leak canary scan (also fixes the worker's precheck order so `missing_llm_key` is reachable)
- Closes #8 — amd64 candidate images pushed from main with unique `main-<sha>-<run-id>-<attempt>` tags; ingestion dashboard stage now builds from the workspace lockfile
- Closes #10 — Gitleaks (fixed the silently-dead allowlist), MIT license-boundary check, SHA/digest pin enforcement
- Closes #9 — Changesets + npm Trusted Publishing (OIDC, no tokens), clean-consumer tarball checks; SDK types now bundle the private shared types
- Closes #11 — dispatch-only platform release workflow: validate → promote digests → tag → release; no `latest`, no tag triggers
- Closes #6 — dependabot.yml (settings applied live: required `ci-ok`, secret scanning + push protection, CodeQL, Dependabot security updates)