### PR TITLE
fix(ingestion): persist client event timestamp instead of server arrival time

### DIFF
--- a/packages/ingestion/db/client_timestamp_test.go
+++ b/packages/ingestion/db/client_timestamp_test.go
@@ -113,7 +113,8 @@ func TestInsertErrorEventAndGroup_ZeroEventTimeFallsBackToServerTime(t *testing.
 }
 
 // A late-arriving older event (offline buffer flush) must not move last_seen
-// backwards on the group or the affected-user junction.
+// backwards, and must pull first_seen back to the true earliest occurrence,
+// on both the group and the affected-user junction.
 func TestInsertErrorEventAndGroup_LastSeenDoesNotRegress(t *testing.T) {
 	pool := testPool(t)
 	ctx := context.Background()
@@ -142,30 +143,36 @@ func TestInsertErrorEventAndGroup_LastSeenDoesNotRegress(t *testing.T) {
 	first := ingest(newer)
 	ingest(older) // out-of-order late delivery
 
-	var lastSeen time.Time
+	var firstSeen, lastSeen time.Time
 	var occurrences int
 	if err := pool.QueryRow(ctx,
-		`SELECT last_seen, occurrence_count FROM error_groups WHERE id = $1`, first.GroupID,
-	).Scan(&lastSeen, &occurrences); err != nil {
+		`SELECT first_seen, last_seen, occurrence_count FROM error_groups WHERE id = $1`, first.GroupID,
+	).Scan(&firstSeen, &lastSeen, &occurrences); err != nil {
 		t.Fatalf("query group: %v", err)
 	}
 	if !lastSeen.Equal(newer) {
 		t.Errorf("group last_seen regressed to %v, want %v", lastSeen, newer)
 	}
+	if !firstSeen.Equal(older) {
+		t.Errorf("group first_seen = %v, want the true earliest occurrence %v", firstSeen, older)
+	}
 	if occurrences != 2 {
 		t.Errorf("occurrence_count = %d, want 2", occurrences)
 	}
 
-	var junctionLastSeen time.Time
+	var junctionFirstSeen, junctionLastSeen time.Time
 	if err := pool.QueryRow(ctx,
-		`SELECT eau.last_seen FROM error_group_affected_users eau
+		`SELECT eau.first_seen, eau.last_seen FROM error_group_affected_users eau
 		  JOIN end_users eu ON eu.id = eau.end_user_id
 		 WHERE eau.error_group_id = $1 AND eu.external_user_id = 'user-1'`,
 		first.GroupID,
-	).Scan(&junctionLastSeen); err != nil {
+	).Scan(&junctionFirstSeen, &junctionLastSeen); err != nil {
 		t.Fatalf("query junction: %v", err)
 	}
 	if !junctionLastSeen.Equal(newer) {
 		t.Errorf("junction last_seen regressed to %v, want %v", junctionLastSeen, newer)
+	}
+	if !junctionFirstSeen.Equal(older) {
+		t.Errorf("junction first_seen = %v, want the true earliest occurrence %v", junctionFirstSeen, older)
 	}
 }

--- a/packages/ingestion/db/client_timestamp_test.go
+++ b/packages/ingestion/db/client_timestamp_test.go
@@ -1,0 +1,171 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/opslane/opslane/packages/ingestion/db"
+)
+
+// Issue #27: error_events.timestamp must be the client event time, not server
+// arrival time. created_at keeps arrival time.
+
+func seedTimestampTenant(t *testing.T, pool *pgxpool.Pool, q *db.Queries, slug string) (projID, envID string) {
+	t.Helper()
+	ctx := context.Background()
+
+	org, err := q.CreateOrg(ctx, slug)
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	t.Cleanup(func() { cleanupTenant(t, pool, org.ID) })
+
+	proj, err := q.CreateProject(ctx, org.ID, slug, ptrStr("org/repo"))
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	env, err := q.CreateEnvironment(ctx, proj.ID, "production")
+	if err != nil {
+		t.Fatalf("CreateEnvironment: %v", err)
+	}
+	return proj.ID, env.ID
+}
+
+func TestInsertErrorEventAndGroup_UsesClientEventTime(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	projID, envID := seedTimestampTenant(t, pool, q, "test-client-ts")
+
+	eventTime := time.Now().UTC().Add(-90 * time.Second).Truncate(time.Millisecond)
+
+	result, err := q.InsertErrorEventAndGroup(ctx, db.IngestParams{
+		ProjectID:     projID,
+		EnvironmentID: envID,
+		ErrorType:     "TypeError",
+		ErrorMessage:  "boom",
+		Fingerprint:   "fp-client-ts",
+		Title:         "TypeError: boom",
+		EventTime:     eventTime,
+	})
+	if err != nil {
+		t.Fatalf("InsertErrorEventAndGroup: %v", err)
+	}
+
+	var stored, createdAt time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT "timestamp", created_at FROM error_events WHERE id = $1`,
+		result.EventID,
+	).Scan(&stored, &createdAt); err != nil {
+		t.Fatalf("query event: %v", err)
+	}
+	if !stored.Equal(eventTime) {
+		t.Errorf("error_events.timestamp = %v, want client time %v", stored, eventTime)
+	}
+	if createdAt.Sub(time.Now()) > time.Minute || time.Since(createdAt) > time.Minute {
+		t.Errorf("created_at should remain server arrival time, got %v", createdAt)
+	}
+
+	// Group impact times follow the client event time.
+	var firstSeen, lastSeen time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT first_seen, last_seen FROM error_groups WHERE id = $1`,
+		result.GroupID,
+	).Scan(&firstSeen, &lastSeen); err != nil {
+		t.Fatalf("query group: %v", err)
+	}
+	if !firstSeen.Equal(eventTime) || !lastSeen.Equal(eventTime) {
+		t.Errorf("group first/last_seen = %v/%v, want %v", firstSeen, lastSeen, eventTime)
+	}
+}
+
+func TestInsertErrorEventAndGroup_ZeroEventTimeFallsBackToServerTime(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	projID, envID := seedTimestampTenant(t, pool, q, "test-client-ts-zero")
+
+	before := time.Now().Add(-5 * time.Second)
+	result, err := q.InsertErrorEventAndGroup(ctx, db.IngestParams{
+		ProjectID:     projID,
+		EnvironmentID: envID,
+		ErrorMessage:  "no timestamp",
+		Fingerprint:   "fp-zero-ts",
+		Title:         "no timestamp",
+		// EventTime deliberately zero
+	})
+	if err != nil {
+		t.Fatalf("InsertErrorEventAndGroup: %v", err)
+	}
+	after := time.Now().Add(5 * time.Second)
+
+	var stored time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT "timestamp" FROM error_events WHERE id = $1`, result.EventID,
+	).Scan(&stored); err != nil {
+		t.Fatalf("query event: %v", err)
+	}
+	if stored.Before(before) || stored.After(after) {
+		t.Errorf("zero EventTime should store server time, got %v", stored)
+	}
+}
+
+// A late-arriving older event (offline buffer flush) must not move last_seen
+// backwards on the group or the affected-user junction.
+func TestInsertErrorEventAndGroup_LastSeenDoesNotRegress(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	projID, envID := seedTimestampTenant(t, pool, q, "test-client-ts-order")
+
+	newer := time.Now().UTC().Add(-1 * time.Minute).Truncate(time.Millisecond)
+	older := newer.Add(-1 * time.Hour)
+
+	ingest := func(ts time.Time) *db.IngestResult {
+		res, err := q.InsertErrorEventAndGroup(ctx, db.IngestParams{
+			ProjectID:     projID,
+			EnvironmentID: envID,
+			ErrorMessage:  "boom",
+			Fingerprint:   "fp-order",
+			Title:         "boom",
+			EventTime:     ts,
+			EndUserID:     "user-1",
+		})
+		if err != nil {
+			t.Fatalf("InsertErrorEventAndGroup(%v): %v", ts, err)
+		}
+		return res
+	}
+
+	first := ingest(newer)
+	ingest(older) // out-of-order late delivery
+
+	var lastSeen time.Time
+	var occurrences int
+	if err := pool.QueryRow(ctx,
+		`SELECT last_seen, occurrence_count FROM error_groups WHERE id = $1`, first.GroupID,
+	).Scan(&lastSeen, &occurrences); err != nil {
+		t.Fatalf("query group: %v", err)
+	}
+	if !lastSeen.Equal(newer) {
+		t.Errorf("group last_seen regressed to %v, want %v", lastSeen, newer)
+	}
+	if occurrences != 2 {
+		t.Errorf("occurrence_count = %d, want 2", occurrences)
+	}
+
+	var junctionLastSeen time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT eau.last_seen FROM error_group_affected_users eau
+		  JOIN end_users eu ON eu.id = eau.end_user_id
+		 WHERE eau.error_group_id = $1 AND eu.external_user_id = 'user-1'`,
+		first.GroupID,
+	).Scan(&junctionLastSeen); err != nil {
+		t.Fatalf("query junction: %v", err)
+	}
+	if !junctionLastSeen.Equal(newer) {
+		t.Errorf("junction last_seen regressed to %v, want %v", junctionLastSeen, newer)
+	}
+}

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -365,7 +365,8 @@ func (q *Queries) InsertErrorEventAndGroup(ctx context.Context, p IngestParams) 
 		`INSERT INTO error_groups (project_id, fingerprint, title, first_seen, last_seen, occurrence_count, sample_event_id)
 		 VALUES ($1, $2, $3, $4, $4, 1, $5)
 		 ON CONFLICT (project_id, fingerprint) DO UPDATE
-		   SET last_seen = GREATEST(error_groups.last_seen, $4),
+		   SET first_seen = LEAST(error_groups.first_seen, $4),
+		       last_seen = GREATEST(error_groups.last_seen, $4),
 		       occurrence_count = error_groups.occurrence_count + 1,
 		       sample_event_id = $5,
 		       updated_at = now()
@@ -417,7 +418,8 @@ func (q *Queries) InsertErrorEventAndGroup(ctx context.Context, p IngestParams) 
 			`INSERT INTO error_group_affected_users (error_group_id, end_user_id, first_seen, last_seen, occurrence_count)
 			 VALUES ($1, $2, $3, $3, 1)
 			 ON CONFLICT (error_group_id, end_user_id) DO UPDATE
-			   SET last_seen = GREATEST(error_group_affected_users.last_seen, $3),
+			   SET first_seen = LEAST(error_group_affected_users.first_seen, $3),
+			       last_seen = GREATEST(error_group_affected_users.last_seen, $3),
 			       occurrence_count = error_group_affected_users.occurrence_count + 1`,
 			groupID, endUserDBID, eventTime,
 		)

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -267,6 +267,11 @@ type IngestParams struct {
 	Context       string // JSON, defaults to "{}"
 	Release       string // source map lookup
 	SessionID     string // links error event to replay
+	// EventTime is the validated client-side event time (issue #27). Zero
+	// means "unknown" and falls back to server arrival time. It feeds
+	// error_events.timestamp and group/junction impact times; created_at
+	// always keeps server arrival time.
+	EventTime time.Time
 
 	// B2B end-user identity (optional, extracted from context.user)
 	EndUserID          string
@@ -318,13 +323,20 @@ func (q *Queries) InsertErrorEventAndGroup(ctx context.Context, p IngestParams) 
 
 	now := time.Now()
 
+	// Client event time (issue #27): when the browser told us when the error
+	// happened, persist that; otherwise fall back to server arrival time.
+	eventTime := p.EventTime
+	if eventTime.IsZero() {
+		eventTime = now
+	}
+
 	// 1. Insert error event
 	var eventID string
 	err = tx.QueryRow(ctx,
 		`INSERT INTO error_events (project_id, environment_id, timestamp, error_type, error_message, stack_trace_raw, breadcrumbs, context, release, session_id)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10)
 		 RETURNING id`,
-		p.ProjectID, p.EnvironmentID, now, p.ErrorType, p.ErrorMessage, p.StackTraceRaw, p.Breadcrumbs, p.Context, nilIfEmpty(p.Release), nilIfEmpty(p.SessionID),
+		p.ProjectID, p.EnvironmentID, eventTime, p.ErrorType, p.ErrorMessage, p.StackTraceRaw, p.Breadcrumbs, p.Context, nilIfEmpty(p.Release), nilIfEmpty(p.SessionID),
 	).Scan(&eventID)
 	if err != nil {
 		return nil, fmt.Errorf("insert error event: %w", err)
@@ -353,12 +365,12 @@ func (q *Queries) InsertErrorEventAndGroup(ctx context.Context, p IngestParams) 
 		`INSERT INTO error_groups (project_id, fingerprint, title, first_seen, last_seen, occurrence_count, sample_event_id)
 		 VALUES ($1, $2, $3, $4, $4, 1, $5)
 		 ON CONFLICT (project_id, fingerprint) DO UPDATE
-		   SET last_seen = $4,
+		   SET last_seen = GREATEST(error_groups.last_seen, $4),
 		       occurrence_count = error_groups.occurrence_count + 1,
 		       sample_event_id = $5,
 		       updated_at = now()
 		 RETURNING id, (xmax = 0) AS is_new`,
-		p.ProjectID, p.Fingerprint, p.Title, now, eventID,
+		p.ProjectID, p.Fingerprint, p.Title, eventTime, eventID,
 	).Scan(&groupID, &isNew)
 	if err != nil {
 		return nil, fmt.Errorf("upsert error group: %w", err)
@@ -405,9 +417,9 @@ func (q *Queries) InsertErrorEventAndGroup(ctx context.Context, p IngestParams) 
 			`INSERT INTO error_group_affected_users (error_group_id, end_user_id, first_seen, last_seen, occurrence_count)
 			 VALUES ($1, $2, $3, $3, 1)
 			 ON CONFLICT (error_group_id, end_user_id) DO UPDATE
-			   SET last_seen = $3,
+			   SET last_seen = GREATEST(error_group_affected_users.last_seen, $3),
 			       occurrence_count = error_group_affected_users.occurrence_count + 1`,
-			groupID, endUserDBID, now,
+			groupID, endUserDBID, eventTime,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("upsert affected user: %w", err)

--- a/packages/ingestion/db/testhelper_test.go
+++ b/packages/ingestion/db/testhelper_test.go
@@ -46,7 +46,9 @@ func cleanupTenant(t *testing.T, pool *pgxpool.Pool, orgID string) {
 	queries := []string{
 		`DELETE FROM error_group_jobs WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 		`DELETE FROM error_events WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+		`DELETE FROM error_group_affected_users WHERE error_group_id IN (SELECT id FROM error_groups WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1))`,
 		`DELETE FROM error_groups WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+		`DELETE FROM end_users WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 		`DELETE FROM environment_api_keys WHERE environment_id IN (SELECT e.id FROM environments e JOIN projects p ON e.project_id = p.id WHERE p.org_id = $1)`,
 		`DELETE FROM environments WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 		`DELETE FROM projects WHERE org_id = $1`,

--- a/packages/ingestion/handler/error_event.go
+++ b/packages/ingestion/handler/error_event.go
@@ -147,6 +147,7 @@ func (d *Dependencies) ingestErrorEvent(w http.ResponseWriter, r *http.Request, 
 	result, err := d.Queries.InsertErrorEventAndGroup(r.Context(), db.IngestParams{
 		ProjectID:          projectID,
 		EnvironmentID:      environmentID,
+		EventTime:          resolveEventTime(payload.Timestamp, start),
 		ErrorType:          payload.Error.Type,
 		ErrorMessage:       payload.Error.Message,
 		StackTraceRaw:      payload.Error.Stack,

--- a/packages/ingestion/handler/error_event_test.go
+++ b/packages/ingestion/handler/error_event_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -453,5 +454,40 @@ func TestIngest_RedactsBreadcrumbsAndContextBeforePersist(t *testing.T) {
 	}
 	if !strings.Contains(ctx, "a@b.com") {
 		t.Errorf("redaction clobbered end-user email: %s", ctx)
+	}
+}
+
+// Issue #27: the client-supplied event timestamp must be persisted as
+// error_events.timestamp instead of server arrival time.
+func TestIngestEvent_PersistsClientTimestamp(t *testing.T) {
+	deps, pool := testDeps(t)
+	_, _, _, rawKey := seedTenant(t, deps.Queries)
+
+	clientTime := time.Now().UTC().Add(-90 * time.Second).Truncate(time.Millisecond)
+	body := `{"timestamp":"` + clientTime.Format(time.RFC3339Nano) +
+		`","error":{"type":"TypeError","message":"stale event","stack":"at a (src/a.ts:1:1)"}}`
+	req := httptest.NewRequest("POST", "/api/v1/events", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", rawKey)
+
+	w := httptest.NewRecorder()
+	handler.NewRouter(deps).ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d (%s)", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var stored time.Time
+	if err := pool.QueryRow(context.Background(),
+		`SELECT "timestamp" FROM error_events WHERE id = $1`, resp["event_id"],
+	).Scan(&stored); err != nil {
+		t.Fatalf("query event: %v", err)
+	}
+	if !stored.Equal(clientTime) {
+		t.Errorf("error_events.timestamp = %v, want client time %v", stored, clientTime)
 	}
 }

--- a/packages/ingestion/handler/event_time.go
+++ b/packages/ingestion/handler/event_time.go
@@ -12,6 +12,13 @@ const futureSkewTolerance = 5 * time.Minute
 // offline-buffered events land at the moment they happened in the browser;
 // missing or unparseable values fall back to server arrival time; timestamps
 // beyond futureSkewTolerance are clamped to server time.
+//
+// Known tradeoff: clamping desyncs the error time from replay/friction
+// timestamps, which keep the raw browser clock. For a clock more than
+// futureSkewTolerance fast, same-session time correlation (e.g. a ±30s
+// error/friction fold) will miss. Accepted for now: it only affects broken
+// clocks, and before issue #27 every event was server-stamped and desynced.
+// If it matters later, treat clamped events as correlation-ineligible there.
 func resolveEventTime(raw string, now time.Time) time.Time {
 	if raw == "" {
 		return now

--- a/packages/ingestion/handler/event_time.go
+++ b/packages/ingestion/handler/event_time.go
@@ -1,0 +1,27 @@
+package handler
+
+import "time"
+
+// futureSkewTolerance bounds how far ahead of server time a client clock may
+// claim before we distrust it entirely. Small positive skew is normal
+// (unsynced client clocks); minutes ahead means the clock is broken.
+const futureSkewTolerance = 5 * time.Minute
+
+// resolveEventTime turns the SDK's client-side ISO timestamp into the event
+// time to persist (issue #27). Valid past timestamps are kept so queued or
+// offline-buffered events land at the moment they happened in the browser;
+// missing or unparseable values fall back to server arrival time; timestamps
+// beyond futureSkewTolerance are clamped to server time.
+func resolveEventTime(raw string, now time.Time) time.Time {
+	if raw == "" {
+		return now
+	}
+	t, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return now
+	}
+	if t.After(now.Add(futureSkewTolerance)) {
+		return now
+	}
+	return t
+}

--- a/packages/ingestion/handler/event_time_test.go
+++ b/packages/ingestion/handler/event_time_test.go
@@ -1,0 +1,64 @@
+package handler
+
+import (
+	"testing"
+	"time"
+)
+
+// resolveEventTime turns the SDK's client-side ISO timestamp into the event
+// time we persist. Contract (issue #27): valid past timestamps are kept,
+// missing/garbage falls back to server time, absurd future skew is clamped.
+func TestResolveEventTime(t *testing.T) {
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		raw  string
+		want time.Time
+	}{
+		{
+			name: "valid timestamp 90s in the past is kept",
+			raw:  now.Add(-90 * time.Second).Format(time.RFC3339Nano),
+			want: now.Add(-90 * time.Second),
+		},
+		{
+			name: "toISOString millisecond format is kept",
+			raw:  "2026-07-15T11:58:30.123Z",
+			want: time.Date(2026, 7, 15, 11, 58, 30, 123_000_000, time.UTC),
+		},
+		{
+			name: "empty falls back to server time",
+			raw:  "",
+			want: now,
+		},
+		{
+			name: "garbage falls back to server time",
+			raw:  "not-a-timestamp",
+			want: now,
+		},
+		{
+			name: "epoch-style number falls back to server time",
+			raw:  "1752580800000",
+			want: now,
+		},
+		{
+			name: "slight future skew (30s) is kept",
+			raw:  now.Add(30 * time.Second).Format(time.RFC3339Nano),
+			want: now.Add(30 * time.Second),
+		},
+		{
+			name: "absurd future skew (10m) is clamped to server time",
+			raw:  now.Add(10 * time.Minute).Format(time.RFC3339Nano),
+			want: now,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveEventTime(tc.raw, now)
+			if !got.Equal(tc.want) {
+				t.Errorf("resolveEventTime(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #27

## Problem

The SDK sends an ISO event `timestamp`; ingestion parsed it and then silently stored `time.Now()` instead. Queued/offline events landed minutes-to-hours late, and the Batch 4 ±30s friction fold (#56) depends on client-side times.

## Changes

- **`handler/event_time.go` (new):** `resolveEventTime` validates the client timestamp — valid past times are kept, missing/garbage falls back to server arrival time, and anything more than 5 minutes in the future is treated as a broken clock and clamped to server time.
- **`handler/error_event.go`:** the parsed `payload.Timestamp` now flows into `IngestParams.EventTime`.
- **`db/queries.go`:** `error_events.timestamp` stores the client event time; `created_at` keeps server arrival time. Group and affected-user impact times use the event time with ordering guards — `GREATEST` on `last_seen`, `LEAST` on `first_seen` — so late out-of-order deliveries can neither regress `last_seen` nor leave `first_seen` at the wrong (newer) occurrence.
- **Test-helper fix:** `cleanupTenant` now also removes `error_group_affected_users` and `end_users` rows (previously left orphans in the test DB).

## Known tradeoff (documented in code)

Clamping a >5min-future timestamp desyncs the error time from replay/friction timestamps, which keep the raw browser clock. Accepted: it only affects broken clocks, and before this fix every event was server-stamped and desynced. Batch 4's fold can treat clamped events as correlation-ineligible if needed. (Raised as P1 in an independent Codex review; the P2 `first_seen` finding from the same review is fixed here.)

## Verification

- New unit tests: 7-case table test for `resolveEventTime`.
- New DB integration tests: 90s-old timestamp stored as-is; zero `EventTime` falls back to server time; out-of-order late delivery keeps `last_seen` at the newest and pulls `first_seen` to the oldest occurrence (group + junction).
- New HTTP-level test: posts a real event through the router and asserts the persisted `error_events.timestamp` equals the wire timestamp.
- Full `go build ./... && go test ./...` green against live Postgres.

## Acceptance (from #27)

- [x] Event with a client timestamp 90s in the past stores that timestamp, not arrival time.
- [x] Missing/garbage timestamp falls back to server time.
- [x] Tests covering both paths.