### PR TITLE
feat(worker): fair job scheduling with a session_analysis concurrency cap

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -39,6 +39,7 @@ Ingestion reads **only** the `REPLAY_STORE_*` names; `MINIO_*` names appear in i
 | `DASHBOARD_URL` / `DASHBOARD_ORIGIN` | no | Links in PR bodies and notifications |
 | `WORKER_ID` | no (generated) | Stable worker identity for lease ownership |
 | `POLL_INTERVAL_MS` / `LEASE_DURATION_MS` / `REAPER_INTERVAL_MS` / `SILENCE_CHECK_INTERVAL_MS` | no | Queue tuning |
+| `SESSION_ANALYSIS_MAX_CONCURRENT` | no (2) | Fleet-wide cap on concurrently claimed `session_analysis` jobs; `0` disables analysis claiming entirely |
 | `HEALTH_PORT` | no (8081) | Health endpoint port |
 | `REPLAY_STORE_ENDPOINT` / `REPLAY_STORE_ACCESS_KEY` / `REPLAY_STORE_SECRET_KEY` / `REPLAY_STORE_BUCKET` | for replay analysis | Reading stored replays |
 | `MINIO_ENDPOINT` / `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` / `MINIO_BUCKET` | legacy aliases | Worker-side fallback names for the same settings |

