### PR TITLE
Always-on session recording (Batch 1): close #47/#48, fix the retention sweep, and make CI actually run the storage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,24 @@ jobs:
           --health-retries 10
     env:
       DATABASE_URL: postgres://opslane:opslane_dev@localhost:5432/opslane?sslmode=disable
+      # Object storage. Without these, every test touching storage calls t.Skip
+      # and the package still reports "ok" -- 30 tests, including the #47 and
+      # #48 regression guards, silently never run.
+      REPLAY_STORE_ENDPOINT: http://localhost:9012
+      REPLAY_STORE_PUBLIC_ENDPOINT: http://localhost:9012
+      REPLAY_STORE_ACCESS_KEY: minio
+      REPLAY_STORE_SECRET_KEY: minio12345
+      REPLAY_STORE_BUCKET: opslane-replays
+      REPLAY_STORE_REGION: us-east-1
+      # error_event_test.go's testMinIO helper reads the worker's MINIO_*
+      # naming rather than ingestion's REPLAY_STORE_*. The split is deliberate
+      # (see packages/worker); both names are set so neither side skips.
+      MINIO_ENDPOINT: http://localhost:9012
+      MINIO_PUBLIC_ENDPOINT: http://localhost:9012
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio12345
+      MINIO_BUCKET: opslane-replays
+      MINIO_REGION: us-east-1
     defaults:
       run:
         working-directory: packages/ingestion
@@ -44,11 +62,30 @@ jobs:
         with:
           go-version-file: packages/ingestion/go.mod
           cache-dependency-path: packages/ingestion/go.sum
+      # Compose rather than a service container, for two reasons: a service
+      # container cannot override the image's command (MinIO needs "server
+      # /data"), and TestAnonymousGetIsForbidden guards the bucket policy that
+      # compose's minio-setup applies. A bare bucket is private by default, so
+      # without minio-setup that test would pass without ever exercising the
+      # `mc anonymous set none` line it exists to protect.
+      # minio defines no healthcheck, so `up --wait` would return as soon as the
+      # container is running rather than serving. minio-setup's own
+      # `until mc alias set ...` loop is the real readiness gate, and `run --rm`
+      # propagates its exit code -- `up` would swallow a failed policy apply.
+      - name: Start object storage
+        working-directory: .
+        run: |
+          docker compose up -d minio
+          docker compose run --rm minio-setup
       - name: Apply migrations
         run: MIGRATION_DIR=db/migrations ../../scripts/run-migrations.sh
       - run: go build ./...
       - run: go vet ./...
-      - run: go test ./...
+      - name: Test (fails on unexpected skips)
+        run: |
+          set -o pipefail
+          go test ./... -v 2>&1 | tee /tmp/go-test.log
+          ../../scripts/check-go-skips.mjs /tmp/go-test.log
 
   js:
     name: JS build and test

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,6 +9,10 @@ description = "Synthetic credentials used to verify secret masking and authentic
 paths = [
   '''packages/ingestion/db/agent_session_test\.go''',
   '''packages/ingestion/masking/masking_test\.go''',
+  # The chunk scrubber's fixtures must look like real keys -- the tests assert
+  # a Stripe-shaped token does not survive redaction, so a token gitleaks
+  # ignores would prove nothing.
+  '''packages/ingestion/scrubber/scrubber_test\.go''',
   '''packages/sdk/src/__tests__/scrub\.test\.ts''',
   '''test-e2e/error-to-pr\.test\.ts''',
   '''test-e2e/replay-contract\.test\.ts''',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     entrypoint: >
       sh -c "until mc alias set local http://minio:9000 minio minio12345; do sleep 1; done &&
       mc mb -p local/opslane-replays || true &&
-      mc anonymous set download local/opslane-replays || true"
+      mc anonymous set none local/opslane-replays || true"
 
   postgres:
     image: postgres:16

--- a/docs/architecture/trust.md
+++ b/docs/architecture/trust.md
@@ -28,8 +28,34 @@ Secrets hygiene in the sandbox: before the agent loop runs, well-known secret va
 
 Defense in two layers, both on by default — with an honest note on their scope:
 
-- **In the browser (SDK):** replays are **opt-in** (`replay.enabled` defaults to false); when enabled, all input values are masked (`maskAllInputs: true`) plus anything matching `.opslane-mask`. For **error events and console breadcrumbs**, captured text and URLs are scrubbed of JWTs, `Bearer` tokens, `password`/`secret`/`api_key`-style pairs, query strings, and URL userinfo before transmission. This scrubbing does *not* run over the replay's serialized DOM — visible page text is captured as rendered unless masked.
-- **Server-side (ingestion):** for events, sensitive headers (`authorization`, `cookie`, `set-cookie`, `x-api-key`, `x-csrf-token`), well-known API-key prefixes (`sk_live_`, `sk_test_`, `AKIA`, `ghp_`, …), and URL-embedded credentials are replaced with `[REDACTED]` before persistence. For **replays**, the browser uploads directly to object storage via a pre-signed URL and ingestion redacts by *rewriting the object at completion* — an upload interrupted before completion leaves the raw recording in storage (compounded by [#13](https://github.com/opslane/opslane-oss/issues/13) and the absence of retention cleanup below).
+**In the browser (SDK):** since SDK 1.0.0, session recording is **on by
+default** (`replay.enabled` defaults to `true`). Earlier versions defaulted to
+off; the default changed only across a major version, so it never flips under an
+existing integration. Opt out with `replay: { enabled: false }`, or disable
+recording for a whole project through the server-side `recording_enabled`
+setting without redeploying. A dashboard control is not included in Batch 1.
+
+Every session is recorded, not only error moments. All input values are masked
+(`maskAllInputs: true`), as is anything matching `.opslane-mask`;
+`.opslane-block` skips a subtree entirely. **Rendered page text is captured as
+displayed unless you mask it** — this has not changed, but it now applies to
+every session rather than only sessions that hit an error. If you have not
+reviewed your masking, do that before upgrading.
+
+For **chunked session recordings**, the browser uploads gzipped ~30s chunks
+directly to private object storage via a size-capped presigned POST policy. A
+server-side scrubber inflates each chunk under a hard ceiling, redacts it, and
+re-stores it. A chunk is **unreadable until that completes**: `scrubbed_at` is
+the only thing that makes it visible to any reader, and a chunk that cannot be
+scrubbed stays unreadable permanently rather than being served raw.
+
+The older error-triggered one-shot replay path still redacts by rewriting the
+object at completion, so an upload interrupted before completion leaves the raw
+recording in storage. That path is retired once error replays resolve to chunk
+pointers.
+
+For error events, ingestion also replaces sensitive headers, well-known API-key
+prefixes, and URL-embedded credentials with `[REDACTED]` before persistence.
 
 See [replay privacy](../replay-privacy.md) for what replay data may contain.
 
@@ -43,7 +69,8 @@ See [replay privacy](../replay-privacy.md) for what replay data may contain.
 
 These are known, tracked, and stated here so you can make an informed deployment decision:
 
-- **No automated replay retention.** `session_replays` rows and stored replay payloads have no expiry column and no cleanup job — replays persist until you delete them. If you enable replay on sensitive flows, plan manual cleanup.
+- **Replay and session retention.** Chunked session recordings are deleted on a per-project clock (default 30 days, `projects.session_retention_days`), removing both the database rows and the entire stored-object prefix. Sessions pinned as incident evidence survive the normal window but are hard-capped at 90 days. Deleted session ids are tombstoned and their prefixes are re-swept continuously, so an upload accepted just before policy expiry cannot permanently recreate the data.
+- **The older one-shot replay path still has no retention.** `session_replays` rows from the error-triggered path have no expiry or cleanup job and persist until you delete them. See [#29](https://github.com/opslane/opslane-oss/issues/29).
 - **`github_token_encrypted` is unused.** The schema has an encrypted-token column, but no code path writes or reads it; GitHub credentials come from the environment (PAT or App key). Envelope-encrypted at-rest token storage is not implemented yet.
 - **The bundled Compose file is a development deployment.** Development credentials, no backups, no upgrade/rollback procedure. A production operations guide is tracked separately and blocked on that work.
 

--- a/docs/plans/2026-07-13-unified-incidents-replay-friction-design.md
+++ b/docs/plans/2026-07-13-unified-incidents-replay-friction-design.md
@@ -16,7 +16,7 @@ Record every session cheaply (compressed, chunked), enrich the recording with a 
 
 ## What changed in v4 (second Codex review)
 
-The core concept held; a second adversarial pass found 20 issues in the *mechanisms*. 19 were accepted and are baked in below; 1 was deferred as a product decision. Two of the accepted findings describe live repository vulnerabilities and were filed as standalone security issues (#47, #48). Accepted corrections, by theme:
+The core concept held; a second adversarial pass found 20 issues in the *mechanisms*. 19 were accepted and are baked in below; 1 (finding 15, always-on vs. opt-in) was a product call, now **decided in favor of always-on** with rollout requirements attached. Two of the accepted findings describe live repository vulnerabilities and were filed as standalone security issues (#47, #48). Accepted corrections, by theme:
 
 **Upload pipe (findings 1, 19, 11, 3)**
 1. **Chunks need a commit signal.** A presigned PUT does not notify ingestion, so `uploaded_at`, `size_bytes`, `last_chunk_at`, scrub-queueing, session close, and re-analysis have no reliable trigger. Added an explicit per-chunk commit call (or storage bucket-event notification). Section 2.
@@ -50,7 +50,7 @@ The core concept held; a second adversarial pass found 20 issues in the *mechani
 19. **Receipts are idempotent + attributable.** GitHub redelivers webhooks; store the delivery id with a UNIQUE constraint; record the fix-job id on the PR at creation so outcomes are attributable. Section 5.
 20. **Rollback story is per-change and honest.** "Ignore new columns" is true only for added columns. Dropped tables lose data; a Postgres enum value cannot be removed. Drops are deferred until the feature is stable; enum additions are permanent, so N−1 compatibility is designed, not assumed. Section 1.
 
-**Deferred (finding 15) — product/legal decision, not resolved here:** always-on recording for everyone silently changes the meaning of an absent `replay` config and contradicts today's public opt-in promise (`docs/architecture/trust.md`). This is an explicit open decision (see Open Questions), owned outside this design. **Until it is decided, the design assumes opt-in remains the default** and always-on is gated behind an affirmative, versioned opt-in.
+**Decided (finding 15) — always-on recording defaults ON for everyone.** This was the one finding raised as a product/legal concern; the product decision is made: recording is on by default, not opt-in. Codex's concern (a silent change to the meaning of an absent `replay` config, contradicting today's public opt-in promise in `docs/architecture/trust.md`) does **not** block the decision — it converts into concrete work items that must ship *with* the switch: a major-version SDK release so the default flips only on a deliberate upgrade, a migration/consent note in the changelog and docs, an updated `trust.md`, and a runtime kill switch + `replay: { enabled: false }` escape hatch. These are requirements, not open questions.
 
 ## What changed in v3 (post-migration re-verification)
 
@@ -76,7 +76,7 @@ The design was written against the `defender` repo; the code now lives in `opsla
 |----------|--------|-----------|
 | Organizing primitive | One unified **incident** (kind: `error` \| `friction`) | One inbox, one status model, one pipeline, one bill. |
 | Error+friction in same session | Fold friction into the error incident as evidence + impact boost, **with real write paths to every impact read** (v4-17) | One moment of pain = one incident. Depends on the client-timestamp fix (#27). |
-| Capture policy | **Opt-in by default (unchanged from today) until the always-on decision is made** (v4-deferred); when enabled: rrweb + interaction telemetry, gzipped chunks every ~30s, each chunk self-contained (full snapshot) | Storage is cheap once compressed; analysis, not storage, is the cost. Always-on is a product/legal call, not assumed. |
+| Capture policy | **Always-on recording, default ON for everyone** (v4-15, decided): rrweb + interaction telemetry, gzipped chunks every ~30s, each chunk self-contained (full snapshot). Ships behind a major-version SDK release + consent/docs update + kill switch. | Storage is cheap once compressed; analysis, not storage, is the cost. Default-on is the product decision; the versioned rollout keeps it honest. |
 | Chunk durability | **Server-acknowledged commit per chunk** (v4-1); **full rrweb snapshot at each chunk boundary** (v4-19); **size-capped presigned PUTs + per-project byte budget** (v4-3, #48) | A recording the server never hears about cannot be scrubbed, closed, or analyzed; a chunk that depends on a lost predecessor is unplayable; unbounded PUTs are a flood/OOM primitive. |
 | SDK role | Recorder + **thin interaction telemetry** (click annotations, network-request-start markers via `send()`, form submits) as rrweb custom events | Server rules need signals rrweb doesn't carry. Detection logic stays server-side. |
 | Friction detection location | **Server-side, on stored streams**, versioned rules | Detector iteration at deploy speed; retroactive re-analysis. |
@@ -92,7 +92,7 @@ The design was written against the `defender` repo; the code now lives in `opsla
 | Retention | 14–30 day deletion for chunks/sessions incl. **MinIO object deletion (new client op)**; **evidence-pinning + tombstones + PII-inclusive sweeps**; incident-referenced windows retained but hard-capped (90 days) (v4-16, #29) | "Open incidents retained" must not mean forever, and deletion must not orphan raw data or leave selector/text PII. |
 | Privacy | **Fail-closed**: private bucket (#47), masking-at-capture primary + scrubber second pass, **read/analyze blocked until `scrubbed_at` set**, selector/text masked (v4-13), strict mode, runtime kill switch, consent snippet in Batch 1 docs | Recording is the FullStory posture — commitments, not parking. |
 | Replay model migration | **Bridge `session_replays` ↔ `sessions`/`session_chunks`**: error replays become pointers into the chunk stream (v4-6) | Don't orphan the dashboard player/worker evidence; don't double-store every error moment. |
-| Deferred | Custom behavioral signals, VLM-on-everything, autonomy auto-promotion, model-level learning; **always-on-by-default (v4-15, product decision)** | YAGNI until the core loop proves out. |
+| Deferred | Custom behavioral signals, VLM-on-everything, autonomy auto-promotion, model-level learning | YAGNI until the core loop proves out. |
 
 ## Dependencies (must land first or alongside)
 
@@ -131,7 +131,7 @@ Old `friction_groups`/`friction_events`/`friction_group_affected_users` (never p
 
 ### 2. Capture: SDK = recorder + thin telemetry
 
-- **Opt-in unchanged until the always-on decision (v4-15).** When recording is enabled:
+- **Always-on, default ON (v4-15, decided).** Shipped behind a major-version SDK bump so the default flips only on a deliberate upgrade; `replay: { enabled: false }` and the runtime kill switch remain the escape hatches.
 - **Durable sessions**: session ID persisted in `sessionStorage`; **`next_chunk_seq` persisted alongside it (v4-15)** so a reload doesn't reset to `chunk-0`; rotated after 30 min idle **and on identity change — login/logout starts a new session (v4-16)**. `setUser()` updates the session server-side.
 - **rrweb records continuously**; the SDK injects custom events: click annotations (derived selector, computed `cursor`), **network-request-start markers via patched XHR `send()` and fetch (v4-12)**, form-submit events. Detection logic stays server-side.
 - **Chunk protocol (v4-1, v4-19, v4-3)**: `POST /sessions/init` registers the session; every ~30s (and on `visibilitychange`) the SDK gzips the buffer (`CompressionStream`) and PUTs `chunk-{seq}.json.gz` to a **size-capped presigned URL** (`content-length-range`, #48). **Each chunk begins with a full rrweb snapshot** so it is independently playable (v4-19). After each PUT the SDK **calls a commit endpoint** (or the server consumes a bucket notification) recording existence + size (v4-1). Failures retry with backoff into a bounded buffer.
@@ -228,7 +228,7 @@ Full-session LLM sweeps; headless rrweb renderer for screenshots (real infra). G
 
 ## Open questions (parked, with owners)
 
-- **Always-on vs. opt-in (v4-15, product/legal):** does recording default on for everyone, silently changing an absent `replay` config and today's public opt-in promise? **Owned outside this design; until decided, opt-in stays the default.** Blocks Batch 1's capture-policy shape.
+- ~~Always-on vs. opt-in (v4-15):~~ **Decided: recording defaults ON.** Ships behind a major-version SDK release + consent/docs update + kill switch (see Decisions). No longer open.
 - Pricing: does a friction fix bill like an error fix? Decide before Batch 5.
 - Consent tooling: snippet ships in Batch 1 docs; full consent-management is customer-side.
 - Mobile chunk cadence vs battery: measure in Batch 1; fallback 60s cadence + visibility-only flushes.

--- a/docs/plans/2026-07-13-unified-incidents-replay-friction-design.md
+++ b/docs/plans/2026-07-13-unified-incidents-replay-friction-design.md
@@ -1,7 +1,7 @@
 # Unified Incidents: Bugs + Session Replay + Friction
 
 **Date:** 2026-07-13
-**Status:** Approved — v2 after Codex adversarial review (2026-07-13); v3 after re-verification against opslane-oss (2026-07-14)
+**Status:** Approved — v2 after Codex adversarial review (2026-07-13); v3 after re-verification against opslane-oss (2026-07-14); v4 after second Codex review (2026-07-14)
 **Author:** Abhishek + Claude; adversarial review by Codex
 
 ## Problem
@@ -14,161 +14,223 @@ Competitors are converging from the other side: Lucent (AI session replay) recor
 
 Record every session cheaply (compressed, chunked), enrich the recording with a thin interaction-telemetry stream, detect friction server-side with versioned deterministic rules, promote repeated friction into the same incident pipeline errors use, and let customers climb an autonomy ladder from "ask me first" to "auto-fix" as the system earns trust.
 
+## What changed in v4 (second Codex review)
+
+The core concept held; a second adversarial pass found 20 issues in the *mechanisms*. 19 were accepted and are baked in below; 1 was deferred as a product decision. Two of the accepted findings describe live repository vulnerabilities and were filed as standalone security issues (#47, #48). Accepted corrections, by theme:
+
+**Upload pipe (findings 1, 19, 11, 3)**
+1. **Chunks need a commit signal.** A presigned PUT does not notify ingestion, so `uploaded_at`, `size_bytes`, `last_chunk_at`, scrub-queueing, session close, and re-analysis have no reliable trigger. Added an explicit per-chunk commit call (or storage bucket-event notification). Section 2.
+2. **Every chunk carries a full rrweb snapshot** ("checkout" at each boundary). Without it, "sequence gaps tolerated" is false: rrweb diffs reference node ids from earlier chunks, so a lost chunk corrupts all following chunks until the next snapshot. Section 2.
+3. **The ≤30s tab-close gate is loosened honestly.** `visibilitychange` cannot finish stringify + gzip + sign + PUT of a large chunk, and the in-memory retry buffer dies on navigation. Gate restated in terms of small keepalive-sized final flushes; the honest worst-case loss is documented, not hidden. Section 2 / Batch 1.
+4. **Size-capped uploads (security, #48).** Public SDK key + presigned PUT with no byte cap = storage flood and gzip-bomb OOM. `content-length-range` policy, per-project byte budget, bounded streaming decompression. Section 2.
+
+**Privacy fails open → fail closed (findings 2, 13, 16)**
+5. **Fail-closed capture (security, #47).** Raw DOM lands before async scrubbing; the bundled bucket is anonymously downloadable, bypassing the authenticated re-scrub read path; the worker reads MinIO directly. Fix: private bucket, masking-at-capture as the primary defense, and **nothing may read or analyze a chunk until `scrubbed_at` is set.** Section 2 / 7.
+6. **Selector + text fingerprints obey masking.** `data-*` values and normalized text can carry emails/IDs/secrets and are stored outside the masked recording and sent to the LLM. Allowlist stable attributes only; mask/hash the rest before storing. Section 3.
+7. **Retention is mechanized.** Explicit evidence-pinning (which sessions an incident holds, until when), tombstones so re-uploads to deleted sessions are rejected, PII columns included in deletion sweeps, hard 90-day cap enforced. Section 7.
+
+**Detection is causal, not proximal (findings 12, 5, 14)**
+8. **Detectors attribute causality, not proximity.** Any unrelated poll/analytics/DOM tick — including Opslane's own chunk PUT — can suppress a dead-click verdict. Count only requests initiated from the click's own handler; filter the SDK's own traffic; **patch XHR `send()`, not just `open()`** (the v2/v3 "SDK already knows request-start" claim was wrong for XHR). Section 3.
+9. **"Idempotent," not "exactly-once."** The `friction_signals` unique key makes duplicate inserts harmless but cannot retract a signal a late chunk disproves, nor count repeat occurrences within one session. Added an occurrence count and a supersede/retract path on re-analysis. Section 3.
+10. **Correlation/aggregation order is fixed:** adjudicate → fold → aggregate the leftovers, and **both gates are scoped by environment** (staging friction never combines with prod). Section 3.
+
+**Status and the pre-human check (findings 4, 10)**
+11. **Two distinct states, not one overloaded `insight`.** `insight` = no code cause, terminal, never a PR. `awaiting_approval` = code cause, parked for a human. TriggerFix accepts only `awaiting_approval`, never `insight`. Section 4.
+12. **Friction is gated out of auto-fix until Batch 5.** Detection turns on in Batch 4, but the existing worker auto-fixes high-confidence findings and stamps PRs "Opslane fixed"; without the gate, one batch of friction PRs would ship auto-generated and mislabeled. Section 4 / Batches.
+13. **A real hidden candidate state before adjudication** (the list API currently shows every row immediately), plus a defined adjudicator-failure policy (retry, then surface flagged-unchecked — never silently publish or drop). Section 4.
+
+**Two replay systems must connect (findings 6, 7, 8, 9, 18)**
+14. **Bridge old and new replay models.** Dashboard + worker read `session_replays`; the new `sessions`/`session_chunks` tables must not orphan them. On error, record a *pointer* (session id + time range) into the chunk stream instead of a duplicate one-shot upload; migrate readers; retire the one-shot path. Section 1 / 6.
+15. **Persist the chunk sequence counter** next to the session id (reload currently resets it and would overwrite `chunk-0`); add `analyzing` / `analysis_failed` / re-analysis-generation statuses; give `session_analysis` jobs a typed session FK (the dispatcher rejects jobs without `error_group_id` today). Section 1 / 3.
+16. **Rotate the session on identity change.** One `end_user_id` per session mis-attributes shared-tab sessions (Alice's friction billed to Bob); friction-only sessions have no end-user-creation path today. Login/logout → new session. Section 2.
+17. **Impact boost has explicit write paths.** Pointing `friction_signals.incident_id` at an error updates nothing the incident UI reads (affected-user count, account rollups, first/last seen, occurrence). Enumerate every impact read path and update it. Section 4.
+18. **Schema ships its access paths.** Indexes for close sweeps (`last_chunk_at`), scrub queue (`scrubbed_at IS NULL`), sessions-by-user/account/time, and 7-day distinct-user-per-fingerprint aggregation. "Per-account flags" need an accounts entity — accounts are derived today, not a table. Section 1.
+
+**Honest claims (findings 17, 20)**
+19. **Receipts are idempotent + attributable.** GitHub redelivers webhooks; store the delivery id with a UNIQUE constraint; record the fix-job id on the PR at creation so outcomes are attributable. Section 5.
+20. **Rollback story is per-change and honest.** "Ignore new columns" is true only for added columns. Dropped tables lose data; a Postgres enum value cannot be removed. Drops are deferred until the feature is stable; enum additions are permanent, so N−1 compatibility is designed, not assumed. Section 1.
+
+**Deferred (finding 15) — product/legal decision, not resolved here:** always-on recording for everyone silently changes the meaning of an absent `replay` config and contradicts today's public opt-in promise (`docs/architecture/trust.md`). This is an explicit open decision (see Open Questions), owned outside this design. **Until it is decided, the design assumes opt-in remains the default** and always-on is gated behind an affirmative, versioned opt-in.
+
 ## What changed in v3 (post-migration re-verification)
 
-The design was written against the `defender` repo; the code now lives in `opslane-oss` with a consolidated `001_baseline.sql`. Every factual claim was re-verified against this codebase on 2026-07-14. The design holds; four things changed:
+The design was written against the `defender` repo; the code now lives in `opslane-oss` with a consolidated `001_baseline.sql`. Every factual claim was re-verified against this codebase on 2026-07-14:
 
-1. **Replay upload is already two-phase presigned**, not a bare one-shot POST: `POST /api/v1/replays/init` returns a presigned MinIO PUT URL; the browser PUTs the full JSON; `POST /api/v1/replays/{id}/complete` finalizes (`packages/ingestion/handler/replay.go:49,125`). Still one object per replay — chunking (manifest, sequencing, per-chunk retry, compression) remains real new work — but the init/finalize/presign pattern is a foundation to extend, not build from zero.
-2. **The "existing Haiku triage stage" is not on the production path.** It exists (`packages/worker/src/agent-fix.ts:456-477`) but only fires when no precomputed investigation is passed; the normal pipeline runs the Sonnet investigation first and skips it. Batch 4's LLM adjudication is wiring work, not pure reuse.
-3. **The SDK already reports upload failures to `/replays/{id}/fail`** (`packages/sdk/src/replay.ts:238-247`) — the *server* route is what's missing (#13). Chunk-upload failure reporting builds on fixing #13, not on an existing endpoint.
-4. **New dependency: #25** (dead-lettered investigate jobs leave groups stuck in `analyzing` forever). The new `session_analysis` job type inherits the same failure mode; the dead-letter fix must cover it.
+1. **Replay upload is already two-phase presigned** (`POST /api/v1/replays/init` → browser PUT → `POST /api/v1/replays/{id}/complete`, `packages/ingestion/handler/replay.go:49,125`). Still one object per replay — chunking is real new work, but the init/finalize/presign pattern is a foundation to extend.
+2. **The "existing Haiku triage stage" is not on the production path** (`packages/worker/src/agent-fix.ts:456-477` only fires when no precomputed investigation is passed). Batch 4 adjudication is new wiring, not reuse.
+3. **The SDK already reports upload failures to `/replays/{id}/fail`** (`packages/sdk/src/replay.ts:238-247`) — the *server* route is missing (#13).
+4. **New dependency: #25** — dead-lettered jobs stuck in `analyzing`; `session_analysis` inherits it.
 
-Dependency issues were re-filed in opslane-oss; all links below now point at this repo's tracker. Note also: migrations here are consolidated into `001_baseline.sql` and new schema changes are append-only starting at `002`.
+## What changed in v2 (first Codex review)
 
-## What changed in v2 (Codex review findings)
-
-The concept survived review; three "reuse existing machinery" claims did not. Corrections baked in below:
-
-1. rrweb alone cannot power the detectors (no network-start, no clickability) → the SDK adds a **thin interaction-telemetry stream**; it is a recorder-plus-annotations, not a dumb recorder.
-2. The one-shot replay upload path is **not** a chunk protocol → chunked upload is designed explicitly (manifest, sequencing, finalization, compression, retry, its own rate budget).
-3. Sessions today are in-memory per page load and carry no user identity → durable session IDs + user linkage are prerequisites for aggregation and the sessions browser.
-4. Batch order fixed: the worker must understand friction **before** anything enqueues it (the current worker would auto-terminate friction jobs via the no-app-frames guard).
-5. Cost model redone with mandatory compression; a schema section added; receipts corrected (they need two small schema additions, they don't exist for free); privacy/retention commitments made concrete.
-6. Independent bug found during review, filed separately: ingestion parses the client event timestamp and then stores server time instead (#27) — correlation windows depend on fixing this.
+1. rrweb alone cannot power the detectors → the SDK adds a **thin interaction-telemetry stream**.
+2. The one-shot replay upload path is **not** a chunk protocol → chunked upload designed explicitly.
+3. Sessions are in-memory per page load with no identity → durable session IDs + user linkage are prerequisites.
+4. Batch order: the worker must understand friction **before** anything enqueues it.
+5. Cost model redone with mandatory compression; schema section added; receipts need schema additions; privacy/retention made concrete.
+6. Independent bug filed: client event timestamp dropped for server time (#27).
 
 ## Decisions
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | Organizing primitive | One unified **incident** (kind: `error` \| `friction`) | One inbox, one status model, one pipeline, one bill. |
-| Error+friction in same session | Fold friction into the error incident as evidence + impact boost | One moment of pain = one incident. Depends on the client-timestamp fix (#27). |
-| Capture policy | **Always-on recording for everyone**: rrweb + interaction telemetry, gzipped chunks every ~30s | Storage is cheap once compressed; analysis, not storage, is the cost. |
-| SDK role | Recorder + **thin interaction telemetry** (click annotations, network-start markers, form submits) injected as rrweb custom events | Server rules need signals rrweb doesn't carry. ~50–100 lines client-side; detection logic still lives server-side. |
-| Friction detection location | **Server-side, on stored streams**, versioned rules | Detector iteration at deploy speed, not SDK-upgrade speed; retroactive re-analysis of stored sessions. |
-| Detection method | Deterministic rules → threshold → LLM adjudication; screenshots only on visual suspicion | Precision-at-the-human is what matters; rules give stable fingerprints. |
-| Incident threshold | Friction signal → incident only after **5+ distinct end users**, same fingerprint, within a rolling 7-day window | Errors surface at occurrence 1; friction must not. |
-| Friction pipeline outcome | Code cause → fix-eligible; no code cause → **insight** (never a PR) | The agent never pretends an opinion is a fix. |
-| Friction fix labeling | Friction-fix PRs ship labeled **Suggestion** until friction repro-tests exist | Codex is right: passing repo tests does not prove a dead click is fixed. "Verified" stays honest. Upgrades to Verified when repro-test-first lands. |
+| Error+friction in same session | Fold friction into the error incident as evidence + impact boost, **with real write paths to every impact read** (v4-17) | One moment of pain = one incident. Depends on the client-timestamp fix (#27). |
+| Capture policy | **Opt-in by default (unchanged from today) until the always-on decision is made** (v4-deferred); when enabled: rrweb + interaction telemetry, gzipped chunks every ~30s, each chunk self-contained (full snapshot) | Storage is cheap once compressed; analysis, not storage, is the cost. Always-on is a product/legal call, not assumed. |
+| Chunk durability | **Server-acknowledged commit per chunk** (v4-1); **full rrweb snapshot at each chunk boundary** (v4-19); **size-capped presigned PUTs + per-project byte budget** (v4-3, #48) | A recording the server never hears about cannot be scrubbed, closed, or analyzed; a chunk that depends on a lost predecessor is unplayable; unbounded PUTs are a flood/OOM primitive. |
+| SDK role | Recorder + **thin interaction telemetry** (click annotations, network-request-start markers via `send()`, form submits) as rrweb custom events | Server rules need signals rrweb doesn't carry. Detection logic stays server-side. |
+| Friction detection location | **Server-side, on stored streams**, versioned rules | Detector iteration at deploy speed; retroactive re-analysis. |
+| Detection method | Deterministic rules → threshold → LLM adjudication; **causal attribution, not temporal proximity** (v4-12); screenshots only on visual suspicion | Precision-at-the-human; rules give stable fingerprints; proximity gives false negatives on busy apps. |
+| Signal semantics | **Idempotent inserts (not "exactly-once"), with occurrence count + retract-on-reanalysis** (v4-5) | The unique key dedupes; it cannot un-emit a disproven signal or count intensity. |
+| Incident threshold | Friction → incident only after **5+ distinct end users, same fingerprint, same environment, rolling 7-day window** (v4-14 adds environment scoping) | Errors surface at occurrence 1; friction must not; staging must not mix with prod. |
+| Correlation/aggregation order | **Adjudicate → fold → aggregate leftovers** (v4-14) | A folded false signal must not bypass the 5-user and LLM gates. |
+| Friction pipeline outcome | Code cause → `awaiting_approval` (fix-eligible); no code cause → `insight` (terminal, **never a PR**) — two distinct states (v4-4) | The agent never pretends an opinion is a fix, and the "never" is enforceable. |
+| Friction fix labeling | Friction-fix PRs ship labeled **Suggestion** until friction repro-tests exist; **friction is gated out of auto-fix until Batch 5** (v4-4) | Passing repo tests proves "nothing broke," not "the dead click is gone." No mislabeled auto-PRs in the Batch 4–5 gap. |
 | Autonomy | Per-project ladder: **ask-first (default)** → auto-fix → auto-fix incl. UX suggestions (opt-in) | Trust earned per category. |
-| Learning loop v1 | Implicit receipts, enabled by two schema additions: `triggered_by` on fix jobs + immutable `pr_outcomes` log | Merge/close webhook exists but currently clears state (`TransitionOnPRClose` wipes `pr_url`/`pr_number`); outcomes must be recorded immutably to be countable. |
-| Retention | 14–30 day deletion for chunks/sessions, **including MinIO object deletion (new client op)**; incident-referenced windows retained but capped (90 days hard) | "Open incidents retained" must not silently mean forever. |
-| Privacy | Masked inputs + a **strict mode** (mask all text); chunk-scrubber job shortly after upload; read-path re-scrub (existing pattern); runtime recording kill switch via config; consent-language snippet shipped with Batch 1 docs | Recording everything is the FullStory posture — commitments, not parking. |
-| Deferred | Custom behavioral signals, VLM-on-everything, autonomy auto-promotion, model-level learning | YAGNI until the core loop proves out. |
+| Adjudication lifecycle | **Hidden `candidate` state the list API cannot see** + defined failure policy (retry → flag unchecked, never silent publish/drop) (v4-10) | "Checked before a human sees it" must be true on day one. |
+| Learning loop v1 | Implicit receipts: `triggered_by` on fix jobs + immutable, **idempotent, attributable** `pr_outcomes` log (v4-17) | Merge/close webhook currently clears state and can redeliver; outcomes must be counted once and traced to a job. |
+| Retention | 14–30 day deletion for chunks/sessions incl. **MinIO object deletion (new client op)**; **evidence-pinning + tombstones + PII-inclusive sweeps**; incident-referenced windows retained but hard-capped (90 days) (v4-16, #29) | "Open incidents retained" must not mean forever, and deletion must not orphan raw data or leave selector/text PII. |
+| Privacy | **Fail-closed**: private bucket (#47), masking-at-capture primary + scrubber second pass, **read/analyze blocked until `scrubbed_at` set**, selector/text masked (v4-13), strict mode, runtime kill switch, consent snippet in Batch 1 docs | Recording is the FullStory posture — commitments, not parking. |
+| Replay model migration | **Bridge `session_replays` ↔ `sessions`/`session_chunks`**: error replays become pointers into the chunk stream (v4-6) | Don't orphan the dashboard player/worker evidence; don't double-store every error moment. |
+| Deferred | Custom behavioral signals, VLM-on-everything, autonomy auto-promotion, model-level learning; **always-on-by-default (v4-15, product decision)** | YAGNI until the core loop proves out. |
 
 ## Dependencies (must land first or alongside)
 
 - **#27 client-timestamp bug**: store the SDK's event timestamp, not server arrival time — the ±30s correlation rule is meaningless without it.
-- **#28 fair scheduling + per-type concurrency caps**: session analysis must not starve fix jobs; friction incidents ride the same queue only with caps in place.
-- **#29 retention**: extended to sessions/chunks; MinIO delete operation added (the MinIO client currently has no delete op at all).
-- **#30 fingerprint normalization**: same deploy-survival thinking applies to friction selectors (below).
-- **#13 replay `/fail` endpoint**: the SDK already posts upload failures there; the server route doesn't exist. Chunk upload error reporting builds on fixing it.
-- **#25 dead-lettered jobs stuck in `analyzing`**: the fix must cover the new `session_analysis` job type, or dead-lettered analysis silently strands sessions.
+- **#28 fair scheduling + per-type concurrency caps**: session analysis must not starve fix jobs.
+- **#29 retention**: extended to sessions/chunks; MinIO delete op; now also evidence-pinning, tombstones, PII sweeps (v4-16).
+- **#30 fingerprint normalization**: same deploy-survival thinking applies to friction selectors, and to masking selector/text (v4-13).
+- **#13 replay `/fail` endpoint**: the SDK already posts upload failures there; the server route doesn't exist. Chunk error reporting builds on fixing it.
+- **#25 dead-lettered jobs stuck in `analyzing`**: the fix must cover the new `session_analysis` job type.
+- **#47 anonymous replay bucket** (security, live today): private bucket is a prerequisite for fail-closed privacy.
+- **#48 unbounded presigned uploads** (security, live today): size-capped PUTs + byte budgets are a prerequisite for always-on chunk upload.
 
 ## Design
 
-### 1. Schema (new section — v2)
+### 1. Schema (v4)
 
-New tables (idempotent migrations, append-only starting at `002`):
+New tables (idempotent, append-only from `002`):
 
-- **`sessions`** — id (client-generated, durable), project_id, environment_id, end_user_id (nullable, set when `setUser` fires), started_at, last_chunk_at, chunk_count, status (`recording` | `closed` | `analyzed`), analyzer_rule_version.
-- **`session_chunks`** — session_id, seq (unique per session), object_key, size_bytes, uploaded_at, scrubbed_at (nullable). Sequence gaps tolerated; late chunks accepted within a grace window, marked for re-analysis.
-- **`friction_signals`** — pre-threshold signal store: session_id, project_id, end_user_id (nullable), rule_version, signal_type, fingerprint, element_selector, page_url_normalized, occurred_at, incident_id (nullable; set when attached/promoted). UNIQUE(session_id, fingerprint, rule_version) makes re-analysis idempotent: new rule version inserts new rows; aggregation reads only the latest version per session.
-- **`error_groups`** gains `kind TEXT NOT NULL DEFAULT 'error' CHECK (kind IN ('error','friction'))` plus nullable `signal_type`, `element_selector`, `page_url_normalized`.
-- **`error_group_jobs`** gains `triggered_by TEXT` (`auto` | `human`) — receipts prerequisite.
-- **`pr_outcomes`** — immutable log: error_group_id, pr_number, outcome (`merged` | `closed`), occurred_at. Webhook writes here **before** any state clearing.
-- **project settings** — autonomy level per category; per-account "record + deep-analyze" flags.
+- **`sessions`** — id (client-generated, durable), project_id, environment_id, end_user_id (nullable), **next_chunk_seq (persisted, v4-15)**, started_at, last_chunk_at, chunk_count, status (`recording` | `closed` | `analyzing` | `analyzed` | `analysis_failed`, v4-15), analyzer_rule_version, **retain_until (nullable, v4-16)**.
+- **`session_chunks`** — session_id, seq (unique per session), object_key, size_bytes (**set by the commit call, v4-1**), uploaded_at, scrubbed_at (nullable), **has_full_snapshot bool (v4-19)**. A chunk is invisible to analysis until `scrubbed_at` is set (v4-5 fail-closed).
+- **`session_chunk_commits`** *(or a bucket-event ingest path)* — the server-side acknowledgement that object `object_key` for (session, seq) exists, its byte size, and content type. Nothing downstream trusts a chunk without a commit row.
+- **`friction_signals`** — session_id, project_id, environment_id (v4-14), end_user_id (nullable), rule_version, signal_type, fingerprint, element_selector (**masked/allowlisted, v4-13**), page_url_normalized, occurred_at, **occurrence_count (v4-5)**, **superseded_by (nullable, v4-5)**, incident_id (nullable). UNIQUE(session_id, fingerprint, rule_version) for idempotent inserts; re-analysis writes a new row and sets `superseded_by` on the old one.
+- **`error_groups`** gains `kind TEXT NOT NULL DEFAULT 'error' CHECK (kind IN ('error','friction'))`, nullable `signal_type` / `element_selector` / `page_url_normalized`, and status values `candidate` (hidden, v4-10), `awaiting_approval` and `insight` (v4-4).
+- **`error_group_jobs`** gains `triggered_by TEXT` (`auto` | `human`) and a nullable typed **`session_id` FK** for `session_analysis` jobs (v4-15).
+- **`pr_outcomes`** — immutable log: error_group_id, pr_number, outcome, occurred_at, **github_delivery_id (UNIQUE, v4-17)**, **fix_job_id (v4-17)**. Webhook writes here before any state clearing.
+- **`accounts`** *(new entity, v4-18)* — accounts are derived today; per-account record/deep-analyze flags need a real row. Introduce the table or key flags by the derived account string and accept the coupling (decision in Batch 3).
+- **project settings** — autonomy level per category; per-account flags.
 
-Old `friction_groups`/`friction_events`/`friction_group_affected_users` (in `001_baseline.sql:379-459`, never populated — verify in prod before dropping): superseded; removed in a cleanup migration during Batch 3.
+**Indexes shipped with the schema (v4-18):** `session_chunks(scrubbed_at) WHERE scrubbed_at IS NULL`; `sessions(last_chunk_at) WHERE status='recording'`; `sessions(end_user_id, started_at)` and an account/time variant; `friction_signals(project_id, environment_id, fingerprint, occurred_at)` for the 7-day distinct-user aggregation.
 
-Migration safety: additive columns with defaults; no rewrite of existing rows; `kind='error'` backfills by default; rollback = ignore new columns.
+**Replay bridge (v4-6):** on error, write a pointer (session_id + time range) rather than a duplicate one-shot upload; migrate `session_replays` readers (dashboard player, `replay-evidence.ts`) to resolve pointers; retire the one-shot path once readers are migrated.
+
+Old `friction_groups`/`friction_events`/`friction_group_affected_users` (never populated — verify in prod before dropping): superseded; dropped in a Batch 3 cleanup.
+
+**Migration safety (v4-20, honest per change):** added columns are reversible (old code ignores them). Dropping the old friction tables is **not** reversible — deferred until the feature is stable and prod-verified empty. Adding enum values (`candidate`, `awaiting_approval`, `insight`) is **permanent** — Postgres cannot remove an enum value — so N−1 compatibility (old workers meeting a new status) is designed explicitly, not assumed.
 
 ### 2. Capture: SDK = recorder + thin telemetry
 
-- **Durable sessions**: session ID persisted in `sessionStorage`, rotated after 30 min idle; survives navigations within a tab. `setUser()` updates the session server-side (identity rides the session, not just error payloads). Today the session ID is an in-memory module variable (`packages/sdk/src/session.ts`) regenerated per page load, and `setUser` attaches only to error payloads — both change.
-- **rrweb records continuously**; the SDK injects **custom events into the same stream**: click annotations (derived selector, computed `cursor` style at click time), network-request-start markers (the SDK already patches fetch/XHR — it knows when requests *begin*), form-submit events. All detection *logic* stays server-side; the client only annotates facts it alone can observe.
-- **Chunk protocol (new endpoints, extending the existing presigned init/complete pattern)**: `POST /sessions/init` registers the session and returns a signing route; every ~30s (and on `visibilitychange`) the SDK gzips the buffer (`CompressionStream`, ~8–10x on rrweb JSON) and PUTs `chunk-{seq}.json.gz`. Upload failures retry with backoff and requeue the chunk (bounded in-memory buffer, oldest-dropped). No explicit "complete" call: the server closes a session after N minutes without chunks; late chunks within a grace window reopen analysis.
-- **Rate limits**: chunks get their own per-project budget sized for concurrent sessions (the current 120/min replay limiter would cap out at ~30 concurrent sessions).
-- Error capture unchanged and real-time. Recording has a runtime kill switch (config endpoint — new; no runtime config fetch exists in the SDK today) and respects `replay: { enabled: false }`.
+- **Opt-in unchanged until the always-on decision (v4-15).** When recording is enabled:
+- **Durable sessions**: session ID persisted in `sessionStorage`; **`next_chunk_seq` persisted alongside it (v4-15)** so a reload doesn't reset to `chunk-0`; rotated after 30 min idle **and on identity change — login/logout starts a new session (v4-16)**. `setUser()` updates the session server-side.
+- **rrweb records continuously**; the SDK injects custom events: click annotations (derived selector, computed `cursor`), **network-request-start markers via patched XHR `send()` and fetch (v4-12)**, form-submit events. Detection logic stays server-side.
+- **Chunk protocol (v4-1, v4-19, v4-3)**: `POST /sessions/init` registers the session; every ~30s (and on `visibilitychange`) the SDK gzips the buffer (`CompressionStream`) and PUTs `chunk-{seq}.json.gz` to a **size-capped presigned URL** (`content-length-range`, #48). **Each chunk begins with a full rrweb snapshot** so it is independently playable (v4-19). After each PUT the SDK **calls a commit endpoint** (or the server consumes a bucket notification) recording existence + size (v4-1). Failures retry with backoff into a bounded buffer.
+- **Tab-close honesty (v4-11)**: the ≤30s gate is restated. On `visibilitychange` the SDK flushes only a **small keepalive-sized final segment** (the retry buffer does not survive navigation); large chunks are not guaranteed on abrupt close. Documented worst-case loss is stated plainly in Batch 1's gate rather than promised away.
+- **Rate limits**: chunks get their own per-project **byte** budget (v4-3), not just a request-count limiter.
+- **Fail-closed (v4-2 / #47)**: uploads go to a **private** bucket; masking-at-capture is the primary defense; a chunk is never read or analyzed until the scrubber sets `scrubbed_at`.
+- Error capture unchanged and real-time. Runtime kill switch (config endpoint — new) and `replay: { enabled: false }` respected.
 
 ### 3. Detection: the four-layer pyramid
 
-1. **Session close** → analyzer job (new `session_analysis` job type in the existing jobs table, with a **per-type concurrency cap** so analysis never starves fix jobs). Deterministic rules over the stitched stream — plain code, no LLM. Rules are versioned; stored sessions re-analyzable. Session size capped (~20MB uncompressed; oversized sessions analyzed on the first 20MB, flagged). Exactly-once via the `friction_signals` unique key.
-   - **Rage+dead click**: 3+ clicks, same element, ~1s, AND no DOM mutation *and* no network-start marker following each click.
-   - **Dead click**: single click on a clickable-annotated element with no response within ~1s; text-selection clicks ignored.
-   - **Form abandonment (qualified)**: 2+ fields touched, 10+ seconds engaged, exit without a submit event — or the strong variants (validation error then exit; same field retyped 3+).
-2. **Aggregation**: 5+ distinct `end_user_id`s on one fingerprint in a rolling 7-day window → incident (or fold, per correlation below). Anonymous sessions (no user set) count by session as a fallback, flagged lower-confidence.
-3. **LLM adjudication** before any human sees the incident. Note (v3): the Haiku triage stage exists in code (`agent-fix.ts`) but is skipped on the production path — this step is new wiring, not reuse.
-4. **Flagged-account deep sweeps**: async LLM over full-session event narratives; **screenshot rendering is real new infra** (headless browser running the rrweb player — `visual-analysis.ts` only consumes screenshots, it does not produce them) and is scoped to the final batch, built only when a design partner asks.
+1. **Session close** → `session_analysis` job (new type, per-type concurrency cap, #28; typed session FK, v4-15). Deterministic rules over the stitched stream; versioned; re-analyzable. Size cap ~20MB **measured with a bounded streaming decompressor** (v4-3). Idempotent via the `friction_signals` unique key; occurrence counts and retraction handled by `occurrence_count` / `superseded_by` (v4-5).
+   - **Rage+dead click**: 3+ clicks, same element, ~1s, no DOM mutation *and* no **causally-attributed** network-start (v4-12: only requests initiated from the click's handler count; SDK's own traffic and known pollers filtered).
+   - **Dead click**: single click on a clickable-annotated element with no *causally-linked* response within ~1s; text-selection clicks ignored.
+   - **Form abandonment (qualified)**: 2+ fields touched, 10+ seconds engaged, exit without submit — or strong variants.
+   - **Retraction (v4-5)**: a late chunk that shows a response/mutation the first pass missed supersedes the earlier signal; if it was already folded/aggregated, the retraction propagates.
+2. **Adjudicate → fold → aggregate (v4-14, fixed order):**
+   - **LLM adjudication** first, into a hidden `candidate` state (v4-10).
+   - **Fold** an adjudicated signal into an error incident when the same session had a captured error within ±30s (client timestamps, #27); nearest error wins.
+   - **Aggregate** the leftovers: 5+ distinct `end_user_id`s on one fingerprint **in the same environment** in a rolling 7-day window → incident. Anonymous sessions count by session, flagged lower-confidence.
+3. **Adjudicator lifecycle (v4-10)**: `candidate` rows are invisible to the list API; on adjudicator failure, retry, then surface flagged-unchecked — never silently publish or drop. Verdict, model id, and prompt version are logged.
+4. **Flagged-account deep sweeps**: async LLM over full-session narratives; **screenshot rendering is real new infra** (headless rrweb player) scoped to the final batch.
 
-**Selector fingerprinting spec** (the stability problem, stated honestly): derive selectors by priority — `data-testid`/`data-*` attrs → `id` (if not hash-like) → tag + normalized text content → DOM path with dynamic-looking classes stripped (same hash-detection family as #30). Page URLs normalized (IDs/UUIDs → placeholders). Fingerprints will still fragment on redesigns; re-analysis with new rule versions is the recovery tool. Iframes and shadow DOM: out of scope v1, signals suppressed there.
-
-**Correlation**: a friction signal folds into an error incident when the same session contains a captured error within ±30s (client timestamps; requires #27). Multiple candidate errors: nearest wins. Folded signals are stored as `friction_signals` rows pointing at the incident (bounded, occurrence-linked) — not accumulated JSONB.
+**Selector fingerprinting (v4-13, privacy-safe):** derive selectors by priority — `data-testid`/allowlisted `data-*` → `id` (if not hash-like) → tag + **masked** normalized text → DOM path with dynamic classes stripped (hash-detection family of #30). Non-allowlisted attribute values and free text are masked/hashed before storage and never sent raw to the LLM. Page URLs normalized. Iframes/shadow DOM out of scope v1.
 
 ### 4. Pipeline: same queue, two verdicts, an autonomy ladder
 
-Sequencing rule (v2): **the worker learns friction before anything enqueues it.** Concretely: `kind` awareness, a friction evidence path (skip the no-app-frames guard for friction; skip sourcemaps), an `insight` status in the shared enum, and TriggerFix accepting `insight` — all ship in Batch 3, and only Batch 4 turns detection on. (Verified: the guard at `packages/worker/src/index.ts:168-185` terminates any stackless job today; TriggerFix accepts only `investigated`.)
+Sequencing (v2, reaffirmed): the worker learns friction before anything enqueues it — `kind` awareness, friction evidence path (skip the no-app-frames guard and sourcemaps), the new statuses, and TriggerFix changes ship in Batch 3; detection turns on in Batch 4.
 
-Friction investigation evidence: event-stream narrative, selector + page, replay links, repo code around the selector (grep by selector/text). Verdicts: **code cause** → fix-eligible via the autonomy ladder; **no code cause** → `insight` (terminal until a human acts).
+**Two terminal-ish states (v4-4):**
+- **`insight`** — no code cause. Terminal. **Never becomes a PR.** TriggerFix rejects it.
+- **`awaiting_approval`** — code cause, parked for a human. TriggerFix accepts *only* this.
 
-Autonomy ladder per project (settings + receipts):
-- **Ask first** (friction default): insight card with **Generate fix** → TriggerFix (now accepting `insight`).
-- **Auto-fix**: code-caused friction routes straight through.
-- **Auto-fix incl. UX suggestions**: explicit opt-in; suggestion-labeled PRs only.
+**Auto-fix gate (v4-4):** the existing worker auto-fixes high-confidence findings (`index.ts:317`) and stamps PRs "Opslane fixed" (`pr.ts:266`). Friction is **hard-gated out of auto-fix until Batch 5** ships ask-first routing + Suggestion labels, so no friction PR ever goes out auto-generated or mislabeled in the Batch 4–5 gap.
 
-Precision gate honesty (v2): friction fixes pass the same tests+judge gate but ship labeled **Suggestion**, because the gate proves "nothing broke," not "the dead click is gone." The judge prompt gains a friction-evidence section. The upgrade path to a true **Verified** label for friction is repro-test-first (agent writes a failing test reproducing the broken interaction) — already on the roadmap; this design raises its priority.
+Autonomy ladder per project: **Ask first** (friction default) → **Auto-fix** (code-caused friction, only after the gate lifts) → **Auto-fix incl. UX suggestions** (opt-in, Suggestion-labeled only).
 
-Lifecycle fixes that unified incidents require: silence-based auto-resolve checks `friction_signals` (not just `error_events` — `resolveSilentMergedGroups` keys solely on `error_events` today) for friction incidents; "impact ordering" (affected-users sort) is **new work** in the list API, not existing behavior; the dead-letter fix (#25) must cover `session_analysis` jobs.
+Precision gate honesty (v2): friction fixes pass the same tests+judge gate but ship **Suggestion**, because the gate proves "nothing broke," not "the dead click is gone." Upgrade to **Verified** is repro-test-first.
 
-### 5. Learning loop: receipts (with the two schema additions)
+**Impact write paths (v4-17):** folding a signal into an incident updates every read the incident UI shows — `error_group_affected_users`, `affected_users_count`, account rollups, first/last seen, occurrence count — not just `friction_signals.incident_id`.
 
-Per category: suggested → generated (`triggered_by='human'` fix jobs) → merged/closed (from `pr_outcomes`, immutable) → archived insights. One aggregation query; stats beside each toggle. Explicit 👍/👎 deferred to v2 of the loop.
+Lifecycle: silence-based auto-resolve checks `friction_signals` (not just `error_events`) for friction incidents; affected-user impact ordering is new list-API work; the #25 dead-letter fix covers `session_analysis`.
+
+### 5. Learning loop: receipts (idempotent + attributable)
+
+Per category: suggested → generated (`triggered_by='human'`) → merged/closed (from `pr_outcomes`). **Idempotent (v4-17):** store GitHub's `github_delivery_id` with a UNIQUE constraint so redelivered webhooks don't double-count. **Attributable (v4-17):** record `fix_job_id` on the PR at creation. One aggregation query; stats beside each toggle.
 
 ### 6. Dashboard
 
-One inbox with kind badges; incident page = narrative + inline player + affected users + PR-or-insight-card; **Sessions section** (browse by user/account/time — requires the session identity work in Batch 1; today `ReplayPlayer.vue` is reachable only from `IncidentDetail.vue`); autonomy settings with receipts; the label rule: **Verified** only ever means tests-passed + judge-passed.
+One inbox with kind badges; `candidate` rows hidden (v4-10). Incident page = narrative + inline player (**resolving replay pointers, v4-6**) + affected users + PR-or-insight card. **Sessions section** (browse by user/account/time). Autonomy settings with receipts. **Verified** only ever means tests-passed + judge-passed.
+
+### 7. Retention & privacy (v4-16, v4-2)
+
+- **Deletion mechanism**: a retention job deletes session/chunk rows *and* MinIO objects (new client delete op, #29) past 14–30 days.
+- **Evidence pinning**: incident-referenced sessions set `retain_until`; the sweep skips pinned sessions but enforces a hard 90-day cap even when pinned.
+- **Tombstones**: a deleted session id is tombstoned so a still-valid presigned URL cannot recreate orphaned raw data.
+- **PII in the sweep**: `friction_signals` selector/text columns are included in deletion, not left behind.
+- **Fail-closed read path**: private bucket (#47), no analysis before `scrubbed_at`, worker re-scrub on read.
 
 ## Cost model (v2 — compression mandatory)
 
-- Raw rrweb for an active 10-min session: ~2–6MB uncompressed. Gzipped: ~200KB–800KB. 1,000 sessions/day ≈ 0.2–0.8GB/day ≈ single-digit dollars/month at S3 pricing, bounded by retention. PUT request costs at 30s chunking: ~20 PUTs/session ≈ $0.10/day per 1,000 sessions. Egress only on watch/analyze.
-- Deterministic analysis: CPU, fractions of a cent per session; benchmark gate in Batch 3 (must prove ~O(seconds) on the 95th-percentile session before enabling by default).
-- LLM: only post-threshold incidents + flagged accounts. Always-on tier adds ~zero LLM cost by design.
-- Client cost: gzip on a worker-thread cadence; measure CPU/battery on low-end mobile in Batch 1 (open question below).
+Unchanged from v3. Raw rrweb 10-min session ~2–6MB → gzipped ~200–800KB; ~$ single digits/month per 1,000 sessions/day, bounded by retention. **Full-snapshot-per-chunk (v4-19) adds bytes** — budget for it; still cheap. Deterministic analysis: CPU, benchmark gate in Batch 3. LLM: only post-threshold + flagged accounts. Client cost: gzip on worker-thread cadence; measure mobile CPU/battery in Batch 1.
 
 ## Testing
 
-- Chunk protocol: out-of-order upload, gap, late chunk after close, retry-after-failure, offline buffer overflow (oldest dropped), gzip round-trip.
-- Session identity: survives navigation; rotates after idle; `setUser` mid-session links user; two tabs = two sessions.
-- Analyzer golden files: fixtures → expected signals (rage+dead, stepper false-positive, text-selection, slow-async guard, all form-abandon variants); rule v2 re-analysis idempotency (unique key holds).
-- Aggregation: 4 users no incident, 5th user incident; anonymous-session fallback flagged; window expiry.
-- Correlation: ±30s fold (client timestamps), nearest-error rule, outside-window standalone.
-- Worker: friction job skips no-app-frames guard and sourcemaps; insight status writes; TriggerFix accepts insight; ladder routing per setting; Suggestion label asserted on friction PRs; Verified never appears on them.
-- Receipts: `triggered_by` recorded; `pr_outcomes` written before state clearing; stats query correctness.
-- Retention: MinIO deletion works; incident-referenced sessions retained but hard-capped at 90 days.
-- Privacy: masked-input fixture absent from stored chunks; strict mode masks text; chunk-scrubber runs; read-path re-scrub.
+- Chunk protocol: out-of-order, gap, late-chunk-after-close, retry-after-failure, offline overflow, gzip round-trip, **commit-call correctness (v4-1)**, **each chunk independently playable (v4-19)**, **oversized/gzip-bomb rejected (v4-3)**.
+- Session identity: survives navigation; **seq counter survives reload (v4-15)**; rotates after idle; **rotates on login/logout (v4-16)**; `setUser` mid-session; two tabs = two sessions.
+- Analyzer golden files: rage+dead, stepper false-positive, text-selection, slow-async guard, form-abandon variants; **causal-attribution: unrelated poll does not suppress a dead click (v4-12)**; **retraction on late chunk (v4-5)**; rule-v2 re-analysis idempotency.
+- Aggregation: 4 users no incident, 5th incident; **staging+prod not mixed (v4-14)**; anonymous fallback flagged; window expiry.
+- Correlation: **adjudicate→fold→aggregate order (v4-14)**; ±30s fold; nearest-error; outside-window standalone; **folded false signal cannot bypass gates**.
+- Pipeline: friction skips no-app-frames guard + sourcemaps; **`insight` rejected by TriggerFix, `awaiting_approval` accepted (v4-4)**; **friction never auto-fixes before Batch 5 (v4-4)**; Suggestion asserted, Verified never; **`candidate` hidden from list API (v4-10)**; **impact numbers update on fold (v4-17)**.
+- Receipts: `triggered_by` recorded; **redelivered webhook counted once (v4-17)**; `pr_outcomes` written before state clearing; stats query correctness.
+- Retention: MinIO deletion; **pinned session retained then hard-capped at 90 days; tombstone rejects re-upload; PII columns deleted (v4-16)**.
+- Privacy: masked-input fixture absent from chunks; **selector/text masked (v4-13)**; **no analysis before `scrubbed_at` (v4-2)**; strict mode; chunk-scrubber runs; read-path re-scrub; **anonymous GET returns 403 (#47)**.
 
-## Delivery batches (v2 order)
+## Delivery batches (v4 order)
 
-**Batch 1 — Record reliably ("the footage exists")** *(the big one — roughly 2x the original estimate)*
-Durable sessions + identity, interaction telemetry, chunk protocol (endpoints, manifest, rate budget, retry), gzip, chunk-scrubber, retention incl. MinIO deletion, kill switch, consent-language snippet in docs, mobile CPU measurement. Gate: dogfood sessions visible, stitched, scrubbed, compressed; old chunks deleted; a mid-session tab close loses ≤30s.
+**Batch 1 — Record reliably ("the footage exists")** *(the big one)*
+Durable sessions + **persisted seq counter** + identity + **rotate-on-identity-change**, interaction telemetry (**`send()` patch**), chunk protocol (endpoints, **commit call**, **full-snapshot-per-chunk**, **size-capped PUTs + byte budget**, retry), gzip, **fail-closed private bucket + chunk-scrubber + no-read-before-scrub**, retention incl. MinIO deletion + **evidence-pinning + tombstones**, kill switch, consent snippet, mobile CPU. **Prereqs: #47, #48.** Gate: dogfood sessions visible, stitched, scrubbed, compressed; each chunk independently playable; old chunks deleted; abrupt tab close loses at most the documented worst-case (honest number, not ≤30s by fiat).
 
 **Batch 2 — See it ("Sessions in the dashboard")**
-Sessions index by user/account/time; player over stitched chunks. Gate: watch any dogfood session end-to-end.
+Sessions index by user/account/time; player over stitched chunks (**pointer resolution for error replays, v4-6**). Gate: watch any dogfood session end-to-end.
 
 **Batch 3 — Teach the system friction exists ("no producers yet")**
-Schema (kind, insight status, friction_signals, settings, receipts columns), worker friction path (guards, evidence, prompts, judge section), TriggerFix accepts insight, analyzer built + benchmarked against stored sessions **without enqueueing incidents**. Gate: replayed fixture sessions produce correct signals at target speed; a hand-created friction incident flows through worker to insight without being auto-terminated.
+Schema (kind, `candidate`/`awaiting_approval`/`insight`, friction_signals with occurrence/supersede, settings, receipts columns, **accounts entity decision**, indexes), worker friction path (guards, evidence, prompts, judge section), TriggerFix accepts `awaiting_approval` only, analyzer built + benchmarked without enqueueing. Gate: replayed fixture sessions produce correct signals at target speed; a hand-created friction incident flows to `insight`/`awaiting_approval` without auto-termination.
 
 **Batch 4 — Turn detection on ("friction becomes incidents")**
-Aggregation threshold, correlation (after #27), adjudication, one inbox with kind badges. Gate: seeded rage-click sessions on the dogfood app → exactly one friction incident, correct affected-user count; stepper fixture → none.
+Adjudicate→fold→aggregate (after #27), environment-scoped thresholds, **hidden `candidate` state + adjudicator-failure policy**, **friction hard-gated out of auto-fix**, one inbox with kind badges. Gate: seeded rage-click sessions → exactly one friction incident, correct env-scoped affected-user count, **impact numbers updated**; stepper fixture → none; no auto-PR emitted.
 
 **Batch 5 — The ladder ("act on it")**
-Insight cards + Generate fix, autonomy settings + receipts stats, Suggestion labeling. Gate: real dogfood friction incident goes insight → click → Suggestion PR (or writeup) with the gate intact.
+Insight cards + Generate fix (from `awaiting_approval` only), autonomy settings + **idempotent/attributable receipts**, Suggestion labeling, auto-fix gate lifted. Gate: real dogfood friction incident goes `awaiting_approval` → click → Suggestion PR with the gate intact.
 
 **Batch 6 — Flagged-account deep tier (only on design-partner demand)**
-Full-session LLM sweeps; headless rrweb renderer for screenshot analysis (real infra, scoped here, not "reused"). Gate: one flagged account yields a subtle-friction insight rules couldn't catch.
+Full-session LLM sweeps; headless rrweb renderer for screenshots (real infra). Gate: one flagged account yields a subtle-friction insight rules couldn't catch.
 
 ## Open questions (parked, with owners)
 
-- Pricing: does a friction fix bill like an error fix? (Presumably yes; decide before Batch 5.)
-- Consent tooling: snippet ships in Batch 1 docs; full consent-management is customer-side — confirm with design partners' counsel.
-- Mobile chunk cadence vs battery: measure in Batch 1; fallback is 60s cadence + visibility-only flushes.
-- Anonymous-session aggregation: is session-count fallback good enough, or should anonymous friction stay sub-threshold? Decide with Batch 4 data.
+- **Always-on vs. opt-in (v4-15, product/legal):** does recording default on for everyone, silently changing an absent `replay` config and today's public opt-in promise? **Owned outside this design; until decided, opt-in stays the default.** Blocks Batch 1's capture-policy shape.
+- Pricing: does a friction fix bill like an error fix? Decide before Batch 5.
+- Consent tooling: snippet ships in Batch 1 docs; full consent-management is customer-side.
+- Mobile chunk cadence vs battery: measure in Batch 1; fallback 60s cadence + visibility-only flushes.
+- Anonymous-session aggregation: session-count fallback good enough, or keep anonymous friction sub-threshold? Decide with Batch 4 data.
+- Accounts entity (v4-18): real table vs. keying flags by derived account string — decide in Batch 3.

--- a/docs/plans/2026-07-13-unified-incidents-replay-friction-design.md
+++ b/docs/plans/2026-07-13-unified-incidents-replay-friction-design.md
@@ -1,0 +1,174 @@
+# Unified Incidents: Bugs + Session Replay + Friction
+
+**Date:** 2026-07-13
+**Status:** Approved — v2 after Codex adversarial review (2026-07-13); v3 after re-verification against opslane-oss (2026-07-14)
+**Author:** Abhishek + Claude; adversarial review by Codex
+
+## Problem
+
+Opslane captures errors and fixes them. But most user pain never throws an exception: broken buttons that fail silently, forms people abandon, UI that makes users rage-click. Today that pain is invisible — the friction tables (in `001_baseline.sql`) exist but have never received a row, the SDK has no friction detection, replays are only reachable from inside an error incident, and replay capture defaults to off.
+
+Competitors are converging from the other side: Lucent (AI session replay) records everything and has AI watch the recordings, producing bug reports. Their pitch validates our thesis — "don't make humans triage" — but they stop at filing a ticket. We go one step further: a verified fix.
+
+## One-sentence design
+
+Record every session cheaply (compressed, chunked), enrich the recording with a thin interaction-telemetry stream, detect friction server-side with versioned deterministic rules, promote repeated friction into the same incident pipeline errors use, and let customers climb an autonomy ladder from "ask me first" to "auto-fix" as the system earns trust.
+
+## What changed in v3 (post-migration re-verification)
+
+The design was written against the `defender` repo; the code now lives in `opslane-oss` with a consolidated `001_baseline.sql`. Every factual claim was re-verified against this codebase on 2026-07-14. The design holds; four things changed:
+
+1. **Replay upload is already two-phase presigned**, not a bare one-shot POST: `POST /api/v1/replays/init` returns a presigned MinIO PUT URL; the browser PUTs the full JSON; `POST /api/v1/replays/{id}/complete` finalizes (`packages/ingestion/handler/replay.go:49,125`). Still one object per replay — chunking (manifest, sequencing, per-chunk retry, compression) remains real new work — but the init/finalize/presign pattern is a foundation to extend, not build from zero.
+2. **The "existing Haiku triage stage" is not on the production path.** It exists (`packages/worker/src/agent-fix.ts:456-477`) but only fires when no precomputed investigation is passed; the normal pipeline runs the Sonnet investigation first and skips it. Batch 4's LLM adjudication is wiring work, not pure reuse.
+3. **The SDK already reports upload failures to `/replays/{id}/fail`** (`packages/sdk/src/replay.ts:238-247`) — the *server* route is what's missing (#13). Chunk-upload failure reporting builds on fixing #13, not on an existing endpoint.
+4. **New dependency: #25** (dead-lettered investigate jobs leave groups stuck in `analyzing` forever). The new `session_analysis` job type inherits the same failure mode; the dead-letter fix must cover it.
+
+Dependency issues were re-filed in opslane-oss; all links below now point at this repo's tracker. Note also: migrations here are consolidated into `001_baseline.sql` and new schema changes are append-only starting at `002`.
+
+## What changed in v2 (Codex review findings)
+
+The concept survived review; three "reuse existing machinery" claims did not. Corrections baked in below:
+
+1. rrweb alone cannot power the detectors (no network-start, no clickability) → the SDK adds a **thin interaction-telemetry stream**; it is a recorder-plus-annotations, not a dumb recorder.
+2. The one-shot replay upload path is **not** a chunk protocol → chunked upload is designed explicitly (manifest, sequencing, finalization, compression, retry, its own rate budget).
+3. Sessions today are in-memory per page load and carry no user identity → durable session IDs + user linkage are prerequisites for aggregation and the sessions browser.
+4. Batch order fixed: the worker must understand friction **before** anything enqueues it (the current worker would auto-terminate friction jobs via the no-app-frames guard).
+5. Cost model redone with mandatory compression; a schema section added; receipts corrected (they need two small schema additions, they don't exist for free); privacy/retention commitments made concrete.
+6. Independent bug found during review, filed separately: ingestion parses the client event timestamp and then stores server time instead (#27) — correlation windows depend on fixing this.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Organizing primitive | One unified **incident** (kind: `error` \| `friction`) | One inbox, one status model, one pipeline, one bill. |
+| Error+friction in same session | Fold friction into the error incident as evidence + impact boost | One moment of pain = one incident. Depends on the client-timestamp fix (#27). |
+| Capture policy | **Always-on recording for everyone**: rrweb + interaction telemetry, gzipped chunks every ~30s | Storage is cheap once compressed; analysis, not storage, is the cost. |
+| SDK role | Recorder + **thin interaction telemetry** (click annotations, network-start markers, form submits) injected as rrweb custom events | Server rules need signals rrweb doesn't carry. ~50–100 lines client-side; detection logic still lives server-side. |
+| Friction detection location | **Server-side, on stored streams**, versioned rules | Detector iteration at deploy speed, not SDK-upgrade speed; retroactive re-analysis of stored sessions. |
+| Detection method | Deterministic rules → threshold → LLM adjudication; screenshots only on visual suspicion | Precision-at-the-human is what matters; rules give stable fingerprints. |
+| Incident threshold | Friction signal → incident only after **5+ distinct end users**, same fingerprint, within a rolling 7-day window | Errors surface at occurrence 1; friction must not. |
+| Friction pipeline outcome | Code cause → fix-eligible; no code cause → **insight** (never a PR) | The agent never pretends an opinion is a fix. |
+| Friction fix labeling | Friction-fix PRs ship labeled **Suggestion** until friction repro-tests exist | Codex is right: passing repo tests does not prove a dead click is fixed. "Verified" stays honest. Upgrades to Verified when repro-test-first lands. |
+| Autonomy | Per-project ladder: **ask-first (default)** → auto-fix → auto-fix incl. UX suggestions (opt-in) | Trust earned per category. |
+| Learning loop v1 | Implicit receipts, enabled by two schema additions: `triggered_by` on fix jobs + immutable `pr_outcomes` log | Merge/close webhook exists but currently clears state (`TransitionOnPRClose` wipes `pr_url`/`pr_number`); outcomes must be recorded immutably to be countable. |
+| Retention | 14–30 day deletion for chunks/sessions, **including MinIO object deletion (new client op)**; incident-referenced windows retained but capped (90 days hard) | "Open incidents retained" must not silently mean forever. |
+| Privacy | Masked inputs + a **strict mode** (mask all text); chunk-scrubber job shortly after upload; read-path re-scrub (existing pattern); runtime recording kill switch via config; consent-language snippet shipped with Batch 1 docs | Recording everything is the FullStory posture — commitments, not parking. |
+| Deferred | Custom behavioral signals, VLM-on-everything, autonomy auto-promotion, model-level learning | YAGNI until the core loop proves out. |
+
+## Dependencies (must land first or alongside)
+
+- **#27 client-timestamp bug**: store the SDK's event timestamp, not server arrival time — the ±30s correlation rule is meaningless without it.
+- **#28 fair scheduling + per-type concurrency caps**: session analysis must not starve fix jobs; friction incidents ride the same queue only with caps in place.
+- **#29 retention**: extended to sessions/chunks; MinIO delete operation added (the MinIO client currently has no delete op at all).
+- **#30 fingerprint normalization**: same deploy-survival thinking applies to friction selectors (below).
+- **#13 replay `/fail` endpoint**: the SDK already posts upload failures there; the server route doesn't exist. Chunk upload error reporting builds on fixing it.
+- **#25 dead-lettered jobs stuck in `analyzing`**: the fix must cover the new `session_analysis` job type, or dead-lettered analysis silently strands sessions.
+
+## Design
+
+### 1. Schema (new section — v2)
+
+New tables (idempotent migrations, append-only starting at `002`):
+
+- **`sessions`** — id (client-generated, durable), project_id, environment_id, end_user_id (nullable, set when `setUser` fires), started_at, last_chunk_at, chunk_count, status (`recording` | `closed` | `analyzed`), analyzer_rule_version.
+- **`session_chunks`** — session_id, seq (unique per session), object_key, size_bytes, uploaded_at, scrubbed_at (nullable). Sequence gaps tolerated; late chunks accepted within a grace window, marked for re-analysis.
+- **`friction_signals`** — pre-threshold signal store: session_id, project_id, end_user_id (nullable), rule_version, signal_type, fingerprint, element_selector, page_url_normalized, occurred_at, incident_id (nullable; set when attached/promoted). UNIQUE(session_id, fingerprint, rule_version) makes re-analysis idempotent: new rule version inserts new rows; aggregation reads only the latest version per session.
+- **`error_groups`** gains `kind TEXT NOT NULL DEFAULT 'error' CHECK (kind IN ('error','friction'))` plus nullable `signal_type`, `element_selector`, `page_url_normalized`.
+- **`error_group_jobs`** gains `triggered_by TEXT` (`auto` | `human`) — receipts prerequisite.
+- **`pr_outcomes`** — immutable log: error_group_id, pr_number, outcome (`merged` | `closed`), occurred_at. Webhook writes here **before** any state clearing.
+- **project settings** — autonomy level per category; per-account "record + deep-analyze" flags.
+
+Old `friction_groups`/`friction_events`/`friction_group_affected_users` (in `001_baseline.sql:379-459`, never populated — verify in prod before dropping): superseded; removed in a cleanup migration during Batch 3.
+
+Migration safety: additive columns with defaults; no rewrite of existing rows; `kind='error'` backfills by default; rollback = ignore new columns.
+
+### 2. Capture: SDK = recorder + thin telemetry
+
+- **Durable sessions**: session ID persisted in `sessionStorage`, rotated after 30 min idle; survives navigations within a tab. `setUser()` updates the session server-side (identity rides the session, not just error payloads). Today the session ID is an in-memory module variable (`packages/sdk/src/session.ts`) regenerated per page load, and `setUser` attaches only to error payloads — both change.
+- **rrweb records continuously**; the SDK injects **custom events into the same stream**: click annotations (derived selector, computed `cursor` style at click time), network-request-start markers (the SDK already patches fetch/XHR — it knows when requests *begin*), form-submit events. All detection *logic* stays server-side; the client only annotates facts it alone can observe.
+- **Chunk protocol (new endpoints, extending the existing presigned init/complete pattern)**: `POST /sessions/init` registers the session and returns a signing route; every ~30s (and on `visibilitychange`) the SDK gzips the buffer (`CompressionStream`, ~8–10x on rrweb JSON) and PUTs `chunk-{seq}.json.gz`. Upload failures retry with backoff and requeue the chunk (bounded in-memory buffer, oldest-dropped). No explicit "complete" call: the server closes a session after N minutes without chunks; late chunks within a grace window reopen analysis.
+- **Rate limits**: chunks get their own per-project budget sized for concurrent sessions (the current 120/min replay limiter would cap out at ~30 concurrent sessions).
+- Error capture unchanged and real-time. Recording has a runtime kill switch (config endpoint — new; no runtime config fetch exists in the SDK today) and respects `replay: { enabled: false }`.
+
+### 3. Detection: the four-layer pyramid
+
+1. **Session close** → analyzer job (new `session_analysis` job type in the existing jobs table, with a **per-type concurrency cap** so analysis never starves fix jobs). Deterministic rules over the stitched stream — plain code, no LLM. Rules are versioned; stored sessions re-analyzable. Session size capped (~20MB uncompressed; oversized sessions analyzed on the first 20MB, flagged). Exactly-once via the `friction_signals` unique key.
+   - **Rage+dead click**: 3+ clicks, same element, ~1s, AND no DOM mutation *and* no network-start marker following each click.
+   - **Dead click**: single click on a clickable-annotated element with no response within ~1s; text-selection clicks ignored.
+   - **Form abandonment (qualified)**: 2+ fields touched, 10+ seconds engaged, exit without a submit event — or the strong variants (validation error then exit; same field retyped 3+).
+2. **Aggregation**: 5+ distinct `end_user_id`s on one fingerprint in a rolling 7-day window → incident (or fold, per correlation below). Anonymous sessions (no user set) count by session as a fallback, flagged lower-confidence.
+3. **LLM adjudication** before any human sees the incident. Note (v3): the Haiku triage stage exists in code (`agent-fix.ts`) but is skipped on the production path — this step is new wiring, not reuse.
+4. **Flagged-account deep sweeps**: async LLM over full-session event narratives; **screenshot rendering is real new infra** (headless browser running the rrweb player — `visual-analysis.ts` only consumes screenshots, it does not produce them) and is scoped to the final batch, built only when a design partner asks.
+
+**Selector fingerprinting spec** (the stability problem, stated honestly): derive selectors by priority — `data-testid`/`data-*` attrs → `id` (if not hash-like) → tag + normalized text content → DOM path with dynamic-looking classes stripped (same hash-detection family as #30). Page URLs normalized (IDs/UUIDs → placeholders). Fingerprints will still fragment on redesigns; re-analysis with new rule versions is the recovery tool. Iframes and shadow DOM: out of scope v1, signals suppressed there.
+
+**Correlation**: a friction signal folds into an error incident when the same session contains a captured error within ±30s (client timestamps; requires #27). Multiple candidate errors: nearest wins. Folded signals are stored as `friction_signals` rows pointing at the incident (bounded, occurrence-linked) — not accumulated JSONB.
+
+### 4. Pipeline: same queue, two verdicts, an autonomy ladder
+
+Sequencing rule (v2): **the worker learns friction before anything enqueues it.** Concretely: `kind` awareness, a friction evidence path (skip the no-app-frames guard for friction; skip sourcemaps), an `insight` status in the shared enum, and TriggerFix accepting `insight` — all ship in Batch 3, and only Batch 4 turns detection on. (Verified: the guard at `packages/worker/src/index.ts:168-185` terminates any stackless job today; TriggerFix accepts only `investigated`.)
+
+Friction investigation evidence: event-stream narrative, selector + page, replay links, repo code around the selector (grep by selector/text). Verdicts: **code cause** → fix-eligible via the autonomy ladder; **no code cause** → `insight` (terminal until a human acts).
+
+Autonomy ladder per project (settings + receipts):
+- **Ask first** (friction default): insight card with **Generate fix** → TriggerFix (now accepting `insight`).
+- **Auto-fix**: code-caused friction routes straight through.
+- **Auto-fix incl. UX suggestions**: explicit opt-in; suggestion-labeled PRs only.
+
+Precision gate honesty (v2): friction fixes pass the same tests+judge gate but ship labeled **Suggestion**, because the gate proves "nothing broke," not "the dead click is gone." The judge prompt gains a friction-evidence section. The upgrade path to a true **Verified** label for friction is repro-test-first (agent writes a failing test reproducing the broken interaction) — already on the roadmap; this design raises its priority.
+
+Lifecycle fixes that unified incidents require: silence-based auto-resolve checks `friction_signals` (not just `error_events` — `resolveSilentMergedGroups` keys solely on `error_events` today) for friction incidents; "impact ordering" (affected-users sort) is **new work** in the list API, not existing behavior; the dead-letter fix (#25) must cover `session_analysis` jobs.
+
+### 5. Learning loop: receipts (with the two schema additions)
+
+Per category: suggested → generated (`triggered_by='human'` fix jobs) → merged/closed (from `pr_outcomes`, immutable) → archived insights. One aggregation query; stats beside each toggle. Explicit 👍/👎 deferred to v2 of the loop.
+
+### 6. Dashboard
+
+One inbox with kind badges; incident page = narrative + inline player + affected users + PR-or-insight-card; **Sessions section** (browse by user/account/time — requires the session identity work in Batch 1; today `ReplayPlayer.vue` is reachable only from `IncidentDetail.vue`); autonomy settings with receipts; the label rule: **Verified** only ever means tests-passed + judge-passed.
+
+## Cost model (v2 — compression mandatory)
+
+- Raw rrweb for an active 10-min session: ~2–6MB uncompressed. Gzipped: ~200KB–800KB. 1,000 sessions/day ≈ 0.2–0.8GB/day ≈ single-digit dollars/month at S3 pricing, bounded by retention. PUT request costs at 30s chunking: ~20 PUTs/session ≈ $0.10/day per 1,000 sessions. Egress only on watch/analyze.
+- Deterministic analysis: CPU, fractions of a cent per session; benchmark gate in Batch 3 (must prove ~O(seconds) on the 95th-percentile session before enabling by default).
+- LLM: only post-threshold incidents + flagged accounts. Always-on tier adds ~zero LLM cost by design.
+- Client cost: gzip on a worker-thread cadence; measure CPU/battery on low-end mobile in Batch 1 (open question below).
+
+## Testing
+
+- Chunk protocol: out-of-order upload, gap, late chunk after close, retry-after-failure, offline buffer overflow (oldest dropped), gzip round-trip.
+- Session identity: survives navigation; rotates after idle; `setUser` mid-session links user; two tabs = two sessions.
+- Analyzer golden files: fixtures → expected signals (rage+dead, stepper false-positive, text-selection, slow-async guard, all form-abandon variants); rule v2 re-analysis idempotency (unique key holds).
+- Aggregation: 4 users no incident, 5th user incident; anonymous-session fallback flagged; window expiry.
+- Correlation: ±30s fold (client timestamps), nearest-error rule, outside-window standalone.
+- Worker: friction job skips no-app-frames guard and sourcemaps; insight status writes; TriggerFix accepts insight; ladder routing per setting; Suggestion label asserted on friction PRs; Verified never appears on them.
+- Receipts: `triggered_by` recorded; `pr_outcomes` written before state clearing; stats query correctness.
+- Retention: MinIO deletion works; incident-referenced sessions retained but hard-capped at 90 days.
+- Privacy: masked-input fixture absent from stored chunks; strict mode masks text; chunk-scrubber runs; read-path re-scrub.
+
+## Delivery batches (v2 order)
+
+**Batch 1 — Record reliably ("the footage exists")** *(the big one — roughly 2x the original estimate)*
+Durable sessions + identity, interaction telemetry, chunk protocol (endpoints, manifest, rate budget, retry), gzip, chunk-scrubber, retention incl. MinIO deletion, kill switch, consent-language snippet in docs, mobile CPU measurement. Gate: dogfood sessions visible, stitched, scrubbed, compressed; old chunks deleted; a mid-session tab close loses ≤30s.
+
+**Batch 2 — See it ("Sessions in the dashboard")**
+Sessions index by user/account/time; player over stitched chunks. Gate: watch any dogfood session end-to-end.
+
+**Batch 3 — Teach the system friction exists ("no producers yet")**
+Schema (kind, insight status, friction_signals, settings, receipts columns), worker friction path (guards, evidence, prompts, judge section), TriggerFix accepts insight, analyzer built + benchmarked against stored sessions **without enqueueing incidents**. Gate: replayed fixture sessions produce correct signals at target speed; a hand-created friction incident flows through worker to insight without being auto-terminated.
+
+**Batch 4 — Turn detection on ("friction becomes incidents")**
+Aggregation threshold, correlation (after #27), adjudication, one inbox with kind badges. Gate: seeded rage-click sessions on the dogfood app → exactly one friction incident, correct affected-user count; stepper fixture → none.
+
+**Batch 5 — The ladder ("act on it")**
+Insight cards + Generate fix, autonomy settings + receipts stats, Suggestion labeling. Gate: real dogfood friction incident goes insight → click → Suggestion PR (or writeup) with the gate intact.
+
+**Batch 6 — Flagged-account deep tier (only on design-partner demand)**
+Full-session LLM sweeps; headless rrweb renderer for screenshot analysis (real infra, scoped here, not "reused"). Gate: one flagged account yields a subtle-friction insight rules couldn't catch.
+
+## Open questions (parked, with owners)
+
+- Pricing: does a friction fix bill like an error fix? (Presumably yes; decide before Batch 5.)
+- Consent tooling: snippet ships in Batch 1 docs; full consent-management is customer-side — confirm with design partners' counsel.
+- Mobile chunk cadence vs battery: measure in Batch 1; fallback is 60s cadence + visibility-only flushes.
+- Anonymous-session aggregation: is session-count fallback good enough, or should anonymous friction stay sub-threshold? Decide with Batch 4 data.

--- a/docs/reference/http-routes.md
+++ b/docs/reference/http-routes.md
@@ -28,9 +28,12 @@ These are curated tables, not a stability contract — the API is early-stage an
 | POST | `/api/v1/events` | yes | Ingest an error event |
 | POST | `/api/v1/replays/init` | yes | Begin a replay upload |
 | POST | `/api/v1/replays/{replayID}/complete` | yes | Finish a replay upload |
+| POST | `/api/v1/replays/{replayID}/fail` | yes | Record a replay upload failure |
+| POST | `/api/v1/sessions/init` | yes | Register a session; returns the recording kill switch |
+| POST | `/api/v1/sessions/{sessionID}/chunks/upload-url` | yes | Size-capped presigned POST policy for one chunk |
+| POST | `/api/v1/sessions/{sessionID}/chunks/{seq}/commit` | yes | Acknowledge an uploaded chunk exists |
+| POST | `/api/v1/sessions/{sessionID}/chunks/{seq}/inline` | yes | Keepalive tail flush on tab close (at most 64KB) |
 | POST | `/api/v1/sourcemaps` | no (build-time upload) | Upload source maps |
-
-> Known gap: the SDK also calls `POST /api/v1/replays/{replayID}/fail`, which is **not registered** — tracked as [#13](https://github.com/opslane/opslane-oss/issues/13). The drift check carries this as an explicit allowlisted exception until the bug is fixed.
 
 ## Session (dashboard/CLI)
 

--- a/docs/reference/sdk-options.md
+++ b/docs/reference/sdk-options.md
@@ -12,7 +12,7 @@ All options accepted by `init()` from `@opslane/sdk`, mirrored from `SdkInitOpti
 | `flushInterval` | `number` | `5000` | Milliseconds between transport flushes. |
 | `maxBatchSize` | `number` | `10` | Maximum events per flush. |
 | `debug` | `boolean` | `false` | Log SDK-internal problems to the console. |
-| `replay` | `{ enabled?: boolean }` | `{ enabled: false }` | Session replay capture — opt-in. |
+| `replay` | `{ enabled?: boolean }` | `{ enabled: true }` | Session recording. **On by default since 1.0.0.** Set `enabled: false` to opt out; a per-project kill switch also exists server-side. Needs `CompressionStream` (Chrome 80+, Safari 16.4+, Firefox 113+). |
 | `sampleRate` | `number` | `1` | Fraction of events sent; clamped to `[0, 1]`. |
 | `errorThrottleMs` | `number` | `1000` | Minimum interval between reports of the same error. |
 | `beforeSend` | `(event) => event \| null` | `undefined` | Final hook: mutate the outgoing payload or return `null` to drop it. |

--- a/docs/replay-privacy.md
+++ b/docs/replay-privacy.md
@@ -5,3 +5,43 @@ Opslane session replay is intended for debugging production errors, not for coll
 By default, applications should mask text input values, password fields, payment fields, and other user-entered secrets before replay data leaves the browser. Teams should also avoid adding breadcrumbs or custom context fields that contain access tokens, credentials, full request bodies, or regulated personal data.
 
 Captured replay data may include page URLs, click/navigation timing, console signals, network status metadata, and masked DOM or screenshot artifacts used to explain what the user saw around an error. Keep retention narrow and review custom SDK configuration before enabling replay on sensitive flows.
+
+## Recording is on by default (SDK 1.0.0+)
+
+Every session is recorded, not just sessions that hit an error. Two things
+follow.
+
+**Review your masking before upgrading.** Input values are masked
+automatically. Rendered text is not — a page that displays an email address, an
+invoice, or a support ticket body captures that text as shown. Mark those
+regions:
+
+```html
+<div class="opslane-mask">alice@example.com</div>   <!-- text is masked -->
+<div class="opslane-block">…</div>                  <!-- subtree not recorded -->
+```
+
+**Tell your users.** Recording every session changes what you collect, which
+usually means your privacy notice needs to say so. A starting point — adapt it
+to your jurisdiction and have your own counsel review it; this is not legal
+advice:
+
+> We record how you interact with this application — pages viewed, clicks, and
+> form interactions — to diagnose errors and fix problems you run into. Values
+> you type into forms are masked before the recording leaves your browser.
+> Recordings are deleted after 30 days.
+
+Adjust the retention figure to your project's actual `session_retention_days`.
+
+### Turning recording off
+
+Per integration:
+
+```js
+init({ apiKey: '...', replay: { enabled: false } });
+```
+
+Per project, set `projects.recording_enabled` to `false` with your database or
+admin tooling. This needs no application redeploy: it stops new sessions
+immediately and stops in-flight ones at their next chunk upload. A dashboard
+toggle is not included in Batch 1.

--- a/packages/ingestion/compress/compress.go
+++ b/packages/ingestion/compress/compress.go
@@ -1,0 +1,48 @@
+// Package compress provides bounded gzip handling for stored session chunks.
+package compress
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ErrTooLarge is returned when decompressed output would exceed the ceiling.
+var ErrTooLarge = errors.New("decompressed size exceeds limit")
+
+// InflateLimited gunzips r while reading at most one byte beyond maxBytes.
+func InflateLimited(r io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("maxBytes must be positive, got %d", maxBytes)
+	}
+
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("open gzip stream: %w", err)
+	}
+	defer zr.Close()
+
+	out, err := io.ReadAll(io.LimitReader(zr, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("inflate: %w", err)
+	}
+	if int64(len(out)) > maxBytes {
+		return out[:maxBytes], ErrTooLarge
+	}
+	return out, nil
+}
+
+// Deflate gzips data for durable chunk storage.
+func Deflate(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(data); err != nil {
+		return nil, fmt.Errorf("gzip write: %w", err)
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("gzip close: %w", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/packages/ingestion/compress/compress_test.go
+++ b/packages/ingestion/compress/compress_test.go
@@ -1,0 +1,72 @@
+package compress_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/opslane/opslane/packages/ingestion/compress"
+)
+
+func mustGzip(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestInflateLimited_RoundTrip(t *testing.T) {
+	original := []byte(`{"events":[{"type":2,"data":{}}]}`)
+	got, err := compress.InflateLimited(bytes.NewReader(mustGzip(t, original)), 1<<20)
+	if err != nil {
+		t.Fatalf("inflate: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("round trip mismatch: got %q, want %q", got, original)
+	}
+}
+
+func TestInflateLimited_AtExactlyTheLimitSucceeds(t *testing.T) {
+	original := bytes.Repeat([]byte("a"), 1000)
+	got, err := compress.InflateLimited(bytes.NewReader(mustGzip(t, original)), 1000)
+	if err != nil || len(got) != 1000 {
+		t.Fatalf("inflate at limit: len=%d err=%v", len(got), err)
+	}
+}
+
+func TestInflateLimited_RejectsGzipBomb(t *testing.T) {
+	bomb := mustGzip(t, bytes.Repeat([]byte("A"), 100<<20))
+	got, err := compress.InflateLimited(bytes.NewReader(bomb), 1<<20)
+	if !errors.Is(err, compress.ErrTooLarge) {
+		t.Fatalf("inflate returned %v, want ErrTooLarge", err)
+	}
+	if len(got) > 1<<20 {
+		t.Fatalf("returned %d bytes despite ceiling", len(got))
+	}
+}
+
+func TestInflateLimited_RejectsNonGzip(t *testing.T) {
+	if _, err := compress.InflateLimited(strings.NewReader("plain text"), 1<<20); err == nil {
+		t.Fatal("non-gzip input inflated without error")
+	}
+}
+
+func TestDeflate_RoundTripsThroughInflate(t *testing.T) {
+	original := []byte(strings.Repeat(`{"k":"v"},`, 500))
+	gz, err := compress.Deflate(original)
+	if err != nil {
+		t.Fatalf("deflate: %v", err)
+	}
+	back, err := compress.InflateLimited(bytes.NewReader(gz), 1<<20)
+	if err != nil || !bytes.Equal(back, original) {
+		t.Fatalf("round trip failed: %v", err)
+	}
+}

--- a/packages/ingestion/db/migrations/002_sessions.sql
+++ b/packages/ingestion/db/migrations/002_sessions.sql
@@ -125,10 +125,20 @@ CREATE INDEX IF NOT EXISTS idx_sessions_end_user_started
 CREATE INDEX IF NOT EXISTS idx_sessions_project_started
   ON sessions(project_id, started_at);
 
--- Retention sweep: find expiry candidates without scanning live recordings.
-CREATE INDEX IF NOT EXISTS idx_sessions_retention
+-- Retention sweep: find expiry candidates. The predicate must match
+-- SessionsToDelete's WHERE exactly -- Postgres only uses a partial index when
+-- the query predicate implies the index predicate, and status <> 'deleting'
+-- does not imply status <> 'recording'.
+DROP INDEX IF EXISTS idx_sessions_retention;
+CREATE INDEX IF NOT EXISTS idx_sessions_retention_not_deleting
   ON sessions(started_at)
-  WHERE status <> 'recording';
+  WHERE status <> 'deleting';
+
+-- Purge sweep: SessionsReadyForPurge orders by deletion_started_at. 'deleting'
+-- is transient, so the partial predicate keeps this index tiny.
+CREATE INDEX IF NOT EXISTS idx_sessions_purge
+  ON sessions(deletion_started_at)
+  WHERE status = 'deleting';
 
 -- Revisit deleted-session prefixes forever. A storage POST accepted just
 -- before policy expiry may finish after the first retention pass.

--- a/packages/ingestion/db/migrations/002_sessions.sql
+++ b/packages/ingestion/db/migrations/002_sessions.sql
@@ -1,0 +1,145 @@
+-- 002_sessions.sql — always-on session recording (epic #31, Batch 1).
+-- Append-only after the 001 baseline.
+--
+-- IDEMPOTENCY IS MANDATORY: there is no migration-tracking table. scripts/
+-- run-migrations.sh psql -f's every *.sql in this directory on every start.
+-- Every statement here must survive being re-run indefinitely.
+--
+-- N-1 COMPATIBILITY: this migration only ADDS tables and columns, so an old
+-- ingestion binary meeting this schema simply ignores it. Note sessions.status
+-- is TEXT + CHECK, not a Postgres enum -- a CHECK constraint can be dropped and
+-- re-added, whereas an enum value is permanent. Deliberate (design v4-20).
+
+-- A recorded browser session. The id is client-generated and durable across
+-- reloads (persisted in sessionStorage), so it is TEXT, not UUID: the SDK falls
+-- back to a non-UUID format when crypto.randomUUID is unavailable in
+-- non-secure contexts (packages/sdk/src/session.ts).
+CREATE TABLE IF NOT EXISTS sessions (
+  id                    TEXT PRIMARY KEY,
+  project_id            UUID NOT NULL REFERENCES projects(id),
+  environment_id        UUID NOT NULL REFERENCES environments(id),
+  end_user_id           UUID REFERENCES end_users(id),
+  -- Server-side high-water mark. The client also persists its own counter; this
+  -- is the authoritative record and the chunks PK is the real duplicate guard.
+  next_chunk_seq        INTEGER NOT NULL DEFAULT 0,
+  started_at            TIMESTAMPTZ NOT NULL,
+  last_chunk_at         TIMESTAMPTZ,
+  chunk_count           INTEGER NOT NULL DEFAULT 0,
+  bytes_stored          BIGINT NOT NULL DEFAULT 0,
+  status                TEXT NOT NULL DEFAULT 'recording'
+                          CHECK (status IN ('recording','closed','analyzing','analyzed','analysis_failed','deleting')),
+  analyzer_rule_version INTEGER,
+  -- Evidence pinning (design v4-16): set when an incident references this
+  -- session. The retention sweep skips pinned sessions but still enforces the
+  -- hard 90-day cap.
+  retain_until          TIMESTAMPTZ,
+  deletion_started_at   TIMESTAMPTZ,
+  page_url              TEXT,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- One gzipped rrweb segment. Every chunk opens with a full rrweb snapshot
+-- (has_full_snapshot), so it is independently playable and a lost predecessor
+-- does not corrupt it (design v4-19).
+--
+-- FAIL-CLOSED: a chunk with scrubbed_at IS NULL has NOT been redacted. Nothing
+-- may read, analyze, or serve it. Every read path must gate on scrubbed_at
+-- IS NOT NULL (design v4-2 / #47).
+CREATE TABLE IF NOT EXISTS session_chunks (
+  session_id        TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  seq               INTEGER NOT NULL,
+  project_id        UUID NOT NULL REFERENCES projects(id),
+  object_key        TEXT NOT NULL,
+  -- NULL until the commit call Stats the object. The server never trusts a
+  -- client-declared size (design v4-1).
+  size_bytes        BIGINT,
+  has_full_snapshot BOOLEAN NOT NULL DEFAULT FALSE,
+  uploaded_at       TIMESTAMPTZ,
+  scrubbed_at       TIMESTAMPTZ,
+  scrub_attempts    INTEGER NOT NULL DEFAULT 0,
+  scrub_claimed_at  TIMESTAMPTZ,
+  scrub_error       TEXT,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (session_id, seq)
+);
+
+-- A deleted session id (design v4-16). Presigned URLs outlive the rows they
+-- were issued for, so without this a URL held past a retention sweep could
+-- recreate orphaned raw data that no retention pass would ever find again.
+-- Deliberately not FK'd to sessions -- the whole point is that the row is gone.
+CREATE TABLE IF NOT EXISTS session_tombstones (
+  session_id TEXT PRIMARY KEY,
+  project_id UUID NOT NULL,
+  deleted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  storage_swept_at TIMESTAMPTZ,
+  storage_sweep_claimed_at TIMESTAMPTZ
+);
+
+-- Re-application also upgrades databases that created these tables from an
+-- earlier draft of this migration.
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS deletion_started_at TIMESTAMPTZ;
+ALTER TABLE session_chunks ADD COLUMN IF NOT EXISTS scrub_claimed_at TIMESTAMPTZ;
+ALTER TABLE session_tombstones ADD COLUMN IF NOT EXISTS storage_swept_at TIMESTAMPTZ;
+ALTER TABLE session_tombstones ADD COLUMN IF NOT EXISTS storage_sweep_claimed_at TIMESTAMPTZ;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'sessions'::regclass
+       AND conname = 'sessions_status_check'
+       AND pg_get_constraintdef(oid) NOT LIKE '%deleting%'
+  ) THEN
+    ALTER TABLE sessions DROP CONSTRAINT sessions_status_check;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'sessions'::regclass AND conname = 'sessions_status_check'
+  ) THEN
+    ALTER TABLE sessions ADD CONSTRAINT sessions_status_check
+      CHECK (status IN ('recording','closed','analyzing','analyzed','analysis_failed','deleting'));
+  END IF;
+END $$;
+
+-- Access paths shipped with the schema (design v4-18). Each one backs a
+-- specific query; do not drop one without deleting its caller.
+
+-- Scrubber claim loop (Task 11).
+CREATE INDEX IF NOT EXISTS idx_session_chunks_unscrubbed
+  ON session_chunks(uploaded_at)
+  WHERE scrubbed_at IS NULL;
+
+-- Idle-session close sweep (Task 12).
+CREATE INDEX IF NOT EXISTS idx_sessions_recording_last_chunk
+  ON sessions(last_chunk_at)
+  WHERE status = 'recording';
+
+-- Sessions-by-user browsing (Batch 2). Sessions-by-account rides this plus the
+-- existing idx_end_users_account via the end_users join -- there is no accounts
+-- table today (design v4-18 parks that decision for Batch 3).
+CREATE INDEX IF NOT EXISTS idx_sessions_end_user_started
+  ON sessions(end_user_id, started_at)
+  WHERE end_user_id IS NOT NULL;
+
+-- Sessions-by-time browsing (Batch 2) and the retention sweep scan (Task 12).
+CREATE INDEX IF NOT EXISTS idx_sessions_project_started
+  ON sessions(project_id, started_at);
+
+-- Retention sweep: find expiry candidates without scanning live recordings.
+CREATE INDEX IF NOT EXISTS idx_sessions_retention
+  ON sessions(started_at)
+  WHERE status <> 'recording';
+
+-- Revisit deleted-session prefixes forever. A storage POST accepted just
+-- before policy expiry may finish after the first retention pass.
+CREATE INDEX IF NOT EXISTS idx_session_tombstones_storage_sweep_order
+  ON session_tombstones((COALESCE(storage_swept_at, deleted_at)), storage_sweep_claimed_at);
+
+-- Per-project recording controls.
+-- recording_enabled is the runtime kill switch: /sessions/init returns
+-- {"recording": false} when it is off, and the chunk upload-url endpoint 403s,
+-- which stops sessions already in flight (see Correction 8).
+ALTER TABLE projects
+  ADD COLUMN IF NOT EXISTS recording_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE projects
+  ADD COLUMN IF NOT EXISTS session_retention_days INTEGER NOT NULL DEFAULT 30;

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -951,6 +951,23 @@ func (q *Queries) ReplayBelongsToProject(ctx context.Context, replayID, projectI
 	return exists, err
 }
 
+// FailReplay marks a pending replay terminally failed. Project-scoped.
+func (q *Queries) FailReplay(ctx context.Context, replayID, projectID, reason string) error {
+	tag, err := q.pool.Exec(ctx,
+		`UPDATE session_replays
+		    SET status = 'failed'
+		  WHERE id = $1 AND project_id = $2 AND status = 'pending'`,
+		replayID, projectID,
+	)
+	if err != nil {
+		return fmt.Errorf("fail replay: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		slog.Warn("fail replay matched no pending row", "replay_id", replayID, "reason", reason)
+	}
+	return nil
+}
+
 // CompleteReplay atomically inserts artifacts and updates replay status.
 // Amendment #11: wrapped in pgx transaction for atomicity.
 func (q *Queries) CompleteReplay(ctx context.Context, replayID string, signals string,

--- a/packages/ingestion/db/sessions.go
+++ b/packages/ingestion/db/sessions.go
@@ -1,0 +1,456 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// ErrChunkSeqTaken is returned when a (session, seq) pair is already reserved.
+// The SDK persists its seq counter, but a reload with a corrupted or reset
+// counter would otherwise silently overwrite an earlier chunk.
+var ErrChunkSeqTaken = errors.New("chunk seq already reserved for this session")
+
+// ErrSessionNotFound is returned when a session does not exist for the project.
+var ErrSessionNotFound = errors.New("session not found for project")
+
+// ErrSessionTombstoned prevents retention races from recreating deleted ids.
+var ErrSessionTombstoned = errors.New("session has been deleted")
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+// InsertSession registers a client-generated session. It is idempotent so a
+// retried init request neither errors nor resets session progress.
+func (q *Queries) InsertSession(ctx context.Context, sessionID, projectID, environmentID string, endUserID *string, startedAt time.Time, pageURL string) error {
+	tag, err := q.pool.Exec(ctx,
+		`INSERT INTO sessions (id, project_id, environment_id, end_user_id, started_at, page_url)
+		 SELECT $1, $2, $3, $4, $5, $6
+		 WHERE NOT EXISTS (SELECT 1 FROM session_tombstones WHERE session_id = $1)
+		 ON CONFLICT (id) DO NOTHING`,
+		sessionID, projectID, environmentID, endUserID, startedAt, pageURL,
+	)
+	if err != nil {
+		return fmt.Errorf("insert session: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		tombstoned, checkErr := q.SessionIsTombstoned(ctx, sessionID)
+		if checkErr != nil {
+			return checkErr
+		}
+		if tombstoned {
+			return ErrSessionTombstoned
+		}
+	}
+	return nil
+}
+
+// SessionBelongsToProject is the ownership gate for every session-scoped route.
+func (q *Queries) SessionBelongsToProject(ctx context.Context, sessionID, projectID string) (bool, error) {
+	var exists bool
+	err := q.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM sessions WHERE id = $1 AND project_id = $2 AND status <> 'deleting')`,
+		sessionID, projectID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("session ownership check: %w", err)
+	}
+	return exists, nil
+}
+
+// SessionIsTombstoned reports whether retention has deleted the session.
+func (q *Queries) SessionIsTombstoned(ctx context.Context, sessionID string) (bool, error) {
+	var exists bool
+	err := q.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM session_tombstones WHERE session_id = $1)`,
+		sessionID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("tombstone check: %w", err)
+	}
+	return exists, nil
+}
+
+// ReserveChunkSeq claims (session, seq) before a presigned URL is issued.
+// The row is a reservation until CommitChunk records its observed size.
+func (q *Queries) ReserveChunkSeq(ctx context.Context, sessionID, projectID string, seq int, objectKey string, hasFullSnapshot bool) error {
+	tag, err := q.pool.Exec(ctx,
+		`INSERT INTO session_chunks (session_id, seq, project_id, object_key, has_full_snapshot)
+		 SELECT $1, $2, $3, $4, $5
+		 WHERE EXISTS (SELECT 1 FROM sessions WHERE id = $1 AND project_id = $3 AND status <> 'deleting')`,
+		sessionID, seq, projectID, objectKey, hasFullSnapshot,
+	)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return ErrChunkSeqTaken
+		}
+		return fmt.Errorf("reserve chunk seq: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrSessionNotFound
+	}
+	return nil
+}
+
+// CommitChunk records that the object exists, with its server-observed size.
+// It is idempotent: retrying a committed chunk does not alter session rollups.
+// Deliberately does not set scrubbed_at; only the scrubber makes data readable.
+func (q *Queries) CommitChunk(ctx context.Context, sessionID, projectID string, seq int, sizeBytes int64) error {
+	tx, err := q.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin commit chunk: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	tag, err := tx.Exec(ctx,
+		`UPDATE session_chunks c
+		    SET size_bytes = $4, uploaded_at = now()
+		  FROM sessions s
+		 WHERE c.session_id = $1 AND c.seq = $2
+		   AND s.id = c.session_id AND s.project_id = $3 AND s.status <> 'deleting'
+		   AND c.uploaded_at IS NULL`,
+		sessionID, seq, projectID, sizeBytes,
+	)
+	if err != nil {
+		return fmt.Errorf("commit chunk: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		var alreadyCommitted bool
+		if qerr := tx.QueryRow(ctx,
+			`SELECT EXISTS(
+			   SELECT 1 FROM session_chunks c JOIN sessions s ON s.id = c.session_id
+			    WHERE c.session_id = $1 AND c.seq = $2 AND s.project_id = $3 AND s.status <> 'deleting'
+			      AND c.uploaded_at IS NOT NULL)`,
+			sessionID, seq, projectID,
+		).Scan(&alreadyCommitted); qerr != nil {
+			return fmt.Errorf("commit chunk recheck: %w", qerr)
+		}
+		if alreadyCommitted {
+			return tx.Commit(ctx)
+		}
+		return ErrSessionNotFound
+	}
+
+	_, err = tx.Exec(ctx,
+		`UPDATE sessions
+		    SET last_chunk_at  = now(),
+		        chunk_count    = chunk_count + 1,
+		        bytes_stored   = bytes_stored + $3,
+		        next_chunk_seq = GREATEST(next_chunk_seq, $2 + 1)
+		  WHERE id = $1 AND project_id = $4`,
+		sessionID, seq, sizeBytes, projectID,
+	)
+	if err != nil {
+		return fmt.Errorf("update session rollup: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}
+
+// ProjectRecordingEnabled reports the per-project recording kill switch.
+func (q *Queries) ProjectRecordingEnabled(ctx context.Context, projectID string) (bool, error) {
+	var enabled bool
+	err := q.pool.QueryRow(ctx,
+		`SELECT recording_enabled FROM projects WHERE id = $1`, projectID,
+	).Scan(&enabled)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read recording_enabled: %w", err)
+	}
+	return enabled, nil
+}
+
+// UpsertEndUser resolves a project-scoped external user id to an end_users row.
+func (q *Queries) UpsertEndUser(ctx context.Context, projectID, externalUserID, accountID, email, accountName string) (string, error) {
+	if externalUserID == "" {
+		return "", errors.New("external user id is required")
+	}
+	now := time.Now()
+	var id string
+	err := q.pool.QueryRow(ctx,
+		`INSERT INTO end_users (project_id, external_user_id, external_account_id, email, account_name, first_seen, last_seen)
+		 VALUES ($1, $2, $3, $4, $5, $6, $6)
+		 ON CONFLICT (project_id, external_user_id) DO UPDATE
+		   SET last_seen = $6,
+		       email = COALESCE(NULLIF($4, ''), end_users.email),
+		       external_account_id = COALESCE(NULLIF($3, ''), end_users.external_account_id),
+		       account_name = COALESCE(NULLIF($5, ''), end_users.account_name)
+		 RETURNING id`,
+		projectID, externalUserID, nilIfEmpty(accountID), nilIfEmpty(email), nilIfEmpty(accountName), now,
+	).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("upsert end user: %w", err)
+	}
+	return id, nil
+}
+
+// maxScrubAttempts bounds retries on a chunk that will not scrub. Past this it
+// remains permanently unreadable because scrubbed_at stays NULL.
+const maxScrubAttempts = 5
+
+// ChunkRef identifies a chunk awaiting scrubbing.
+type ChunkRef struct {
+	SessionID string
+	Seq       int
+	ProjectID string
+	ObjectKey string
+}
+
+// ClaimUnscrubbedChunks atomically claims up to limit uploaded chunks,
+// incrementing scrub_attempts so a poison chunk eventually gives up.
+func (q *Queries) ClaimUnscrubbedChunks(ctx context.Context, limit int) ([]ChunkRef, error) {
+	rows, err := q.pool.Query(ctx,
+		`UPDATE session_chunks
+		    SET scrub_attempts = scrub_attempts + 1, scrub_claimed_at = now()
+		  WHERE (session_id, seq) IN (
+		          SELECT c.session_id, c.seq FROM session_chunks c
+		          JOIN sessions s ON s.id = c.session_id
+		           WHERE c.scrubbed_at IS NULL
+		             AND c.uploaded_at IS NOT NULL
+		             AND c.uploaded_at <= now() - interval '30 seconds'
+		             AND (c.scrub_claimed_at IS NULL OR c.scrub_claimed_at < now() - interval '2 minutes')
+		             AND c.scrub_attempts < $2
+		             AND s.status <> 'deleting'
+		           ORDER BY c.uploaded_at ASC
+		           LIMIT $1
+		           FOR UPDATE SKIP LOCKED
+		        )
+		 RETURNING session_id, seq, project_id, object_key`,
+		limit, maxScrubAttempts,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("claim unscrubbed chunks: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ChunkRef
+	for rows.Next() {
+		var c ChunkRef
+		if err := rows.Scan(&c.SessionID, &c.Seq, &c.ProjectID, &c.ObjectKey); err != nil {
+			return nil, fmt.Errorf("scan chunk ref: %w", err)
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// MarkChunkScrubbed makes a chunk readable. Call it only after the redacted
+// bytes are durably stored.
+func (q *Queries) MarkChunkScrubbed(ctx context.Context, sessionID, projectID string, seq int) error {
+	_, err := q.pool.Exec(ctx,
+		`UPDATE session_chunks SET scrubbed_at = now(), scrub_error = NULL, scrub_claimed_at = NULL
+		  WHERE session_id = $1 AND seq = $2 AND project_id = $3`,
+		sessionID, seq, projectID,
+	)
+	if err != nil {
+		return fmt.Errorf("mark chunk scrubbed: %w", err)
+	}
+	return nil
+}
+
+// MarkChunkScrubFailed records why scrubbing failed while leaving the chunk
+// unreadable.
+func (q *Queries) MarkChunkScrubFailed(ctx context.Context, sessionID, projectID string, seq int, reason string) error {
+	if len(reason) > 500 {
+		reason = reason[:500]
+	}
+	_, err := q.pool.Exec(ctx,
+		`UPDATE session_chunks SET scrub_error = $4, scrub_claimed_at = NULL
+		  WHERE session_id = $1 AND seq = $2 AND project_id = $3`,
+		sessionID, seq, projectID, reason,
+	)
+	if err != nil {
+		return fmt.Errorf("mark chunk scrub failed: %w", err)
+	}
+	return nil
+}
+
+// hardCapDays is the ceiling on retention even for evidence-pinned sessions.
+const hardCapDays = 90
+
+// SessionRef identifies a session slated for deletion.
+type SessionRef struct {
+	ID        string
+	ProjectID string
+}
+
+// SessionsToDelete returns sessions past either their project retention window
+// when unpinned, or the absolute hard cap whether pinned or not.
+func (q *Queries) SessionsToDelete(ctx context.Context, limit int) ([]SessionRef, error) {
+	rows, err := q.pool.Query(ctx,
+		`SELECT s.id, s.project_id
+		   FROM sessions s
+		   JOIN projects p ON p.id = s.project_id
+		  WHERE s.status <> 'deleting'
+		    AND (s.started_at < now() - make_interval(days => $1)
+		     OR (
+		          s.started_at < now() - make_interval(days => p.session_retention_days)
+		          AND (s.retain_until IS NULL OR s.retain_until <= now())
+		        ))
+		  ORDER BY s.started_at ASC
+		  LIMIT $2`,
+		hardCapDays, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("select sessions to delete: %w", err)
+	}
+	defer rows.Close()
+
+	var out []SessionRef
+	for rows.Next() {
+		var s SessionRef
+		if err := rows.Scan(&s.ID, &s.ProjectID); err != nil {
+			return nil, fmt.Errorf("scan session ref: %w", err)
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// MarkSessionDeleting tombstones a session and blocks uploads/scrub claims.
+func (q *Queries) MarkSessionDeleting(ctx context.Context, sessionID, projectID string) error {
+	tx, err := q.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin mark session deleting: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO session_tombstones (session_id, project_id) VALUES ($1, $2)
+		 ON CONFLICT (session_id) DO NOTHING`,
+		sessionID, projectID,
+	); err != nil {
+		return fmt.Errorf("insert tombstone: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE sessions SET status = 'deleting', deletion_started_at = COALESCE(deletion_started_at, now())
+		  WHERE id = $1 AND project_id = $2`,
+		sessionID, projectID,
+	); err != nil {
+		return fmt.Errorf("mark session deleting: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+
+// SessionsReadyForPurge returns tombstoned sessions after all upload policies
+// and scrub leases issued before deletion have expired.
+func (q *Queries) SessionsReadyForPurge(ctx context.Context, grace time.Duration, limit int) ([]SessionRef, error) {
+	rows, err := q.pool.Query(ctx,
+		`SELECT id, project_id FROM sessions
+		  WHERE status = 'deleting' AND deletion_started_at <= now() - make_interval(secs => $1)
+		  ORDER BY deletion_started_at ASC LIMIT $2`, int(grace.Seconds()), limit)
+	if err != nil {
+		return nil, fmt.Errorf("select sessions ready for purge: %w", err)
+	}
+	defer rows.Close()
+	var out []SessionRef
+	for rows.Next() {
+		var ref SessionRef
+		if err := rows.Scan(&ref.ID, &ref.ProjectID); err != nil {
+			return nil, fmt.Errorf("scan purge session: %w", err)
+		}
+		out = append(out, ref)
+	}
+	return out, rows.Err()
+}
+
+// DeleteMarkedSession removes a session only after its objects are gone.
+func (q *Queries) DeleteMarkedSession(ctx context.Context, sessionID, projectID string) error {
+	_, err := q.pool.Exec(ctx,
+		`DELETE FROM sessions WHERE id = $1 AND project_id = $2 AND status = 'deleting'`,
+		sessionID, projectID)
+	if err != nil {
+		return fmt.Errorf("delete marked session: %w", err)
+	}
+	return nil
+}
+
+// ClaimTombstonesForStorageSweep rotates through deleted sessions so a late
+// object created after the first purge cannot remain orphaned forever. The
+// lease prevents every ingestion replica from re-sweeping the same prefixes.
+func (q *Queries) ClaimTombstonesForStorageSweep(ctx context.Context, limit int) ([]SessionRef, error) {
+	rows, err := q.pool.Query(ctx,
+		`UPDATE session_tombstones
+		    SET storage_sweep_claimed_at = now()
+		  WHERE session_id IN (
+		        SELECT t.session_id
+		          FROM session_tombstones t
+		          LEFT JOIN sessions s ON s.id = t.session_id
+		         WHERE s.id IS NULL
+		           AND (t.storage_sweep_claimed_at IS NULL
+		                OR t.storage_sweep_claimed_at < now() - interval '2 minutes')
+		         ORDER BY COALESCE(t.storage_swept_at, t.deleted_at) ASC
+		         LIMIT $1
+		         FOR UPDATE OF t SKIP LOCKED
+		       )
+		 RETURNING session_id, project_id`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("select tombstones for storage sweep: %w", err)
+	}
+	defer rows.Close()
+	var out []SessionRef
+	for rows.Next() {
+		var ref SessionRef
+		if err := rows.Scan(&ref.ID, &ref.ProjectID); err != nil {
+			return nil, fmt.Errorf("scan storage-sweep tombstone: %w", err)
+		}
+		out = append(out, ref)
+	}
+	return out, rows.Err()
+}
+
+func (q *Queries) MarkTombstoneStorageSwept(ctx context.Context, sessionID, projectID string) error {
+	_, err := q.pool.Exec(ctx,
+		`UPDATE session_tombstones
+		    SET storage_swept_at = now(), storage_sweep_claimed_at = NULL
+		  WHERE session_id = $1 AND project_id = $2`, sessionID, projectID)
+	if err != nil {
+		return fmt.Errorf("mark tombstone storage swept: %w", err)
+	}
+	return nil
+}
+
+func (q *Queries) ReleaseTombstoneStorageSweep(ctx context.Context, sessionID, projectID string) error {
+	_, err := q.pool.Exec(ctx,
+		`UPDATE session_tombstones SET storage_sweep_claimed_at = NULL
+		  WHERE session_id = $1 AND project_id = $2`, sessionID, projectID)
+	if err != nil {
+		return fmt.Errorf("release tombstone storage sweep: %w", err)
+	}
+	return nil
+}
+
+// ReleaseChunkReservation makes a failed inline attempt retryable.
+func (q *Queries) ReleaseChunkReservation(ctx context.Context, sessionID, projectID string, seq int) error {
+	_, err := q.pool.Exec(ctx,
+		`DELETE FROM session_chunks
+		  WHERE session_id = $1 AND project_id = $2 AND seq = $3 AND uploaded_at IS NULL`,
+		sessionID, projectID, seq)
+	if err != nil {
+		return fmt.Errorf("release chunk reservation: %w", err)
+	}
+	return nil
+}
+
+// CloseIdleSessions marks recording sessions with no recent chunk as closed.
+func (q *Queries) CloseIdleSessions(ctx context.Context, idleMinutes int) (int64, error) {
+	tag, err := q.pool.Exec(ctx,
+		`UPDATE sessions
+		    SET status = 'closed'
+		  WHERE status = 'recording'
+		    AND COALESCE(last_chunk_at, started_at) < now() - make_interval(mins => $1)`,
+		idleMinutes,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("close idle sessions: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}

--- a/packages/ingestion/db/sessions_index_test.go
+++ b/packages/ingestion/db/sessions_index_test.go
@@ -1,0 +1,155 @@
+package db_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// The retention sweep's indexes are partial. Postgres will only use a partial
+// index when the query's predicate *implies* the index's predicate, so an index
+// whose WHERE clause disagrees with its caller is not merely slow -- it is
+// unusable, and the planner silently falls back to scanning the whole table.
+// sessions grows one row per browser session under always-on recording, and the
+// sweep runs on every replica, so that fallback is not a rounding error.
+//
+// These tests probe usability rather than speed: with seq scans discouraged, a
+// usable index gets picked and an unusable one cannot be, no matter how much the
+// planner would like to. That makes the assertion deterministic and independent
+// of table size, unlike a timing or row-count threshold.
+//
+// A previous version of 002_sessions.sql indexed WHERE status <> 'recording'
+// while SessionsToDelete filtered status <> 'deleting'. These tests fail against
+// that schema.
+
+// explainWithoutSeqScan returns the query plan for sql with seq scans
+// discouraged. SET LOCAL keeps the setting scoped to a transaction that always
+// rolls back, so it cannot leak onto a pooled connection and skew other tests.
+func explainWithoutSeqScan(t *testing.T, pool *pgxpool.Pool, sql string, args ...any) string {
+	t.Helper()
+	ctx := context.Background()
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `SET LOCAL enable_seqscan = off`); err != nil {
+		t.Fatalf("disable seqscan: %v", err)
+	}
+
+	rows, err := tx.Query(ctx, "EXPLAIN "+sql, args...)
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer rows.Close()
+
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan plan: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("plan rows: %v", err)
+	}
+	return plan.String()
+}
+
+// seedSessionsForPlanner inserts enough rows that the planner makes a realistic
+// choice instead of trivially scanning a near-empty table.
+func seedSessionsForPlanner(t *testing.T, pool *pgxpool.Pool, projectID, envID string, n int) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO sessions (id, project_id, environment_id, started_at, status, deletion_started_at)
+		 SELECT $1 || g, $2, $3,
+		        now() - make_interval(mins => g),
+		        CASE WHEN g % 100 = 0 THEN 'deleting' ELSE 'closed' END,
+		        CASE WHEN g % 100 = 0 THEN now() - interval '10 minutes' ELSE NULL END
+		   FROM generate_series(1, $4) g`,
+		fmt.Sprintf("idxtest_%d_", n), projectID, envID, n)
+	if err != nil {
+		t.Fatalf("seed sessions: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `ANALYZE sessions`); err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+}
+
+// SessionsToDelete (db/sessions.go) must be servable by idx_sessions_retention_not_deleting.
+func TestSessionsToDelete_UsesRetentionIndex(t *testing.T) {
+	_, pool := sessionTestQueries(t)
+	projectID, envID := seedSessionProject(t, pool)
+	seedSessionsForPlanner(t, pool, projectID, envID, 5000)
+
+	// Verbatim from Queries.SessionsToDelete.
+	const sql = `SELECT s.id, s.project_id
+	   FROM sessions s
+	   JOIN projects p ON p.id = s.project_id
+	  WHERE s.status <> 'deleting'
+	    AND (s.started_at < now() - make_interval(days => $1)
+	     OR (
+	          s.started_at < now() - make_interval(days => p.session_retention_days)
+	          AND (s.retain_until IS NULL OR s.retain_until <= now())
+	        ))
+	  ORDER BY s.started_at ASC
+	  LIMIT $2`
+
+	plan := explainWithoutSeqScan(t, pool, sql, 90, 100)
+
+	if !strings.Contains(plan, "idx_sessions_retention_not_deleting") {
+		t.Fatalf("SessionsToDelete does not use idx_sessions_retention_not_deleting.\n"+
+			"The index predicate must imply the query predicate (status <> 'deleting').\nPlan:\n%s", plan)
+	}
+	if strings.Contains(plan, "Seq Scan on sessions") {
+		t.Fatalf("SessionsToDelete falls back to a sequential scan of sessions.\nPlan:\n%s", plan)
+	}
+}
+
+// SessionsReadyForPurge (db/sessions.go) orders by deletion_started_at and must
+// be servable by idx_sessions_purge rather than sorting the table.
+func TestSessionsReadyForPurge_UsesPurgeIndex(t *testing.T) {
+	_, pool := sessionTestQueries(t)
+	projectID, envID := seedSessionProject(t, pool)
+	seedSessionsForPlanner(t, pool, projectID, envID, 5000)
+
+	// Verbatim from Queries.SessionsReadyForPurge.
+	const sql = `SELECT id, project_id FROM sessions
+		  WHERE status = 'deleting' AND deletion_started_at <= now() - make_interval(secs => $1)
+		  ORDER BY deletion_started_at ASC LIMIT $2`
+
+	plan := explainWithoutSeqScan(t, pool, sql, 60, 100)
+
+	if !strings.Contains(plan, "idx_sessions_purge") {
+		t.Fatalf("SessionsReadyForPurge does not use idx_sessions_purge -- "+
+			"deletion_started_at is unindexed, so every pass sorts the table.\nPlan:\n%s", plan)
+	}
+}
+
+// The old predicate-mismatched index must not survive a migration re-run.
+func TestRetentionIndex_OldMismatchedIndexIsGone(t *testing.T) {
+	_, pool := sessionTestQueries(t)
+	ctx := context.Background()
+
+	var exists bool
+	err := pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM pg_indexes
+		                WHERE tablename = 'sessions' AND indexname = 'idx_sessions_retention')`,
+	).Scan(&exists)
+	if err != nil && err != pgx.ErrNoRows {
+		t.Fatalf("check old index: %v", err)
+	}
+	if exists {
+		t.Fatal("idx_sessions_retention (predicate: status <> 'recording') still exists; " +
+			"002_sessions.sql should have dropped it in favour of idx_sessions_retention_not_deleting")
+	}
+}

--- a/packages/ingestion/db/sessions_test.go
+++ b/packages/ingestion/db/sessions_test.go
@@ -1,0 +1,399 @@
+package db_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/opslane/opslane/packages/ingestion/db"
+)
+
+func sessionTestQueries(t *testing.T) (*db.Queries, *pgxpool.Pool) {
+	t.Helper()
+	pool := testPool(t)
+	return db.New(pool), pool
+}
+
+func seedSessionProject(t *testing.T, pool *pgxpool.Pool) (projectID, envID string) {
+	t.Helper()
+	ctx := context.Background()
+	name := fmt.Sprintf("t-%s-%d", t.Name(), time.Now().UnixNano())
+
+	var orgID string
+	if err := pool.QueryRow(ctx, `INSERT INTO orgs (name) VALUES ($1) RETURNING id`, name).Scan(&orgID); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO projects (org_id, name) VALUES ($1, $2) RETURNING id`, orgID, name,
+	).Scan(&projectID); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO environments (project_id, name) VALUES ($1, 'production') RETURNING id`, projectID,
+	).Scan(&envID); err != nil {
+		t.Fatalf("seed environment: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM session_tombstones WHERE project_id = $1`, projectID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM sessions WHERE project_id = $1`, projectID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM end_users WHERE project_id = $1`, projectID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM environments WHERE project_id = $1`, projectID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM projects WHERE id = $1`, projectID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM orgs WHERE id = $1`, orgID)
+	})
+	return projectID, envID
+}
+
+func newSessionID(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("sess_%d", time.Now().UnixNano())
+}
+
+func TestInsertSession_AndScopedLookup(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	otherProjectID, _ := seedSessionProject(t, pool)
+	sid := newSessionID(t)
+
+	if err := q.InsertSession(ctx, sid, projectID, envID, nil, time.Now(), "https://app.example.com/x"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	ok, err := q.SessionBelongsToProject(ctx, sid, projectID)
+	if err != nil || !ok {
+		t.Fatalf("SessionBelongsToProject(owner) = %v, %v; want true, nil", ok, err)
+	}
+	ok, err = q.SessionBelongsToProject(ctx, sid, otherProjectID)
+	if err != nil || ok {
+		t.Fatalf("cross-tenant lookup = %v, %v; want false, nil", ok, err)
+	}
+}
+
+func TestInsertSession_IsIdempotent(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	projectID, envID := seedSessionProject(t, pool)
+	sid := newSessionID(t)
+	start := time.Now()
+	for i := 0; i < 2; i++ {
+		if err := q.InsertSession(context.Background(), sid, projectID, envID, nil, start, "https://a"); err != nil {
+			t.Fatalf("insert %d: %v", i+1, err)
+		}
+	}
+}
+
+func TestReserveChunkSeq_RejectsDuplicateSeq(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	sid := newSessionID(t)
+	if err := q.InsertSession(ctx, sid, projectID, envID, nil, time.Now(), "https://a"); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if err := q.ReserveChunkSeq(ctx, sid, projectID, 0, "sessions/p/s/chunk-000000.json.gz", true); err != nil {
+		t.Fatalf("first reserve: %v", err)
+	}
+	if err := q.ReserveChunkSeq(ctx, sid, projectID, 0, "sessions/p/s/chunk-000000.json.gz", true); err != db.ErrChunkSeqTaken {
+		t.Fatalf("duplicate seq returned %v, want ErrChunkSeqTaken", err)
+	}
+}
+
+func TestCommitChunk_SetsSizeAndUpdatesSession(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	sid := newSessionID(t)
+	if err := q.InsertSession(ctx, sid, projectID, envID, nil, time.Now(), "https://a"); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if err := q.ReserveChunkSeq(ctx, sid, projectID, 0, "k0", true); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if err := q.CommitChunk(ctx, sid, projectID, 0, 4096); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var size int64
+	var uploadedAt, scrubbedAt *time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT size_bytes, uploaded_at, scrubbed_at FROM session_chunks WHERE session_id=$1 AND seq=0`, sid,
+	).Scan(&size, &uploadedAt, &scrubbedAt); err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	if size != 4096 || uploadedAt == nil || scrubbedAt != nil {
+		t.Fatalf("chunk = size %d, uploaded %v, scrubbed %v; want 4096, non-nil, nil", size, uploadedAt, scrubbedAt)
+	}
+
+	var chunkCount int
+	var bytesStored int64
+	var lastChunkAt *time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT chunk_count, bytes_stored, last_chunk_at FROM sessions WHERE id=$1`, sid,
+	).Scan(&chunkCount, &bytesStored, &lastChunkAt); err != nil {
+		t.Fatalf("read session: %v", err)
+	}
+	if chunkCount != 1 || bytesStored != 4096 || lastChunkAt == nil {
+		t.Fatalf("session rollup = count %d, bytes %d, last %v", chunkCount, bytesStored, lastChunkAt)
+	}
+}
+
+func TestCommitChunk_IsTenantScoped(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	otherProjectID, _ := seedSessionProject(t, pool)
+	sid := newSessionID(t)
+	if err := q.InsertSession(ctx, sid, projectID, envID, nil, time.Now(), "https://a"); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if err := q.ReserveChunkSeq(ctx, sid, projectID, 0, "k0", true); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if err := q.CommitChunk(ctx, sid, otherProjectID, 0, 4096); err == nil {
+		t.Fatal("commit succeeded for a different project")
+	}
+}
+
+func TestTombstone_BlocksSessionReuse(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	sid := newSessionID(t)
+	if tombstoned, err := q.SessionIsTombstoned(ctx, sid); err != nil || tombstoned {
+		t.Fatalf("fresh tombstone lookup = %v, %v", tombstoned, err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO session_tombstones (session_id, project_id) VALUES ($1, $2)`, sid, projectID,
+	); err != nil {
+		t.Fatalf("seed tombstone: %v", err)
+	}
+	if tombstoned, err := q.SessionIsTombstoned(ctx, sid); err != nil || !tombstoned {
+		t.Fatalf("tombstoned lookup = %v, %v", tombstoned, err)
+	}
+	if err := q.InsertSession(ctx, sid, projectID, envID, nil, time.Now(), "https://a"); !errors.Is(err, db.ErrSessionTombstoned) {
+		t.Fatalf("insert tombstoned session returned %v, want ErrSessionTombstoned", err)
+	}
+}
+
+func TestProjectRecordingEnabled_KillSwitch(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, _ := seedSessionProject(t, pool)
+	if on, err := q.ProjectRecordingEnabled(ctx, projectID); err != nil || !on {
+		t.Fatalf("default recording_enabled = %v, %v", on, err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE projects SET recording_enabled = FALSE WHERE id = $1`, projectID); err != nil {
+		t.Fatalf("flip switch: %v", err)
+	}
+	if on, err := q.ProjectRecordingEnabled(ctx, projectID); err != nil || on {
+		t.Fatalf("disabled recording_enabled = %v, %v", on, err)
+	}
+}
+
+func TestUpsertEndUser_IsStableAcrossCalls(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	projectID, _ := seedSessionProject(t, pool)
+	id1, err := q.UpsertEndUser(context.Background(), projectID, "user-42", "acct-1", "a@example.com", "Acme")
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	id2, err := q.UpsertEndUser(context.Background(), projectID, "user-42", "", "", "")
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if id1 != id2 {
+		t.Fatalf("upsert minted a second row (%s vs %s)", id1, id2)
+	}
+}
+
+func TestClaimUnscrubbedChunks_OnlyReturnsUploadedAndUnscrubbed(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	sid := newSessionID(t)
+	if err := q.InsertSession(ctx, sid, projectID, envID, nil, time.Now(), "https://a"); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if err := q.ReserveChunkSeq(ctx, sid, projectID, 0, "k0", true); err != nil {
+		t.Fatalf("reserve 0: %v", err)
+	}
+	if err := q.ReserveChunkSeq(ctx, sid, projectID, 1, "k1", true); err != nil {
+		t.Fatalf("reserve 1: %v", err)
+	}
+	if err := q.CommitChunk(ctx, sid, projectID, 1, 100); err != nil {
+		t.Fatalf("commit 1: %v", err)
+	}
+	if err := q.ReserveChunkSeq(ctx, sid, projectID, 2, "k2", true); err != nil {
+		t.Fatalf("reserve 2: %v", err)
+	}
+	if err := q.CommitChunk(ctx, sid, projectID, 2, 100); err != nil {
+		t.Fatalf("commit 2: %v", err)
+	}
+	// Put this test's rows first even when a developer database contains chunks
+	// left by other integration packages.
+	if _, err := pool.Exec(ctx,
+		`UPDATE session_chunks SET uploaded_at = '1900-01-01'::timestamptz
+		  WHERE session_id = $1 AND uploaded_at IS NOT NULL`, sid,
+	); err != nil {
+		t.Fatalf("age test chunks: %v", err)
+	}
+	if err := q.MarkChunkScrubbed(ctx, sid, projectID, 2); err != nil {
+		t.Fatalf("mark scrubbed: %v", err)
+	}
+
+	claimed, err := q.ClaimUnscrubbedChunks(ctx, 10000)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	var seqs []int
+	for _, chunk := range claimed {
+		if chunk.SessionID == sid {
+			seqs = append(seqs, chunk.Seq)
+		}
+	}
+	if len(seqs) != 1 || seqs[0] != 1 {
+		t.Fatalf("claimed seqs %v, want exactly [1]", seqs)
+	}
+}
+
+func TestClaimUnscrubbedChunks_GivesUpAfterMaxAttempts(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	sid := newSessionID(t)
+	if err := q.InsertSession(ctx, sid, projectID, envID, nil, time.Now(), "https://a"); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if err := q.ReserveChunkSeq(ctx, sid, projectID, 0, "k0", true); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if err := q.CommitChunk(ctx, sid, projectID, 0, 100); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE session_chunks SET uploaded_at = '1900-01-01'::timestamptz WHERE session_id = $1`, sid,
+	); err != nil {
+		t.Fatalf("age test chunk: %v", err)
+	}
+
+	for i := 0; i < 10; i++ {
+		claimed, err := q.ClaimUnscrubbedChunks(ctx, 10000)
+		if err != nil {
+			t.Fatalf("claim %d: %v", i, err)
+		}
+		for _, chunk := range claimed {
+			if chunk.SessionID == sid {
+				if err := q.MarkChunkScrubFailed(ctx, sid, projectID, 0, "test failure"); err != nil {
+					t.Fatalf("release claim %d: %v", i, err)
+				}
+			}
+		}
+	}
+	claimed, err := q.ClaimUnscrubbedChunks(ctx, 10000)
+	if err != nil {
+		t.Fatalf("final claim: %v", err)
+	}
+	for _, chunk := range claimed {
+		if chunk.SessionID == sid {
+			t.Fatal("chunk still claimed after exceeding max attempts")
+		}
+	}
+
+	var scrubbedAt *time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT scrubbed_at FROM session_chunks WHERE session_id=$1 AND seq=0`, sid,
+	).Scan(&scrubbedAt); err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	if scrubbedAt != nil {
+		t.Fatal("a chunk that never scrubbed is marked scrubbed")
+	}
+}
+
+func TestClaimUnscrubbedChunks_DoesNotReclaimAnActiveLease(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	sid := newSessionID(t)
+	if err := q.InsertSession(ctx, sid, projectID, envID, nil, time.Now(), "https://a"); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if err := q.ReserveChunkSeq(ctx, sid, projectID, 0, "lease-k0", true); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if err := q.CommitChunk(ctx, sid, projectID, 0, 100); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE session_chunks SET uploaded_at = '1900-01-01'::timestamptz WHERE session_id = $1`, sid,
+	); err != nil {
+		t.Fatalf("age chunk: %v", err)
+	}
+
+	first, err := q.ClaimUnscrubbedChunks(ctx, 10000)
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	found := false
+	for _, chunk := range first {
+		if chunk.SessionID == sid {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("first claim did not return test chunk")
+	}
+
+	second, err := q.ClaimUnscrubbedChunks(ctx, 10000)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	for _, chunk := range second {
+		if chunk.SessionID == sid {
+			t.Fatal("active scrub lease was claimed concurrently")
+		}
+	}
+}
+
+func TestClaimTombstonesForStorageSweep_DoesNotDuplicateAcrossReplicas(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	sid := newSessionID(t)
+	if err := q.InsertSession(ctx, sid, projectID, envID, nil, time.Now(), "https://a"); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if err := q.MarkSessionDeleting(ctx, sid, projectID); err != nil {
+		t.Fatalf("mark deleting: %v", err)
+	}
+	if err := q.DeleteMarkedSession(ctx, sid, projectID); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+
+	first, err := q.ClaimTombstonesForStorageSweep(ctx, 10000)
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	found := false
+	for _, tombstone := range first {
+		if tombstone.ID == sid {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("first claim did not return test tombstone")
+	}
+
+	second, err := q.ClaimTombstonesForStorageSweep(ctx, 10000)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	for _, tombstone := range second {
+		if tombstone.ID == sid {
+			t.Fatal("active tombstone sweep lease was claimed concurrently")
+		}
+	}
+}

--- a/packages/ingestion/handler/auth.go
+++ b/packages/ingestion/handler/auth.go
@@ -143,3 +143,9 @@ func writeJSONError(w http.ResponseWriter, status int, message string) {
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(map[string]string{"error": message})
 }
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/packages/ingestion/handler/auth_handlers.go
+++ b/packages/ingestion/handler/auth_handlers.go
@@ -59,6 +59,65 @@ func (rl *rateLimiter) allow(ip string) bool {
 	return rl.counts[ip] <= rl.maxPerIP
 }
 
+// byteBudget caps aggregate uploaded bytes per key in a fixed one-minute window.
+//
+// The request-count rateLimiter above bounds how *often* a project may call in;
+// this bounds how *much* it may store. Both are needed: the SDK key is public,
+// so without a byte budget a single attacker under the request limit can still
+// flood storage with large objects (#48).
+//
+// Same limitations as rateLimiter, deliberately: in-memory and per-process, so
+// N ingestion replicas allow N times the budget. Accepted for now — see the
+// note on rateLimiter.
+type byteBudget struct {
+	mu         sync.Mutex
+	used       map[string]int64
+	resetAt    time.Time
+	maxPerKey  int64
+	maxEntries int
+}
+
+func newByteBudget(maxPerKey int64) *byteBudget {
+	return &byteBudget{
+		used:       make(map[string]int64),
+		resetAt:    time.Now().Add(time.Minute),
+		maxPerKey:  maxPerKey,
+		maxEntries: 10000,
+	}
+}
+
+// allow reserves n bytes for key, reporting whether the reservation fit.
+// A rejected reservation consumes nothing.
+func (b *byteBudget) allow(key string, n int64) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := time.Now()
+	if now.After(b.resetAt) {
+		b.used = make(map[string]int64)
+		b.resetAt = now.Add(time.Minute)
+	}
+	if len(b.used) >= b.maxEntries {
+		if _, known := b.used[key]; !known {
+			b.used = make(map[string]int64)
+			b.resetAt = now.Add(time.Minute)
+		}
+	}
+
+	if b.used[key]+n > b.maxPerKey {
+		return false
+	}
+	b.used[key] += n
+	return true
+}
+
+// forceRollover expires the current window. Test hook.
+func (b *byteBudget) forceRollover() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.resetAt = time.Now().Add(-time.Second)
+}
+
 // loginLimiter is shared across login and OAuth authorize endpoints.
 var loginLimiter = newRateLimiter(10)
 

--- a/packages/ingestion/handler/byte_budget_test.go
+++ b/packages/ingestion/handler/byte_budget_test.go
@@ -1,0 +1,72 @@
+package handler
+
+import "testing"
+
+func TestByteBudget_AllowsUpToLimit(t *testing.T) {
+	b := newByteBudget(1000)
+	if !b.allow("proj-1", 600) {
+		t.Fatal("first 600 bytes rejected, want allowed")
+	}
+	if !b.allow("proj-1", 400) {
+		t.Fatal("second 400 bytes rejected, want allowed (total exactly at limit)")
+	}
+}
+
+func TestByteBudget_RejectsOverLimit(t *testing.T) {
+	b := newByteBudget(1000)
+	if !b.allow("proj-1", 900) {
+		t.Fatal("900 bytes rejected, want allowed")
+	}
+	if b.allow("proj-1", 200) {
+		t.Fatal("200 bytes allowed after 900 of a 1000 budget, want rejected")
+	}
+}
+
+// A rejected reservation must not consume budget, or one oversized request
+// starves everything behind it.
+func TestByteBudget_RejectedReservationDoesNotConsume(t *testing.T) {
+	b := newByteBudget(1000)
+	if b.allow("proj-1", 5000) {
+		t.Fatal("5000 bytes allowed against a 1000 budget, want rejected")
+	}
+	if !b.allow("proj-1", 900) {
+		t.Fatal("900 bytes rejected after a failed oversize reservation; the reject consumed budget")
+	}
+}
+
+func TestByteBudget_IsPerProject(t *testing.T) {
+	b := newByteBudget(1000)
+	if !b.allow("proj-1", 1000) {
+		t.Fatal("proj-1 full budget rejected")
+	}
+	if !b.allow("proj-2", 1000) {
+		t.Fatal("proj-2 rejected; budgets are leaking across projects")
+	}
+}
+
+func TestByteBudget_ResetsOnWindowRollover(t *testing.T) {
+	b := newByteBudget(1000)
+	if !b.allow("proj-1", 1000) {
+		t.Fatal("full budget rejected")
+	}
+	if b.allow("proj-1", 1) {
+		t.Fatal("1 byte allowed over budget, want rejected")
+	}
+	b.forceRollover()
+	if !b.allow("proj-1", 1000) {
+		t.Fatal("budget not reset after window rollover")
+	}
+}
+
+// Mirrors rateLimiter's 10k-entry DDoS guard: an attacker rotating project keys
+// must not grow the map without bound.
+func TestByteBudget_EvictsWhenMapGrowsUnbounded(t *testing.T) {
+	b := newByteBudget(1000)
+	b.maxEntries = 3
+	for _, p := range []string{"a", "b", "c", "d"} {
+		b.allow(p, 10)
+	}
+	if len(b.used) > 3 {
+		t.Fatalf("map holds %d entries, want <= 3", len(b.used))
+	}
+}

--- a/packages/ingestion/handler/cors_test.go
+++ b/packages/ingestion/handler/cors_test.go
@@ -27,6 +27,25 @@ func TestCORS_SDKEndpointReflectsOrigin(t *testing.T) {
 	}
 }
 
+func TestCORS_SessionEndpointReflectsOrigin(t *testing.T) {
+	deps := &handler.Dependencies{}
+	router := handler.NewRouter(deps)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodOptions, srv.URL+"/api/v1/sessions/init", nil)
+	req.Header.Set("Origin", "https://customer.example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://customer.example.com" {
+		t.Fatalf("expected reflected origin, got %q", got)
+	}
+}
+
 func TestCORS_DashboardEndpointRestricted(t *testing.T) {
 	deps := &handler.Dependencies{}
 	router := handler.NewRouter(deps)

--- a/packages/ingestion/handler/ingest_limits.go
+++ b/packages/ingestion/handler/ingest_limits.go
@@ -14,6 +14,18 @@ var (
 	eventsLimiter     = newRateLimiter(600) // ~10 errors/sec sustained
 	replaysLimiter    = newRateLimiter(120)
 	sourcemapsLimiter = newRateLimiter(20)
+
+	// Always-on recording: every session uploads a chunk every ~30s, and each
+	// chunk costs 2 ingestion requests (upload-url + commit). The 120/min
+	// replays budget is a whole-project budget and would cap a project at ~30
+	// concurrent sessions. 6000/min supports ~1500 concurrent sessions per
+	// replica; the byte budget below is the real ceiling.
+	chunksLimiter = newRateLimiter(6000)
+
+	// 512 MB/min/project of compressed chunks. A 30s chunk gzips to roughly
+	// 200-800KB, so this is ~1000 concurrent sessions before shedding — far
+	// above real load, but a hard stop on a storage flood (#48).
+	chunkBytesBudget = newByteBudget(512 << 20)
 )
 
 // rateLimitByProject returns middleware that rate-limits by project_id set by

--- a/packages/ingestion/handler/replay.go
+++ b/packages/ingestion/handler/replay.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -13,6 +15,42 @@ import (
 	"github.com/opslane/opslane/packages/ingestion/db"
 	"github.com/opslane/opslane/packages/ingestion/masking"
 )
+
+type replayFailRequest struct {
+	Reason string `json:"reason"`
+}
+
+// ReplayFail records that the browser could not upload a replay.
+// POST /api/v1/replays/{replayID}/fail
+func (d *Dependencies) ReplayFail(w http.ResponseWriter, r *http.Request) {
+	projectID := ProjectIDFromCtx(r.Context())
+	if projectID == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing project context")
+		return
+	}
+	replayID := chi.URLParam(r, "replayID")
+	if replayID == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing replay id")
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 4<<10))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+	var req replayFailRequest
+	_ = json.Unmarshal(body, &req)
+	if len(req.Reason) > 500 {
+		req.Reason = req.Reason[:500]
+	}
+	if err := d.Queries.FailReplay(r.Context(), replayID, projectID, req.Reason); err != nil {
+		slog.Error("fail replay", "error", err, "replay_id", replayID)
+		writeJSONError(w, http.StatusInternalServerError, "failed to record replay failure")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "failed"})
+}
 
 const maxReplayBytes = 8 << 20 // 8 MiB hard cap on recording.json reads
 

--- a/packages/ingestion/handler/replay_fail_integration_test.go
+++ b/packages/ingestion/handler/replay_fail_integration_test.go
@@ -1,0 +1,41 @@
+package handler_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/opslane/opslane/packages/ingestion/handler"
+)
+
+func TestReplayFail_MarksPendingReplayFailed(t *testing.T) {
+	deps, pool := testDeps(t)
+	_, projectID, _, apiKey := seedTenant(t, deps.Queries)
+	replayID := uuid.NewString()
+	if err := deps.Queries.InsertReplay(context.Background(), replayID, projectID, nil, nil,
+		"sess_replay_fail", "error", "", "", "", "replays/test/recording.json"); err != nil {
+		t.Fatalf("insert replay: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/replays/"+replayID+"/fail",
+		strings.NewReader(`{"reason":"storage upload failed"}`))
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	handler.NewRouterWithPool(deps, pool).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("replay fail returned %d: %s", w.Code, w.Body.String())
+	}
+
+	var status string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT status FROM session_replays WHERE id=$1 AND project_id=$2`, replayID, projectID,
+	).Scan(&status); err != nil {
+		t.Fatalf("read replay: %v", err)
+	}
+	if status != "failed" {
+		t.Fatalf("replay status = %q, want failed", status)
+	}
+}

--- a/packages/ingestion/handler/replay_test.go
+++ b/packages/ingestion/handler/replay_test.go
@@ -162,3 +162,16 @@ func TestReplayComplete_MissingReplayIDFromEmptyParam(t *testing.T) {
 		t.Errorf("expected 400 for missing replay ID (no chi context), got %d", w.Code)
 	}
 }
+
+func TestReplayFail_MissingProjectContextReturns401(t *testing.T) {
+	deps := &Dependencies{}
+	req := httptest.NewRequest("POST", "/api/v1/replays/r-123/fail", strings.NewReader(`{"reason":"upload failed"}`))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("replayID", "r-123")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	deps.ReplayFail(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d, want 401 without project context", w.Code)
+	}
+}

--- a/packages/ingestion/handler/routes.go
+++ b/packages/ingestion/handler/routes.go
@@ -66,6 +66,11 @@ func NewRouterWithPool(deps *Dependencies, pool *pgxpool.Pool) *chi.Mux {
 		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(eventsLimiter)).Post("/events", deps.IngestEvent)
 		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(replaysLimiter)).Post("/replays/init", deps.ReplayInit)
 		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(replaysLimiter)).Post("/replays/{replayID}/complete", deps.ReplayComplete)
+		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(replaysLimiter)).Post("/replays/{replayID}/fail", deps.ReplayFail)
+		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(chunksLimiter)).Post("/sessions/init", deps.SessionInit)
+		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(chunksLimiter)).Post("/sessions/{sessionID}/chunks/upload-url", deps.ChunkUploadURL)
+		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(chunksLimiter)).Post("/sessions/{sessionID}/chunks/{seq}/commit", deps.ChunkCommit)
+		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(chunksLimiter)).Post("/sessions/{sessionID}/chunks/{seq}/inline", deps.ChunkInline)
 		r.With(deps.AuthenticateSDK, rateLimitByProject(sourcemapsLimiter)).Post("/sourcemaps", deps.UploadSourceMap)
 
 		// Session-authenticated endpoints (dashboard + CLI)
@@ -203,5 +208,6 @@ func corsMiddleware() func(http.Handler) http.Handler {
 func isSDKEndpoint(path string) bool {
 	return strings.HasPrefix(path, "/api/v1/events") ||
 		strings.HasPrefix(path, "/api/v1/replays") ||
+		strings.HasPrefix(path, "/api/v1/sessions") ||
 		strings.HasPrefix(path, "/api/v1/sourcemaps")
 }

--- a/packages/ingestion/handler/session.go
+++ b/packages/ingestion/handler/session.go
@@ -1,0 +1,394 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/opslane/opslane/packages/ingestion/db"
+	"github.com/opslane/opslane/packages/ingestion/masking"
+)
+
+const (
+	defaultChunkIntervalMs = 30_000
+	maxChunkBytes          = 5 << 20
+	maxInlineChunkBytes    = 64 << 10
+	// Scrubbing waits this out because POST policies are replayable until expiry.
+	chunkUploadPolicyTTL = 30 * time.Second
+)
+
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{8,128}$`)
+
+func validSessionID(id string) bool {
+	return sessionIDPattern.MatchString(id)
+}
+
+type sessionInitRequest struct {
+	SessionID string `json:"session_id"`
+	StartedAt string `json:"started_at"`
+	PageURL   string `json:"page_url"`
+	User      *struct {
+		ID          string `json:"id"`
+		Email       string `json:"email"`
+		AccountID   string `json:"account_id"`
+		AccountName string `json:"account_name"`
+	} `json:"user"`
+}
+
+type sessionInitResponse struct {
+	Recording       bool  `json:"recording"`
+	ChunkIntervalMs int   `json:"chunk_interval_ms"`
+	MaxChunkBytes   int64 `json:"max_chunk_bytes"`
+}
+
+// SessionInit registers a client-generated session and carries the recording
+// kill switch. POST /api/v1/sessions/init
+func (d *Dependencies) SessionInit(w http.ResponseWriter, r *http.Request) {
+	projectID := ProjectIDFromCtx(r.Context())
+	if projectID == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing project context")
+		return
+	}
+	if d.MinIO == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "object storage not configured")
+		return
+	}
+	environmentID := EnvironmentIDFromCtx(r.Context())
+	if environmentID == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing project context")
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 64<<10))
+	if err != nil {
+		if err.Error() == "http: request body too large" {
+			writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		writeJSONError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+
+	var req sessionInitRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if !validSessionID(req.SessionID) {
+		writeJSONError(w, http.StatusBadRequest, "invalid session_id")
+		return
+	}
+
+	tombstoned, err := d.Queries.SessionIsTombstoned(r.Context(), req.SessionID)
+	if err != nil {
+		slog.Error("tombstone check failed", "error", err, "session_id", req.SessionID)
+		writeJSONError(w, http.StatusInternalServerError, "failed to register session")
+		return
+	}
+	if tombstoned {
+		writeJSONError(w, http.StatusGone, "session has been deleted")
+		return
+	}
+
+	enabled, err := d.Queries.ProjectRecordingEnabled(r.Context(), projectID)
+	if err != nil {
+		slog.Error("recording flag lookup failed", "error", err, "project_id", projectID)
+		writeJSONError(w, http.StatusInternalServerError, "failed to register session")
+		return
+	}
+	if !enabled {
+		writeJSON(w, http.StatusOK, sessionInitResponse{Recording: false})
+		return
+	}
+
+	startedAt := time.Now()
+	if req.StartedAt != "" {
+		if parsed, parseErr := time.Parse(time.RFC3339, req.StartedAt); parseErr == nil && parsed.Before(startedAt) {
+			startedAt = parsed
+		}
+	}
+
+	var endUserID *string
+	if req.User != nil && req.User.ID != "" {
+		id, upsertErr := d.Queries.UpsertEndUser(r.Context(), projectID, req.User.ID,
+			req.User.AccountID, req.User.Email, req.User.AccountName)
+		if upsertErr != nil {
+			slog.Warn("end user upsert failed", "error", upsertErr, "project_id", projectID)
+		} else {
+			endUserID = &id
+		}
+	}
+
+	if err := d.Queries.InsertSession(r.Context(), req.SessionID, projectID, environmentID,
+		endUserID, startedAt, masking.RedactURL(req.PageURL)); err != nil {
+		if errors.Is(err, db.ErrSessionTombstoned) {
+			writeJSONError(w, http.StatusGone, "session has been deleted")
+			return
+		}
+		slog.Error("insert session failed", "error", err, "session_id", req.SessionID)
+		writeJSONError(w, http.StatusInternalServerError, "failed to register session")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, sessionInitResponse{
+		Recording:       true,
+		ChunkIntervalMs: defaultChunkIntervalMs,
+		MaxChunkBytes:   maxChunkBytes,
+	})
+}
+
+func chunkObjectKey(projectID, sessionID string, seq int) string {
+	return fmt.Sprintf("sessions/%s/%s/chunk-%06d.json.gz", projectID, sessionID, seq)
+}
+
+type chunkUploadURLRequest struct {
+	Seq             int   `json:"seq"`
+	SizeBytes       int64 `json:"size_bytes"`
+	HasFullSnapshot bool  `json:"has_full_snapshot"`
+}
+
+type chunkUploadURLResponse struct {
+	UploadURL string            `json:"upload_url"`
+	FormData  map[string]string `json:"form_data"`
+	ObjectKey string            `json:"object_key"`
+}
+
+// ChunkUploadURL reserves a sequence and issues an exactly size-capped POST
+// policy. POST /api/v1/sessions/{sessionID}/chunks/upload-url
+func (d *Dependencies) ChunkUploadURL(w http.ResponseWriter, r *http.Request) {
+	projectID := ProjectIDFromCtx(r.Context())
+	if projectID == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing project context")
+		return
+	}
+	if d.MinIO == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "object storage not configured")
+		return
+	}
+
+	sessionID := chi.URLParam(r, "sessionID")
+	if !validSessionID(sessionID) {
+		writeJSONError(w, http.StatusBadRequest, "invalid session_id")
+		return
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 4<<10))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+	var req chunkUploadURLRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if req.Seq < 0 {
+		writeJSONError(w, http.StatusBadRequest, "seq must be non-negative")
+		return
+	}
+	if req.SizeBytes <= 0 {
+		writeJSONError(w, http.StatusBadRequest, "size_bytes must be positive")
+		return
+	}
+	if req.SizeBytes > maxChunkBytes {
+		writeJSONError(w, http.StatusRequestEntityTooLarge, "chunk exceeds maximum size")
+		return
+	}
+
+	enabled, err := d.Queries.ProjectRecordingEnabled(r.Context(), projectID)
+	if err != nil {
+		slog.Error("recording flag lookup failed", "error", err, "project_id", projectID)
+		writeJSONError(w, http.StatusInternalServerError, "failed to issue upload url")
+		return
+	}
+	if !enabled {
+		writeJSONError(w, http.StatusForbidden, "recording disabled for this project")
+		return
+	}
+	owned, err := d.Queries.SessionBelongsToProject(r.Context(), sessionID, projectID)
+	if err != nil {
+		slog.Error("session ownership check failed", "error", err, "session_id", sessionID)
+		writeJSONError(w, http.StatusInternalServerError, "failed to issue upload url")
+		return
+	}
+	if !owned {
+		writeJSONError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	objectKey := chunkObjectKey(projectID, sessionID, req.Seq)
+	if err := d.Queries.ReserveChunkSeq(r.Context(), sessionID, projectID, req.Seq, objectKey, req.HasFullSnapshot); err != nil {
+		if errors.Is(err, db.ErrChunkSeqTaken) {
+			writeJSONError(w, http.StatusConflict, "chunk seq already used")
+			return
+		}
+		slog.Error("reserve chunk seq failed", "error", err, "session_id", sessionID, "seq", req.Seq)
+		writeJSONError(w, http.StatusInternalServerError, "failed to issue upload url")
+		return
+	}
+	if !chunkBytesBudget.allow(projectID, req.SizeBytes) {
+		_ = d.Queries.ReleaseChunkReservation(r.Context(), sessionID, projectID, req.Seq)
+		slog.Warn("chunk byte budget exceeded", "project_id", projectID, "size_bytes", req.SizeBytes)
+		writeJSONError(w, http.StatusTooManyRequests, "byte budget exceeded")
+		return
+	}
+
+	uploadURL, formData, err := d.MinIO.PresignedPostPolicy(
+		r.Context(), objectKey, "application/gzip", req.SizeBytes, chunkUploadPolicyTTL)
+	if err != nil {
+		slog.Error("presign chunk policy failed", "error", err, "object_key", objectKey)
+		_ = d.Queries.ReleaseChunkReservation(r.Context(), sessionID, projectID, req.Seq)
+		writeJSONError(w, http.StatusInternalServerError, "failed to issue upload url")
+		return
+	}
+	writeJSON(w, http.StatusOK, chunkUploadURLResponse{UploadURL: uploadURL, FormData: formData, ObjectKey: objectKey})
+}
+
+// ChunkCommit records a stored chunk using the size observed from storage.
+// POST /api/v1/sessions/{sessionID}/chunks/{seq}/commit
+func (d *Dependencies) ChunkCommit(w http.ResponseWriter, r *http.Request) {
+	projectID := ProjectIDFromCtx(r.Context())
+	if projectID == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing project context")
+		return
+	}
+	if d.MinIO == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "object storage not configured")
+		return
+	}
+	sessionID := chi.URLParam(r, "sessionID")
+	if !validSessionID(sessionID) {
+		writeJSONError(w, http.StatusBadRequest, "invalid session_id")
+		return
+	}
+	seq, err := strconv.Atoi(chi.URLParam(r, "seq"))
+	if err != nil || seq < 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid seq")
+		return
+	}
+	owned, err := d.Queries.SessionBelongsToProject(r.Context(), sessionID, projectID)
+	if err != nil {
+		slog.Error("session ownership check failed", "error", err, "session_id", sessionID)
+		writeJSONError(w, http.StatusInternalServerError, "failed to commit chunk")
+		return
+	}
+	if !owned {
+		writeJSONError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	objectKey := chunkObjectKey(projectID, sessionID, seq)
+	size, err := d.MinIO.StatObject(r.Context(), objectKey)
+	if err != nil {
+		slog.Warn("commit for missing object", "object_key", objectKey, "error", err)
+		writeJSONError(w, http.StatusConflict, "chunk object not found in storage")
+		return
+	}
+	if err := d.Queries.CommitChunk(r.Context(), sessionID, projectID, seq, size); err != nil {
+		if errors.Is(err, db.ErrSessionNotFound) {
+			writeJSONError(w, http.StatusNotFound, "chunk reservation not found")
+			return
+		}
+		slog.Error("commit chunk failed", "error", err, "session_id", sessionID, "seq", seq)
+		writeJSONError(w, http.StatusInternalServerError, "failed to commit chunk")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "committed"})
+}
+
+var gzipMagic = []byte{0x1f, 0x8b}
+
+// ChunkInline stores and commits a keepalive-sized final gzip chunk in one
+// request. POST /api/v1/sessions/{sessionID}/chunks/{seq}/inline
+func (d *Dependencies) ChunkInline(w http.ResponseWriter, r *http.Request) {
+	projectID := ProjectIDFromCtx(r.Context())
+	if projectID == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing project context")
+		return
+	}
+	if d.MinIO == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "object storage not configured")
+		return
+	}
+	sessionID := chi.URLParam(r, "sessionID")
+	if !validSessionID(sessionID) {
+		writeJSONError(w, http.StatusBadRequest, "invalid session_id")
+		return
+	}
+	seq, err := strconv.Atoi(chi.URLParam(r, "seq"))
+	if err != nil || seq < 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid seq")
+		return
+	}
+
+	payload, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxInlineChunkBytes))
+	if err != nil {
+		if err.Error() == "http: request body too large" {
+			writeJSONError(w, http.StatusRequestEntityTooLarge, "inline chunk too large")
+			return
+		}
+		writeJSONError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+	if len(payload) < 2 || !bytes.Equal(payload[:2], gzipMagic) {
+		writeJSONError(w, http.StatusBadRequest, "body is not gzip")
+		return
+	}
+
+	enabled, err := d.Queries.ProjectRecordingEnabled(r.Context(), projectID)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to store chunk")
+		return
+	}
+	if !enabled {
+		writeJSONError(w, http.StatusForbidden, "recording disabled for this project")
+		return
+	}
+	owned, err := d.Queries.SessionBelongsToProject(r.Context(), sessionID, projectID)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to store chunk")
+		return
+	}
+	if !owned {
+		writeJSONError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	objectKey := chunkObjectKey(projectID, sessionID, seq)
+	if err := d.Queries.ReserveChunkSeq(r.Context(), sessionID, projectID, seq, objectKey, false); err != nil {
+		if errors.Is(err, db.ErrChunkSeqTaken) {
+			writeJSONError(w, http.StatusConflict, "chunk seq already used")
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, "failed to store chunk")
+		return
+	}
+	if !chunkBytesBudget.allow(projectID, int64(len(payload))) {
+		_ = d.Queries.ReleaseChunkReservation(r.Context(), sessionID, projectID, seq)
+		writeJSONError(w, http.StatusTooManyRequests, "byte budget exceeded")
+		return
+	}
+	putCtx, cancelPut := context.WithTimeout(r.Context(), 30*time.Second)
+	putErr := d.MinIO.PutObject(putCtx, objectKey, payload, "application/gzip")
+	cancelPut()
+	if putErr != nil {
+		slog.Error("inline chunk put failed", "error", putErr, "object_key", objectKey)
+		_ = d.Queries.ReleaseChunkReservation(r.Context(), sessionID, projectID, seq)
+		writeJSONError(w, http.StatusInternalServerError, "failed to store chunk")
+		return
+	}
+	if err := d.Queries.CommitChunk(r.Context(), sessionID, projectID, seq, int64(len(payload))); err != nil {
+		slog.Error("inline chunk commit failed", "error", err, "session_id", sessionID, "seq", seq)
+		_ = d.MinIO.RemoveObject(r.Context(), objectKey)
+		_ = d.Queries.ReleaseChunkReservation(r.Context(), sessionID, projectID, seq)
+		writeJSONError(w, http.StatusInternalServerError, "failed to store chunk")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "committed"})
+}

--- a/packages/ingestion/handler/session_integration_test.go
+++ b/packages/ingestion/handler/session_integration_test.go
@@ -1,0 +1,400 @@
+package handler_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/opslane/opslane/packages/ingestion/db"
+	"github.com/opslane/opslane/packages/ingestion/handler"
+	minioPkg "github.com/opslane/opslane/packages/ingestion/minio"
+)
+
+const maxInlineChunkBytesForTest = 64 << 10
+
+func storageEnv(primary, legacy string) string {
+	if value := os.Getenv(primary); value != "" {
+		return value
+	}
+	return os.Getenv(legacy)
+}
+
+func testDepsWithStorage(t *testing.T) (*handler.Dependencies, *pgxpool.Pool) {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	endpoint := storageEnv("REPLAY_STORE_ENDPOINT", "MINIO_ENDPOINT")
+	if dsn == "" || endpoint == "" {
+		t.Skip("DATABASE_URL / REPLAY_STORE_ENDPOINT not set; skipping session integration test")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	mc, err := minioPkg.New(
+		endpoint,
+		storageEnv("REPLAY_STORE_PUBLIC_ENDPOINT", "MINIO_PUBLIC_ENDPOINT"),
+		storageEnv("REPLAY_STORE_ACCESS_KEY", "MINIO_ACCESS_KEY"),
+		storageEnv("REPLAY_STORE_SECRET_KEY", "MINIO_SECRET_KEY"),
+		storageEnv("REPLAY_STORE_BUCKET", "MINIO_BUCKET"),
+		storageEnv("REPLAY_STORE_REGION", "MINIO_REGION"),
+	)
+	if err != nil {
+		t.Fatalf("minio client: %v", err)
+	}
+	return &handler.Dependencies{Queries: db.New(pool), MinIO: mc}, pool
+}
+
+func seedTenantWithKey(t *testing.T, pool *pgxpool.Pool) (projectID, envID, apiKey string) {
+	t.Helper()
+	_, projectID, envID, apiKey = seedTenant(t, db.New(pool))
+	return projectID, envID, apiKey
+}
+
+func newTestRouter(t *testing.T, deps *handler.Dependencies, pool *pgxpool.Pool) http.Handler {
+	t.Helper()
+	return handler.NewRouterWithPool(deps, pool)
+}
+
+func initSession(t *testing.T, router http.Handler, apiKey, sessionID string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"session_id":%q,"started_at":%q,"page_url":"https://app.example.com/"}`,
+		sessionID, time.Now().UTC().Format(time.RFC3339))
+	req := httptest.NewRequest("POST", "/api/v1/sessions/init", strings.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("session init returned %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func requestUploadURL(t *testing.T, router http.Handler, apiKey, sessionID string, seq int, size int64) (int, map[string]any) {
+	t.Helper()
+	body := fmt.Sprintf(`{"seq":%d,"size_bytes":%d,"has_full_snapshot":true}`, seq, size)
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/v1/sessions/%s/chunks/upload-url", sessionID), strings.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	var out map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &out)
+	return w.Code, out
+}
+
+func gzipBytes(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func postForm(t *testing.T, uploadURL string, fields map[string]string, payload []byte) int {
+	t.Helper()
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	for key, value := range fields {
+		if err := w.WriteField(key, value); err != nil {
+			t.Fatalf("write form field: %v", err)
+		}
+	}
+	part, err := w.CreateFormFile("file", "chunk.json.gz")
+	if err != nil {
+		t.Fatalf("create file field: %v", err)
+	}
+	if _, err := part.Write(payload); err != nil {
+		t.Fatalf("write file field: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close multipart: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, uploadURL, &body)
+	if err != nil {
+		t.Fatalf("new storage request: %v", err)
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("storage request: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+func uploadToPolicy(t *testing.T, out map[string]any, payload []byte) {
+	t.Helper()
+	uploadURL, _ := out["upload_url"].(string)
+	rawForm, _ := out["form_data"].(map[string]any)
+	form := make(map[string]string, len(rawForm))
+	for key, value := range rawForm {
+		form[key], _ = value.(string)
+	}
+	if code := postForm(t, uploadURL, form, payload); code >= 400 {
+		t.Fatalf("storage upload returned %d", code)
+	}
+}
+
+func commitChunk(t *testing.T, router http.Handler, apiKey, sessionID string, seq int) int {
+	t.Helper()
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/v1/sessions/%s/chunks/%d/commit", sessionID, seq), strings.NewReader(`{}`))
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w.Code
+}
+
+func postInlineChunk(t *testing.T, router http.Handler, apiKey, sessionID string, seq int, payload []byte) int {
+	t.Helper()
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/v1/sessions/%s/chunks/%d/inline", sessionID, seq), bytes.NewReader(payload))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/gzip")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w.Code
+}
+
+func TestChunkUploadURL_DuplicateSeqReturns409(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	_, _, apiKey := seedTenantWithKey(t, pool)
+	router := newTestRouter(t, deps, pool)
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	initSession(t, router, apiKey, sid)
+	if code, _ := requestUploadURL(t, router, apiKey, sid, 0, 1024); code != http.StatusOK {
+		t.Fatalf("first upload-url returned %d, want 200", code)
+	}
+	if code, _ := requestUploadURL(t, router, apiKey, sid, 0, 1024); code != http.StatusConflict {
+		t.Fatalf("duplicate seq returned %d, want 409", code)
+	}
+}
+
+func TestChunkUploadURL_RejectsOversizeDeclaration(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	_, _, apiKey := seedTenantWithKey(t, pool)
+	router := newTestRouter(t, deps, pool)
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	initSession(t, router, apiKey, sid)
+	code, _ := requestUploadURL(t, router, apiKey, sid, 0, 50<<20)
+	if code != http.StatusRequestEntityTooLarge && code != http.StatusBadRequest {
+		t.Fatalf("50MiB declaration returned %d, want 413/400", code)
+	}
+}
+
+func TestChunkUploadURL_UnknownSessionReturns404(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	_, _, apiKey := seedTenantWithKey(t, pool)
+	router := newTestRouter(t, deps, pool)
+	code, _ := requestUploadURL(t, router, apiKey, "sess_neverregistered", 0, 1024)
+	if code != http.StatusNotFound {
+		t.Fatalf("unknown session returned %d, want 404", code)
+	}
+}
+
+func TestChunkUploadURL_CrossTenantReturns404(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	_, _, apiKeyA := seedTenantWithKey(t, pool)
+	_, _, apiKeyB := seedTenantWithKey(t, pool)
+	router := newTestRouter(t, deps, pool)
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	initSession(t, router, apiKeyA, sid)
+	code, _ := requestUploadURL(t, router, apiKeyB, sid, 0, 1024)
+	if code != http.StatusNotFound {
+		t.Fatalf("cross-tenant upload-url returned %d, want 404", code)
+	}
+}
+
+func TestChunkCommit_MissingObjectReturns409(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	_, _, apiKey := seedTenantWithKey(t, pool)
+	router := newTestRouter(t, deps, pool)
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	initSession(t, router, apiKey, sid)
+	if code, _ := requestUploadURL(t, router, apiKey, sid, 0, 1024); code != http.StatusOK {
+		t.Fatal("upload-url failed")
+	}
+	if code := commitChunk(t, router, apiKey, sid, 0); code != http.StatusConflict {
+		t.Fatalf("commit of a never-uploaded chunk returned %d, want 409", code)
+	}
+}
+
+func TestChunkCommit_RecordsServerObservedSize(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	_, _, apiKey := seedTenantWithKey(t, pool)
+	router := newTestRouter(t, deps, pool)
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	initSession(t, router, apiKey, sid)
+	payload := gzipBytes(t, []byte(`{"events":[]}`))
+	code, out := requestUploadURL(t, router, apiKey, sid, 0, int64(len(payload)))
+	if code != http.StatusOK {
+		t.Fatalf("upload-url returned %d", code)
+	}
+	uploadToPolicy(t, out, payload)
+	if code := commitChunk(t, router, apiKey, sid, 0); code != http.StatusOK {
+		t.Fatalf("commit returned %d, want 200", code)
+	}
+
+	var size int64
+	var scrubbedAt *time.Time
+	if err := pool.QueryRow(context.Background(),
+		`SELECT size_bytes, scrubbed_at FROM session_chunks WHERE session_id=$1 AND seq=0`, sid,
+	).Scan(&size, &scrubbedAt); err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	if size != int64(len(payload)) {
+		t.Fatalf("recorded size %d, want %d", size, len(payload))
+	}
+	if scrubbedAt != nil {
+		t.Fatal("commit set scrubbed_at")
+	}
+}
+
+func TestChunkCommit_IsIdempotent(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	_, _, apiKey := seedTenantWithKey(t, pool)
+	router := newTestRouter(t, deps, pool)
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	initSession(t, router, apiKey, sid)
+	payload := gzipBytes(t, []byte(`{"events":[]}`))
+	_, out := requestUploadURL(t, router, apiKey, sid, 0, int64(len(payload)))
+	uploadToPolicy(t, out, payload)
+	commitChunk(t, router, apiKey, sid, 0)
+	commitChunk(t, router, apiKey, sid, 0)
+
+	var chunkCount int
+	var bytesStored int64
+	if err := pool.QueryRow(context.Background(),
+		`SELECT chunk_count, bytes_stored FROM sessions WHERE id=$1`, sid,
+	).Scan(&chunkCount, &bytesStored); err != nil {
+		t.Fatalf("read session: %v", err)
+	}
+	if chunkCount != 1 || bytesStored != int64(len(payload)) {
+		t.Fatalf("double commit rollup = count %d, bytes %d", chunkCount, bytesStored)
+	}
+}
+
+func TestChunkInline_StoresAndCommitsInOneCall(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	_, _, apiKey := seedTenantWithKey(t, pool)
+	router := newTestRouter(t, deps, pool)
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	initSession(t, router, apiKey, sid)
+	payload := gzipBytes(t, []byte(`{"events":[{"type":2}]}`))
+	if code := postInlineChunk(t, router, apiKey, sid, 0, payload); code != http.StatusOK {
+		t.Fatalf("inline flush returned %d, want 200", code)
+	}
+
+	var size int64
+	var uploadedAt, scrubbedAt *time.Time
+	if err := pool.QueryRow(context.Background(),
+		`SELECT size_bytes, uploaded_at, scrubbed_at FROM session_chunks WHERE session_id=$1 AND seq=0`, sid,
+	).Scan(&size, &uploadedAt, &scrubbedAt); err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	if size != int64(len(payload)) || uploadedAt == nil || scrubbedAt != nil {
+		t.Fatalf("inline chunk = size %d, uploaded %v, scrubbed %v", size, uploadedAt, scrubbedAt)
+	}
+}
+
+func TestChunkInline_RejectsOversizeBody(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	_, _, apiKey := seedTenantWithKey(t, pool)
+	router := newTestRouter(t, deps, pool)
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	initSession(t, router, apiKey, sid)
+	if code := postInlineChunk(t, router, apiKey, sid, 0, make([]byte, maxInlineChunkBytesForTest+1)); code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversize inline body returned %d, want 413", code)
+	}
+}
+
+func TestChunkInline_RejectsNonGzipBody(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	_, _, apiKey := seedTenantWithKey(t, pool)
+	router := newTestRouter(t, deps, pool)
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	initSession(t, router, apiKey, sid)
+	if code := postInlineChunk(t, router, apiKey, sid, 0, []byte("this is not gzip at all")); code != http.StatusBadRequest {
+		t.Fatalf("non-gzip body returned %d, want 400", code)
+	}
+}
+
+func TestSessionInit_RecordingDisabledDoesNotCreateSession(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	projectID, _, apiKey := seedTenantWithKey(t, pool)
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE projects SET recording_enabled = FALSE WHERE id = $1`, projectID); err != nil {
+		t.Fatalf("disable recording: %v", err)
+	}
+	router := newTestRouter(t, deps, pool)
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	body := fmt.Sprintf(`{"session_id":%q,"started_at":%q}`, sid, time.Now().UTC().Format(time.RFC3339))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/init", strings.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"recording":false`) {
+		t.Fatalf("disabled init returned %d: %s", w.Code, w.Body.String())
+	}
+	var count int
+	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM sessions WHERE id=$1`, sid).Scan(&count); err != nil {
+		t.Fatalf("count sessions: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("disabled init created %d sessions, want 0", count)
+	}
+}
+
+func TestSessionInit_TombstoneReturns410(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	projectID, _, apiKey := seedTenantWithKey(t, pool)
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO session_tombstones (session_id, project_id) VALUES ($1, $2)`, sid, projectID); err != nil {
+		t.Fatalf("seed tombstone: %v", err)
+	}
+	router := newTestRouter(t, deps, pool)
+	body := fmt.Sprintf(`{"session_id":%q}`, sid)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/init", strings.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusGone {
+		t.Fatalf("tombstoned init returned %d: %s, want 410", w.Code, w.Body.String())
+	}
+}
+
+func TestChunkUploadURL_RecordingDisabledReturns403(t *testing.T) {
+	deps, pool := testDepsWithStorage(t)
+	projectID, _, apiKey := seedTenantWithKey(t, pool)
+	router := newTestRouter(t, deps, pool)
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	initSession(t, router, apiKey, sid)
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE projects SET recording_enabled = FALSE WHERE id = $1`, projectID); err != nil {
+		t.Fatalf("disable recording: %v", err)
+	}
+	if code, _ := requestUploadURL(t, router, apiKey, sid, 0, 1024); code != http.StatusForbidden {
+		t.Fatalf("upload-url while disabled returned %d, want 403", code)
+	}
+}

--- a/packages/ingestion/handler/session_test.go
+++ b/packages/ingestion/handler/session_test.go
@@ -1,0 +1,83 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func postSessionInit(t *testing.T, deps *Dependencies, body string, withProject bool) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/v1/sessions/init", strings.NewReader(body))
+	if withProject {
+		req = req.WithContext(withProjectCtx(req.Context(), "proj-123"))
+	}
+	w := httptest.NewRecorder()
+	deps.SessionInit(w, req)
+	return w
+}
+
+func TestSessionInit_NoMinIOReturns503(t *testing.T) {
+	deps := &Dependencies{}
+	w := postSessionInit(t, deps, `{"session_id":"sess_abcdefgh","started_at":"2026-07-14T00:00:00Z"}`, true)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("got %d, want 503 when object storage is unconfigured", w.Code)
+	}
+}
+
+func TestSessionInit_MissingProjectContextReturns401(t *testing.T) {
+	deps := &Dependencies{}
+	w := postSessionInit(t, deps, `{"session_id":"sess_abcdefgh"}`, false)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d, want 401 without project context", w.Code)
+	}
+}
+
+func TestValidSessionID(t *testing.T) {
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"550e8400-e29b-41d4-a716-446655440000", true},
+		{"sess_1752451200000_a1b2c3", true},
+		{"abcdefgh", true},
+		{"short", false},
+		{strings.Repeat("a", 129), false},
+		{"", false},
+		{"has spaces here", false},
+		{"path/traversal", false},
+		{"../../etc/passwd", false},
+		{"semi;colon", false},
+		{"quote'inject", false},
+	}
+	for _, tc := range cases {
+		if got := validSessionID(tc.id); got != tc.want {
+			t.Errorf("validSessionID(%q) = %v, want %v", tc.id, got, tc.want)
+		}
+	}
+}
+
+func TestChunkObjectKey_IsDeterministicAndSorted(t *testing.T) {
+	got := chunkObjectKey("proj-1", "sess_abc", 7)
+	want := "sessions/proj-1/sess_abc/chunk-000007.json.gz"
+	if got != want {
+		t.Fatalf("chunkObjectKey = %q, want %q", got, want)
+	}
+	if !(chunkObjectKey("p", "s", 9) < chunkObjectKey("p", "s", 10)) {
+		t.Fatal("chunk keys do not sort lexically by seq")
+	}
+}
+
+func TestChunkUploadURL_RejectsOversizeDeclaration(t *testing.T) {
+	deps := &Dependencies{}
+	body := `{"seq":0,"size_bytes":` + strconv.FormatInt(maxChunkBytes+1, 10) + `,"has_full_snapshot":true}`
+	req := httptest.NewRequest("POST", "/api/v1/sessions/sess_abcdefgh/chunks/upload-url", strings.NewReader(body))
+	req = req.WithContext(withProjectCtx(req.Context(), "proj-123"))
+	w := httptest.NewRecorder()
+	deps.ChunkUploadURL(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("got %d, want 503 when object storage is unconfigured", w.Code)
+	}
+}

--- a/packages/ingestion/handler/session_test.go
+++ b/packages/ingestion/handler/session_test.go
@@ -70,7 +70,11 @@ func TestChunkObjectKey_IsDeterministicAndSorted(t *testing.T) {
 	}
 }
 
-func TestChunkUploadURL_RejectsOversizeDeclaration(t *testing.T) {
+// Storage is optional (main.go leaves Dependencies.MinIO nil when
+// REPLAY_STORE_ENDPOINT is unset), so the nil guard must win before any
+// request validation. The oversize-declaration 413 itself is asserted by the
+// integration test of the same name.
+func TestChunkUploadURL_NoMinIOReturns503(t *testing.T) {
 	deps := &Dependencies{}
 	body := `{"seq":0,"size_bytes":` + strconv.FormatInt(maxChunkBytes+1, 10) + `,"has_full_snapshot":true}`
 	req := httptest.NewRequest("POST", "/api/v1/sessions/sess_abcdefgh/chunks/upload-url", strings.NewReader(body))

--- a/packages/ingestion/main.go
+++ b/packages/ingestion/main.go
@@ -11,6 +11,8 @@ import (
 	"github.com/opslane/opslane/packages/ingestion/db"
 	"github.com/opslane/opslane/packages/ingestion/handler"
 	minioPkg "github.com/opslane/opslane/packages/ingestion/minio"
+	"github.com/opslane/opslane/packages/ingestion/retention"
+	"github.com/opslane/opslane/packages/ingestion/scrubber"
 )
 
 func main() {
@@ -117,6 +119,19 @@ func main() {
 			}
 		}
 	}()
+
+	// Raw chunks are fail-closed until this pass overwrites them with redacted
+	// bytes and stamps scrubbed_at. Every replica runs a scrubber; claims use
+	// FOR UPDATE SKIP LOCKED to avoid duplicate work.
+	if minioClient != nil {
+		s := &scrubber.Scrubber{Q: queries, MinIO: minioClient}
+		go s.Start(context.Background(), 15*time.Second)
+		slog.Info("chunk scrubber started")
+
+		sweeper := &retention.Sweeper{Q: queries, MinIO: minioClient}
+		go sweeper.Start(context.Background(), time.Hour)
+		slog.Info("retention sweeper started")
+	}
 
 	slog.Info("Opslane ingestion starting", "port", port)
 	if err := http.ListenAndServe(fmt.Sprintf(":%s", port), r); err != nil {

--- a/packages/ingestion/minio/anonymous_test.go
+++ b/packages/ingestion/minio/anonymous_test.go
@@ -1,0 +1,51 @@
+package minio_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	minioPkg "github.com/opslane/opslane/packages/ingestion/minio"
+)
+
+// TestAnonymousGetIsForbidden asserts the replay bucket is not world-readable.
+// Guards against a regression of #47: `mc anonymous set download` made every
+// stored replay/chunk downloadable by anyone who could guess an object key.
+func TestAnonymousGetIsForbidden(t *testing.T) {
+	endpoint := os.Getenv("REPLAY_STORE_ENDPOINT")
+	publicEndpoint := os.Getenv("REPLAY_STORE_PUBLIC_ENDPOINT")
+	if endpoint == "" || publicEndpoint == "" {
+		t.Skip("REPLAY_STORE_ENDPOINT/PUBLIC_ENDPOINT not set; skipping integration test")
+	}
+
+	client, err := minioPkg.New(
+		endpoint, publicEndpoint,
+		os.Getenv("REPLAY_STORE_ACCESS_KEY"), os.Getenv("REPLAY_STORE_SECRET_KEY"),
+		os.Getenv("REPLAY_STORE_BUCKET"), os.Getenv("REPLAY_STORE_REGION"),
+	)
+	if err != nil {
+		t.Fatalf("minio client: %v", err)
+	}
+
+	ctx := context.Background()
+	key := fmt.Sprintf("test/anon-probe-%d.json", time.Now().UnixNano())
+	t.Cleanup(func() { _ = client.RemoveObject(context.Background(), key) })
+	if err := client.PutObject(ctx, key, []byte(`{"secret":"pii"}`), "application/json"); err != nil {
+		t.Fatalf("seed object: %v", err)
+	}
+
+	// Unauthenticated GET straight at the storage host, bypassing ingestion.
+	url := fmt.Sprintf("%s/%s/%s", publicEndpoint, os.Getenv("REPLAY_STORE_BUCKET"), key)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("anonymous GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("anonymous GET returned %d, want 403 — bucket is publicly readable (#47)", resp.StatusCode)
+	}
+}

--- a/packages/ingestion/minio/client.go
+++ b/packages/ingestion/minio/client.go
@@ -114,3 +114,77 @@ func (c *Client) GetObject(ctx context.Context, objectKey string) ([]byte, error
 	defer obj.Close()
 	return io.ReadAll(obj)
 }
+
+// PresignedPostPolicy generates a presigned POST form policy for uploading a
+// single object with a hard, storage-enforced byte ceiling.
+//
+// This exists because presigned PUT URLs carry no size condition: S3 signs the
+// URL, not a policy document, so a PUT holder can upload arbitrarily many bytes.
+// content-length-range is only expressible on a POST policy (#48). The caller
+// passes the exact declared size; storage rejects anything larger, so a public
+// SDK key cannot be turned into a storage-flood primitive.
+//
+// Returns the POST URL and the form fields the client must send *before* the
+// file field (which must be named "file" and sent last).
+func (c *Client) PresignedPostPolicy(ctx context.Context, objectKey, contentType string, maxBytes int64, expiry time.Duration) (string, map[string]string, error) {
+	if maxBytes <= 0 {
+		return "", nil, fmt.Errorf("maxBytes must be positive, got %d", maxBytes)
+	}
+
+	policy := minio.NewPostPolicy()
+	if err := policy.SetBucket(c.bucket); err != nil {
+		return "", nil, err
+	}
+	if err := policy.SetKey(objectKey); err != nil {
+		return "", nil, err
+	}
+	if err := policy.SetExpires(time.Now().UTC().Add(expiry)); err != nil {
+		return "", nil, err
+	}
+	if err := policy.SetContentType(contentType); err != nil {
+		return "", nil, err
+	}
+	// The ceiling. Storage — not application code — enforces this.
+	if err := policy.SetContentLengthRange(1, maxBytes); err != nil {
+		return "", nil, err
+	}
+
+	// Sign against the public host when configured, so the browser's Host header
+	// matches the signature (same reason as PresignedPutURL).
+	client := c.mc
+	if c.publicMC != nil {
+		client = c.publicMC
+	}
+
+	u, formData, err := client.PresignedPostPolicy(ctx, policy)
+	if err != nil {
+		return "", nil, err
+	}
+	return u.String(), formData, nil
+}
+
+// RemoveObject deletes the object at objectKey.
+//
+// Deleting a key that does not exist is not an error: retention sweeps are
+// idempotent and may re-run over a partially-completed batch (#29).
+func (c *Client) RemoveObject(ctx context.Context, objectKey string) error {
+	return c.mc.RemoveObject(ctx, c.bucket, objectKey, minio.RemoveObjectOptions{})
+}
+
+// RemovePrefix deletes every object below prefix. Retention uses this instead
+// of trusting database rows because an upload policy can outlive those rows.
+func (c *Client) RemovePrefix(ctx context.Context, prefix string) error {
+	objects := c.mc.ListObjects(ctx, c.bucket, minio.ListObjectsOptions{
+		Prefix:    prefix,
+		Recursive: true,
+	})
+	for object := range objects {
+		if object.Err != nil {
+			return object.Err
+		}
+		if err := c.RemoveObject(ctx, object.Key); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/packages/ingestion/minio/client_test.go
+++ b/packages/ingestion/minio/client_test.go
@@ -1,0 +1,165 @@
+package minio_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	minioPkg "github.com/opslane/opslane/packages/ingestion/minio"
+)
+
+func testClient(t *testing.T) *minioPkg.Client {
+	t.Helper()
+	endpoint := os.Getenv("REPLAY_STORE_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("REPLAY_STORE_ENDPOINT not set; skipping integration test")
+	}
+	c, err := minioPkg.New(
+		endpoint, os.Getenv("REPLAY_STORE_PUBLIC_ENDPOINT"),
+		os.Getenv("REPLAY_STORE_ACCESS_KEY"), os.Getenv("REPLAY_STORE_SECRET_KEY"),
+		os.Getenv("REPLAY_STORE_BUCKET"), os.Getenv("REPLAY_STORE_REGION"),
+	)
+	if err != nil {
+		t.Fatalf("minio client: %v", err)
+	}
+	return c
+}
+
+// postForm performs the browser-side half of a presigned POST policy upload:
+// every signed form field, then the file field last.
+func postForm(t *testing.T, url string, formData map[string]string, body []byte) int {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for k, v := range formData {
+		if err := w.WriteField(k, v); err != nil {
+			t.Fatalf("write field %s: %v", k, err)
+		}
+	}
+	fw, err := w.CreateFormFile("file", "chunk.json.gz")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := fw.Write(body); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	resp, err := http.Post(url, w.FormDataContentType(), &buf)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+func TestPresignedPostPolicy_WithinCapSucceeds(t *testing.T) {
+	c := testClient(t)
+	ctx := context.Background()
+	key := fmt.Sprintf("test/policy-ok-%d.gz", time.Now().UnixNano())
+	t.Cleanup(func() { _ = c.RemoveObject(context.Background(), key) })
+
+	payload := []byte(strings.Repeat("a", 500))
+	url, formData, err := c.PresignedPostPolicy(ctx, key, "application/gzip", int64(len(payload)), 5*time.Minute)
+	if err != nil {
+		t.Fatalf("presign: %v", err)
+	}
+
+	if code := postForm(t, url, formData, payload); code != http.StatusNoContent && code != http.StatusOK {
+		t.Fatalf("upload within cap returned %d, want 204/200", code)
+	}
+
+	size, err := c.StatObject(ctx, key)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if size != int64(len(payload)) {
+		t.Fatalf("stored size %d, want %d", size, len(payload))
+	}
+}
+
+func TestPresignedPostPolicy_OverCapRejectedByStorage(t *testing.T) {
+	c := testClient(t)
+	ctx := context.Background()
+	key := fmt.Sprintf("test/policy-toobig-%d.gz", time.Now().UnixNano())
+	t.Cleanup(func() { _ = c.RemoveObject(context.Background(), key) })
+
+	// Sign for 500 bytes, then try to upload 5000. Storage must refuse.
+	url, formData, err := c.PresignedPostPolicy(ctx, key, "application/gzip", 500, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("presign: %v", err)
+	}
+
+	code := postForm(t, url, formData, []byte(strings.Repeat("a", 5000)))
+	if code < 400 {
+		t.Fatalf("oversize upload returned %d, want 4xx — storage is not enforcing content-length-range (#48)", code)
+	}
+
+	// And it must not have landed.
+	if _, err := c.StatObject(ctx, key); err == nil {
+		t.Fatal("oversize object exists in storage; the policy did not reject it")
+	}
+}
+
+func TestRemoveObject(t *testing.T) {
+	c := testClient(t)
+	ctx := context.Background()
+	key := fmt.Sprintf("test/remove-%d.json", time.Now().UnixNano())
+
+	if err := c.PutObject(ctx, key, []byte(`{}`), "application/json"); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if _, err := c.StatObject(ctx, key); err != nil {
+		t.Fatalf("stat before remove: %v", err)
+	}
+	if err := c.RemoveObject(ctx, key); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := c.StatObject(ctx, key); err == nil {
+		t.Fatal("object still exists after RemoveObject")
+	}
+}
+
+// Retention deletes keys that may already be gone (crash mid-sweep, concurrent
+// replica). That must not be an error, or the sweep wedges permanently.
+func TestRemoveObject_MissingKeyIsNotAnError(t *testing.T) {
+	c := testClient(t)
+	key := fmt.Sprintf("test/never-existed-%d.json", time.Now().UnixNano())
+	if err := c.RemoveObject(context.Background(), key); err != nil {
+		t.Fatalf("removing a missing key returned %v, want nil (retention must be idempotent)", err)
+	}
+}
+
+func TestRemovePrefix(t *testing.T) {
+	c := testClient(t)
+	ctx := context.Background()
+	base := fmt.Sprintf("test/prefix-%d", time.Now().UnixNano())
+	inside := []string{base + "/a.gz", base + "/nested/b.gz"}
+	outside := base + "-other/c.gz"
+	for _, key := range append(inside, outside) {
+		if err := c.PutObject(ctx, key, []byte("x"), "application/gzip"); err != nil {
+			t.Fatalf("put %s: %v", key, err)
+		}
+	}
+	t.Cleanup(func() { _ = c.RemoveObject(context.Background(), outside) })
+
+	if err := c.RemovePrefix(ctx, base+"/"); err != nil {
+		t.Fatalf("remove prefix: %v", err)
+	}
+	for _, key := range inside {
+		if _, err := c.StatObject(ctx, key); err == nil {
+			t.Fatalf("object %s survived prefix removal", key)
+		}
+	}
+	if _, err := c.StatObject(ctx, outside); err != nil {
+		t.Fatalf("neighboring prefix was removed: %v", err)
+	}
+}

--- a/packages/ingestion/retention/interval_test.go
+++ b/packages/ingestion/retention/interval_test.go
@@ -1,0 +1,41 @@
+package retention
+
+import (
+	"testing"
+	"time"
+)
+
+// The sweep interval is the caller's to choose. A previous version clamped it
+// down to deletionGrace, so main.go's time.Hour silently became one minute and
+// every replica ran a full retention scan 60x more often than intended.
+// deletionGrace is a floor on how long a session waits before purge
+// (SessionsReadyForPurge), not a ceiling on how often the sweep runs.
+func TestResolveInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Duration
+		want time.Duration
+	}{
+		{"caller's hour is honored", time.Hour, time.Hour},
+		{"main.go's actual argument", time.Hour, time.Hour},
+		{"a sub-grace interval is honored too", 30 * time.Second, 30 * time.Second},
+		{"an interval above grace is not clamped", 5 * time.Minute, 5 * time.Minute},
+		{"zero falls back to the default", 0, defaultInterval},
+		{"negative falls back to the default", -time.Second, defaultInterval},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveInterval(tt.in); got != tt.want {
+				t.Fatalf("resolveInterval(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// defaultInterval must be reachable. The clamp made it dead code: it was set
+// on the zero path and then immediately overwritten with deletionGrace.
+func TestResolveInterval_DefaultIsReachable(t *testing.T) {
+	if got := resolveInterval(0); got != time.Hour {
+		t.Fatalf("resolveInterval(0) = %v, want %v (defaultInterval is unreachable)", got, time.Hour)
+	}
+}

--- a/packages/ingestion/retention/retention.go
+++ b/packages/ingestion/retention/retention.go
@@ -27,14 +27,19 @@ type Sweeper struct {
 	MinIO *minioPkg.Client
 }
 
+// resolveInterval picks the tick interval for Start. Only a non-positive
+// interval is overridden; deletionGrace is a floor on how long a session waits
+// before purge (see SessionsReadyForPurge) and must not bound the tick rate.
+func resolveInterval(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return defaultInterval
+	}
+	return interval
+}
+
 // Start closes idle sessions and sweeps expired sessions until cancellation.
 func (s *Sweeper) Start(ctx context.Context, interval time.Duration) {
-	if interval <= 0 {
-		interval = defaultInterval
-	}
-	if interval > deletionGrace {
-		interval = deletionGrace
-	}
+	interval = resolveInterval(interval)
 	s.runPass(ctx)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/packages/ingestion/retention/retention.go
+++ b/packages/ingestion/retention/retention.go
@@ -1,0 +1,126 @@
+// Package retention removes expired session recordings from storage and Postgres.
+package retention
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/opslane/opslane/packages/ingestion/db"
+	minioPkg "github.com/opslane/opslane/packages/ingestion/minio"
+)
+
+const (
+	batchSize        = 100
+	tombstoneBatch   = 1000
+	defaultInterval  = time.Hour
+	idleCloseMinutes = 30
+	// 30s POST-policy TTL + 30s bounded scrub operation.
+	deletionGrace = time.Minute
+)
+
+// Sweeper owns one bounded retention pass.
+type Sweeper struct {
+	Q     *db.Queries
+	MinIO *minioPkg.Client
+}
+
+// Start closes idle sessions and sweeps expired sessions until cancellation.
+func (s *Sweeper) Start(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = defaultInterval
+	}
+	if interval > deletionGrace {
+		interval = deletionGrace
+	}
+	s.runPass(ctx)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.runPass(ctx)
+		}
+	}
+}
+
+func (s *Sweeper) runPass(ctx context.Context) {
+	if closed, err := s.Q.CloseIdleSessions(ctx, idleCloseMinutes); err != nil {
+		slog.Error("close idle sessions failed", "error", err)
+	} else if closed > 0 {
+		slog.Info("closed idle sessions", "count", closed)
+	}
+	if deleted, err := s.RunOnce(ctx); err != nil {
+		slog.Error("retention sweep failed", "error", err)
+	} else if deleted > 0 {
+		slog.Info("retention sweep", "sessions_deleted", deleted)
+	}
+}
+
+// RunOnce first tombstones expiry candidates, then purges sessions whose
+// pre-existing upload policies and scrub leases have expired.
+func (s *Sweeper) RunOnce(ctx context.Context) (int, error) {
+	if s.Q == nil || s.MinIO == nil {
+		return 0, errors.New("retention dependencies are not configured")
+	}
+	sessions, err := s.Q.SessionsToDelete(ctx, batchSize)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, session := range sessions {
+		if err := s.Q.MarkSessionDeleting(ctx, session.ID, session.ProjectID); err != nil {
+			slog.Error("mark session deleting failed", "error", err, "session_id", session.ID)
+		}
+	}
+
+	ready, err := s.Q.SessionsReadyForPurge(ctx, deletionGrace, batchSize)
+	if err != nil {
+		return 0, err
+	}
+	deleted := 0
+	for _, session := range ready {
+		if err := s.MinIO.RemovePrefix(ctx, sessionPrefix(session)); err != nil {
+			slog.Error("remove session objects failed", "error", err, "session_id", session.ID)
+			continue
+		}
+		if err := s.Q.DeleteMarkedSession(ctx, session.ID, session.ProjectID); err != nil {
+			slog.Error("delete session failed", "error", err, "session_id", session.ID)
+			continue
+		}
+		deleted++
+	}
+	if err := s.sweepDeletedPrefixes(ctx); err != nil {
+		return deleted, err
+	}
+	return deleted, nil
+}
+
+func sessionPrefix(session db.SessionRef) string {
+	return fmt.Sprintf("sessions/%s/%s/", session.ProjectID, session.ID)
+}
+
+// A POST accepted before policy expiry can finish after the initial purge.
+// Tombstones are permanent, so rotate through their prefixes on every pass and
+// make any such late object temporary rather than permanently orphaned.
+func (s *Sweeper) sweepDeletedPrefixes(ctx context.Context) error {
+	tombstones, err := s.Q.ClaimTombstonesForStorageSweep(ctx, tombstoneBatch)
+	if err != nil {
+		return err
+	}
+	for _, tombstone := range tombstones {
+		if err := s.MinIO.RemovePrefix(ctx, sessionPrefix(tombstone)); err != nil {
+			slog.Error("re-sweep tombstoned session failed", "error", err, "session_id", tombstone.ID)
+			_ = s.Q.ReleaseTombstoneStorageSweep(ctx, tombstone.ID, tombstone.ProjectID)
+			continue
+		}
+		if err := s.Q.MarkTombstoneStorageSwept(ctx, tombstone.ID, tombstone.ProjectID); err != nil {
+			slog.Error("mark tombstone storage sweep failed", "error", err, "session_id", tombstone.ID)
+		}
+	}
+	return nil
+}

--- a/packages/ingestion/retention/retention_test.go
+++ b/packages/ingestion/retention/retention_test.go
@@ -1,0 +1,187 @@
+package retention_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/opslane/opslane/packages/ingestion/db"
+	minioPkg "github.com/opslane/opslane/packages/ingestion/minio"
+	"github.com/opslane/opslane/packages/ingestion/retention"
+)
+
+func setup(t *testing.T) (*retention.Sweeper, *db.Queries, *minioPkg.Client, *pgxpool.Pool) {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	endpoint := os.Getenv("REPLAY_STORE_ENDPOINT")
+	if dsn == "" || endpoint == "" {
+		t.Skip("DATABASE_URL / REPLAY_STORE_ENDPOINT not set; skipping integration test")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	q := db.New(pool)
+	mc, err := minioPkg.New(endpoint, os.Getenv("REPLAY_STORE_PUBLIC_ENDPOINT"),
+		os.Getenv("REPLAY_STORE_ACCESS_KEY"), os.Getenv("REPLAY_STORE_SECRET_KEY"),
+		os.Getenv("REPLAY_STORE_BUCKET"), os.Getenv("REPLAY_STORE_REGION"))
+	if err != nil {
+		t.Fatalf("minio: %v", err)
+	}
+	return &retention.Sweeper{Q: q, MinIO: mc}, q, mc, pool
+}
+
+type seededSession struct {
+	id, projectID, key string
+}
+
+func seedSession(t *testing.T, q *db.Queries, pool *pgxpool.Pool, mc *minioPkg.Client, ageDays, retentionDays int, retainUntil *time.Time) seededSession {
+	t.Helper()
+	ctx := context.Background()
+	name := fmt.Sprintf("retain-%d", time.Now().UnixNano())
+	var orgID, projectID, envID string
+	if err := pool.QueryRow(ctx, `INSERT INTO orgs (name) VALUES ($1) RETURNING id`, name).Scan(&orgID); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `INSERT INTO projects (org_id, name, session_retention_days) VALUES ($1, $2, $3) RETURNING id`, orgID, name, retentionDays).Scan(&projectID); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `INSERT INTO environments (project_id, name) VALUES ($1, 'production') RETURNING id`, projectID).Scan(&envID); err != nil {
+		t.Fatalf("seed environment: %v", err)
+	}
+	sid := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	started := time.Now().AddDate(0, 0, -ageDays)
+	if err := q.InsertSession(ctx, sid, projectID, envID, nil, started, "https://example.test"); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if retainUntil != nil {
+		if _, err := pool.Exec(ctx, `UPDATE sessions SET retain_until=$2 WHERE id=$1`, sid, *retainUntil); err != nil {
+			t.Fatalf("pin session: %v", err)
+		}
+	}
+	key := fmt.Sprintf("sessions/%s/%s/chunk-000000.json.gz", projectID, sid)
+	if err := q.ReserveChunkSeq(ctx, sid, projectID, 0, key, true); err != nil {
+		t.Fatalf("reserve chunk: %v", err)
+	}
+	payload := []byte("stored-chunk")
+	if err := mc.PutObject(ctx, key, payload, "application/gzip"); err != nil {
+		t.Fatalf("seed object: %v", err)
+	}
+	if err := q.CommitChunk(ctx, sid, projectID, 0, int64(len(payload))); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	return seededSession{id: sid, projectID: projectID, key: key}
+}
+
+func assertDeleted(t *testing.T, pool *pgxpool.Pool, mc *minioPkg.Client, session seededSession) {
+	t.Helper()
+	ctx := context.Background()
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM sessions WHERE id=$1`, session.id).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("session count=%d err=%v, want 0", count, err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM session_chunks WHERE session_id=$1`, session.id).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("chunk count=%d err=%v, want 0", count, err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM session_tombstones WHERE session_id=$1`, session.id).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("tombstone count=%d err=%v, want 1", count, err)
+	}
+	if _, err := mc.StatObject(ctx, session.key); err == nil {
+		t.Fatal("retained object still exists")
+	}
+}
+
+func runThroughGrace(t *testing.T, sweeper *retention.Sweeper, pool *pgxpool.Pool, session seededSession) {
+	t.Helper()
+	if _, err := sweeper.RunOnce(context.Background()); err != nil {
+		t.Fatalf("mark deleting: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE sessions SET deletion_started_at = now() - interval '2 minutes' WHERE id = $1`, session.id); err != nil {
+		t.Fatalf("age deletion grace: %v", err)
+	}
+	if _, err := sweeper.RunOnce(context.Background()); err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+}
+
+func TestSweep_DeletesExpiredSessionAndItsObjects(t *testing.T) {
+	s, q, mc, pool := setup(t)
+	session := seedSession(t, q, pool, mc, 40, 30, nil)
+	runThroughGrace(t, s, pool, session)
+	assertDeleted(t, pool, mc, session)
+}
+
+func TestSweep_SkipsPinnedSessionInsideHardCap(t *testing.T) {
+	s, q, mc, pool := setup(t)
+	pinnedUntil := time.Now().AddDate(0, 0, 30)
+	session := seedSession(t, q, pool, mc, 40, 30, &pinnedUntil)
+	t.Cleanup(func() { _ = mc.RemoveObject(context.Background(), session.key) })
+	if _, err := s.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	var count int
+	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM sessions WHERE id=$1`, session.id).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("pinned session count=%d err=%v, want 1", count, err)
+	}
+	if _, err := mc.StatObject(context.Background(), session.key); err != nil {
+		t.Fatalf("pinned object removed: %v", err)
+	}
+}
+
+func TestSweep_DeletesPinnedSessionPastHardCap(t *testing.T) {
+	s, q, mc, pool := setup(t)
+	pinnedUntil := time.Now().AddDate(1, 0, 0)
+	session := seedSession(t, q, pool, mc, 100, 30, &pinnedUntil)
+	runThroughGrace(t, s, pool, session)
+	assertDeleted(t, pool, mc, session)
+}
+
+func TestSweep_RespectsPerProjectRetentionDays(t *testing.T) {
+	s, q, mc, pool := setup(t)
+	expired := seedSession(t, q, pool, mc, 20, 14, nil)
+	live := seedSession(t, q, pool, mc, 20, 30, nil)
+	t.Cleanup(func() { _ = mc.RemoveObject(context.Background(), live.key) })
+	runThroughGrace(t, s, pool, expired)
+	assertDeleted(t, pool, mc, expired)
+	var count int
+	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM sessions WHERE id=$1`, live.id).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("live session count=%d err=%v, want 1", count, err)
+	}
+}
+
+func TestSweep_IsIdempotent(t *testing.T) {
+	s, q, mc, pool := setup(t)
+	session := seedSession(t, q, pool, mc, 40, 30, nil)
+	if err := mc.RemoveObject(context.Background(), session.key); err != nil {
+		t.Fatalf("pre-delete object: %v", err)
+	}
+	runThroughGrace(t, s, pool, session)
+	if _, err := s.RunOnce(context.Background()); err != nil {
+		t.Fatalf("second RunOnce: %v", err)
+	}
+	assertDeleted(t, pool, mc, session)
+}
+
+func TestSweep_RemovesObjectThatArrivesAfterSessionDeletion(t *testing.T) {
+	s, q, mc, pool := setup(t)
+	session := seedSession(t, q, pool, mc, 40, 30, nil)
+	runThroughGrace(t, s, pool, session)
+	if err := mc.PutObject(context.Background(), session.key, []byte("late-policy-upload"), "application/gzip"); err != nil {
+		t.Fatalf("simulate late upload: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE session_tombstones SET storage_swept_at = NULL WHERE session_id = $1`, session.id); err != nil {
+		t.Fatalf("queue tombstone re-sweep: %v", err)
+	}
+	if _, err := s.RunOnce(context.Background()); err != nil {
+		t.Fatalf("late-object sweep: %v", err)
+	}
+	if _, err := mc.StatObject(context.Background(), session.key); err == nil {
+		t.Fatal("object uploaded after row deletion remained orphaned")
+	}
+}

--- a/packages/ingestion/scrubber/scrubber.go
+++ b/packages/ingestion/scrubber/scrubber.go
@@ -1,0 +1,122 @@
+// Package scrubber redacts stored session chunks before they become readable.
+package scrubber
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/opslane/opslane/packages/ingestion/compress"
+	"github.com/opslane/opslane/packages/ingestion/db"
+	"github.com/opslane/opslane/packages/ingestion/masking"
+	minioPkg "github.com/opslane/opslane/packages/ingestion/minio"
+)
+
+const (
+	batchSize         = 20
+	defaultInterval   = 15 * time.Second
+	defaultMaxInflate = 20 << 20
+	scrubTimeout      = 30 * time.Second
+)
+
+// Scrubber processes committed, unscrubbed chunks in bounded batches.
+type Scrubber struct {
+	Q               *db.Queries
+	MinIO           *minioPkg.Client
+	MaxInflateBytes int64
+}
+
+// Start runs scrub passes until ctx is cancelled.
+func (s *Scrubber) Start(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = defaultInterval
+	}
+	if s.MaxInflateBytes <= 0 {
+		s.MaxInflateBytes = defaultMaxInflate
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			scrubbed, failed, err := s.RunOnce(ctx)
+			if err != nil {
+				slog.Error("chunk scrub pass failed", "error", err)
+			} else if scrubbed > 0 || failed > 0 {
+				slog.Info("chunk scrub pass", "scrubbed", scrubbed, "failed", failed)
+			}
+		}
+	}
+}
+
+// RunOnce claims and processes one batch. A failed chunk remains unreadable.
+func (s *Scrubber) RunOnce(ctx context.Context) (scrubbed, failed int, err error) {
+	if s.Q == nil || s.MinIO == nil {
+		return 0, 0, errors.New("scrubber dependencies are not configured")
+	}
+	if s.MaxInflateBytes <= 0 {
+		s.MaxInflateBytes = defaultMaxInflate
+	}
+
+	chunks, err := s.Q.ClaimUnscrubbedChunks(ctx, batchSize)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, chunk := range chunks {
+		chunkCtx, cancel := context.WithTimeout(ctx, scrubTimeout)
+		scrubErr := s.scrubOne(chunkCtx, chunk)
+		cancel()
+		if scrubErr != nil {
+			failed++
+			slog.Warn("chunk scrub failed", "session_id", chunk.SessionID, "seq", chunk.Seq, "error", scrubErr)
+			if markErr := s.Q.MarkChunkScrubFailed(ctx, chunk.SessionID, chunk.ProjectID, chunk.Seq, scrubErr.Error()); markErr != nil {
+				slog.Error("recording scrub failure failed", "error", markErr)
+			}
+			continue
+		}
+		scrubbed++
+	}
+	return scrubbed, failed, nil
+}
+
+func (s *Scrubber) scrubOne(ctx context.Context, chunk db.ChunkRef) error {
+	size, err := s.MinIO.StatObject(ctx, chunk.ObjectKey)
+	if err != nil {
+		return fmt.Errorf("stat chunk: %w", err)
+	}
+	if size > s.MaxInflateBytes {
+		_ = s.MinIO.RemoveObject(ctx, chunk.ObjectKey)
+		return errors.New("compressed chunk exceeds inflate ceiling")
+	}
+
+	raw, err := s.MinIO.GetObject(ctx, chunk.ObjectKey)
+	if err != nil {
+		return fmt.Errorf("read chunk: %w", err)
+	}
+	plain, err := compress.InflateLimited(bytes.NewReader(raw), s.MaxInflateBytes)
+	if err != nil {
+		if errors.Is(err, compress.ErrTooLarge) {
+			_ = s.MinIO.RemoveObject(ctx, chunk.ObjectKey)
+		}
+		return err
+	}
+	if !json.Valid(plain) {
+		_ = s.MinIO.RemoveObject(ctx, chunk.ObjectKey)
+		return errors.New("chunk is not valid JSON")
+	}
+
+	regz, err := compress.Deflate(masking.RedactRecording(plain))
+	if err != nil {
+		return err
+	}
+	if err := s.MinIO.PutObject(ctx, chunk.ObjectKey, regz, "application/gzip"); err != nil {
+		return fmt.Errorf("store scrubbed chunk: %w", err)
+	}
+	return s.Q.MarkChunkScrubbed(ctx, chunk.SessionID, chunk.ProjectID, chunk.Seq)
+}

--- a/packages/ingestion/scrubber/scrubber_test.go
+++ b/packages/ingestion/scrubber/scrubber_test.go
@@ -1,0 +1,180 @@
+package scrubber_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/opslane/opslane/packages/ingestion/compress"
+	"github.com/opslane/opslane/packages/ingestion/db"
+	minioPkg "github.com/opslane/opslane/packages/ingestion/minio"
+	"github.com/opslane/opslane/packages/ingestion/scrubber"
+)
+
+func setup(t *testing.T) (*scrubber.Scrubber, *db.Queries, *minioPkg.Client, *pgxpool.Pool) {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	endpoint := os.Getenv("REPLAY_STORE_ENDPOINT")
+	if dsn == "" || endpoint == "" {
+		t.Skip("DATABASE_URL / REPLAY_STORE_ENDPOINT not set; skipping integration test")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	q := db.New(pool)
+	mc, err := minioPkg.New(endpoint, os.Getenv("REPLAY_STORE_PUBLIC_ENDPOINT"),
+		os.Getenv("REPLAY_STORE_ACCESS_KEY"), os.Getenv("REPLAY_STORE_SECRET_KEY"),
+		os.Getenv("REPLAY_STORE_BUCKET"), os.Getenv("REPLAY_STORE_REGION"))
+	if err != nil {
+		t.Fatalf("minio: %v", err)
+	}
+	return &scrubber.Scrubber{Q: q, MinIO: mc, MaxInflateBytes: 20 << 20}, q, mc, pool
+}
+
+func seedChunk(t *testing.T, q *db.Queries, pool *pgxpool.Pool) (sessionID, projectID, key string) {
+	t.Helper()
+	ctx := context.Background()
+	name := fmt.Sprintf("scrub-%d", time.Now().UnixNano())
+	var orgID, envID string
+	if err := pool.QueryRow(ctx, `INSERT INTO orgs (name) VALUES ($1) RETURNING id`, name).Scan(&orgID); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `INSERT INTO projects (org_id, name) VALUES ($1, $2) RETURNING id`, orgID, name).Scan(&projectID); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `INSERT INTO environments (project_id, name) VALUES ($1, 'production') RETURNING id`, projectID).Scan(&envID); err != nil {
+		t.Fatalf("seed environment: %v", err)
+	}
+	sessionID = fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	key = fmt.Sprintf("sessions/%s/%s/chunk-000000.json.gz", projectID, sessionID)
+	if err := q.InsertSession(ctx, sessionID, projectID, envID, nil, time.Now(), "https://example.test"); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if err := q.ReserveChunkSeq(ctx, sessionID, projectID, 0, key, true); err != nil {
+		t.Fatalf("reserve chunk: %v", err)
+	}
+	return sessionID, projectID, key
+}
+
+func readScrubbedAt(t *testing.T, pool *pgxpool.Pool, sessionID string) time.Time {
+	t.Helper()
+	var at *time.Time
+	if err := pool.QueryRow(context.Background(),
+		`SELECT scrubbed_at FROM session_chunks WHERE session_id=$1 AND seq=0`, sessionID).Scan(&at); err != nil {
+		t.Fatalf("read scrubbed_at: %v", err)
+	}
+	if at == nil {
+		t.Fatal("chunk is not scrubbed")
+	}
+	return *at
+}
+
+func ageChunkPolicy(t *testing.T, pool *pgxpool.Pool, sessionID string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE session_chunks SET uploaded_at = now() - interval '31 seconds' WHERE session_id = $1`, sessionID); err != nil {
+		t.Fatalf("age chunk policy: %v", err)
+	}
+}
+
+func TestScrubber_RedactsSecretsAndMarksScrubbed(t *testing.T) {
+	s, q, mc, pool := setup(t)
+	ctx := context.Background()
+	sid, projectID, key := seedChunk(t, q, pool)
+	t.Cleanup(func() { _ = mc.RemoveObject(context.Background(), key) })
+	raw := []byte(`{"events":[{"type":5,"data":{"headers":{"authorization":"Bearer sk_live_SUPERSECRET"}}}]}`)
+	gz, err := compress.Deflate(raw)
+	if err != nil {
+		t.Fatalf("deflate: %v", err)
+	}
+	if err := mc.PutObject(ctx, key, gz, "application/gzip"); err != nil {
+		t.Fatalf("seed object: %v", err)
+	}
+	if err := q.CommitChunk(ctx, sid, projectID, 0, int64(len(gz))); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	ageChunkPolicy(t, pool, sid)
+
+	scrubbed, failed, err := s.RunOnce(ctx)
+	if err != nil || scrubbed < 1 || failed != 0 {
+		t.Fatalf("RunOnce scrubbed=%d failed=%d err=%v", scrubbed, failed, err)
+	}
+	stored, err := mc.GetObject(ctx, key)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	plain, err := compress.InflateLimited(bytes.NewReader(stored), 20<<20)
+	if err != nil {
+		t.Fatalf("inflate stored: %v", err)
+	}
+	if strings.Contains(string(plain), "sk_live_SUPERSECRET") {
+		t.Fatal("secret survived scrubbing")
+	}
+	_ = readScrubbedAt(t, pool, sid)
+}
+
+func TestScrubber_RejectsGzipBombAndLeavesItUnreadable(t *testing.T) {
+	s, q, mc, pool := setup(t)
+	ctx := context.Background()
+	sid, projectID, key := seedChunk(t, q, pool)
+	s.MaxInflateBytes = 1 << 20
+	bomb, err := compress.Deflate(bytes.Repeat([]byte("A"), 50<<20))
+	if err != nil {
+		t.Fatalf("build bomb: %v", err)
+	}
+	if err := mc.PutObject(ctx, key, bomb, "application/gzip"); err != nil {
+		t.Fatalf("seed bomb: %v", err)
+	}
+	if err := q.CommitChunk(ctx, sid, projectID, 0, int64(len(bomb))); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	ageChunkPolicy(t, pool, sid)
+	_, failed, err := s.RunOnce(ctx)
+	if err != nil || failed < 1 {
+		t.Fatalf("RunOnce failed=%d err=%v", failed, err)
+	}
+	var scrubbedAt *time.Time
+	var scrubErr *string
+	if err := pool.QueryRow(ctx, `SELECT scrubbed_at, scrub_error FROM session_chunks WHERE session_id=$1 AND seq=0`, sid).Scan(&scrubbedAt, &scrubErr); err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	if scrubbedAt != nil || scrubErr == nil {
+		t.Fatalf("fail-closed fields scrubbed_at=%v scrub_error=%v", scrubbedAt, scrubErr)
+	}
+	if _, err := mc.StatObject(ctx, key); err == nil {
+		t.Fatal("gzip bomb object still exists")
+	}
+}
+
+func TestScrubber_IsIdempotent(t *testing.T) {
+	s, q, mc, pool := setup(t)
+	ctx := context.Background()
+	sid, projectID, key := seedChunk(t, q, pool)
+	t.Cleanup(func() { _ = mc.RemoveObject(context.Background(), key) })
+	gz, _ := compress.Deflate([]byte(`{"events":[]}`))
+	if err := mc.PutObject(ctx, key, gz, "application/gzip"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := q.CommitChunk(ctx, sid, projectID, 0, int64(len(gz))); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	ageChunkPolicy(t, pool, sid)
+	if _, _, err := s.RunOnce(ctx); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	before := readScrubbedAt(t, pool, sid)
+	if _, _, err := s.RunOnce(ctx); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	after := readScrubbedAt(t, pool, sid)
+	if !before.Equal(after) {
+		t.Fatal("second pass re-scrubbed the chunk")
+	}
+}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,0 +1,39 @@
+# @opslane/sdk changelog
+
+## 1.0.0
+
+### BREAKING: session recording is now on by default
+
+`replay.enabled` previously defaulted to `false`. It now defaults to `true`.
+Upgrading to 1.0.0 starts recording every session unless you opt out:
+
+```js
+init({ apiKey: '...', replay: { enabled: false } });
+```
+
+This is a deliberate major version so the default changes only when you choose
+to upgrade. A project-level kill switch can also stop new and in-flight
+recording without redeploying.
+
+Before upgrading, read [the replay privacy guide](../../docs/replay-privacy.md):
+
+- Check masking. Inputs are masked by default; rendered text is not. Use
+  `.opslane-mask` for sensitive text and `.opslane-block` to exclude a subtree.
+- Tell users that every session, rather than only error moments, is recorded.
+- Check retention. The default is 30 days and the hard maximum is 90 days.
+
+Other changes:
+
+- Sessions survive page loads in `sessionStorage`, rotate after 30 minutes idle,
+  and rotate on login/logout so one session maps to one end user.
+- Recording uploads as gzipped, independently playable chunks at roughly
+  30-second intervals.
+- Chunks are redacted server-side before downstream reads.
+- Recording requires `CompressionStream` (Chrome/Edge 80+, Safari 16.4+,
+  Firefox 113+). Error reporting remains available on older browsers.
+- `setUser()` and `clearUser()` now rotate the recording session.
+
+### Fixed
+
+- Replay upload failures can now be reported to the server instead of leaving
+  replay rows pending indefinitely.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opslane/sdk",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "type": "module",
   "description": "Browser error monitoring SDK for Opslane",
   "license": "MIT",

--- a/packages/sdk/src/__tests__/browser-contract.test.ts
+++ b/packages/sdk/src/__tests__/browser-contract.test.ts
@@ -107,6 +107,7 @@ describe.skipIf(!playwrightAvailable)('SDK browser contract', () => {
                   apiKey: 'sk-test-browser',
                   flushInterval: 200,
                   maxBatchSize: 1,
+                  replay: { enabled: false },
                 });`
               );
             }

--- a/packages/sdk/src/__tests__/chunk-upload.test.ts
+++ b/packages/sdk/src/__tests__/chunk-upload.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { _resetChunkUploadState, flushInline, uploadChunk } from '../chunk-upload';
+import { loadConfig, resetConfig } from '../config';
+
+const ENDPOINT = 'https://ingest.example.com';
+
+function policyResponse() {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      upload_url: 'https://storage.example.com/opslane-replays',
+      form_data: { key: 'sessions/p/s/chunk-000000.json.gz', policy: 'abc', 'x-amz-signature': 'sig' },
+    }),
+  };
+}
+
+describe('uploadChunk', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    resetConfig();
+    _resetChunkUploadState();
+    loadConfig({ apiKey: 'test-key', endpoint: ENDPOINT });
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it('runs upload-url -> storage POST -> commit in order', async () => {
+    fetchMock
+      .mockResolvedValueOnce(policyResponse())
+      .mockResolvedValueOnce({ ok: true, status: 204 })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    expect(await uploadChunk('sess_abc', 0, [{ type: 2, timestamp: 1 }] as never, true)).toBe(true);
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      `${ENDPOINT}/api/v1/sessions/sess_abc/chunks/upload-url`,
+      'https://storage.example.com/opslane-replays',
+      `${ENDPOINT}/api/v1/sessions/sess_abc/chunks/0/commit`,
+    ]);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({ seq: 0, has_full_snapshot: true });
+  });
+
+  it('declares the exact compressed byte length and appends file last', async () => {
+    let declared = -1;
+    let sent = -1;
+    let order: string[] = [];
+    fetchMock
+      .mockImplementationOnce(async (_url, options) => {
+        declared = JSON.parse(options.body).size_bytes;
+        return policyResponse();
+      })
+      .mockImplementationOnce(async (_url, options) => {
+        const form = options.body as FormData;
+        sent = (form.get('file') as Blob).size;
+        order = Array.from(form.keys());
+        return { ok: true, status: 204 };
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    await uploadChunk('sess_abc', 0, [{ type: 2, timestamp: 1 }] as never, true);
+    expect(declared).toBe(sent);
+    expect(order.at(-1)).toBe('file');
+  });
+
+  it('does not commit when storage fails', async () => {
+    fetchMock.mockResolvedValueOnce(policyResponse()).mockResolvedValueOnce({ ok: false, status: 400 });
+    expect(await uploadChunk('sess_abc', 0, [{ type: 2, timestamp: 1 }] as never, true)).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports stop on 403 and 410', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 403 });
+    expect(await uploadChunk('sess_abc', 0, [{ type: 2, timestamp: 1 }] as never, true)).toBe('stop');
+    _resetChunkUploadState();
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 410 });
+    expect(await uploadChunk('sess_abc', 1, [{ type: 2, timestamp: 1 }] as never, true)).toBe('stop');
+  });
+
+  it('never throws and skips empty chunks', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    await expect(uploadChunk('sess_abc', 0, [{ type: 2, timestamp: 1 }] as never, true)).resolves.toBe(false);
+    fetchMock.mockClear();
+    expect(await uploadChunk('sess_abc', 0, [] as never, true)).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('flushInline', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    resetConfig();
+    _resetChunkUploadState();
+    loadConfig({ apiKey: 'test-key', endpoint: ENDPOINT });
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it('sends one keepalive request with gzip inline', async () => {
+    expect(await flushInline('sess_abc', 3, [{ type: 2, timestamp: 1 }] as never)).toBe(true);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${ENDPOINT}/api/v1/sessions/sess_abc/chunks/3/inline`);
+    expect(options).toMatchObject({ keepalive: true, headers: { 'Content-Type': 'application/gzip' } });
+  });
+
+  it('drops an over-budget tail and never throws', async () => {
+    const huge = Array.from({ length: 20_000 }, (_, i) => ({
+      type: 3, timestamp: i, data: { text: `unique-${Math.random()}-${i}` },
+    }));
+    expect(await flushInline('sess_abc', 4, huge as never)).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    fetchMock.mockRejectedValue(new Error('page gone'));
+    await expect(flushInline('sess_abc', 5, [{ type: 2, timestamp: 1 }] as never)).resolves.toBe(false);
+  });
+});

--- a/packages/sdk/src/__tests__/config.test.ts
+++ b/packages/sdk/src/__tests__/config.test.ts
@@ -27,7 +27,7 @@ describe('SDK Config', () => {
       flushInterval: 5_000,
       maxBatchSize: 10,
       debug: false,
-      replayEnabled: false,
+      replayEnabled: true,
       sampleRate: 1,
       errorThrottleMs: 1000,
       beforeSend: undefined,
@@ -78,6 +78,24 @@ describe('SDK Config', () => {
 
     const config = getConfig();
     expect(config.replayEnabled).toBe(true);
+  });
+
+  describe('replay default (design v4-15)', () => {
+    it('defaults replay to enabled when absent or empty', () => {
+      loadConfig({ apiKey: 'k' });
+      expect(getConfig().replayEnabled).toBe(true);
+      resetConfig();
+      loadConfig({ apiKey: 'k', replay: {} });
+      expect(getConfig().replayEnabled).toBe(true);
+    });
+
+    it('honours explicit opt-out and opt-in', () => {
+      loadConfig({ apiKey: 'k', replay: { enabled: false } });
+      expect(getConfig().replayEnabled).toBe(false);
+      resetConfig();
+      loadConfig({ apiKey: 'k', replay: { enabled: true } });
+      expect(getConfig().replayEnabled).toBe(true);
+    });
   });
 
   it('should throw if getConfig called before loadConfig', () => {

--- a/packages/sdk/src/__tests__/gzip.test.ts
+++ b/packages/sdk/src/__tests__/gzip.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { gunzipSync } from 'node:zlib';
+import { gzip, gzipSupported } from '../gzip';
+
+describe('gzip', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('reports support when CompressionStream exists', () => {
+    expect(gzipSupported()).toBe(true);
+  });
+
+  it('produces real gzip that inflates back to the input', async () => {
+    const original = JSON.stringify({ events: Array.from({ length: 50 }, (_, i) => ({ type: 3, i })) });
+    const out = await gzip(original);
+    expect(gunzipSync(Buffer.from(out!)).toString('utf8')).toBe(original);
+    expect(out?.[0]).toBe(0x1f);
+    expect(out?.[1]).toBe(0x8b);
+  });
+
+  it('compresses repetitive rrweb-like payloads', async () => {
+    const original = JSON.stringify({ events: Array.from({ length: 500 }, () => ({ type: 3, data: { source: 2, x: 1, y: 2 } })) });
+    expect((await gzip(original))!.byteLength).toBeLessThan(original.length / 5);
+  });
+
+  it('handles unicode without corruption', async () => {
+    const original = JSON.stringify({ text: 'héllo 世界 🎉' });
+    expect(gunzipSync(Buffer.from((await gzip(original))!)).toString('utf8')).toBe(original);
+  });
+
+  it('returns null when CompressionStream is unavailable', async () => {
+    vi.stubGlobal('CompressionStream', undefined);
+    expect(gzipSupported()).toBe(false);
+    expect(await gzip('{"a":1}')).toBeNull();
+  });
+
+  it('returns null rather than throwing when compression fails', async () => {
+    vi.stubGlobal('CompressionStream', class { constructor() { throw new Error('boom'); } });
+    expect(await gzip('{"a":1}')).toBeNull();
+  });
+});

--- a/packages/sdk/src/__tests__/index.test.ts
+++ b/packages/sdk/src/__tests__/index.test.ts
@@ -7,6 +7,7 @@ vi.mock('../core', () => ({
   captureException: vi.fn(),
   setUser: vi.fn(),
   clearUser: vi.fn(),
+  onIdentityChange: vi.fn(),
 }));
 
 vi.mock('../console', () => ({
@@ -33,6 +34,11 @@ vi.mock('../replay', () => ({
   stopReplayCapture: vi.fn(),
 }));
 
+vi.mock('../telemetry', () => ({
+  installInteractionTelemetry: vi.fn(),
+  uninstallInteractionTelemetry: vi.fn(),
+}));
+
 import { init, destroy } from '../index';
 import { loadConfig, resetConfig } from '../config';
 import * as core from '../core';
@@ -40,6 +46,7 @@ import * as consolePatcher from '../console';
 import * as network from '../network';
 import * as transport from '../transport';
 import * as replay from '../replay';
+import * as telemetry from '../telemetry';
 
 describe('SDK Public API', () => {
   afterEach(() => {
@@ -58,6 +65,7 @@ describe('SDK Public API', () => {
     expect(consolePatcher.patchConsole).toHaveBeenCalledTimes(1);
     expect(network.patchFetch).toHaveBeenCalledTimes(1);
     expect(network.patchXHR).toHaveBeenCalledTimes(1);
+    expect(telemetry.installInteractionTelemetry).toHaveBeenCalledTimes(1);
     expect(transport.startTransport).toHaveBeenCalledTimes(1);
     expect(replay.startReplayCapture).toHaveBeenCalledTimes(1);
   });
@@ -74,6 +82,7 @@ describe('SDK Public API', () => {
     expect(consolePatcher.unpatchConsole).toHaveBeenCalledTimes(1);
     expect(network.unpatchFetch).toHaveBeenCalledTimes(1);
     expect(network.unpatchXHR).toHaveBeenCalledTimes(1);
+    expect(telemetry.uninstallInteractionTelemetry).toHaveBeenCalledTimes(1);
     expect(transport.stopTransport).toHaveBeenCalledTimes(1);
     expect(replay.stopReplayCapture).toHaveBeenCalledTimes(1);
   });

--- a/packages/sdk/src/__tests__/network.test.ts
+++ b/packages/sdk/src/__tests__/network.test.ts
@@ -4,6 +4,7 @@ import {
   unpatchFetch,
   patchXHR,
   unpatchXHR,
+  sdkFetch,
 } from '../network';
 import { clearBreadcrumbs, getBreadcrumbs } from '../breadcrumbs';
 import { loadConfig, resetConfig } from '../config';
@@ -115,6 +116,15 @@ describe('Network Interceptor', () => {
       unpatchFetch();
 
       expect(globalThis.fetch).toBe(originalFetch);
+    });
+
+    it('bypasses telemetry and breadcrumbs for SDK-owned storage traffic', async () => {
+      const originalFetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+      globalThis.fetch = originalFetch;
+      patchFetch();
+      await sdkFetch('https://storage.example.com/chunk', { method: 'POST' });
+      expect(originalFetch).toHaveBeenCalledTimes(1);
+      expect(getBreadcrumbs()).toHaveLength(0);
     });
 
     it('should never throw even if breadcrumb adding fails', async () => {

--- a/packages/sdk/src/__tests__/replay-browser.test.ts
+++ b/packages/sdk/src/__tests__/replay-browser.test.ts
@@ -59,6 +59,11 @@ describe.skipIf(!playwrightAvailable)('rrweb replay capture (real browser)', () 
              .end(JSON.stringify({ event_id: 'evt_test', group_id: 'grp_test', error_group_id: 'grp_test' }));
           return;
         }
+        if (url === '/api/v1/sessions/init') {
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+             .end(JSON.stringify({ recording: true, chunk_interval_ms: 30000, max_chunk_bytes: 5242880 }));
+          return;
+        }
         if (url === '/api/v1/replays/init') {
           try { initBody = JSON.parse(body); } catch { initBody = null; }
           res.writeHead(200, { 'Content-Type': 'application/json' })

--- a/packages/sdk/src/__tests__/replay.test.ts
+++ b/packages/sdk/src/__tests__/replay.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EventType, type eventWithTime } from '@rrweb/types';
-import type { ErrorEventPayload } from '@opslane/shared';
-import { addBreadcrumb, clearBreadcrumbs } from '../breadcrumbs';
+import { clearBreadcrumbs } from '../breadcrumbs';
 import { loadConfig, resetConfig } from '../config';
-import { enqueueEvent, flushEvents, _resetQueue } from '../transport';
-import { _resetThrottle } from '../throttle';
+import { clearUser, setUser } from '../core';
+import { emitTelemetry } from '../telemetry';
+import { _rehydrateFromStorage, peekChunkSeq, resetSessionId } from '../session';
 import {
   _resetReplayState,
   snapshotRrwebEvents,
@@ -27,6 +27,8 @@ const rrwebState = vi.hoisted(() => {
     options: undefined as unknown,
     stop: vi.fn(),
     record: vi.fn(),
+    takeFullSnapshot: vi.fn(),
+    addCustomEvent: vi.fn(),
   };
   state.record.mockImplementation((options: unknown) => {
     state.options = options;
@@ -35,19 +37,23 @@ const rrwebState = vi.hoisted(() => {
   return state;
 });
 
-vi.mock('rrweb', () => ({
-  record: rrwebState.record,
+const chunkMocks = vi.hoisted(() => ({
+  reset: vi.fn(),
+  uploadChunk: vi.fn(),
+  flushInline: vi.fn(),
 }));
 
-function installRecordMock(): void {
-  rrwebState.options = undefined;
-  rrwebState.stop.mockClear();
-  rrwebState.record.mockReset();
-  rrwebState.record.mockImplementation((options: unknown) => {
-    rrwebState.options = options;
-    return rrwebState.stop;
-  });
-}
+vi.mock('rrweb', () => ({
+  record: rrwebState.record,
+  takeFullSnapshot: rrwebState.takeFullSnapshot,
+  addCustomEvent: rrwebState.addCustomEvent,
+}));
+
+vi.mock('../chunk-upload', () => ({
+  _resetChunkUploadState: chunkMocks.reset,
+  uploadChunk: chunkMocks.uploadChunk,
+  flushInline: chunkMocks.flushInline,
+}));
 
 function recordOptions(): RecordOptions {
   expect(rrwebState.options).toBeTruthy();
@@ -55,109 +61,136 @@ function recordOptions(): RecordOptions {
 }
 
 function emit(event: eventWithTime, isCheckout?: boolean): void {
-  const options = recordOptions();
-  expect(typeof options.emit).toBe('function');
-  options.emit?.(event, isCheckout);
+  recordOptions().emit?.(event, isCheckout);
 }
 
 function fullSnapshot(timestamp: number): eventWithTime {
   return {
     type: EventType.FullSnapshot,
     timestamp,
-    data: {
-      node: { id: 1, type: 0, childNodes: [] },
-      initialOffset: { top: 0, left: 0 },
-    },
+    data: { node: { id: 1, type: 0, childNodes: [] }, initialOffset: { top: 0, left: 0 } },
   } as unknown as eventWithTime;
 }
 
-function customEvent(timestamp: number, payload: Record<string, unknown> = {}): eventWithTime {
+function meta(timestamp: number): eventWithTime {
   return {
-    type: EventType.Custom,
+    type: EventType.Meta,
     timestamp,
-    data: {
-      tag: 'opslane.test',
-      payload,
-    },
+    data: { href: 'https://example.test/', width: 1280, height: 720 },
   } as eventWithTime;
 }
 
-function makeEvent(overrides?: Partial<ErrorEventPayload>): ErrorEventPayload {
+function incremental(timestamp: number, text = ''): eventWithTime {
   return {
-    timestamp: new Date().toISOString(),
-    error: {
-      type: 'TypeError',
-      message: 'Cannot read properties of null',
-      stack: 'TypeError: Cannot read properties of null\n at UserCard.vue:8:20',
-    },
-    breadcrumbs: [],
-    context: {
-      url: 'http://localhost:4173/user',
-      user_agent: 'vitest',
-    },
-    sdk_version: '0.2.0',
-    ...overrides,
-  };
+    type: EventType.IncrementalSnapshot,
+    timestamp,
+    data: { source: 2, text },
+  } as unknown as eventWithTime;
 }
 
 async function drainMicrotasks(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
+  for (let i = 0; i < 8; i += 1) await Promise.resolve();
 }
 
-async function waitForFetchCallCount(count: number): Promise<void> {
-  for (let i = 0; i < 20; i += 1) {
-    if (fetchMockCallCount() >= count) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-}
-
-function fetchMockCallCount(): number {
-  return vi.mocked(globalThis.fetch).mock.calls.length;
-}
-
-describe('rrweb replay capture', () => {
+describe('continuous chunked recording', () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
-    installRecordMock();
-    _resetQueue();
-    _resetThrottle();
     _resetReplayState();
+    clearUser();
+    sessionStorage.clear();
+    resetSessionId();
     clearBreadcrumbs();
     resetConfig();
+    loadConfig({ apiKey: 'key-abc', endpoint: 'https://ingest.example.com', replay: { enabled: true } });
     fetchMock.mockReset();
-    globalThis.fetch = fetchMock;
-    window.history.replaceState({}, '', '/');
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    chunkMocks.uploadChunk.mockReset().mockResolvedValue(true);
+    chunkMocks.flushInline.mockReset().mockResolvedValue(true);
+    chunkMocks.reset.mockClear();
+    rrwebState.options = undefined;
+    rrwebState.stop.mockClear();
+    rrwebState.takeFullSnapshot.mockClear();
+    rrwebState.addCustomEvent.mockClear();
+    rrwebState.record.mockReset().mockImplementation((options: unknown) => {
+      rrwebState.options = options;
+      return rrwebState.stop;
+    });
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
   });
 
   afterEach(() => {
     stopReplayCapture();
-    _resetQueue();
-    _resetReplayState();
-    clearBreadcrumbs();
     resetConfig();
+    sessionStorage.clear();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it('does not start rrweb when replay is disabled', async () => {
-    loadConfig({ endpoint: 'https://ingest.example.com', apiKey: 'key-abc' });
-
+  async function startEnabled(): Promise<void> {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ recording: true, chunk_interval_ms: 30_000, max_chunk_bytes: 5_242_880 }),
+    });
     await startReplayCapture();
+    await drainMicrotasks();
+  }
 
-    expect(rrwebState.record).not.toHaveBeenCalled();
-    expect(snapshotRrwebEvents()).toEqual([]);
+  it('registers the session before recording', async () => {
+    await startEnabled();
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/api/v1/sessions/init');
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+      session_id: expect.any(String),
+      started_at: expect.any(String),
+    });
+    expect(fetchMock.mock.invocationCallOrder[0]).toBeLessThan(rrwebState.record.mock.invocationCallOrder[0]);
   });
 
-  it('lazy-loads and starts rrweb with fixed C4 masking options', async () => {
-    loadConfig({ endpoint: 'https://ingest.example.com', apiKey: 'key-abc', replay: { enabled: true } });
+  it('registers the latest identity when it changes during initial session registration', async () => {
+    let resolveInitial!: (value: { ok: boolean; json: () => Promise<{ recording: boolean }> }) => void;
+    fetchMock
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveInitial = resolve; }))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ recording: true }) });
 
+    const starting = startReplayCapture();
+    await drainMicrotasks();
+    const firstID = (JSON.parse(fetchMock.mock.calls[0][1].body) as { session_id: string }).session_id;
+    setUser({ id: 'alice' });
+    resolveInitial({ ok: true, json: async () => ({ recording: true }) });
+    await starting;
+
+    const initCalls = fetchMock.mock.calls.filter((call) => String(call[0]).includes('/sessions/init'));
+    expect(initCalls).toHaveLength(2);
+    const latestID = (JSON.parse(initCalls[1][1].body) as { session_id: string }).session_id;
+    expect(latestID).not.toBe(firstID);
+    emit(fullSnapshot(1_000), true);
+    emit(incremental(1_500));
+    emit(fullSnapshot(31_000), true);
+    await drainMicrotasks();
+    expect(chunkMocks.uploadChunk).toHaveBeenCalledWith(latestID, 0, expect.any(Array), true);
+  });
+
+  it('does not start rrweb when disabled, unsupported, or killed server-side', async () => {
+    resetConfig();
+    loadConfig({ apiKey: 'k', endpoint: 'https://ingest.example.com', replay: { enabled: false } });
     await startReplayCapture();
+    expect(rrwebState.record).not.toHaveBeenCalled();
 
-    expect(rrwebState.record).toHaveBeenCalledTimes(1);
+    resetConfig();
+    loadConfig({ apiKey: 'k', endpoint: 'https://ingest.example.com', replay: { enabled: true } });
+    vi.stubGlobal('CompressionStream', undefined);
+    await startReplayCapture();
+    expect(rrwebState.record).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ recording: false }) });
+    await startReplayCapture();
+    expect(rrwebState.record).not.toHaveBeenCalled();
+  });
+
+  it('configures checkout snapshots and masking', async () => {
+    await startEnabled();
     expect(recordOptions()).toMatchObject({
       checkoutEveryNms: 30_000,
       maskAllInputs: true,
@@ -167,171 +200,191 @@ describe('rrweb replay capture', () => {
     });
   });
 
-  it('keeps two rrweb windows and preserves a full snapshot at the start', async () => {
-    loadConfig({ endpoint: 'https://ingest.example.com', apiKey: 'key-abc', replay: { enabled: true } });
-    await startReplayCapture();
-
+  it('cuts independently playable chunks on checkout boundaries', async () => {
+    await startEnabled();
+    emit(meta(999), false);
     emit(fullSnapshot(1_000), true);
-    emit(customEvent(1_100, { phase: 'first-window' }));
+    emit(incremental(1_500));
+    emit(meta(30_999), true);
     emit(fullSnapshot(31_000), true);
-    emit(customEvent(31_100, { phase: 'second-window' }));
+    emit(incremental(31_500));
+    emit(meta(60_999), true);
+    emit(fullSnapshot(61_000), true);
+    await drainMicrotasks();
 
-    const events = snapshotRrwebEvents();
-    expect(events).toHaveLength(4);
-    expect(events[0]?.type).toBe(EventType.FullSnapshot);
-    expect(events[2]?.type).toBe(EventType.FullSnapshot);
+    expect(chunkMocks.uploadChunk).toHaveBeenCalledTimes(2);
+    expect(chunkMocks.uploadChunk.mock.calls.map((call) => call[1])).toEqual([0, 1]);
+    for (const call of chunkMocks.uploadChunk.mock.calls) {
+      expect((call[2] as eventWithTime[])[0].type).toBe(EventType.FullSnapshot);
+      expect(call[3]).toBe(true);
+    }
   });
 
-  it('drops the older window whole when the combined recording exceeds the SDK byte cap', async () => {
-    loadConfig({ endpoint: 'https://ingest.example.com', apiKey: 'key-abc', replay: { enabled: true } });
-    await startReplayCapture();
-
+  it('does not upload an empty chunk on the first checkout', async () => {
+    await startEnabled();
     emit(fullSnapshot(1_000), true);
-    emit(customEvent(1_100, { body: 'x'.repeat(2 * 1024 * 1024) }));
-    emit(fullSnapshot(31_000), true);
-    emit(customEvent(31_100, { phase: 'survives' }));
-
-    const events = snapshotRrwebEvents();
-    expect(events).toHaveLength(2);
-    expect(events[0]?.timestamp).toBe(31_000);
-    expect(events[0]?.type).toBe(EventType.FullSnapshot);
-    expect(events[1]?.timestamp).toBe(31_100);
+    await drainMicrotasks();
+    expect(chunkMocks.uploadChunk).not.toHaveBeenCalled();
   });
 
-  it('uploads recording.json and completes with breadcrumb-derived C4 signals', async () => {
-    vi.spyOn(Date, 'now').mockReturnValue(1_717_000_045_000);
-    window.history.replaceState({}, '', '/dashboard?token=secret#access_token=abc');
-    loadConfig({ endpoint: 'https://ingest.example.com', apiKey: 'key-abc', replay: { enabled: true } });
-    await startReplayCapture();
-    emit(fullSnapshot(1_717_000_000_000), true);
-    emit(customEvent(1_717_000_001_000, { click: 'submit' }));
-    addBreadcrumb({
-      type: 'console',
-      timestamp: new Date().toISOString(),
-      category: 'console',
-      level: 'error',
-      message: 'render failed',
-    });
-    addBreadcrumb({
-      type: 'fetch',
-      timestamp: new Date().toISOString(),
-      category: 'http',
-      level: 'error',
-      message: 'POST /api/users failed',
-      data: { method: 'POST', url: 'https://api.example.com/users?token=secret', status_code: 500 },
-    });
+  it('resumes the sequence counter after a reload', async () => {
+    await startEnabled();
+    emit(fullSnapshot(1_000), true);
+    emit(incremental(1_500));
+    emit(fullSnapshot(31_000), true);
+    await drainMicrotasks();
+    expect(chunkMocks.uploadChunk.mock.calls[0][1]).toBe(0);
+
+    stopReplayCapture();
+    resetSessionId();
+    _rehydrateFromStorage();
+    chunkMocks.uploadChunk.mockClear();
+    await startEnabled();
+    emit(fullSnapshot(60_000), true);
+    emit(incremental(60_500));
+    emit(fullSnapshot(90_000), true);
+    await drainMicrotasks();
+    expect(chunkMocks.uploadChunk.mock.calls[0][1]).toBe(1);
+  });
+
+  it('forces a checkout before a raw chunk exceeds the signed cap', async () => {
+    await startEnabled();
+    emit(fullSnapshot(1_000), true);
+    emit(incremental(1_500, 'x'.repeat(21 * 1024 * 1024)));
+    expect(rrwebState.takeFullSnapshot).toHaveBeenCalledWith(true);
+  });
+
+  it('stops when the server signals stop mid-session', async () => {
+    await startEnabled();
+    chunkMocks.uploadChunk.mockResolvedValue('stop');
+    emit(fullSnapshot(1_000), true);
+    emit(incremental(1_500));
+    emit(fullSnapshot(31_000), true);
+    await drainMicrotasks();
+    expect(rrwebState.stop).toHaveBeenCalled();
+  });
+
+  it('flushes inline when the page becomes hidden', async () => {
+    await startEnabled();
+    emit(fullSnapshot(1_000), true);
+    emit(incremental(1_500));
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await drainMicrotasks();
+    expect(chunkMocks.flushInline).toHaveBeenCalledWith(expect.any(String), 0, expect.any(Array));
+    expect(rrwebState.takeFullSnapshot).toHaveBeenCalledWith(true);
+  });
+
+  it('falls back to the normal uploader when the inline tail cannot land', async () => {
+    await startEnabled();
+    chunkMocks.flushInline.mockResolvedValueOnce(false);
+    emit(fullSnapshot(1_000), true);
+    emit(incremental(1_500));
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await drainMicrotasks();
+    expect(chunkMocks.uploadChunk).toHaveBeenCalledWith(expect.any(String), 0, expect.any(Array), true);
+  });
+
+  it('registers a new session when identity changes', async () => {
+    await startEnabled();
+    emit(fullSnapshot(1_000), true);
+    emit(incremental(1_500));
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ recording: true }) });
+    setUser({ id: 'alice' });
+    await drainMicrotasks();
+    const initCalls = fetchMock.mock.calls.filter((call) => String(call[0]).includes('/sessions/init'));
+    expect(initCalls).toHaveLength(2);
+    expect(chunkMocks.uploadChunk).toHaveBeenCalledTimes(1);
+    expect(rrwebState.takeFullSnapshot).toHaveBeenCalledWith(true);
+  });
+
+  it('closes the old identity with its next seq without advancing the new session', async () => {
+    await startEnabled();
+    emit(fullSnapshot(1_000), true);
+    emit(incremental(1_500));
+    emit(fullSnapshot(31_000), true); // old session seq 0
+    emit(incremental(31_500));
+    await drainMicrotasks();
+    chunkMocks.uploadChunk.mockClear();
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ recording: true }) });
+
+    setUser({ id: 'alice' });
+    await drainMicrotasks();
+
+    expect(chunkMocks.uploadChunk.mock.calls[0]?.[1]).toBe(1);
+    expect(peekChunkSeq()).toBe(0);
+  });
+
+  it('rotates idle capture without mixing old events into the new session', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-14T12:00:00Z'));
+    await startEnabled();
+    const firstInit = JSON.parse(fetchMock.mock.calls[0][1].body) as { session_id: string };
+    emit(fullSnapshot(1_000), true);
+    emit(incremental(1_500, 'old-session'));
+
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ recording: true }) });
+    vi.setSystemTime(new Date('2026-07-14T12:31:00Z'));
+    emit(incremental(2_000, 'idle-boundary'));
+    await drainMicrotasks();
+
+    const initCalls = fetchMock.mock.calls.filter((call) => String(call[0]).includes('/sessions/init'));
+    expect(initCalls).toHaveLength(2);
+    const secondInit = JSON.parse(initCalls[1][1].body) as { session_id: string };
+    expect(secondInit.session_id).not.toBe(firstInit.session_id);
+    expect(chunkMocks.uploadChunk).toHaveBeenCalledWith(
+      firstInit.session_id,
+      0,
+      expect.arrayContaining([expect.objectContaining({ timestamp: 1_500 })]),
+      true,
+    );
+
+    // Incrementals emitted while registration/snapshot rotation is incomplete
+    // cannot form an independently playable chunk and must be discarded.
+    emit(incremental(2_500, 'before-snapshot'));
+    emit(fullSnapshot(3_000), true);
+    emit(incremental(3_500, 'new-session'));
+    emit(fullSnapshot(33_000), true);
+    await drainMicrotasks();
+
+    const newSessionCall = chunkMocks.uploadChunk.mock.calls.find((call) => call[0] === secondInit.session_id);
+    expect(newSessionCall?.[1]).toBe(0);
+    expect((newSessionCall?.[2] as eventWithTime[])[0].type).toBe(EventType.FullSnapshot);
+    expect(JSON.stringify(newSessionCall?.[2])).not.toContain('before-snapshot');
+    vi.useRealTimers();
+  });
+
+  it('routes telemetry into rrweb custom events', async () => {
+    await startEnabled();
+    emitTelemetry({ kind: 'click', clickId: 'c_1', selector: '#buy', cursor: 'pointer', at: 1 });
+    expect(rrwebState.addCustomEvent).toHaveBeenCalledWith(
+      'opslane.telemetry',
+      expect.objectContaining({ kind: 'click', selector: '#buy' }),
+    );
+  });
+
+  it('retains the legacy error-triggered upload until Batch 2', async () => {
+    await startEnabled();
+    emit(fullSnapshot(1_000), true);
+    emit(incremental(1_500));
     fetchMock
-      .mockResolvedValueOnce(new Response(JSON.stringify({
-        replay_id: 'replay-1',
-        upload_url: 'https://s3.example.com/upload',
-        upload_headers: { 'x-amz-meta-test': '1' },
-      }), { status: 201 }))
-      .mockResolvedValueOnce(new Response('', { status: 200 }))
-      .mockResolvedValueOnce(new Response('', { status: 200 }));
-
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ replay_id: 'replay-1', upload_url: 'https://storage.example.com/replay', upload_headers: {} }),
+      })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true });
     await uploadReplayForTrigger({
       triggerType: 'uncaught_error',
-      errorType: 'TypeError',
-      errorMessage: 'Cannot read properties of null',
+      errorType: 'Error',
+      errorMessage: 'boom',
       eventId: 'event-1',
-      errorGroupId: 'group-1',
     });
-
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-
-    const initCall = fetchMock.mock.calls[0];
-    expect(String(initCall?.[0])).toBe('https://ingest.example.com/api/v1/replays/init');
-    const initBody = JSON.parse(String(initCall?.[1]?.body || '{}'));
-    expect(initBody).toEqual({
-      session_id: expect.any(String),
-      error_event_id: 'event-1',
-      error_group_id: 'group-1',
-      trigger_type: 'uncaught_error',
-      page_url: 'http://localhost:3000/dashboard',
-      started_at: '2024-05-29T16:26:40.000Z',
-      ended_at: '2024-05-29T16:27:25.000Z',
-    });
-    expect(initBody).not.toHaveProperty('masking_profile');
-    expect(initBody).not.toHaveProperty('content_type');
-
-    const uploadCall = fetchMock.mock.calls[1];
-    expect(String(uploadCall?.[0])).toBe('https://s3.example.com/upload');
-    expect(uploadCall?.[1]?.method).toBe('PUT');
-    expect(uploadCall?.[1]?.headers).toMatchObject({
-      'Content-Type': 'application/json',
-      'x-amz-meta-test': '1',
-    });
-    const recording = JSON.parse(String(uploadCall?.[1]?.body || '{}'));
-    expect(recording.events).toHaveLength(2);
-    expect(recording.events[0].type).toBe(EventType.FullSnapshot);
-    expect(recording.meta).toEqual({
-      sdk_version: expect.any(String),
-      page_url: 'http://localhost:3000/dashboard',
-      started_at: 1_717_000_000_000,
-      ended_at: 1_717_000_045_000,
-      crash_timestamp: 1_717_000_045_000,
-    });
-
-    const completeCall = fetchMock.mock.calls[2];
-    expect(String(completeCall?.[0])).toBe('https://ingest.example.com/api/v1/replays/replay-1/complete');
-    const completeBody = JSON.parse(String(completeCall?.[1]?.body || '{}'));
-    expect(completeBody).not.toHaveProperty('artifacts');
-    expect(completeBody).not.toHaveProperty('content_type');
-    expect(completeBody).toMatchObject({
-      size_bytes: expect.any(Number),
-      signals: {
-        console: {
-          error_count: 1,
-          warning_count: 0,
-          error_messages: ['render failed'],
-          warning_messages: [],
-        },
-        network: {
-          anomaly_count: 1,
-          anomalies: [{
-            type: 'fetch',
-            method: 'POST',
-            url: 'https://api.example.com/users?token=secret',
-            status_code: 500,
-            message: 'POST /api/users failed',
-          }],
-        },
-      },
-    });
-  });
-
-  it('uploads replay for uncaught_error trigger after event ingestion', async () => {
-    loadConfig({ endpoint: 'https://ingest.example.com', apiKey: 'key-abc', replay: { enabled: true } });
-    await startReplayCapture();
-    emit(fullSnapshot(1_717_000_000_000), true);
-    fetchMock
-      .mockResolvedValueOnce(new Response(JSON.stringify({ event_id: 'event-1', error_group_id: 'group-1' }), { status: 202 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ replay_id: 'replay-1', upload_url: 'https://s3.example.com/upload', upload_headers: {} }), { status: 201 }))
-      .mockResolvedValueOnce(new Response('', { status: 200 }))
-      .mockResolvedValueOnce(new Response('', { status: 200 }));
-
-    enqueueEvent(makeEvent(), 'uncaught_error');
-    await flushEvents();
-    await drainMicrotasks();
-    await waitForFetchCallCount(4);
-
-    const calls = fetchMock.mock.calls.map((c) => String(c[0]));
-    expect(calls).toContain('https://ingest.example.com/api/v1/events');
-    expect(calls).toContain('https://ingest.example.com/api/v1/replays/init');
-    expect(calls).toContain('https://ingest.example.com/api/v1/replays/replay-1/complete');
-  });
-
-  it('does not upload replay for non-triggered events', async () => {
-    loadConfig({ endpoint: 'https://ingest.example.com', apiKey: 'key-abc', replay: { enabled: true } });
-    await startReplayCapture();
-    emit(fullSnapshot(1_717_000_000_000), true);
-    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 202 }));
-
-    enqueueEvent(makeEvent());
-    await flushEvents();
-
-    const calls = fetchMock.mock.calls.map((c) => String(c[0]));
-    expect(calls).toContain('https://ingest.example.com/api/v1/events');
-    expect(calls).not.toContain('https://ingest.example.com/api/v1/replays/init');
+    const urls = fetchMock.mock.calls.map((call) => String(call[0]));
+    expect(urls).toContain('https://ingest.example.com/api/v1/replays/init');
+    expect(urls).toContain('https://storage.example.com/replay');
+    expect(urls).toContain('https://ingest.example.com/api/v1/replays/replay-1/complete');
+    expect(snapshotRrwebEvents()[0].type).toBe(EventType.FullSnapshot);
   });
 });

--- a/packages/sdk/src/__tests__/selector.test.ts
+++ b/packages/sdk/src/__tests__/selector.test.ts
@@ -12,6 +12,32 @@ describe('deriveSelector', () => {
     expect(deriveSelector(document.querySelector('button'))).toBe('#checkout');
   });
 
+  // The attribute value is page-controlled. Escaping the quote but not the
+  // backslash lets a value ending in a backslash close the string early: the
+  // emitted selector then no longer denotes the element it was derived from.
+  it('emits a valid selector when the attribute value contains a backslash', () => {
+    const raw = 'a\\"b';
+    document.body.innerHTML = '<button>Buy</button>';
+    const el = document.querySelector('button')!;
+    el.setAttribute('data-testid', raw);
+
+    const selector = deriveSelector(el);
+
+    expect(() => document.querySelector(selector)).not.toThrow();
+    expect(document.querySelector(selector)).toBe(el);
+  });
+
+  it('emits a valid selector for a value ending in a backslash', () => {
+    document.body.innerHTML = '<button>Buy</button>';
+    const el = document.querySelector('button')!;
+    el.setAttribute('data-testid', 'trailing\\');
+
+    const selector = deriveSelector(el);
+
+    expect(() => document.querySelector(selector)).not.toThrow();
+    expect(document.querySelector(selector)).toBe(el);
+  });
+
   it('rejects hash-like ids and falls back to a path', () => {
     document.body.innerHTML = '<div><button id="a1b2c3d4e5f6a1b2c3d4">Buy</button></div>';
     const selector = deriveSelector(document.querySelector('button'));

--- a/packages/sdk/src/__tests__/selector.test.ts
+++ b/packages/sdk/src/__tests__/selector.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { deriveSelector } from '../selector';
+
+describe('deriveSelector', () => {
+  it('prefers data-testid', () => {
+    document.body.innerHTML = '<button data-testid="checkout-btn" id="x" class="a b">Buy</button>';
+    expect(deriveSelector(document.querySelector('button'))).toBe('[data-testid="checkout-btn"]');
+  });
+
+  it('falls back to a stable id', () => {
+    document.body.innerHTML = '<button id="checkout">Buy</button>';
+    expect(deriveSelector(document.querySelector('button'))).toBe('#checkout');
+  });
+
+  it('rejects hash-like ids and falls back to a path', () => {
+    document.body.innerHTML = '<div><button id="a1b2c3d4e5f6a1b2c3d4">Buy</button></div>';
+    const selector = deriveSelector(document.querySelector('button'));
+    expect(selector).not.toContain('a1b2c3d4');
+    expect(selector).toContain('button');
+  });
+
+  it('builds an nth-of-type path when nothing stable exists', () => {
+    document.body.innerHTML = '<div class="wrap"><span>a</span><span>b</span></div>';
+    expect(deriveSelector(document.querySelectorAll('span')[1])).toContain('span:nth-of-type(2)');
+  });
+
+  it('never includes element text or arbitrary attributes', () => {
+    document.body.innerHTML = '<button data-user-email="alice@example.com" data-order="ord_9931">alice@example.com</button>';
+    const selector = deriveSelector(document.querySelector('button'));
+    expect(selector).not.toContain('alice@example.com');
+    expect(selector).not.toContain('ord_9931');
+  });
+
+  it('strips dynamic-looking classes', () => {
+    document.body.innerHTML = '<div><i class="icon css-1a2b3c4 sc-AxjAm">x</i></div>';
+    const selector = deriveSelector(document.querySelector('i'));
+    expect(selector).not.toContain('css-1a2b3c4');
+    expect(selector).not.toContain('sc-AxjAm');
+  });
+
+  it('is bounded in depth and length', () => {
+    document.body.innerHTML = `${'<div>'.repeat(51)}<button>x</button>${'</div>'.repeat(51)}`;
+    expect(deriveSelector(document.querySelector('button')).length).toBeLessThanOrEqual(256);
+  });
+});

--- a/packages/sdk/src/__tests__/session.test.ts
+++ b/packages/sdk/src/__tests__/session.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  _rehydrateFromStorage,
+  ensureSessionID,
+  getSessionId,
+  nextChunkSeq,
+  peekChunkSeq,
+  resetSessionId,
+  rotateSessionIfIdle,
+  setSessionUser,
+  touchSession,
+} from '../session';
+
+describe('session', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    resetSessionId();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('mints an id and persists it to sessionStorage', () => {
+    const id = ensureSessionID();
+    expect(id).toBeTruthy();
+    expect(ensureSessionID()).toBe(id);
+    expect(sessionStorage.getItem('opslane_session')).toContain(id);
+  });
+
+  it('restores the id and seq counter across a reload', () => {
+    const id = ensureSessionID();
+    expect(nextChunkSeq()).toBe(0);
+    expect(nextChunkSeq()).toBe(1);
+    expect(nextChunkSeq()).toBe(2);
+    resetSessionId();
+    _rehydrateFromStorage();
+    expect(ensureSessionID()).toBe(id);
+    expect(nextChunkSeq()).toBe(3);
+  });
+
+  it('peekChunkSeq does not consume', () => {
+    ensureSessionID();
+    expect(peekChunkSeq()).toBe(0);
+    expect(peekChunkSeq()).toBe(0);
+    expect(nextChunkSeq()).toBe(0);
+    expect(peekChunkSeq()).toBe(1);
+  });
+
+  it('rotates after 30 minutes idle', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-14T12:00:00Z'));
+    const first = ensureSessionID();
+    vi.setSystemTime(new Date('2026-07-14T12:31:00Z'));
+    expect(ensureSessionID()).toBe(first);
+    const rotation = rotateSessionIfIdle();
+    expect(rotation?.previous).toEqual({ id: first, nextSeq: 0 });
+    expect(rotation?.newSessionID).not.toBe(first);
+    expect(peekChunkSeq()).toBe(0);
+  });
+
+  it('does not rotate while active', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-14T12:00:00Z'));
+    const first = ensureSessionID();
+    for (let i = 1; i <= 3; i += 1) {
+      const minutes = i * 20;
+      vi.setSystemTime(new Date(`2026-07-14T${String(12 + Math.floor(minutes / 60)).padStart(2, '0')}:${String(minutes % 60).padStart(2, '0')}:00Z`));
+      touchSession();
+      expect(ensureSessionID()).toBe(first);
+    }
+  });
+
+  it('rotates on identity change', () => {
+    const anon = ensureSessionID();
+    expect(setSessionUser('alice')).toBe(true);
+    const alice = getSessionId();
+    expect(alice).not.toBe(anon);
+    expect(setSessionUser('alice')).toBe(false);
+    expect(getSessionId()).toBe(alice);
+    expect(setSessionUser('bob')).toBe(true);
+    expect(getSessionId()).not.toBe(alice);
+    expect(setSessionUser(null)).toBe(true);
+  });
+
+  it('resets the seq counter on rotation', () => {
+    ensureSessionID();
+    nextChunkSeq();
+    nextChunkSeq();
+    setSessionUser('alice');
+    expect(peekChunkSeq()).toBe(0);
+  });
+
+  it('falls back to memory when sessionStorage throws', () => {
+    const original = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get() { throw new Error('SecurityError'); },
+    });
+    try {
+      resetSessionId();
+      const id = ensureSessionID();
+      expect(ensureSessionID()).toBe(id);
+      expect(nextChunkSeq()).toBe(0);
+      expect(nextChunkSeq()).toBe(1);
+    } finally {
+      if (original) Object.defineProperty(window, 'sessionStorage', original);
+    }
+  });
+
+  it('recovers from corrupted stored state', () => {
+    sessionStorage.setItem('opslane_session', 'not json');
+    resetSessionId();
+    _rehydrateFromStorage();
+    expect(ensureSessionID()).toBeTruthy();
+    expect(peekChunkSeq()).toBe(0);
+  });
+});

--- a/packages/sdk/src/__tests__/telemetry.test.ts
+++ b/packages/sdk/src/__tests__/telemetry.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  currentClickId,
+  installInteractionTelemetry,
+  setTelemetrySink,
+  type TelemetryEvent,
+  uninstallInteractionTelemetry,
+} from '../telemetry';
+import { loadConfig, resetConfig } from '../config';
+
+describe('interaction telemetry', () => {
+  let events: TelemetryEvent[];
+
+  beforeEach(() => {
+    events = [];
+    resetConfig();
+    loadConfig({ apiKey: 'k', endpoint: 'https://ingest.example.com' });
+    setTelemetrySink((event) => events.push(event));
+    document.body.innerHTML = '';
+    uninstallInteractionTelemetry();
+    installInteractionTelemetry();
+  });
+
+  it('emits a click event with selector and cursor', () => {
+    document.body.innerHTML = '<button data-testid="buy">Buy</button>';
+    document.querySelector('button')?.click();
+    expect(events.find((event) => event.kind === 'click')).toMatchObject({
+      kind: 'click', selector: '[data-testid="buy"]', cursor: expect.any(String),
+    });
+  });
+
+  it('sets click context before app handlers run', () => {
+    document.body.innerHTML = '<button id="b">Buy</button>';
+    let seen: string | null = null;
+    document.querySelector('button')?.addEventListener('click', () => { seen = currentClickId(); });
+    document.querySelector('button')?.click();
+    expect(seen).toBeTruthy();
+    expect(seen).toBe((events.find((event) => event.kind === 'click') as { clickId: string }).clickId);
+  });
+
+  it('has no click context outside a click', () => {
+    expect(currentClickId()).toBeNull();
+  });
+
+  it('emits form_submit with a selector', () => {
+    document.body.innerHTML = '<form data-testid="signup"><input name="e"/></form>';
+    const form = document.querySelector('form')!;
+    form.addEventListener('submit', (event) => event.preventDefault());
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    expect(events.find((event) => event.kind === 'form_submit')).toMatchObject({
+      kind: 'form_submit', selector: '[data-testid="signup"]',
+    });
+  });
+
+  it('contains throwing or absent sinks', () => {
+    setTelemetrySink(null);
+    document.body.innerHTML = '<button>x</button>';
+    expect(() => document.querySelector('button')?.click()).not.toThrow();
+    setTelemetrySink(() => { throw new Error('sink exploded'); });
+    expect(() => document.querySelector('button')?.click()).not.toThrow();
+  });
+
+  it('uninstall stops emission', () => {
+    uninstallInteractionTelemetry();
+    document.body.innerHTML = '<button>x</button>';
+    document.querySelector('button')?.click();
+    expect(events).toHaveLength(0);
+  });
+
+  it('emits request_start from XHR send, not open, and filters SDK traffic', () => {
+    const { patchXHR, unpatchXHR } = requireNetwork();
+    patchXHR();
+    try {
+      const xhr = new XMLHttpRequest();
+      xhr.open('POST', 'https://api.example.com/cart');
+      expect(events.find((event) => event.kind === 'request_start')).toBeUndefined();
+      try { xhr.send('{}'); } catch { /* jsdom may reject the network request */ }
+      expect(events.find((event) => event.kind === 'request_start')).toMatchObject({
+        kind: 'request_start', method: 'POST', url: 'https://api.example.com/cart',
+      });
+
+      events.length = 0;
+      const own = new XMLHttpRequest();
+      own.open('POST', 'https://ingest.example.com/api/v1/events');
+      try { own.send('{}'); } catch { /* noop */ }
+      expect(events.find((event) => event.kind === 'request_start')).toBeUndefined();
+    } finally {
+      unpatchXHR();
+    }
+  });
+});
+
+function requireNetwork(): typeof import('../network') {
+  // Static import would be equivalent, but this helper keeps the XHR patch
+  // lifecycle visually local to the one test that owns it.
+  return networkModule;
+}
+
+import * as networkModule from '../network';

--- a/packages/sdk/src/__tests__/user-session.test.ts
+++ b/packages/sdk/src/__tests__/user-session.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearUser, getCurrentUser, onIdentityChange, setUser } from '../core';
+import { ensureSessionID, getSessionId, resetSessionId } from '../session';
+import { loadConfig, resetConfig } from '../config';
+
+describe('setUser session rotation', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    resetSessionId();
+    resetConfig();
+    onIdentityChange(null);
+    clearUser();
+    loadConfig({ apiKey: 'k', endpoint: 'https://x.example.com' });
+  });
+
+  it('rotates the session id when identity changes', () => {
+    const anon = ensureSessionID();
+    setUser({ id: 'alice' });
+    expect(getSessionId()).not.toBe(anon);
+  });
+
+  it('does not rotate when the same user is set twice', () => {
+    setUser({ id: 'alice' });
+    const first = getSessionId();
+    setUser({ id: 'alice', email: 'alice@example.com' });
+    expect(getSessionId()).toBe(first);
+  });
+
+  it('rotates on logout', () => {
+    setUser({ id: 'alice' });
+    const alice = getSessionId();
+    clearUser();
+    expect(getSessionId()).not.toBe(alice);
+  });
+
+  it('notifies the identity-change listener with the new session', () => {
+    const listener = vi.fn();
+    onIdentityChange(listener);
+    setUser({ id: 'alice' });
+    expect(listener).toHaveBeenCalledWith(
+      getSessionId(),
+      expect.objectContaining({ id: expect.any(String), nextSeq: 0 }),
+    );
+    setUser({ id: 'alice' });
+    expect(listener).toHaveBeenCalledTimes(1);
+    clearUser();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('still records identity for error payloads', () => {
+    setUser({ id: 'alice', email: 'a@example.com', account: { id: 'acct-1' } });
+    expect(getCurrentUser()?.id).toBe('alice');
+    clearUser();
+    expect(getCurrentUser()).toBeNull();
+  });
+});

--- a/packages/sdk/src/chunk-upload.ts
+++ b/packages/sdk/src/chunk-upload.ts
@@ -1,0 +1,110 @@
+import type { eventWithTime } from '@rrweb/types';
+import { getConfig } from './config';
+import { gzip } from './gzip';
+import { sdkFetch } from './network';
+import { SDK_VERSION } from './version';
+
+const INLINE_BUDGET_BYTES = 64 * 1024;
+
+export type UploadResult = boolean | 'stop';
+
+let stopped = false;
+
+export function _resetChunkUploadState(): void {
+  stopped = false;
+}
+
+function buildBody(events: eventWithTime[], hasFullSnapshot: boolean): string {
+  return JSON.stringify({
+    events,
+    meta: {
+      sdk_version: SDK_VERSION,
+      has_full_snapshot: hasFullSnapshot,
+      chunked_at: Date.now(),
+    },
+  });
+}
+
+export async function uploadChunk(
+  sessionID: string,
+  seq: number,
+  events: eventWithTime[],
+  hasFullSnapshot: boolean,
+): Promise<UploadResult> {
+  if (stopped || events.length === 0) return false;
+  try {
+    const config = getConfig();
+    const compressed = await gzip(buildBody(events, hasFullSnapshot));
+    if (!compressed) return false;
+
+    const policyResponse = await sdkFetch(
+      `${config.endpoint}/api/v1/sessions/${encodeURIComponent(sessionID)}/chunks/upload-url`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-API-Key': config.apiKey },
+        body: JSON.stringify({
+          seq,
+          size_bytes: compressed.byteLength,
+          has_full_snapshot: hasFullSnapshot,
+        }),
+      },
+    );
+    if (!policyResponse.ok) {
+      if (policyResponse.status === 403 || policyResponse.status === 410) {
+        stopped = true;
+        return 'stop';
+      }
+      return false;
+    }
+
+    const payload = (await policyResponse.json()) as {
+      upload_url: string;
+      form_data: Record<string, string>;
+    };
+    if (!payload.upload_url || !payload.form_data) return false;
+
+    const form = new FormData();
+    for (const [key, value] of Object.entries(payload.form_data)) form.append(key, value);
+    form.append('file', new Blob([compressed as Uint8Array<ArrayBuffer>], { type: 'application/gzip' }));
+
+    const storageResponse = await sdkFetch(payload.upload_url, { method: 'POST', body: form });
+    if (!storageResponse.ok) return false;
+
+    const commitResponse = await sdkFetch(
+      `${config.endpoint}/api/v1/sessions/${encodeURIComponent(sessionID)}/chunks/${seq}/commit`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-API-Key': config.apiKey },
+        body: '{}',
+      },
+    );
+    return commitResponse.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function flushInline(
+  sessionID: string,
+  seq: number,
+  events: eventWithTime[],
+): Promise<boolean> {
+  if (stopped || events.length === 0 || seq < 0) return false;
+  try {
+    const config = getConfig();
+    const compressed = await gzip(buildBody(events, false));
+    if (!compressed || compressed.byteLength > INLINE_BUDGET_BYTES) return false;
+    const response = await sdkFetch(
+      `${config.endpoint}/api/v1/sessions/${encodeURIComponent(sessionID)}/chunks/${seq}/inline`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/gzip', 'X-API-Key': config.apiKey },
+        body: compressed as Uint8Array<ArrayBuffer>,
+        keepalive: true,
+      },
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -44,7 +44,8 @@ const DEFAULTS: Omit<SdkConfig, 'endpoint' | 'apiKey' | 'release'> = {
   flushInterval: 5_000,
   maxBatchSize: 10,
   debug: false,
-  replayEnabled: false,
+  // BREAKING in 1.0: recording is always-on unless explicitly opted out.
+  replayEnabled: true,
   sampleRate: 1,
   errorThrottleMs: 1000,
 };

--- a/packages/sdk/src/core.ts
+++ b/packages/sdk/src/core.ts
@@ -2,7 +2,7 @@ import type { ErrorEventPayload, Breadcrumb } from '@opslane/shared';
 import { getConfig } from './config';
 import { addBreadcrumb, getBreadcrumbs } from './breadcrumbs';
 import { enqueueEvent } from './transport';
-import { getSessionId } from './session.js';
+import { getSessionId, getSessionProgress, setSessionUser, type SessionProgress } from './session.js';
 import { SDK_VERSION } from './version';
 
 let installed = false;
@@ -17,13 +17,32 @@ interface UserIdentity {
 
 let currentUser: UserIdentity | null = null;
 
+type IdentityListener = (newSessionID: string, previous: SessionProgress) => void;
+let identityListener: IdentityListener | null = null;
+
+export function onIdentityChange(listener: IdentityListener | null): void {
+  identityListener = listener;
+}
+
+function rotateForIdentity(userId: string | null): void {
+  const previous = getSessionProgress();
+  if (!setSessionUser(userId)) return;
+  try {
+    identityListener?.(getSessionId(), previous);
+  } catch {
+    // SDK must never throw.
+  }
+}
+
 export function setUser(user: UserIdentity): void {
   if (!user.id) return;
   currentUser = user;
+  rotateForIdentity(user.id);
 }
 
 export function clearUser(): void {
   currentUser = null;
+  rotateForIdentity(null);
 }
 
 export function getCurrentUser(): UserIdentity | null {

--- a/packages/sdk/src/gzip.ts
+++ b/packages/sdk/src/gzip.ts
@@ -1,0 +1,23 @@
+/** Browser-side gzip for session chunks. No uncompressed fallback. */
+
+export function gzipSupported(): boolean {
+  try {
+    return typeof CompressionStream !== 'undefined';
+  } catch {
+    return false;
+  }
+}
+
+export async function gzip(text: string): Promise<Uint8Array | null> {
+  if (!gzipSupported()) return null;
+  try {
+    const compression = new CompressionStream('gzip');
+    const writer = compression.writable.getWriter();
+    const output = new Response(compression.readable).arrayBuffer();
+    await writer.write(new TextEncoder().encode(text));
+    await writer.close();
+    return new Uint8Array(await output);
+  } catch {
+    return null;
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,12 +1,13 @@
 import type { SdkInitOptions } from './config';
 import { loadConfig, resetConfig } from './config';
-import { captureException, installGlobalHandlers, uninstallGlobalHandlers, setUser, clearUser } from './core';
+import { captureException, installGlobalHandlers, onIdentityChange, uninstallGlobalHandlers, setUser, clearUser } from './core';
 import { patchConsole, unpatchConsole } from './console';
 import { patchFetch, unpatchFetch, patchXHR, unpatchXHR } from './network';
 import { startTransport, stopTransport } from './transport';
 import { clearBreadcrumbs } from './breadcrumbs';
 import { startReplayCapture, stopReplayCapture } from './replay';
 import { ensureSessionID } from './session.js';
+import { installInteractionTelemetry, uninstallInteractionTelemetry } from './telemetry';
 
 export { opslaneVuePlugin } from './vue';
 export type { SdkInitOptions } from './config';
@@ -37,6 +38,7 @@ export function init(options: SdkInitOptions): void {
   safeCall(patchConsole);
   safeCall(patchFetch);
   safeCall(patchXHR);
+  safeCall(installInteractionTelemetry);
   safeCall(startTransport);
   safeCall(ensureSessionID);
   safeCall(() => { void startReplayCapture().catch(() => {}); });
@@ -50,9 +52,11 @@ export function destroy(): void {
   safeCall(unpatchConsole);
   safeCall(unpatchFetch);
   safeCall(unpatchXHR);
+  safeCall(uninstallInteractionTelemetry);
   safeCall(stopTransport);
   safeCall(stopReplayCapture);
   safeCall(clearBreadcrumbs);
+  safeCall(() => onIdentityChange(null));
   safeCall(clearUser);
   safeCall(resetConfig);
 }

--- a/packages/sdk/src/network.ts
+++ b/packages/sdk/src/network.ts
@@ -1,10 +1,17 @@
 import type { Breadcrumb } from '@opslane/shared';
 import { addBreadcrumb } from './breadcrumbs';
 import { getConfig } from './config';
+import { currentClickId, emitTelemetry, nextRequestId } from './telemetry';
 
 // -- Fetch interceptor --
 
 let originalFetch: typeof globalThis.fetch | null = null;
+
+/** Executes SDK-owned traffic without generating app network telemetry. */
+export function sdkFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const implementation = originalFetch ?? globalThis.fetch;
+  return implementation.call(globalThis, input, init);
+}
 
 function isSdkEndpoint(url: string): boolean {
   try {
@@ -49,8 +56,20 @@ export function patchFetch(): void {
       return orig.call(globalThis, input, init);
     }
 
+    const requestId = nextRequestId('f');
+    emitTelemetry({
+      kind: 'request_start',
+      requestId,
+      clickId: currentClickId(),
+      method,
+      url,
+      at: Date.now(),
+    });
+
     try {
       const response = await orig.call(globalThis, input, init);
+
+      emitTelemetry({ kind: 'request_end', requestId, status: response.status, at: Date.now() });
 
       try {
         const crumb: Breadcrumb = {
@@ -72,6 +91,7 @@ export function patchFetch(): void {
 
       return response;
     } catch (error: unknown) {
+      emitTelemetry({ kind: 'request_end', requestId, status: 0, at: Date.now() });
       try {
         const crumb: Breadcrumb = {
           type: 'fetch',
@@ -104,10 +124,12 @@ export function unpatchFetch(): void {
 // -- XMLHttpRequest interceptor --
 
 let originalXHROpen: typeof XMLHttpRequest.prototype.open | null = null;
+let originalXHRSend: typeof XMLHttpRequest.prototype.send | null = null;
 
 interface XHRWithOpslane extends XMLHttpRequest {
   _opslaneMethod?: string;
   _opslaneUrl?: string;
+  _opslaneRequestId?: string;
 }
 
 export function patchXHR(): void {
@@ -153,10 +175,44 @@ export function patchXHR(): void {
     // XHR.open has overloaded signatures; targeted cast to forward variadic args
     (origOpen as (...args: unknown[]) => void).apply(this, [method, url, ...rest]);
   };
+
+  originalXHRSend = XMLHttpRequest.prototype.send;
+  const origSend = originalXHRSend;
+  XMLHttpRequest.prototype.send = function (
+    this: XHRWithOpslane,
+    ...args: Parameters<XMLHttpRequest['send']>
+  ): void {
+    try {
+      const url = this._opslaneUrl || '';
+      if (url && !isSdkEndpoint(url)) {
+        const requestId = nextRequestId('x');
+        this._opslaneRequestId = requestId;
+        emitTelemetry({
+          kind: 'request_start',
+          requestId,
+          clickId: currentClickId(),
+          method: this._opslaneMethod || 'GET',
+          url,
+          at: Date.now(),
+        });
+        this.addEventListener('loadend', () => {
+          emitTelemetry({ kind: 'request_end', requestId, status: this.status, at: Date.now() });
+        }, { once: true });
+      }
+    } catch {
+      // SDK must never throw.
+    }
+    return origSend.apply(this, args);
+  };
 }
 
 export function unpatchXHR(): void {
-  if (!originalXHROpen) return;
-  XMLHttpRequest.prototype.open = originalXHROpen;
-  originalXHROpen = null;
+  if (originalXHROpen) {
+    XMLHttpRequest.prototype.open = originalXHROpen;
+    originalXHROpen = null;
+  }
+  if (originalXHRSend) {
+    XMLHttpRequest.prototype.send = originalXHRSend;
+    originalXHRSend = null;
+  }
 }

--- a/packages/sdk/src/replay.ts
+++ b/packages/sdk/src/replay.ts
@@ -1,9 +1,14 @@
 import type { Breadcrumb } from '@opslane/shared';
-import type { eventWithTime } from '@rrweb/types';
-import { getConfig } from './config';
+import { EventType, type eventWithTime } from '@rrweb/types';
 import { getBreadcrumbs } from './breadcrumbs';
-import { ensureSessionID, resetSessionId } from './session.js';
+import { _resetChunkUploadState, flushInline, uploadChunk } from './chunk-upload';
+import { getConfig } from './config';
+import { getCurrentUser, onIdentityChange } from './core';
+import { gzipSupported } from './gzip';
+import { sdkFetch } from './network';
+import { ensureSessionID, nextChunkSeq, resetSessionId, rotateSessionIfIdle, touchSession, type SessionProgress } from './session.js';
 import { scrubUrl } from './scrub';
+import { setTelemetrySink } from './telemetry';
 import { SDK_VERSION } from './version';
 
 export type ReplayTriggerType = 'uncaught_error' | 'capture_exception';
@@ -41,19 +46,20 @@ interface ReplaySignals {
   };
 }
 
-const CHECKOUT_MS = 30_000;
-const MAX_RECORDING_BYTES = 2 * 1024 * 1024;
+const CHUNK_MS = 30_000;
+const MAX_CHUNK_RAW_BYTES = 20 * 1024 * 1024;
 
-let currentWindow: eventWithTime[] = [];
-let previousWindow: eventWithTime[] = [];
-// Running byte totals tracked incrementally so the budget check is O(1) per event.
-// Re-serializing the whole buffer on every rrweb event would be O(n^2) on the main
-// thread (rrweb emits thousands of events per session) and cause page jank.
-let currentWindowBytes = 0;
-let previousWindowBytes = 0;
+let buffer: eventWithTime[] = [];
+let bufferBytes = 0;
+let currentSessionID = '';
+let currentSeq = -1;
 let replayInstalled = false;
 let stopFn: (() => void) | null = null;
+let takeFullSnapshotFn: ((isCheckout?: boolean) => void) | null = null;
 let startGeneration = 0;
+let rotationGeneration = 0;
+let streamReady = false;
+let awaitingRotationSnapshot = false;
 
 function approxEventBytes(event: eventWithTime): number {
   try {
@@ -63,55 +69,141 @@ function approxEventBytes(event: eventWithTime): number {
   }
 }
 
-function enforceReplayBudget(): void {
-  if (previousWindow.length === 0) {
-    return;
-  }
+/** A checkout begins a self-contained chunk with a fresh full snapshot. */
+function onEmit(event: eventWithTime, isCheckout?: boolean): void {
+  try {
+    const idleRotation = rotateSessionIfIdle();
+    if (idleRotation) {
+      beginSessionRotation(idleRotation.newSessionID, idleRotation.previous);
+      return;
+    }
 
-  if (previousWindowBytes + currentWindowBytes > MAX_RECORDING_BYTES) {
-    previousWindow = [];
-    previousWindowBytes = 0;
+    if (!streamReady) {
+      if (event.type === EventType.FullSnapshot && awaitingRotationSnapshot) {
+        buffer = [event];
+        bufferBytes = approxEventBytes(event);
+        awaitingRotationSnapshot = false;
+        streamReady = true;
+      }
+      return;
+    }
+    // rrweb emits checkout metadata immediately before the checkout's full
+    // snapshot, and marks both events isCheckout=true. Metadata cannot open an
+    // independently playable chunk, so wait for the FullSnapshot boundary.
+    if (isCheckout && event.type !== EventType.FullSnapshot) return;
+    if (isCheckout && buffer.length > 0) {
+      const chunk = buffer;
+      const seq = currentSeq >= 0 ? currentSeq : nextChunkSeq();
+      const sessionID = currentSessionID;
+      buffer = [event];
+      bufferBytes = approxEventBytes(event);
+      currentSeq = -1;
+      if (seq >= 0 && sessionID) void shipChunk(sessionID, seq, chunk);
+      return;
+    }
+
+    if (isCheckout) {
+      buffer = [event];
+      bufferBytes = approxEventBytes(event);
+      return;
+    }
+
+    buffer.push(event);
+    bufferBytes += approxEventBytes(event);
+    touchSession();
+    if (bufferBytes > MAX_CHUNK_RAW_BYTES) {
+      try {
+        takeFullSnapshotFn?.(true);
+      } catch {
+        // rrweb is best-effort.
+      }
+    }
+  } catch {
+    // SDK must never throw.
   }
 }
 
-function recordReplayEvent(event: eventWithTime, isCheckout?: boolean): void {
-  if (isCheckout) {
-    previousWindow = currentWindow;
-    previousWindowBytes = currentWindowBytes;
-    currentWindow = [];
-    currentWindowBytes = 0;
-  }
+async function shipChunk(sessionID: string, seq: number, events: eventWithTime[]): Promise<void> {
+  const result = await uploadChunk(sessionID, seq, events, true);
+  if (result === 'stop') stopReplayCapture();
+}
 
-  currentWindow.push(event);
-  currentWindowBytes += approxEventBytes(event);
-  enforceReplayBudget();
+async function registerSession(sessionID = ensureSessionID()): Promise<boolean> {
+  try {
+    const config = getConfig();
+    const user = getCurrentUser();
+    const response = await sdkFetch(`${config.endpoint}/api/v1/sessions/init`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': config.apiKey },
+      body: JSON.stringify({
+        session_id: sessionID,
+        started_at: new Date().toISOString(),
+        page_url: currentPageUrl(),
+        user: user ? {
+          id: user.id,
+          email: user.email,
+          account_id: user.account?.id,
+          account_name: user.account?.name,
+        } : null,
+      }),
+    });
+    if (!response.ok) return false;
+    const body = (await response.json()) as { recording?: boolean };
+    if (body.recording !== true) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Identity can change while the init request is in flight. Register the latest
+// durable id before rrweb starts so capture never opens under a retired id.
+async function registerStableSession(generation: number): Promise<string | null> {
+  let sessionID = ensureSessionID();
+  while (generation === startGeneration && replayInstalled) {
+    if (!(await registerSession(sessionID))) return null;
+    const latestSessionID = ensureSessionID();
+    if (latestSessionID === sessionID) return sessionID;
+    sessionID = latestSessionID;
+  }
+  return null;
 }
 
 export async function startReplayCapture(): Promise<void> {
-  if (replayInstalled) {
-    return;
-  }
-
-  let replayEnabled = false;
+  if (replayInstalled) return;
   try {
-    replayEnabled = getConfig().replayEnabled;
+    if (!getConfig().replayEnabled) return;
   } catch {
     return;
   }
-
-  if (!replayEnabled || typeof window === 'undefined' || typeof document === 'undefined') {
-    return;
-  }
+  if (typeof window === 'undefined' || typeof document === 'undefined' || !gzipSupported()) return;
 
   replayInstalled = true;
-  ensureSessionID();
-
   const generation = ++startGeneration;
+  const initialSessionID = await registerStableSession(generation);
+  if (!initialSessionID || generation !== startGeneration || !replayInstalled) {
+    if (generation === startGeneration) replayInstalled = false;
+    return;
+  }
+  currentSessionID = initialSessionID;
+  streamReady = false;
+  awaitingRotationSnapshot = true;
+  _resetChunkUploadState();
+  onIdentityChange(handleIdentityChange);
+
   try {
-    const { record } = await import('rrweb');
+    const { record, addCustomEvent, takeFullSnapshot } = await import('rrweb');
+    setTelemetrySink((event) => {
+      try {
+        addCustomEvent('opslane.telemetry', event);
+      } catch {
+        // rrweb may not have started yet.
+      }
+    });
+    takeFullSnapshotFn = takeFullSnapshot;
     const stop = record({
-      emit: recordReplayEvent,
-      checkoutEveryNms: CHECKOUT_MS,
+      emit: onEmit,
+      checkoutEveryNms: CHUNK_MS,
       maskAllInputs: true,
       maskTextSelector: '.opslane-mask',
       blockSelector: '.opslane-block',
@@ -119,29 +211,100 @@ export async function startReplayCapture(): Promise<void> {
     });
 
     if (!replayInstalled || generation !== startGeneration) {
-      if (typeof stop === 'function') {
-        stop();
-      }
+      if (typeof stop === 'function') stop();
       return;
     }
-
     stopFn = typeof stop === 'function' ? stop : null;
     if (!stopFn) {
-      replayInstalled = false;
+      stopReplayCapture();
+      return;
     }
+    document.addEventListener('visibilitychange', onVisibilityChange);
   } catch {
-    replayInstalled = false;
-    stopFn = null;
+    stopReplayCapture();
+  }
+}
+
+function handleIdentityChange(newSessionID: string, previous: SessionProgress): void {
+  beginSessionRotation(newSessionID, previous);
+}
+
+function beginSessionRotation(newSessionID: string, previous: SessionProgress): void {
+  const generation = ++rotationGeneration;
+  const pending = buffer;
+  const pendingSeq = pending.length > 0
+    ? (currentSeq >= 0 ? currentSeq : previous.nextSeq)
+    : -1;
+  const oldSessionID = previous.id || currentSessionID;
+
+  buffer = [];
+  bufferBytes = 0;
+  currentSeq = -1;
+  currentSessionID = newSessionID;
+  streamReady = false;
+  awaitingRotationSnapshot = false;
+
+  if (pending.length > 0 && pendingSeq >= 0 && oldSessionID) {
+    void uploadChunk(oldSessionID, pendingSeq, pending, true);
+  }
+
+  void (async () => {
+    if (!(await registerSession(newSessionID))) {
+      if (generation !== rotationGeneration) return;
+      stopReplayCapture();
+      return;
+    }
+    if (generation !== rotationGeneration || !replayInstalled) return;
+    currentSessionID = newSessionID;
+    awaitingRotationSnapshot = true;
+    try {
+      takeFullSnapshotFn?.(true);
+    } catch {
+      // best-effort
+    }
+  })();
+}
+
+function onVisibilityChange(): void {
+  if (document.visibilityState !== 'hidden' || buffer.length === 0) return;
+  if (currentSeq < 0) currentSeq = nextChunkSeq();
+  const tail = buffer;
+  const tailSeq = currentSeq;
+  const tailSessionID = currentSessionID;
+  buffer = [];
+  bufferBytes = 0;
+  currentSeq = -1;
+  void flushInline(tailSessionID, tailSeq, tail).then((landed) => {
+    // A backgrounded page may survive. If keepalive could not carry the tail
+    // (most commonly because gzip exceeded 64KB), fall back to the normal
+    // storage-policy flow. A closing page will simply run out of time.
+    if (!landed) void shipChunk(tailSessionID, tailSeq, tail);
+  });
+  // If the page survives backgrounding, resume from a new full snapshot. This
+  // also prevents the regular uploader from reusing the inline tail's seq.
+  try {
+    takeFullSnapshotFn?.(true);
+  } catch {
+    // The page may already be tearing down.
   }
 }
 
 export function stopReplayCapture(): void {
-  if (!replayInstalled && !stopFn) {
-    return;
-  }
-
-  replayInstalled = false;
   startGeneration += 1;
+  rotationGeneration += 1;
+  if (typeof document !== 'undefined') {
+    document.removeEventListener('visibilitychange', onVisibilityChange);
+  }
+  onIdentityChange(null);
+  setTelemetrySink(null);
+  takeFullSnapshotFn = null;
+  buffer = [];
+  bufferBytes = 0;
+  currentSeq = -1;
+  currentSessionID = '';
+  streamReady = false;
+  awaitingRotationSnapshot = false;
+  replayInstalled = false;
 
   const stop = stopFn;
   stopFn = null;
@@ -149,50 +312,41 @@ export function stopReplayCapture(): void {
     try {
       stop();
     } catch {
-      // replay is best-effort
+      // replay is best-effort.
     }
   }
 }
 
+/**
+ * Legacy error-triggered replay upload retained until Batch 2 migrates the
+ * dashboard and worker readers from session_replays to chunk pointers.
+ */
 export async function uploadReplayForTrigger(input: ReplayUploadInput): Promise<void> {
   let replayID = '';
-
   try {
     const config = getConfig();
-    if (!config.replayEnabled) {
-      return;
-    }
-
+    if (!config.replayEnabled) return;
     const events = snapshotRrwebEvents();
-    if (events.length === 0) {
-      return;
-    }
+    if (events.length === 0) return;
 
     const sessionID = ensureSessionID();
     const now = Date.now();
     const startedAt = Number.isFinite(events[0]?.timestamp) ? events[0].timestamp : now;
-    const endedAt = now;
     const pageURL = currentPageUrl();
-
-    const recording = {
+    const body = JSON.stringify({
       events,
       meta: {
         sdk_version: SDK_VERSION,
         page_url: pageURL,
         started_at: startedAt,
-        ended_at: endedAt,
+        ended_at: now,
         crash_timestamp: now,
       },
-    };
-    const body = JSON.stringify(recording);
-    const sizeBytes = utf8ByteLength(body);
+    });
 
-    const initRes = await fetch(`${config.endpoint}/api/v1/replays/init`, {
+    const initResponse = await sdkFetch(`${config.endpoint}/api/v1/replays/init`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-API-Key': config.apiKey,
-      },
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': config.apiKey },
       body: JSON.stringify({
         session_id: sessionID,
         error_event_id: input.eventId ?? null,
@@ -200,53 +354,41 @@ export async function uploadReplayForTrigger(input: ReplayUploadInput): Promise<
         trigger_type: input.triggerType,
         page_url: pageURL,
         started_at: new Date(startedAt).toISOString(),
-        ended_at: new Date(endedAt).toISOString(),
+        ended_at: new Date(now).toISOString(),
       }),
     });
+    if (!initResponse.ok) return;
 
-    if (!initRes.ok) {
-      return;
-    }
-
-    const initPayload = (await initRes.json()) as ReplayInitResponse;
+    const initPayload = (await initResponse.json()) as ReplayInitResponse;
     replayID = initPayload.replay_id;
-    const signals = buildReplaySignals(getBreadcrumbs());
-
-    const uploadRes = await fetch(initPayload.upload_url, {
+    const uploadResponse = await sdkFetch(initPayload.upload_url, {
       method: 'PUT',
-      headers: {
-        ...(initPayload.upload_headers || {}),
-        'Content-Type': 'application/json',
-      },
+      headers: { ...(initPayload.upload_headers || {}), 'Content-Type': 'application/json' },
       body,
     });
+    if (!uploadResponse.ok) throw new Error(`upload failed with status ${uploadResponse.status}`);
 
-    if (!uploadRes.ok) {
-      throw new Error(`upload failed with status ${uploadRes.status}`);
-    }
-
-    const completed = await completeReplayUpload(config.endpoint, config.apiKey, replayID, sizeBytes, signals);
-    if (!completed) {
-      throw new Error('complete replay upload failed');
-    }
-  } catch (err) {
+    const completed = await completeReplayUpload(
+      config.endpoint,
+      config.apiKey,
+      replayID,
+      utf8ByteLength(body),
+      buildReplaySignals(getBreadcrumbs()),
+    );
+    if (!completed) throw new Error('complete replay upload failed');
+  } catch (error) {
     try {
+      if (!replayID) return;
       const config = getConfig();
-      if (!replayID) {
-        return;
-      }
-      await fetch(`${config.endpoint}/api/v1/replays/${encodeURIComponent(replayID)}/fail`, {
+      await sdkFetch(`${config.endpoint}/api/v1/replays/${encodeURIComponent(replayID)}/fail`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-API-Key': config.apiKey,
-        },
+        headers: { 'Content-Type': 'application/json', 'X-API-Key': config.apiKey },
         body: JSON.stringify({
-          reason: err instanceof Error ? err.message : 'unknown replay upload error',
+          reason: error instanceof Error ? error.message : 'unknown replay upload error',
         }),
       });
     } catch {
-      // replay is best-effort
+      // replay is best-effort.
     }
   }
 }
@@ -256,19 +398,13 @@ async function completeReplayUpload(
   apiKey: string,
   replayID: string,
   sizeBytes: number,
-  signals: ReplaySignals
+  signals: ReplaySignals,
 ): Promise<boolean> {
   try {
-    const response = await fetch(`${endpoint}/api/v1/replays/${encodeURIComponent(replayID)}/complete`, {
+    const response = await sdkFetch(`${endpoint}/api/v1/replays/${encodeURIComponent(replayID)}/complete`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-API-Key': apiKey,
-      },
-      body: JSON.stringify({
-        size_bytes: sizeBytes,
-        signals,
-      }),
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
+      body: JSON.stringify({ size_bytes: sizeBytes, signals }),
     });
     return response.ok;
   } catch {
@@ -282,27 +418,17 @@ function buildReplaySignals(breadcrumbs: Breadcrumb[]): ReplaySignals {
   const consoleErrorMessages: string[] = [];
   const consoleWarningMessages: string[] = [];
   let networkAnomalyCount = 0;
-  const networkAnomalies: Array<{
-    type: string;
-    method: string;
-    url: string;
-    status_code: number | null;
-    message: string;
-  }> = [];
+  const networkAnomalies: ReplaySignals['network']['anomalies'] = [];
 
   for (const crumb of breadcrumbs) {
     if (crumb.type === 'console') {
       if (crumb.level === 'error') {
         consoleErrorCount += 1;
-        if (crumb.message) {
-          consoleErrorMessages.push(crumb.message);
-        }
+        if (crumb.message) consoleErrorMessages.push(crumb.message);
       }
       if (crumb.level === 'warning') {
         consoleWarningCount += 1;
-        if (crumb.message) {
-          consoleWarningMessages.push(crumb.message);
-        }
+        if (crumb.message) consoleWarningMessages.push(crumb.message);
       }
     }
     if (crumb.type === 'fetch' || crumb.type === 'xhr') {
@@ -329,24 +455,21 @@ function buildReplaySignals(breadcrumbs: Breadcrumb[]): ReplaySignals {
       error_messages: uniqueHead(consoleErrorMessages, 5),
       warning_messages: uniqueHead(consoleWarningMessages, 5),
     },
-    network: {
-      anomaly_count: networkAnomalyCount,
-      anomalies: networkAnomalies.slice(-5),
-    },
+    network: { anomaly_count: networkAnomalyCount, anomalies: networkAnomalies.slice(-5) },
   };
 }
 
 function uniqueHead(values: string[], limit: number): string[] {
-  const out: string[] = [];
+  const output: string[] = [];
   const seen = new Set<string>();
   for (const value of values) {
     const trimmed = value.trim();
     if (!trimmed || seen.has(trimmed)) continue;
     seen.add(trimmed);
-    out.push(trimmed);
-    if (out.length >= limit) break;
+    output.push(trimmed);
+    if (output.length >= limit) break;
   }
-  return out;
+  return output;
 }
 
 function currentPageUrl(): string {
@@ -365,18 +488,12 @@ function utf8ByteLength(value: string): number {
   }
 }
 
-export function _resetReplayState(): void {
-  stopReplayCapture();
-  currentWindow = [];
-  previousWindow = [];
-  currentWindowBytes = 0;
-  previousWindowBytes = 0;
-  replayInstalled = false;
-  stopFn = null;
-  startGeneration = 0;
-  resetSessionId();
+export function snapshotRrwebEvents(): eventWithTime[] {
+  return [...buffer].sort((left, right) => left.timestamp - right.timestamp);
 }
 
-export function snapshotRrwebEvents(): eventWithTime[] {
-  return [...previousWindow, ...currentWindow].sort((a, b) => a.timestamp - b.timestamp);
+export function _resetReplayState(): void {
+  stopReplayCapture();
+  startGeneration = 0;
+  resetSessionId();
 }

--- a/packages/sdk/src/selector.ts
+++ b/packages/sdk/src/selector.ts
@@ -43,7 +43,10 @@ export function deriveSelector(element: Element | null): string {
     for (const attr of ALLOWED_ATTRS) {
       const value = element.getAttribute(attr);
       if (value && !isHashLike(value)) {
-        return `[${attr}="${value.replace(/"/g, '\\"')}"]`.slice(0, MAX_LENGTH);
+        // Backslash first: escaping the quote first would then escape the
+        // backslash we just added, letting a value ending in \ close the string.
+        const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        return `[${attr}="${escaped}"]`.slice(0, MAX_LENGTH);
       }
     }
 

--- a/packages/sdk/src/selector.ts
+++ b/packages/sdk/src/selector.ts
@@ -1,0 +1,75 @@
+/**
+ * Derives a bounded, stable CSS selector without capturing free text or
+ * arbitrary attribute values. Selectors live outside the masked recording and
+ * can later reach an LLM, so privacy takes priority over specificity.
+ */
+
+const ALLOWED_ATTRS = ['data-testid', 'data-test-id', 'data-test', 'data-cy'];
+const MAX_DEPTH = 8;
+const MAX_LENGTH = 256;
+
+function isHashLike(value: string): boolean {
+  if (value.length >= 16 && /^[a-f0-9]+$/i.test(value)) return true;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(value);
+}
+
+function isDynamicClass(value: string): boolean {
+  if (/^(css|sc|emotion|jsx)-/i.test(value)) return true;
+  if (/\d/.test(value) && /^[a-z]+[-_]?[a-z0-9]{5,}$/i.test(value)) return true;
+  return isHashLike(value);
+}
+
+function escapeIdent(value: string): string {
+  try {
+    if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') return CSS.escape(value);
+  } catch {
+    // Fall through to a conservative escape.
+  }
+  return value.replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+}
+
+function nthOfType(element: Element): string {
+  const tag = element.tagName.toLowerCase();
+  const parent = element.parentElement;
+  if (!parent) return tag;
+  const siblings = Array.from(parent.children).filter((child) => child.tagName === element.tagName);
+  if (siblings.length === 1) return tag;
+  return `${tag}:nth-of-type(${siblings.indexOf(element) + 1})`;
+}
+
+export function deriveSelector(element: Element | null): string {
+  if (!element?.tagName) return '';
+  try {
+    for (const attr of ALLOWED_ATTRS) {
+      const value = element.getAttribute(attr);
+      if (value && !isHashLike(value)) {
+        return `[${attr}="${value.replace(/"/g, '\\"')}"]`.slice(0, MAX_LENGTH);
+      }
+    }
+
+    if (element.id && !isHashLike(element.id)) {
+      return `#${escapeIdent(element.id)}`.slice(0, MAX_LENGTH);
+    }
+
+    const parts: string[] = [];
+    let node: Element | null = element;
+    let depth = 0;
+    while (node && depth < MAX_DEPTH && node.tagName !== 'HTML') {
+      let part = nthOfType(node);
+      const classes = Array.from(node.classList)
+        .filter((value) => !isDynamicClass(value))
+        .slice(0, 2);
+      if (classes.length > 0) part += classes.map((value) => `.${escapeIdent(value)}`).join('');
+      parts.unshift(part);
+      if (node.id && !isHashLike(node.id)) {
+        parts.unshift(`#${escapeIdent(node.id)}`);
+        break;
+      }
+      node = node.parentElement;
+      depth += 1;
+    }
+    return parts.join(' > ').slice(0, MAX_LENGTH);
+  } catch {
+    return '';
+  }
+}

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -28,15 +28,22 @@ export interface SessionRotation {
 
 let state: SessionState | null = null;
 
+// A session id is a bearer of evidence: anyone who can guess a live id can
+// reserve a chunk seq against it with the project's public SDK key. It must not
+// be predictable, so Math.random (xorshift128+, recoverable from a few outputs)
+// is not an acceptable source.
 function newId(): string {
   try {
     if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
       return crypto.randomUUID();
     }
   } catch {
-    // randomUUID needs a secure context; fall through.
+    // randomUUID is restricted to secure contexts. getRandomValues is not, so
+    // an http:// origin still gets a CSPRNG rather than a guessable id.
   }
-  return `sess_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return `sess_${Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')}`;
 }
 
 function readStorage(): SessionState | null {

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -1,27 +1,155 @@
-let sessionID = '';
+/**
+ * Durable session identity for always-on recording.
+ *
+ * sessionStorage is deliberate: it is per-tab, survives navigation, and dies
+ * with the tab rather than trailing an identity across days.
+ */
 
-export function ensureSessionID(): string {
-  if (sessionID) {
-    return sessionID;
-  }
+const STORAGE_KEY = 'opslane_session';
+const IDLE_MS = 30 * 60 * 1000;
 
+interface SessionState {
+  id: string;
+  /** Next chunk sequence number to hand out. */
+  seq: number;
+  lastActivityAt: number;
+  userId: string | null;
+}
+
+export interface SessionProgress {
+  id: string;
+  nextSeq: number;
+}
+
+export interface SessionRotation {
+  previous: SessionProgress;
+  newSessionID: string;
+}
+
+let state: SessionState | null = null;
+
+function newId(): string {
   try {
     if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-      sessionID = crypto.randomUUID();
-      return sessionID;
+      return crypto.randomUUID();
     }
   } catch {
-    // noop
+    // randomUUID needs a secure context; fall through.
   }
+  return `sess_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
 
-  sessionID = `sess_${Date.now()}_${Math.random().toString(16).slice(2)}`;
-  return sessionID;
+function readStorage(): SessionState | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof (parsed as SessionState).id !== 'string' ||
+      typeof (parsed as SessionState).seq !== 'number' ||
+      !Number.isInteger((parsed as SessionState).seq) ||
+      (parsed as SessionState).seq < 0 ||
+      typeof (parsed as SessionState).lastActivityAt !== 'number' ||
+      !(
+        (parsed as SessionState).userId === null ||
+        typeof (parsed as SessionState).userId === 'string'
+      )
+    ) {
+      return null;
+    }
+    return parsed as SessionState;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(next: SessionState): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // Memory-only fallback; state remains correct for this page load.
+  }
+}
+
+function freshState(userId: string | null): SessionState {
+  return { id: newId(), seq: 0, lastActivityAt: Date.now(), userId };
+}
+
+function isExpired(value: SessionState): boolean {
+  return Date.now() - value.lastActivityAt > IDLE_MS;
+}
+
+function load(): SessionState {
+  if (!state) {
+    state = readStorage();
+    if (!state || isExpired(state)) {
+      state = freshState(state?.userId ?? null);
+      writeStorage(state);
+    }
+  }
+  return state;
+}
+
+export function ensureSessionID(): string {
+  return load().id;
 }
 
 export function getSessionId(): string {
-  return sessionID;
+  return state?.id ?? '';
 }
 
+export function touchSession(): void {
+  const current = load();
+  current.lastActivityAt = Date.now();
+  writeStorage(current);
+}
+
+export function nextChunkSeq(): number {
+  const current = load();
+  const seq = current.seq;
+  current.seq = seq + 1;
+  current.lastActivityAt = Date.now();
+  writeStorage(current);
+  return seq;
+}
+
+export function peekChunkSeq(): number {
+  return load().seq;
+}
+
+/** Snapshot progress before an identity rotation replaces persisted state. */
+export function getSessionProgress(): SessionProgress {
+  const current = load();
+  return { id: current.id, nextSeq: current.seq };
+}
+
+/** Rotates an already-loaded session after an idle gap. */
+export function rotateSessionIfIdle(): SessionRotation | null {
+  const current = load();
+  if (!isExpired(current)) return null;
+  const previous = { id: current.id, nextSeq: current.seq };
+  state = freshState(current.userId);
+  writeStorage(state);
+  return { previous, newSessionID: state.id };
+}
+
+/** Rotates the session when its end-user identity changes. */
+export function setSessionUser(userId: string | null): boolean {
+  const current = load();
+  if (current.userId === userId) return false;
+  state = freshState(userId);
+  writeStorage(state);
+  return true;
+}
+
+/** Test hook: drops only in-memory state, like a page reload. */
 export function resetSessionId(): void {
-  sessionID = '';
+  state = null;
+}
+
+/** Test hook: explicitly reloads persisted state. */
+export function _rehydrateFromStorage(): void {
+  state = readStorage();
 }

--- a/packages/sdk/src/telemetry.ts
+++ b/packages/sdk/src/telemetry.ts
@@ -1,0 +1,87 @@
+import { deriveSelector } from './selector';
+
+export type TelemetryEvent =
+  | { kind: 'click'; clickId: string; selector: string; cursor: string; at: number }
+  | { kind: 'request_start'; requestId: string; clickId: string | null; method: string; url: string; at: number }
+  | { kind: 'request_end'; requestId: string; status: number; at: number }
+  | { kind: 'form_submit'; selector: string; at: number };
+
+type Sink = (event: TelemetryEvent) => void;
+
+let sink: Sink | null = null;
+let installed = false;
+let counter = 0;
+let activeClickId: string | null = null;
+
+export function setTelemetrySink(next: Sink | null): void {
+  sink = next;
+}
+
+export function emitTelemetry(event: TelemetryEvent): void {
+  try {
+    sink?.(event);
+  } catch {
+    // SDK must never throw.
+  }
+}
+
+function nextId(prefix: string): string {
+  counter += 1;
+  return `${prefix}_${counter}`;
+}
+
+export function nextRequestId(prefix: 'f' | 'x'): string {
+  return nextId(prefix);
+}
+
+export function currentClickId(): string | null {
+  return activeClickId;
+}
+
+function onClick(event: Event): void {
+  try {
+    const target = event.target instanceof Element ? event.target : null;
+    if (!target) return;
+    const clickId = nextId('c');
+    activeClickId = clickId;
+    let cursor = '';
+    try {
+      cursor = getComputedStyle(target).cursor || '';
+    } catch {
+      // Detached nodes may reject style lookup.
+    }
+    emitTelemetry({ kind: 'click', clickId, selector: deriveSelector(target), cursor, at: Date.now() });
+    queueMicrotask(() => {
+      setTimeout(() => {
+        if (activeClickId === clickId) activeClickId = null;
+      }, 0);
+    });
+  } catch {
+    // SDK must never throw.
+  }
+}
+
+function onSubmit(event: Event): void {
+  try {
+    const target = event.target instanceof Element ? event.target : null;
+    if (!target) return;
+    emitTelemetry({ kind: 'form_submit', selector: deriveSelector(target), at: Date.now() });
+  } catch {
+    // SDK must never throw.
+  }
+}
+
+export function installInteractionTelemetry(): void {
+  if (installed || typeof document === 'undefined') return;
+  document.addEventListener('click', onClick, true);
+  document.addEventListener('submit', onSubmit, true);
+  installed = true;
+}
+
+export function uninstallInteractionTelemetry(): void {
+  if (typeof document === 'undefined') return;
+  document.removeEventListener('click', onClick, true);
+  document.removeEventListener('submit', onSubmit, true);
+  installed = false;
+  activeClickId = null;
+}

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -149,6 +149,8 @@ export async function flushEvents(): Promise<void> {
             ingest = undefined;
           }
 
+          // Retained until Batch 2 migrates the dashboard and worker readers
+          // from session_replays onto chunk-stream pointers (design v4-6).
           void uploadReplayForTrigger({
             triggerType: queued.replayTrigger,
             errorType: event.error.type,

--- a/scripts/check-docs-drift.mjs
+++ b/scripts/check-docs-drift.mjs
@@ -19,9 +19,7 @@ const read = (p) => readFileSync(join(root, p), 'utf8');
 const problems = [];
 
 // Known drift, allowlisted with a tracking issue. Remove entries as bugs close.
-const KNOWN_DRIFT = new Map([
-  ['POST /api/v1/replays/{param}/fail', 'https://github.com/opslane/opslane-oss/issues/13'],
-]);
+const KNOWN_DRIFT = new Map([]);
 
 const normalize = (p) => p.replace(/\{[^}]+\}/g, '{param}');
 

--- a/scripts/check-go-skips.mjs
+++ b/scripts/check-go-skips.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Enforce hard Go test results from `go test ./... -v` output:
+ *   - no failed tests
+ *   - no skipped tests except those matching an explicit allowlist
+ *   - a minimum total test count (guards against building nothing)
+ *
+ * `go test` prints "ok" for a package in which every test called t.Skip, and
+ * exits 0. The integration tests here skip when DATABASE_URL or
+ * REPLAY_STORE_ENDPOINT is unset, so a misconfigured job reports success while
+ * running nothing -- which is how the #47 and #48 regression guards sat unrun.
+ * This makes that state loud. Mirrors scripts/check-e2e-results.mjs.
+ *
+ * Usage: node scripts/check-go-skips.mjs <go-test-verbose.log>
+ * Env:
+ *   GO_ALLOWED_SKIP_PATTERN  regex of test names allowed to skip (default: none)
+ *   GO_MIN_TESTS             minimum passing tests (default: 100)
+ */
+import { readFileSync } from 'node:fs';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: check-go-skips.mjs <go-test-verbose.log>');
+  process.exit(2);
+}
+
+const log = readFileSync(file, 'utf8');
+const allowedPattern = process.env.GO_ALLOWED_SKIP_PATTERN;
+const allowed = allowedPattern ? new RegExp(allowedPattern) : null;
+const minTests = Number(process.env.GO_MIN_TESTS ?? '100');
+
+// `--- PASS: TestFoo (0.01s)` / `    --- SKIP: TestFoo/sub (0.00s)`
+const RESULT = /^\s*--- (PASS|FAIL|SKIP): (\S+)/gm;
+
+const problems = [];
+let passed = 0;
+let allowedSkips = 0;
+
+for (const [, status, name] of log.matchAll(RESULT)) {
+  if (status === 'PASS') {
+    passed += 1;
+  } else if (status === 'FAIL') {
+    problems.push(`FAILED: ${name}`);
+  } else if (allowed && allowed.test(name)) {
+    allowedSkips += 1;
+  } else {
+    problems.push(`UNEXPECTED SKIP: ${name}`);
+  }
+}
+
+if (passed < minTests) {
+  problems.push(`Only ${passed} tests passed; expected at least ${minTests}`);
+}
+
+if (problems.length > 0) {
+  console.error('Go result check FAILED:');
+  for (const p of problems) console.error(`  - ${p}`);
+  console.error(
+    '\nA skip here usually means a service is missing (DATABASE_URL / REPLAY_STORE_ENDPOINT).\n' +
+      'Fix the job so the test runs; do not add it to the allowlist to make this pass.'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Go OK: ${passed} passed, ${allowedSkips} allowlisted skip(s), no failures, no unexpected skips.`
+);


### PR DESCRIPTION
Batch 1 of the unified-incidents epic (#31): every browser session is continuously recorded, uploaded as independently-playable gzipped chunks, scrubbed before anything may read it, and deleted on a retention clock. Closes the two live storage vulnerabilities first.

Closes #47. Closes #48. Closes #13.

## What lands

**Recording is always on** (SDK 1.0.0, major bump — `replay.enabled` now defaults true). rrweb runs permanently instead of buffering-until-error; a chunk is cut at each rrweb checkout boundary, so every chunk opens with a full snapshot and is independently playable. Chunks are gzipped in the browser and uploaded straight to object storage.

**#47 — the replay bucket was world-readable.** `docker-compose.yml` ran `mc anonymous set download`, making every stored recording downloadable by anyone who could guess a key, bypassing the re-scrubbing read path entirely. Now `set none`, which actively revokes on existing dev volumes rather than merely not-granting on new ones.

**#48 — presigned uploads had no size cap.** A presigned PUT is a bare signed URL and carries no size condition, so a public SDK key was a storage-flood primitive. `content-length-range` only exists on POST policies, so chunk upload is now a multipart POST signed to the client's exact declared size, plus a per-project byte budget and a bounded gzip inflate.

**Fail-closed redaction.** A chunk with `scrubbed_at IS NULL` has not been redacted and nothing may read it. A background scrubber inflates under a hard ceiling, redacts, re-uploads, and stamps the column.

**Retention.** Sessions and their objects are deleted on a per-project clock with a 90-day hard cap, leaving a tombstone so a still-valid presigned URL cannot resurrect deleted data.

## Review fixes (`11f5743`)

Three defects found reviewing the above, each verified red/green:

- **The retention sweep ran 60x too often.** `Start()` clamped its interval down to `deletionGrace`, so `main.go`'s `time.Hour` silently became a 60s ticker on every replica. Measured against the running service: the clamped build swept at 05:40:48, 05:41:48, 05:42:48; the fixed build sweeps once at startup. `defaultInterval` was unreachable.
- **Two retention indexes were unusable, not just slow.** `idx_sessions_retention` was predicated on `status <> 'recording'` while its only caller filters `status <> 'deleting'` — Postgres only uses a partial index when the query predicate implies the index predicate. On 200k live rows the planner ignored it and ran a Parallel Seq Scan (3252 buffers); repredicated it is an Index Scan (205 buffers, 0.199ms). `SessionsReadyForPurge` ordered by `deletion_started_at` with no index at all.
- **A test asserted the opposite of its name.** `TestChunkUploadURL_RejectsOversizeDeclaration` built `Dependencies{}` with a nil MinIO and returned at the 503 guard, never reaching the size check. It also collided with the real integration test of the same name in `package handler_test`, which is why the gap was invisible.

## CI (`32da0c5`)

**The `go` lane started Postgres but no object storage**, so every test needing a bucket called `t.Skip` and its package still printed `ok` with exit 0. Measured on this branch: **185 pass / 30 skip, green**. Among the 30 were the regression guards for *both* security issues this PR closes — so reintroducing `mc anonymous set download` would not have failed CI.

With storage wired up: **215 pass / 0 skip**.

`scripts/check-go-skips.mjs` makes a silent skip loud, mirroring `check-e2e-results.mjs`, which already guards the E2E lane against exactly this. `go test` cannot express "fail on skip", so the `-v` log is parsed.

This is not hypothetical. Two commits on main tell the same story: `bd20bed` added CI and fixed two latent test bugs in the same commit; `4b0efd0` added the keyless E2E lane and fixed the worker's reason-code ordering. Each time a test first ran for real, it found something.

## Verification

Run against a live stack (ingestion, worker, postgres, minio) from `docker compose down -v`:

- `go build` / `go vet` — exit 0
- `go test ./...` — **215 pass, 0 skip, 0 fail**
- `pnpm -r build` / `pnpm test` — exit 0 (docs-drift clean)
- `docker compose config --quiet` — exit 0
- E2E — `22/23 passed, 1 allowlisted skip, no failures, no unexpected skips`

End-to-end through the real API — init → reserve seq → presigned POST to storage → commit → scrubber — reading the actual stored bytes back out:

```
before (scrubbed_at NULL):  {"data":{"authorization":"sk_live_ABCDEF1234567890SECRET"}}
after  (scrubbed_at set):   {"data":{"authorization":"[REDACTED]"}}
```

Anonymous GET → 403. Upload signed for 500 bytes, sent 5000 → refused by storage, not app code. Duplicate seq → 409.

The CI change was verified by reintroducing the vulnerability: with `mc anonymous set download` restored, the lane fails with `anonymous GET returned 200, want 403 — bucket is publicly readable (#47)` and exits 1.

Migration 002 re-runs on every service start (there is no migration-tracking table), so it was applied five times against a clean database, and the upgrade path from the old index was verified by re-running it against a database holding the old schema.

## Known gaps — filed, not fixed

- **#49** — a 19KB chunk inflates to 564MB of heap in the scrubber. The inflate ceiling bounds bytes, not memory; `json.Unmarshal` into `interface{}` boxes every number. It fits the 64KB inline cap, and the scrubber runs in-process with ingestion. Note this means **#48's acceptance criterion reads as satisfied while the attack still works** — the bomb sits *under* the ceiling rather than beating it.
- **#50** — a chunk whose object landed but whose commit never arrived (tab closed mid-upload) is invisible to the scrubber (`uploaded_at IS NOT NULL`) and keeps raw PII at rest until retention deletes it, 30 days later.
- **#51** — the fail-closed guarantee reduces to `t2 − t1 > i − m`: the presign→commit round trip must exceed the ingestion-vs-MinIO clock skew. One second of NTP drift inverts it.

Also unaddressed here: the legacy `/replays/init` path still uses an uncapped `PresignedPutURL`, so #48's fix does not cover it.