--- a/packages/ingestion/db/migrations/006_job_scheduling.sql
+++ b/packages/ingestion/db/migrations/006_job_scheduling.sql
@@ -1,0 +1,20 @@
+-- 006_job_scheduling.sql — claim-time scheduling support (issue #28).
+-- The worker's claim query enforces a session_analysis concurrency cap and
+-- alternates lanes using MAX(claimed_at) per lane. These partial indexes keep
+-- both lookups index-only as completed jobs accumulate.
+--
+-- Migrations are append-only and re-applied on every boot, so every statement
+-- must be idempotent.
+
+-- Lane recency: MAX(claimed_at) per lane resolves via a backward index scan.
+CREATE INDEX IF NOT EXISTS idx_jobs_analysis_last_claim
+  ON error_group_jobs (claimed_at DESC)
+  WHERE job_type = 'session_analysis' AND claimed_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_jobs_interactive_last_claim
+  ON error_group_jobs (claimed_at DESC)
+  WHERE job_type <> 'session_analysis' AND claimed_at IS NOT NULL;
+
+-- Running-count for the cap: live claimed analysis jobs only.
+CREATE INDEX IF NOT EXISTS idx_jobs_analysis_running
+  ON error_group_jobs (lease_expires_at)
+  WHERE status = 'claimed' AND job_type = 'session_analysis';

--- a/packages/worker/src/__tests__/db-queries.test.ts
+++ b/packages/worker/src/__tests__/db-queries.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock pg module
+// Mock pg module. claimJob checks out a client for its advisory-locked
+// transaction; route the client's queries through the same mock so tests can
+// assert on the claim SQL.
 const mockQuery = vi.fn();
+const mockClient = { query: mockQuery, release: vi.fn() };
 vi.mock('pg', () => ({
-  default: { Pool: vi.fn(() => ({ query: mockQuery, end: vi.fn() })) },
-  Pool: vi.fn(() => ({ query: mockQuery, end: vi.fn() })),
+  default: { Pool: vi.fn(() => ({ query: mockQuery, connect: vi.fn(async () => mockClient), end: vi.fn() })) },
+  Pool: vi.fn(() => ({ query: mockQuery, connect: vi.fn(async () => mockClient), end: vi.fn() })),
 }));
 
 import {
@@ -106,28 +109,41 @@ describe('claimJob friction scheduling fields', () => {
   beforeEach(() => mockQuery.mockReset());
 
   it('demotes session analysis and returns receipts/session identity', async () => {
+    // Transaction sequence: BEGIN, advisory lock, UPDATE, COMMIT.
+    mockQuery.mockResolvedValueOnce({}); // BEGIN
+    mockQuery.mockResolvedValueOnce({}); // pg_advisory_xact_lock
     mockQuery.mockResolvedValueOnce({ rows: [{
       id: 'j1', error_group_id: null, source_id: null, project_id: 'p1',
       job_type: 'session_analysis', attempts: 0, guidance: null,
       worker_id: 'worker-1', lease_generation: '1',
       triggered_by: 'auto', session_id: 's1',
     }] });
+    mockQuery.mockResolvedValueOnce({}); // COMMIT
 
     const job = await claimJob('worker-1', 30_000);
 
     expect(job).toEqual(expect.objectContaining({ sessionId: 's1', triggeredBy: 'auto' }));
-    // Scheduling policy (issue #28): error_fix first, capped analysis, lane alternation.
-    expect(mockQuery.mock.calls[0][0]).toContain("WHEN job_type = 'error_fix' THEN 0");
-    expect(mockQuery.mock.calls[0][0]).toContain("AND job_type = 'session_analysis'");
-    expect(mockQuery.mock.calls[0][0]).toContain('< $3');
+    // Serialized admission (issue #28): the claim runs under an advisory lock.
+    expect(mockQuery.mock.calls[0][0]).toBe('BEGIN');
+    expect(mockQuery.mock.calls[1][0]).toContain('pg_advisory_xact_lock');
+    // Scheduling policy: error_fix first, capped analysis, lane alternation.
+    const claimSql = mockQuery.mock.calls[2][0] as string;
+    expect(claimSql).toContain("WHEN job_type = 'error_fix' THEN 0");
+    expect(claimSql).toContain("AND job_type = 'session_analysis'");
+    expect(claimSql).toContain('< $3');
     // Cap defaults to 2 when SESSION_ANALYSIS_MAX_CONCURRENT is unset.
-    expect(mockQuery.mock.calls[0][1]).toEqual(['worker-1', 30, 2]);
+    expect(mockQuery.mock.calls[2][1]).toEqual(['worker-1', 30, 2]);
+    expect(mockQuery.mock.calls[3][0]).toBe('COMMIT');
+    expect(mockClient.release).toHaveBeenCalled();
   });
 
   it('passes an explicit session_analysis cap through to the claim query', async () => {
+    mockQuery.mockResolvedValueOnce({}); // BEGIN
+    mockQuery.mockResolvedValueOnce({}); // advisory lock
     mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockQuery.mockResolvedValueOnce({}); // COMMIT
     await claimJob('worker-1', 30_000, 0);
-    expect(mockQuery.mock.calls[0][1]).toEqual(['worker-1', 30, 0]);
+    expect(mockQuery.mock.calls[2][1]).toEqual(['worker-1', 30, 0]);
   });
 });
 

--- a/packages/worker/src/__tests__/db-queries.test.ts
+++ b/packages/worker/src/__tests__/db-queries.test.ts
@@ -116,7 +116,18 @@ describe('claimJob friction scheduling fields', () => {
     const job = await claimJob('worker-1', 30_000);
 
     expect(job).toEqual(expect.objectContaining({ sessionId: 's1', triggeredBy: 'auto' }));
-    expect(mockQuery.mock.calls[0][0]).toContain("WHEN job_type = 'session_analysis' THEN 2");
+    // Scheduling policy (issue #28): error_fix first, capped analysis, lane alternation.
+    expect(mockQuery.mock.calls[0][0]).toContain("WHEN job_type = 'error_fix' THEN 0");
+    expect(mockQuery.mock.calls[0][0]).toContain("AND job_type = 'session_analysis'");
+    expect(mockQuery.mock.calls[0][0]).toContain('< $3');
+    // Cap defaults to 2 when SESSION_ANALYSIS_MAX_CONCURRENT is unset.
+    expect(mockQuery.mock.calls[0][1]).toEqual(['worker-1', 30, 2]);
+  });
+
+  it('passes an explicit session_analysis cap through to the claim query', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await claimJob('worker-1', 30_000, 0);
+    expect(mockQuery.mock.calls[0][1]).toEqual(['worker-1', 30, 0]);
   });
 });
 

--- a/packages/worker/src/__tests__/db.test.ts
+++ b/packages/worker/src/__tests__/db.test.ts
@@ -304,6 +304,30 @@ describeDb('db.ts integration tests', () => {
       ]);
     });
 
+    it('enforces the cap under truly concurrent claimers (no overshoot)', async () => {
+      for (let i = 0; i < 3; i++) {
+        await seedAnalysisJob();
+        await sleep(5);
+      }
+      for (let i = 0; i < 3; i++) {
+        await seedTypedJob('fix');
+        await sleep(5);
+      }
+
+      // Six workers poll at the same instant with cap 1. Without serialized
+      // admission they would all see zero running analysis jobs and overshoot.
+      const claims = await Promise.all(
+        Array.from({ length: 6 }, (_, i) => claimJob(`cw${i}`, 600_000, 1))
+      );
+
+      const byType = claims
+        .filter((c): c is NonNullable<typeof c> => c !== null)
+        .map((c) => c.jobType);
+      expect(byType.filter((t) => t === 'session_analysis')).toHaveLength(1);
+      expect(byType.filter((t) => t === 'fix')).toHaveLength(3);
+      expect(claims.filter((c) => c === null)).toHaveLength(2);
+    });
+
     it('completing an analysis job releases its cap slot', async () => {
       await seedAnalysisJob();
       await sleep(5);

--- a/packages/worker/src/__tests__/db.test.ts
+++ b/packages/worker/src/__tests__/db.test.ts
@@ -78,6 +78,7 @@ async function cleanupTestData(): Promise<void> {
   await testPool.query(`DELETE FROM error_group_jobs WHERE project_id = $1`, [testProjectId]);
   await testPool.query(`DELETE FROM error_events WHERE project_id = $1`, [testProjectId]);
   await testPool.query(`DELETE FROM error_groups WHERE project_id = $1`, [testProjectId]);
+  await testPool.query(`DELETE FROM sessions WHERE project_id = $1`, [testProjectId]);
   await testPool.query(`DELETE FROM environments WHERE project_id = $1`, [testProjectId]);
   await testPool.query(`DELETE FROM projects WHERE id = $1`, [testProjectId]);
   await testPool.query(`DELETE FROM orgs WHERE id = $1`, [testOrgId]);
@@ -194,6 +195,142 @@ describeDb('db.ts integration tests', () => {
       const job = await claimJob('worker-1', 60_000);
       expect(job).not.toBeNull();
       expect(job!.id).toBe(pendingJobId);
+    });
+  });
+
+  describe('fair scheduling and per-type caps (issue #28)', () => {
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+    async function seedSession(): Promise<string> {
+      const envResult = await testPool.query<{ id: string }>(
+        `INSERT INTO environments (project_id, name) VALUES ($1, $2) RETURNING id`,
+        [testProjectId, `env-${crypto.randomUUID()}`]
+      );
+      const sessionId = `sess-${crypto.randomUUID()}`;
+      await testPool.query(
+        `INSERT INTO sessions (id, project_id, environment_id, started_at)
+         VALUES ($1, $2, $3, now())`,
+        [sessionId, testProjectId, envResult.rows[0]!.id]
+      );
+      return sessionId;
+    }
+
+    async function seedAnalysisJob(): Promise<string> {
+      const sessionId = await seedSession();
+      const res = await testPool.query<{ id: string }>(
+        `INSERT INTO error_group_jobs (project_id, status, job_type, session_id)
+         VALUES ($1, 'pending', 'session_analysis', $2) RETURNING id`,
+        [testProjectId, sessionId]
+      );
+      return res.rows[0]!.id;
+    }
+
+    async function seedTypedJob(jobType: 'fix' | 'error_fix' | 'investigate'): Promise<string> {
+      const { jobId } = await seedErrorGroupAndJob();
+      await testPool.query(
+        `UPDATE error_group_jobs SET job_type = $2 WHERE id = $1`,
+        [jobId, jobType]
+      );
+      return jobId;
+    }
+
+    it('caps concurrently claimed session_analysis jobs', async () => {
+      await seedAnalysisJob();
+      await sleep(5);
+      await seedAnalysisJob();
+      await sleep(5);
+      await seedAnalysisJob();
+
+      const first = await claimJob('w1', 60_000, 2);
+      const second = await claimJob('w2', 60_000, 2);
+      expect(first?.jobType).toBe('session_analysis');
+      expect(second?.jobType).toBe('session_analysis');
+
+      // Third pending analysis job exists, but the cap is reached.
+      const third = await claimJob('w3', 60_000, 2);
+      expect(third).toBeNull();
+    });
+
+    it('a cap of zero blocks session_analysis claims entirely', async () => {
+      await seedAnalysisJob();
+      const claim = await claimJob('w1', 60_000, 0);
+      expect(claim).toBeNull();
+    });
+
+    it('a fresh error_fix is claimed immediately during an analysis flood', async () => {
+      await seedAnalysisJob();
+      await sleep(5);
+      await seedAnalysisJob();
+      await sleep(5);
+      await seedAnalysisJob();
+
+      // Analysis flood in progress: two claimed (at cap), one still pending.
+      await claimJob('w1', 60_000, 2);
+      await claimJob('w2', 60_000, 2);
+
+      const fixJobId = await seedTypedJob('error_fix');
+      const next = await claimJob('w3', 60_000, 2);
+      expect(next?.id).toBe(fixJobId);
+    });
+
+    it('error_fix outranks a pending analysis backlog from a cold start too', async () => {
+      await seedAnalysisJob();
+      await sleep(5);
+      const fixJobId = await seedTypedJob('error_fix');
+      const first = await claimJob('w1', 60_000, 2);
+      expect(first?.id).toBe(fixJobId);
+    });
+
+    it('session_analysis makes progress under a fix backlog, up to its cap', async () => {
+      for (let i = 0; i < 5; i++) {
+        await seedTypedJob('fix');
+        await sleep(5);
+      }
+      for (let i = 0; i < 3; i++) {
+        await seedAnalysisJob();
+        await sleep(5);
+      }
+
+      // Long leases: claimed jobs stay running for the whole test, so the
+      // sequence shows lane alternation and then the cap binding.
+      const types: string[] = [];
+      for (let i = 0; i < 6; i++) {
+        const job = await claimJob(`w${i}`, 600_000, 2);
+        expect(job).not.toBeNull();
+        types.push(job!.jobType);
+      }
+      expect(types).toEqual([
+        'fix', 'session_analysis', 'fix', 'session_analysis', 'fix', 'fix',
+      ]);
+    });
+
+    it('completing an analysis job releases its cap slot', async () => {
+      await seedAnalysisJob();
+      await sleep(5);
+      await seedAnalysisJob();
+      await sleep(5);
+      await seedAnalysisJob();
+      await sleep(5);
+      await seedTypedJob('fix');
+
+      // Cold start: both lanes tie, so the interactive lane goes first.
+      const f1 = await claimJob('w1', 600_000, 2);
+      expect(f1?.jobType).toBe('fix');
+
+      const a1 = await claimJob('w2', 600_000, 2);
+      const a2 = await claimJob('w3', 600_000, 2);
+      expect(a1?.jobType).toBe('session_analysis');
+      expect(a2?.jobType).toBe('session_analysis');
+
+      // At cap with only analysis pending: nothing is claimable.
+      const blocked = await claimJob('w4', 600_000, 2);
+      expect(blocked).toBeNull();
+
+      // Completion releases a slot; the pending analysis job is claimable again.
+      const completed = await completeJob(a1!.id, 'w2', a1!.leaseGeneration);
+      expect(completed).toBe(true);
+      const a3 = await claimJob('w5', 600_000, 2);
+      expect(a3?.jobType).toBe('session_analysis');
     });
   });
 

--- a/packages/worker/src/db.ts
+++ b/packages/worker/src/db.ts
@@ -76,11 +76,37 @@ export async function assertJobLease(lease: JobLease): Promise<void> {
   if ((result.rowCount ?? 0) === 0) throw new LeaseLostError(lease.id);
 }
 
-/** Claims the oldest pending job using FOR UPDATE SKIP LOCKED.
- * Priority: error_fix first, interactive work next, session analysis last. */
+/** Default fleet-wide ceiling on concurrently claimed session_analysis jobs. */
+const DEFAULT_SESSION_ANALYSIS_CAP = 2;
+
+function sessionAnalysisCapFromEnv(): number {
+  const raw = process.env['SESSION_ANALYSIS_MAX_CONCURRENT'];
+  if (raw === undefined || raw === '') return DEFAULT_SESSION_ANALYSIS_CAP;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : DEFAULT_SESSION_ANALYSIS_CAP;
+}
+
+/** Claims one pending job using FOR UPDATE SKIP LOCKED (issue #28 scheduling).
+ *
+ * Policy, in order:
+ * 1. error_fix always wins — rare, human-facing work is never queued behind
+ *    background analysis.
+ * 2. session_analysis is capped: it is claimable only while fewer than
+ *    `sessionAnalysisCap` analysis jobs hold a live lease. The count is read
+ *    outside the row lock, so concurrent claimers can briefly overshoot the
+ *    cap by at most the worker-fleet size — a soft cap by design.
+ * 3. Within the remaining work, the analysis lane and the interactive lane
+ *    (investigate/fix/setup_pr) alternate: analysis is preferred only when
+ *    its most recent claim is older than the interactive lane's. A fix
+ *    backlog therefore cannot starve analysis, and an analysis backlog
+ *    cannot starve fixes, without any scheduler state outside the jobs table.
+ *
+ * Lease and terminal-status semantics are untouched: only the candidate
+ * selection changed. */
 export async function claimJob(
   workerId: string,
-  leaseDurationMs: number
+  leaseDurationMs: number,
+  sessionAnalysisCap: number = sessionAnalysisCapFromEnv()
 ): Promise<ClaimedJob | null> {
   const db = getPool();
   const result = await db.query<{
@@ -106,10 +132,21 @@ export async function claimJob(
      WHERE id = (
        SELECT id FROM error_group_jobs
        WHERE status = 'pending'
+         AND (job_type <> 'session_analysis'
+              OR (SELECT COUNT(*) FROM error_group_jobs
+                   WHERE status = 'claimed'
+                     AND job_type = 'session_analysis'
+                     AND lease_expires_at > now()) < $3)
        ORDER BY CASE
          WHEN job_type = 'error_fix' THEN 0
-         WHEN job_type = 'session_analysis' THEN 2
-         ELSE 1
+         WHEN job_type = 'session_analysis'
+              AND COALESCE((SELECT MAX(claimed_at) FROM error_group_jobs
+                             WHERE job_type = 'session_analysis'), 'epoch'::timestamptz)
+                < COALESCE((SELECT MAX(claimed_at) FROM error_group_jobs
+                             WHERE job_type <> 'session_analysis'), 'epoch'::timestamptz)
+           THEN 1
+         WHEN job_type <> 'session_analysis' THEN 2
+         ELSE 3
        END, created_at ASC
        LIMIT 1
        FOR UPDATE SKIP LOCKED
@@ -117,7 +154,7 @@ export async function claimJob(
      RETURNING id, error_group_id, source_id, project_id, job_type, attempts, guidance,
                worker_id, lease_generation::text AS lease_generation,
                triggered_by, session_id`,
-    [workerId, leaseDurationMs / 1000]
+    [workerId, leaseDurationMs / 1000, sessionAnalysisCap]
   );
 
   const row = result.rows[0];

--- a/packages/worker/src/db.ts
+++ b/packages/worker/src/db.ts
@@ -92,14 +92,18 @@ function sessionAnalysisCapFromEnv(): number {
  * 1. error_fix always wins — rare, human-facing work is never queued behind
  *    background analysis.
  * 2. session_analysis is capped: it is claimable only while fewer than
- *    `sessionAnalysisCap` analysis jobs hold a live lease. The count is read
- *    outside the row lock, so concurrent claimers can briefly overshoot the
- *    cap by at most the worker-fleet size — a soft cap by design.
+ *    `sessionAnalysisCap` analysis jobs hold a live lease.
  * 3. Within the remaining work, the analysis lane and the interactive lane
  *    (investigate/fix/setup_pr) alternate: analysis is preferred only when
  *    its most recent claim is older than the interactive lane's. A fix
  *    backlog therefore cannot starve analysis, and an analysis backlog
  *    cannot starve fixes, without any scheduler state outside the jobs table.
+ *
+ * Admission is serialized with a transaction-scoped advisory lock: without
+ * it, simultaneous claimers all read the same running count and lane maxima
+ * and can overshoot the cap by up to the fleet size. Claims are
+ * millisecond-scale single-row updates against multi-second poll intervals,
+ * so the serialization is not a throughput concern.
  *
  * Lease and terminal-status semantics are untouched: only the candidate
  * selection changed. */
@@ -108,8 +112,8 @@ export async function claimJob(
   leaseDurationMs: number,
   sessionAnalysisCap: number = sessionAnalysisCapFromEnv()
 ): Promise<ClaimedJob | null> {
-  const db = getPool();
-  const result = await db.query<{
+  const client = await getPool().connect();
+  let result: pg.QueryResult<{
     id: string;
     error_group_id: string | null;
     source_id: string | null;
@@ -121,8 +125,14 @@ export async function claimJob(
     lease_generation: string;
     triggered_by: 'auto' | 'human' | null;
     session_id: string | null;
-  }>(
-    `UPDATE error_group_jobs
+  }>;
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `SELECT pg_advisory_xact_lock(hashtext('opslane-job-claim'))`
+    );
+    result = await client.query(
+      `UPDATE error_group_jobs
      SET status = 'claimed',
          worker_id = $1,
          claimed_at = now(),
@@ -154,8 +164,15 @@ export async function claimJob(
      RETURNING id, error_group_id, source_id, project_id, job_type, attempts, guidance,
                worker_id, lease_generation::text AS lease_generation,
                triggered_by, session_id`,
-    [workerId, leaseDurationMs / 1000, sessionAnalysisCap]
-  );
+      [workerId, leaseDurationMs / 1000, sessionAnalysisCap]
+    );
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
 
   const row = result.rows[0];
   if (!row) return null;


### PR DESCRIPTION
Closes #28

## Problem

The claim query used a static priority order with no per-type caps. Two failure modes, both about to become real when Batch 4 (#56) makes `session_analysis` jobs heavy with LLM adjudication:

- an analysis flood could occupy the entire worker fleet, queueing customer-visible investigate/fix work behind slow LLM calls, or
- a fix backlog could starve `session_analysis` forever, silently stopping friction detection.

## Changes

All in the candidate-selection subquery of `claimJob`; lease and terminal-status contracts are untouched.

- **`error_fix` keeps absolute priority** — rare, human-triggered work is claimed on the next poll even mid-flood.
- **Hard concurrency cap on `session_analysis`** — claimable only while fewer than `SESSION_ANALYSIS_MAX_CONCURRENT` (default 2) analysis jobs hold a *live* lease. Expired leases don't count, so a crashed worker can't wedge the cap before the reaper runs. A cap of 0 is a kill switch.
- **Stateless lane alternation** — the analysis lane and the interactive lane (investigate/fix/setup_pr) take turns, decided by comparing each lane's `MAX(claimed_at)`. No scheduler state outside the jobs table; neither backlog starves the other.
- **Serialized admission** — the claim runs in a transaction holding `pg_advisory_xact_lock`, making the cap exact and alternation claim-by-claim under concurrent claimers. Claims are millisecond single-row updates against multi-second poll intervals.
- **Migration `006_job_scheduling.sql`** — three partial indexes keep the running-count and lane-recency lookups index-only as completed jobs accumulate. Applied twice to a clean DB to prove idempotency.

## Review

Independent Codex review flagged the original unlocked count check as a P1 race. Confirmed empirically: a 6-concurrent-claimers test failed 3 of 6 runs against the soft-cap version. With the advisory lock it passes 6/6. Its `error_fix`-aging P2 was declined as pre-existing intended behavior for rare human-triggered work.

## Verification

- New DB integration tests: cap enforcement, cap=0 kill switch, error_fix immediacy during an analysis flood (cold start and mid-flood), deterministic lane alternation under a fix backlog (`[fix, analysis, fix, analysis, fix, fix]`), cap-slot release on completion, and the concurrent-claimers race test.
- Full worker suite: 349 passed / 0 failed. DB-backed suites run against a disposable Postgres with all migrations applied.

## Acceptance (from #28)

- [x] With a large `session_analysis` backlog, a new `error_fix` job is claimed within one poll cycle.
- [x] With a large fix backlog, `session_analysis` still makes progress up to its cap.
- [x] Lease/terminal-status contracts unchanged.