### PR TITLE
Add a deterministic browser-smoke CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,8 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Install Playwright chromium (browser smoke)
+        run: pnpm --filter @opslane/test-e2e exec playwright install --with-deps chromium
       - name: Assert the LLM key is absent
         run: |
           if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
@@ -195,7 +197,7 @@ jobs:
         env:
           # The with-secrets PR pipeline suite is the only allowed skip here.
           E2E_ALLOWED_SKIP_PATTERN: '^pr_created pipeline \(full flow\)'
-          E2E_MIN_TESTS: "15"
+          E2E_MIN_TESTS: "27"
         run: node scripts/check-e2e-results.mjs "${{ runner.temp }}/e2e-results.json"
       - name: Token-leak scan over logs and public HTTP surfaces
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,12 @@ jobs:
           # The with-secrets PR pipeline suite is the only allowed skip here.
           E2E_ALLOWED_SKIP_PATTERN: '^pr_created pipeline \(full flow\)'
           E2E_MIN_TESTS: "27"
+          # The browser smoke suites must be collected AND pass by name, so a
+          # future edit cannot drop them while keeping the total count intact.
+          E2E_REQUIRED_PATTERNS: |
+            ^browser smoke: Vue error to needs_human >
+            ^browser smoke: React error to needs_human >
+            ^browser smoke: rage click to friction signal >
         run: node scripts/check-e2e-results.mjs "${{ runner.temp }}/e2e-results.json"
       - name: Token-leak scan over logs and public HTTP surfaces
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ docker compose config --quiet
 - Shared types or workspace metadata: run `pnpm -r build` and affected tests.
 - CLI: run `pnpm --filter @opslane/cli build` and `pnpm --filter @opslane/cli test`.
 - Compose or health checks: validate config, start services, and inspect health. Build any affected Compose image after Dockerfile changes.
-- Pipeline changes require a live smoke: apply migrations, run `scripts/seed-e2e.sql`, rebuild ingestion and worker, send an event to `http://localhost:8082/api/v1/events`, and confirm the job reaches its expected terminal state. Use `test-fixtures/vue-app` for browser fixtures.
+- Pipeline changes require a live smoke: apply migrations, run `scripts/seed-e2e.sql`, rebuild ingestion and worker, send an event to `http://localhost:8082/api/v1/events`, and confirm the job reaches its expected terminal state. Use `test-fixtures/vue-app` or `test-fixtures/react-app` for browser fixtures.
 
 ## Cross-cutting conventions
 

--- a/docs/plans/2026-07-15-browser-smoke-lane.md
+++ b/docs/plans/2026-07-15-browser-smoke-lane.md
@@ -1,0 +1,982 @@
+# Deterministic Browser-Smoke CI Lane Implementation Plan
+
+> **Execution:** Work task-by-task in order; each task ends in a verified state and a commit. Any agent or human can execute this — no tool-specific workflow assumed. Commit messages are intent-first sentences matching this repo's log style (e.g. "Keep deterministic reliability checks portable across CI").
+
+**Goal:** A CI lane where a real Chromium browser drives Vue and React fixture apps with the real SDK pointed at the real (keyless) ingestion stack, deterministically asserting that a browser error becomes a `needs_human` incident and that browser rage-clicks become a `rage_click` friction signal.
+
+**Architecture:** New browser tests live in `test-e2e/` and run inside the existing `e2e-keyless` CI job (the full compose stack is already booted there, keyless). A small harness boots a Vite dev server per fixture app, aliases `@opslane/sdk` to SDK source, and injects test config (seeded API key, real endpoint, fast flush) via the proven `inject-sdk-init` transform from `packages/sdk/src/__tests__/browser-contract.test.ts`. Assertions poll the real incidents API and the DB — no `waitForTimeout`-and-hope.
+
+**Tech Stack:** Playwright (Chromium), Vite, Vitest, pg, existing compose stack (ingestion:8082, postgres:5434, minio:9012).
+
+---
+
+## Context an implementer must know (all verified against source)
+
+**Error path (fully auto, deterministic keyless):**
+browser click → SDK captures → `POST /api/v1/events` → ingestion groups → job created → keyless worker → `error_groups.status = 'needs_human'`, `reason.reason_code = 'missing_llm_key'`. This is exactly what `test-e2e/needs-human-contract.test.ts:143-226` asserts for a hand-built payload; the browser tests replace the hand-built payload with a real SDK one.
+
+**Friction path (auto only up to signals — this is a product gap, not a plan bug):**
+1. SDK: `init({ replay: { enabled: true } })` → `POST /api/v1/sessions/init` → chunk upload via presigned MinIO POST (`REPLAY_STORE_PUBLIC_ENDPOINT` = `http://localhost:9012`, reachable from a host browser) → `POST .../chunks/{seq}/commit`. Interaction telemetry (clicks) rides inside replay chunks as rrweb type-5 events tagged `opslane.telemetry` (`packages/sdk/src/replay.ts:205-211`) — replay must be enabled.
+2. Chunks flush every 30s (`CHUNK_MS`, `replay.ts:13`) — **or immediately when an error event is accepted** (`flushReplayBufferForError`, `packages/sdk/src/transport.ts:133-135`). The tests use the error-trigger to avoid 30s waits.
+3. Ingestion's scrubber claims chunks `uploaded_at <= now() - 30s`, every 15s (`packages/ingestion/main.go:128`, `db/sessions.go:218`). Worker reads only `scrubbed_at IS NOT NULL` chunks. Expect ~45–60s before a chunk is analyzable. Not tunable via env — poll with a generous deadline.
+4. **Nothing auto-creates a `session_analysis` job in Batch 3** (`004_friction.sql:6-8`), and idle-close takes 30 min via an hourly sweeper. The test inserts the job row itself (`error_group_id` is nullable since `001_baseline.sql:449`). When auto-scheduling lands, delete the manual insert.
+5. Worker (`session_analysis` handler, `packages/worker/src/index.ts:494-531`): sessions.status `analyzing` → `analyzed`; writes `friction_signals`. It does **not** create friction incidents. So the friction test asserts on `friction_signals`, not on an incident.
+
+**Rage-click rule** (`packages/worker/src/friction/analyzer.ts:10-12, 253-257`): ≥3 clicks on the same selector, consecutive gaps ≤1000ms, and the **last** click "unanswered" — no DOM mutation (rrweb type 3 / source 0) and no click-attributed `request_start` within 1000ms after it. **Therefore: after rage-clicking, wait >1s before touching anything that mutates the DOM.**
+
+**Selector shape:** `deriveSelector` returns `[data-testid="dead-button"]` when a `data-testid` is present (`packages/sdk/src/selector.ts:43-51`). Assert exact equality.
+
+**CORS:** SDK endpoints (`/api/v1/events`, `/api/v1/sessions`, ...) reflect any Origin (`packages/ingestion/handler/routes.go:194-199`), so a fixture on a random localhost port can POST to `localhost:8082`. MinIO presigned POST from the browser is the one surface no test exercises today — Task 0 spikes it before anything else is built, so a CORS surprise can't invalidate later work.
+
+**Replay readiness is asynchronous.** `init()` fire-and-forgets `startReplayCapture()` (`packages/sdk/src/index.ts:44`), which awaits a `POST /sessions/init` round-trip and then a dynamic `import('rrweb')` before installing the telemetry sink (`replay.ts:193-211`). Clicks before the sink exists are silently dropped. The friction test therefore gates on a test-only readiness hook (Task 3) instead of sleeping and hoping.
+
+**SDK has no public `flush()`** — inject `flushInterval: 200, maxBatchSize: 1` like the SDK's own browser tests do.
+
+**Recording is on by default** for new projects (`projects.recording_enabled DEFAULT TRUE`, `002_sessions.sql:153`) — `seedTenant` needs no change.
+
+**Keyless gating:** copy the exact gate from `needs-human-contract.test.ts:153-156`: run only when `E2E_WORKER_NO_KEY === '1'` and no `ANTHROPIC_API_KEY`. Also skip if the Chromium **binary** is missing — detected via `chromium.executablePath()` + filesystem check, not just a successful import (an import-only check would make a missing binary explode in `beforeAll` instead of skipping). CI enforces the tests actually ran via `scripts/check-e2e-results.mjs` (unexpected skips fail; `E2E_MIN_TESTS` raised in Task 8 from a measured baseline).
+
+---
+
+### Task 0: Spike — browser presigned POST to MinIO (CORS)
+
+This is the only transport seam in the whole design that nothing exercises today. Prove it works before building anything on top of it. Throwaway code; nothing is committed except (if needed) a compose/MinIO config fix.
+
+**Step 1: Boot the stack** (recipe from Task 5 Step 1) and install Chromium.
+
+**Step 2: Run a one-off probe script** (put it in your scratch dir, not the repo). It seeds a tenant, opens the Vue fixture through a minimal Vite server with the SDK pointed at the real stack and `replay: { enabled: true }`, triggers an error (which forces an immediate chunk upload), and then checks the DB:
+
+```sql
+SELECT seq, uploaded_at FROM session_chunks sc
+  JOIN sessions s ON s.id = sc.session_id
+ WHERE s.project_id = '<seeded project id>';
+```
+
+The fastest honest version: temporarily point the existing `packages/sdk/src/__tests__/replay-browser.test.ts` machinery at the real stack, or write a ~40-line script with `chromium.launch()` + `page.on('requestfailed')` logging.
+
+**Step 3: Interpret.**
+- Chunk row appears with `uploaded_at` set → the browser→MinIO presigned POST works. Proceed; delete the probe.
+- Upload request fails with a CORS error in `page.on('requestfailed')` → fix MinIO CORS in compose (`MINIO_API_CORS_ALLOW_ORIGIN=*` env on the `minio` service, or `mc admin config set local api cors_allow_origin="*"` in `minio-setup`), commit that fix alone ("Let browsers upload replay chunks to compose MinIO"), and re-run the probe until green.
+
+---
+
+### Task 1: Vue fixture — dead-button view for friction
+
+**Files:**
+- Create: `test-fixtures/vue-app/src/components/DeadEnd.vue`
+- Modify: `test-fixtures/vue-app/src/App.vue`
+
+**Step 1: Create the component.** It must be static — no handlers, no reactive state — so clicks cause zero DOM mutations (a mutation within 1s of the last click suppresses the rage-click signal).
+
+```vue
+<script setup lang="ts">
+// Intentionally inert: no handlers, no reactive state. Clicking must cause
+// zero DOM mutations or the friction analyzer treats the click as "answered".
+</script>
+
+<template>
+  <div>
+    <p>This button does nothing.</p>
+    <button data-testid="dead-button" type="button">Save changes</button>
+  </div>
+</template>
+```
+
+**Step 2: Wire it into `App.vue`.** Add to the nav (after the `nav-fetch` button):
+
+```html
+      <button data-testid="nav-dead" @click="currentView = 'dead'">DeadEnd</button>
+```
+
+Add the import `import DeadEnd from './components/DeadEnd.vue';` and to `<main>`:
+
+```html
+      <DeadEnd v-if="currentView === 'dead'" />
+```
+
+**Step 3: Verify the fixture builds**
+
+Run from repo root: `pnpm --filter opslane-fixture-app build`
+Expected: vite build succeeds.
+
+**Step 4: Commit**
+
+```bash
+git add test-fixtures/vue-app
+git commit -m "Give the Vue fixture an inert dead button so rage clicks stay unanswered"
+```
+
+---
+
+### Task 2: React fixture app
+
+**Files:**
+- Create: `test-fixtures/react-app/package.json`
+- Create: `test-fixtures/react-app/tsconfig.json`
+- Create: `test-fixtures/react-app/vite.config.ts`
+- Create: `test-fixtures/react-app/index.html`
+- Create: `test-fixtures/react-app/src/main.tsx`
+- Create: `test-fixtures/react-app/src/App.tsx`
+- Create: `test-fixtures/react-app/src/BuggyProfile.tsx`
+
+`test-fixtures/*` is already a workspace glob (`pnpm-workspace.yaml`), so the package joins the workspace on `pnpm install`.
+
+**Step 1: `package.json`** (mirror the vue fixture, `test-fixtures/vue-app/package.json`):
+
+```json
+{
+  "name": "opslane-fixture-react",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "license": "AGPL-3.0-only",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo ok"
+  },
+  "dependencies": {
+    "@opslane/sdk": "workspace:*",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.4.0",
+    "vite": "^6.0.0"
+  }
+}
+```
+
+**Step 2: `tsconfig.json`** — copy `test-fixtures/vue-app/tsconfig.json` and adjust `jsx`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}
+```
+
+(Verify against the vue fixture's actual tsconfig and keep any extra flags it has.)
+
+**Step 3: `vite.config.ts`:**
+
+```ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});
+```
+
+**Step 4: `index.html`:**
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Opslane React Fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+**Step 5: `src/main.tsx`** — the `init({...});` block MUST match the regex `/init\(\{[\s\S]*?\}\);/` that the harness transform replaces (same contract as `test-fixtures/vue-app/src/main.ts`):
+
+```tsx
+import { createRoot } from 'react-dom/client';
+import { init } from '@opslane/sdk';
+import { OpslaneErrorBoundary } from '@opslane/sdk/react';
+import { App } from './App';
+
+init({
+  endpoint: 'http://localhost:8082',
+  apiKey: 'e2e-test-key-plaintext',
+  release: 'e2e-react-fixture-v1',
+  replay: { enabled: true },
+});
+
+createRoot(document.getElementById('root')!).render(
+  <OpslaneErrorBoundary fallback={<p data-testid="boundary-fallback">Something broke</p>}>
+    <App />
+  </OpslaneErrorBoundary>
+);
+```
+
+**Step 6: `src/App.tsx` and `src/BuggyProfile.tsx`.** The bug: clicking sets state so the next render reads a property of `null` — a render-phase throw that `OpslaneErrorBoundary.componentDidCatch` captures (`packages/sdk/src/react.tsx:19-29`), covering the React integration path specifically.
+
+```tsx
+// App.tsx
+import { useState } from 'react';
+import { BuggyProfile } from './BuggyProfile';
+
+export function App() {
+  const [view, setView] = useState('home');
+  return (
+    <div>
+      <nav>
+        <button data-testid="nav-home" onClick={() => setView('home')}>Home</button>
+        <button data-testid="nav-profile" onClick={() => setView('profile')}>Profile</button>
+      </nav>
+      <main>
+        {view === 'home' && <p>Select a bug to trigger</p>}
+        {view === 'profile' && <BuggyProfile />}
+      </main>
+    </div>
+  );
+}
+```
+
+```tsx
+// BuggyProfile.tsx
+import { useState } from 'react';
+
+interface Profile { displayName: string }
+
+export function BuggyProfile() {
+  const [profile, setProfile] = useState<Profile | null | undefined>(undefined);
+  if (profile === null) {
+    // Render-phase throw: TypeError reading 'displayName' of null.
+    return <p>{(profile as unknown as Profile).displayName.toUpperCase()}</p>;
+  }
+  return (
+    <button data-testid="load-profile-btn" onClick={() => setProfile(null)}>
+      Load profile
+    </button>
+  );
+}
+```
+
+**Step 7: Install and build**
+
+Run: `pnpm install` then `pnpm --filter opslane-fixture-react build`
+Expected: install links the workspace package; vite build succeeds.
+
+**Step 8: Run the license boundary check** (fixtures are AGPL; this guards against accidental MIT leakage): `node scripts/check-licenses.mjs`
+Expected: passes.
+
+**Step 9: Commit**
+
+```bash
+git add test-fixtures/react-app pnpm-lock.yaml
+git commit -m "Cover the React error-boundary capture path with a browser fixture"
+```
+
+---
+
+### Task 3: SDK replay-ready hook + browser harness in test-e2e
+
+**Files:**
+- Modify: `packages/sdk/src/replay.ts`
+- Modify: `test-e2e/package.json`
+- Create: `test-e2e/browser-helpers.ts`
+
+**Step 0a: Add a test-only readiness hook to the SDK.** Precedent: `transport.ts` already exports test-only hooks (`getQueueLength`, `_resetQueue`). Append to `packages/sdk/src/replay.ts`:
+
+```ts
+/** Test-only: true once rrweb record() is active and the telemetry sink is
+ *  installed — i.e. clicks from this point on land in replay chunks. */
+export function _replayStarted(): boolean {
+  return replayInstalled && stopFn !== null;
+}
+```
+
+(`stopFn` is assigned only after `record()` succeeded, which is after `setTelemetrySink` — so `stopFn !== null` implies the sink is live. Verify those lines still hold: `replay.ts:205-228`.)
+
+**Step 0b: Verify the SDK:** `pnpm --filter @opslane/sdk build && pnpm --filter @opslane/sdk test` — green, including the real-browser contract tests executing rather than skipping (SDK `AGENTS.md` requirement).
+
+**Step 0c: Commit:**
+
+```bash
+git add packages/sdk/src/replay.ts
+git commit -m "Expose a test-only replay-readiness hook so browser tests can gate on it"
+```
+
+**Step 1: Add devDependencies** to `test-e2e/package.json` (versions matched to `packages/sdk/package.json` devDeps — check and mirror them exactly):
+
+```json
+  "devDependencies": {
+    "@types/pg": "^8.11.0",
+    "@playwright/test": "<same major as packages/sdk>",
+    "@vitejs/plugin-react": "^4.3.0",
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^6.0.0",
+    "vitest": "^3.2.0"
+  }
+```
+
+Run `pnpm install`.
+
+**Step 2: Create `test-e2e/browser-helpers.ts`.** This generalizes the proven pattern from `packages/sdk/src/__tests__/browser-contract.test.ts:84-126`: Vite dev server rooted at the fixture, `@opslane/sdk` aliased to SDK **source** (no build-order dependency; Vite compiles the TS), and an `inject-sdk-init` transform that swaps the fixture's `init({...});` block for test config with the seeded API key and real endpoint.
+
+```ts
+/**
+ * Browser-smoke harness: boots a fixture app under Vite with the SDK aliased
+ * to source and init() config injected (real ingestion endpoint + seeded key).
+ */
+import { resolve } from 'node:path';
+import type { PluginOption } from 'vite';
+
+const SDK_SRC = resolve(__dirname, '../packages/sdk/src');
+
+export interface FixtureServer {
+  url: string;
+  close(): Promise<void>;
+}
+
+export async function startFixture(opts: {
+  fixtureDir: string;            // absolute path to the fixture app
+  apiKey: string;                // seeded tenant key
+  ingestionUrl: string;          // e.g. http://localhost:8082
+  entryPattern: RegExp;          // /\/main\.tsx?$/ — file whose init() block gets replaced
+  plugins: PluginOption[];       // [vue()] or [react()]
+}): Promise<FixtureServer> {
+  const { createServer } = await import('vite');
+  const server = await createServer({
+    root: opts.fixtureDir,
+    configFile: false,
+    logLevel: 'error',
+    resolve: {
+      alias: [
+        // Order matters: subpaths before the bare specifier.
+        { find: '@opslane/sdk/react', replacement: resolve(SDK_SRC, 'react.tsx') },
+        { find: '@opslane/sdk/_replay', replacement: resolve(SDK_SRC, 'replay.ts') },
+        { find: '@opslane/sdk', replacement: resolve(SDK_SRC, 'index.ts') },
+      ],
+    },
+    server: { port: 0 },
+    plugins: [
+      ...opts.plugins,
+      {
+        name: 'inject-sdk-init',
+        transform(code: string, id: string) {
+          if (opts.entryPattern.test(id)) {
+            const replaced = code.replace(
+              /init\(\{[\s\S]*?\}\);/,
+              `init({
+                endpoint: '${opts.ingestionUrl}',
+                apiKey: '${opts.apiKey}',
+                flushInterval: 200,
+                maxBatchSize: 1,
+                replay: { enabled: true },
+              });`
+            );
+            // Replay starts asynchronously (session registration + dynamic
+            // rrweb import) — expose readiness so tests can gate on it
+            // instead of sleeping (see plan context; index.ts:44).
+            return [
+              `import { _replayStarted as __opslaneReplayStarted } from '@opslane/sdk/_replay';`,
+              replaced,
+              `const __opslaneReadyTimer = setInterval(() => {`,
+              `  if (__opslaneReplayStarted()) {`,
+              `    (window as unknown as { __opslaneReplayReady?: boolean }).__opslaneReplayReady = true;`,
+              `    clearInterval(__opslaneReadyTimer);`,
+              `  }`,
+              `}, 50);`,
+            ].join('\n');
+          }
+        },
+      },
+    ],
+  });
+  await server.listen();
+  const port = server.config.server.port;
+  return {
+    url: `http://localhost:${port}`,
+    close: () => server.close(),
+  };
+}
+
+export async function isPlaywrightAvailable(): Promise<boolean> {
+  try {
+    const pw = await import('@playwright/test');
+    // Import success is not enough: the chromium BINARY may be missing, and
+    // that would fail beforeAll instead of skipping. Check the executable.
+    const { existsSync } = await import('node:fs');
+    const path = pw.chromium.executablePath();
+    return !!path && existsSync(path);
+  } catch {
+    return false;
+  }
+}
+```
+
+Note: this is deliberately stricter than the SDK's own import-only detection (`browser-contract.test.ts:6-16`) — a missing binary skips locally instead of exploding in `beforeAll`. In CI the skip is still caught: these tests are not in `E2E_ALLOWED_SKIP_PATTERN`, so `check-e2e-results.mjs` fails the job on any skip.
+
+**Step 3: Type-check the package**
+
+Run: `pnpm --filter @opslane/test-e2e exec tsc --noEmit`
+Expected: clean. (If `test-e2e/tsconfig.json` excludes new files, add them.)
+
+**Step 4: Commit**
+
+```bash
+git add test-e2e/package.json test-e2e/browser-helpers.ts pnpm-lock.yaml
+git commit -m "Let E2E tests drive fixture apps through a real browser against the real stack"
+```
+
+---
+
+### Task 4: DB helpers for the friction path
+
+**Files:**
+- Modify: `test-e2e/helpers.ts`
+
+**Step 1: Add session/friction helpers** (append to `helpers.ts`; schemas verified against `002_sessions.sql`, `004_friction.sql`, `001_baseline.sql:111-124,371,449`):
+
+```ts
+// ---------------------------------------------------------------------------
+// Session / friction helpers (browser smoke)
+// ---------------------------------------------------------------------------
+
+/** Polls until the project has a session (created by SDK /sessions/init). */
+export async function pollSessionForProject(
+  projectId: string,
+  timeoutMs = 30_000
+): Promise<string> {
+  const db = getPool();
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { rows } = await db.query<{ id: string }>(
+      `SELECT id FROM sessions WHERE project_id = $1 ORDER BY started_at DESC LIMIT 1`,
+      [projectId]
+    );
+    if (rows[0]) return rows[0].id;
+    await new Promise((r) => setTimeout(r, 1_000));
+  }
+  throw new Error(`No session appeared for project ${projectId} within ${timeoutMs}ms`);
+}
+
+/** Polls until at least one chunk for the session is scrubbed (analyzable).
+ *  Scrubber cadence: eligible 30s after upload, swept every 15s — expect ~45-60s. */
+export async function pollScrubbedChunk(
+  sessionId: string,
+  timeoutMs = 120_000
+): Promise<void> {
+  const db = getPool();
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { rows } = await db.query(
+      `SELECT 1 FROM session_chunks WHERE session_id = $1 AND scrubbed_at IS NOT NULL LIMIT 1`,
+      [sessionId]
+    );
+    if (rows.length > 0) return;
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  throw new Error(`No scrubbed chunk for session ${sessionId} within ${timeoutMs}ms`);
+}
+
+/** Batch 3 gap: the product does not yet auto-create session_analysis jobs
+ *  (see 004_friction.sql header). Insert one directly; delete this helper when
+ *  auto-scheduling lands. */
+export async function insertSessionAnalysisJob(
+  projectId: string,
+  sessionId: string
+): Promise<void> {
+  const db = getPool();
+  await db.query(
+    `INSERT INTO error_group_jobs (project_id, session_id, job_type, status, triggered_by)
+     VALUES ($1, $2, 'session_analysis', 'pending', 'auto')`,
+    [projectId, sessionId]
+  );
+}
+
+/** Polls sessions.status until it reaches one of the given values. */
+export async function pollSessionStatus(
+  sessionId: string,
+  statuses: string[],
+  timeoutMs = 60_000
+): Promise<string> {
+  const db = getPool();
+  const deadline = Date.now() + timeoutMs;
+  let last = '';
+  while (Date.now() < deadline) {
+    const { rows } = await db.query<{ status: string }>(
+      `SELECT status FROM sessions WHERE id = $1`,
+      [sessionId]
+    );
+    last = rows[0]?.status ?? '(missing)';
+    if (statuses.includes(last)) return last;
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  throw new Error(`Session ${sessionId} stuck at '${last}' after ${timeoutMs}ms`);
+}
+
+export interface FrictionSignalRow {
+  signal_type: string;
+  element_selector: string | null;
+  occurrence_count: number;
+}
+
+/** Active (non-retracted, non-superseded) friction signals for a session. */
+export async function getActiveFrictionSignals(
+  sessionId: string
+): Promise<FrictionSignalRow[]> {
+  const db = getPool();
+  const { rows } = await db.query<FrictionSignalRow>(
+    `SELECT signal_type, element_selector, occurrence_count
+       FROM friction_signals
+      WHERE session_id = $1 AND retracted_at IS NULL AND superseded_by IS NULL`,
+    [sessionId]
+  );
+  return rows;
+}
+```
+
+**Step 2: Extend `cleanupTenant`.** Browser tests create `sessions` rows (with cascading `session_chunks` and `friction_signals`). In `cleanupTenant` (`helpers.ts:340`), after the `error_group_jobs` delete, add:
+
+```ts
+  // Sessions cascade to session_chunks and friction_signals (ON DELETE CASCADE).
+  await db.query(
+    `DELETE FROM sessions WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+    [orgId]
+  );
+```
+
+If the delete fails on an FK (e.g. `end_users`), inspect `002_sessions.sql` for the offending table and delete it in the same scoped style — do not disable constraints.
+
+**Step 3: Type-check:** `pnpm --filter @opslane/test-e2e exec tsc --noEmit` — clean.
+
+**Step 4: Commit**
+
+```bash
+git add test-e2e/helpers.ts
+git commit -m "Make the friction pipeline pollable from E2E tests"
+```
+
+---
+
+### Task 5: Browser error smoke — Vue
+
+**Files:**
+- Create: `test-e2e/browser-smoke.test.ts`
+
+**Step 1: Boot the keyless stack locally** (same recipe as the `e2e-keyless` CI job, `ci.yml:178-184`):
+
+```bash
+docker compose up -d postgres minio minio-setup
+docker compose run --rm migrate
+docker compose up -d --build --wait ingestion worker
+pnpm --filter @opslane/sdk exec playwright install --with-deps chromium
+```
+
+Confirm the worker is keyless: `docker compose exec -T worker sh -c '[ -z "$ANTHROPIC_API_KEY" ]'` (exit 0).
+
+**Step 2: Write the test.** Gate identically to `needs-human-contract.test.ts` plus the Playwright check.
+
+```ts
+// @vitest-environment node
+/**
+ * Browser smoke: a real Chromium drives the fixture apps with the real SDK
+ * pointed at the real keyless stack. Proves the whole seam the API-level E2E
+ * suite can't: real SDK payloads are accepted, grouped, and driven to a
+ * terminal state.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { resolve } from 'node:path';
+import {
+  getConfig, seedTenant, cleanupTenant, closePool,
+  listIncidents, pollUntilTerminal,
+  type TestTenant, type Incident,
+} from './helpers.js';
+import { startFixture, isPlaywrightAvailable, type FixtureServer } from './browser-helpers.js';
+
+const hasLLMKey = !!process.env['ANTHROPIC_API_KEY'];
+const keylessWorkerRunning = process.env['E2E_WORKER_NO_KEY'] === '1';
+const playwrightAvailable = await isPlaywrightAvailable();
+
+const VUE_FIXTURE = resolve(__dirname, '../test-fixtures/vue-app');
+
+async function pollIncidentMatching(
+  tenant: TestTenant,
+  predicate: (i: Incident) => boolean,
+  timeoutMs = 60_000
+): Promise<Incident> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const incidents = await listIncidents(tenant.apiKey, tenant.projectId);
+    const hit = incidents.find(predicate);
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  throw new Error(`No matching incident within ${timeoutMs}ms`);
+}
+
+describe.skipIf(hasLLMKey || !keylessWorkerRunning || !playwrightAvailable)(
+  'browser smoke: Vue error to needs_human',
+  () => {
+    let tenant: TestTenant;
+    let fixture: FixtureServer;
+    let browser: import('@playwright/test').Browser;
+
+    beforeAll(async () => {
+      tenant = await seedTenant();
+      const vue = (await import('@vitejs/plugin-vue')).default;
+      fixture = await startFixture({
+        fixtureDir: VUE_FIXTURE,
+        apiKey: tenant.apiKey,
+        ingestionUrl: getConfig().ingestionUrl,
+        entryPattern: /\/main\.ts$/,
+        plugins: [vue()],
+      });
+      const { chromium } = await import('@playwright/test');
+      browser = await chromium.launch();
+    }, 60_000);
+
+    afterAll(async () => {
+      await browser?.close();
+      await fixture?.close();
+      if (tenant) await cleanupTenant(tenant.orgId);
+      await closePool();
+    });
+
+    it('real Vue SDK error reaches needs_human with missing_llm_key', async () => {
+      const page = await browser.newPage();
+      await page.goto(fixture.url);
+      await page.click('[data-testid="nav-usercard"]');
+      await page.click('[data-testid="edit-profile-btn"]');
+
+      // Incident appears via real grouping of the real SDK payload.
+      const incident = await pollIncidentMatching(
+        tenant,
+        (i) => i.title.toLowerCase().includes('null')
+      );
+      expect(incident.status).toBeTruthy();
+
+      const terminal = await pollUntilTerminal(
+        tenant.apiKey, tenant.projectId, incident.id, ['needs_human'], 90_000
+      );
+      expect(terminal.status).toBe('needs_human');
+      expect(terminal.reason?.reason_code).toBe('missing_llm_key');
+      expect(terminal.reason?.reason_message).toBeTruthy();
+      expect(terminal.reason?.remediation).toBeTruthy();
+      await page.close();
+    }, 180_000);
+  }
+);
+```
+
+Adjust the title predicate after the first live run: the fixture's UserCard bug throws a TypeError reading a property of `null` — verify the actual `title` the incident gets (it derives from the error message) and pin the predicate to something stable from it. Keep it a substring match, not exact.
+
+**Step 3: Run it to verify it fails first** (before Tasks 1–4 land it fails on missing imports; after them, first run may fail on the title predicate — that's the calibration step):
+
+```bash
+DATABASE_URL=postgres://opslane:opslane_dev@localhost:5434/opslane \
+INGESTION_URL=http://localhost:8082 \
+E2E_WORKER_NO_KEY=1 \
+pnpm --filter @opslane/test-e2e exec vitest run browser-smoke
+```
+
+**Step 4: Fix predicate if needed, re-run until PASS.** Paste the real terminal incident JSON into the PR description as evidence.
+
+**Step 5: Commit**
+
+```bash
+git add test-e2e/browser-smoke.test.ts
+git commit -m "Prove a real Vue browser error reaches needs_human keylessly"
+```
+
+---
+
+### Task 6: Browser error smoke — React
+
+**Files:**
+- Modify: `test-e2e/browser-smoke.test.ts`
+
+**Step 1: Add a second describe block** (same gates), booting the React fixture:
+
+```ts
+const REACT_FIXTURE = resolve(__dirname, '../test-fixtures/react-app');
+
+describe.skipIf(hasLLMKey || !keylessWorkerRunning || !playwrightAvailable)(
+  'browser smoke: React error to needs_human',
+  () => {
+    let tenant: TestTenant;
+    let fixture: FixtureServer;
+    let browser: import('@playwright/test').Browser;
+
+    beforeAll(async () => {
+      tenant = await seedTenant();
+      const react = (await import('@vitejs/plugin-react')).default;
+      fixture = await startFixture({
+        fixtureDir: REACT_FIXTURE,
+        apiKey: tenant.apiKey,
+        ingestionUrl: getConfig().ingestionUrl,
+        entryPattern: /\/main\.tsx$/,
+        plugins: [react()],
+      });
+      const { chromium } = await import('@playwright/test');
+      browser = await chromium.launch();
+    }, 60_000);
+
+    afterAll(async () => {
+      await browser?.close();
+      await fixture?.close();
+      if (tenant) await cleanupTenant(tenant.orgId);
+      // closePool() is called once by the last suite teardown; harmless if repeated.
+    });
+
+    it('React error-boundary error reaches needs_human with missing_llm_key', async () => {
+      const page = await browser.newPage();
+      await page.goto(fixture.url);
+      await page.click('[data-testid="nav-profile"]');
+      await page.click('[data-testid="load-profile-btn"]');
+      // Boundary fallback proves componentDidCatch ran (the capture path under test).
+      await page.waitForSelector('[data-testid="boundary-fallback"]');
+
+      const incident = await pollIncidentMatching(
+        tenant,
+        (i) => i.title.toLowerCase().includes('displayname') || i.title.toLowerCase().includes('null')
+      );
+      const terminal = await pollUntilTerminal(
+        tenant.apiKey, tenant.projectId, incident.id, ['needs_human'], 90_000
+      );
+      expect(terminal.status).toBe('needs_human');
+      expect(terminal.reason?.reason_code).toBe('missing_llm_key');
+      await page.close();
+    }, 180_000);
+  }
+);
+```
+
+Note on `closePool()`: it lives in one shared module — make sure only the **final** `afterAll` in the file calls it, or make `closePool` idempotent-safe for repeated calls (it already nulls the pool; calling `getPool` again recreates it, so calling it in each suite is safe — verify once locally).
+
+**Step 2: Run:** same command as Task 5. Expected: both suites PASS. Calibrate the React title predicate from the real incident on first run, same as Task 5.
+
+**Step 3: Commit**
+
+```bash
+git add test-e2e/browser-smoke.test.ts
+git commit -m "Prove a React boundary error reaches needs_human keylessly"
+```
+
+---
+
+### Task 7: Friction smoke — rage click to friction signal
+
+**Files:**
+- Create: `test-e2e/friction-smoke.test.ts`
+
+**Step 1: Write the test.** Sequence and the reasons for each wait:
+
+```ts
+// @vitest-environment node
+/**
+ * Friction smoke: real rage-clicks in Chromium produce rrweb telemetry inside
+ * replay chunks; the real scrubber and the real analyzer turn them into a
+ * rage_click friction signal.
+ *
+ * Batch 3 gap (004_friction.sql): nothing auto-creates the session_analysis
+ * job yet, so this test inserts it directly. When auto-scheduling lands,
+ * remove insertSessionAnalysisJob and let the product drive it.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { resolve } from 'node:path';
+import {
+  getConfig, seedTenant, cleanupTenant, closePool,
+  pollSessionForProject, pollScrubbedChunk, insertSessionAnalysisJob,
+  pollSessionStatus, getActiveFrictionSignals,
+  type TestTenant,
+} from './helpers.js';
+import { startFixture, isPlaywrightAvailable, type FixtureServer } from './browser-helpers.js';
+
+const hasLLMKey = !!process.env['ANTHROPIC_API_KEY'];
+const keylessWorkerRunning = process.env['E2E_WORKER_NO_KEY'] === '1';
+const playwrightAvailable = await isPlaywrightAvailable();
+
+const VUE_FIXTURE = resolve(__dirname, '../test-fixtures/vue-app');
+
+describe.skipIf(hasLLMKey || !keylessWorkerRunning || !playwrightAvailable)(
+  'browser smoke: rage click to friction signal',
+  () => {
+    let tenant: TestTenant;
+    let fixture: FixtureServer;
+    let browser: import('@playwright/test').Browser;
+
+    beforeAll(async () => {
+      tenant = await seedTenant();
+      const vue = (await import('@vitejs/plugin-vue')).default;
+      fixture = await startFixture({
+        fixtureDir: VUE_FIXTURE,
+        apiKey: tenant.apiKey,
+        ingestionUrl: getConfig().ingestionUrl,
+        entryPattern: /\/main\.ts$/,
+        plugins: [vue()],
+      });
+      const { chromium } = await import('@playwright/test');
+      browser = await chromium.launch();
+    }, 60_000);
+
+    afterAll(async () => {
+      await browser?.close();
+      await fixture?.close();
+      if (tenant) await cleanupTenant(tenant.orgId);
+      await closePool();
+    });
+
+    it('rage clicks on a dead button become a rage_click friction signal', async () => {
+      const page = await browser.newPage();
+      await page.goto(fixture.url);
+
+      // Gate on replay readiness: the telemetry sink installs only after the
+      // async /sessions/init round-trip and the dynamic rrweb import
+      // (replay.ts:193-211). Clicks before that are silently dropped — under
+      // CI load a sleep is not a guarantee, so wait for the injected marker.
+      await page.waitForFunction(
+        () => (window as unknown as { __opslaneReplayReady?: boolean }).__opslaneReplayReady === true,
+        undefined,
+        { timeout: 30_000 }
+      );
+
+      // Navigate to the inert view, then let render mutations settle so the
+      // rage cluster is clean.
+      await page.click('[data-testid="nav-dead"]');
+      await page.waitForTimeout(500);
+
+      // Rage cluster: >=3 clicks, same selector, gaps <=1s (analyzer.ts:10-12).
+      for (let i = 0; i < 5; i++) {
+        await page.click('[data-testid="dead-button"]');
+        await page.waitForTimeout(100);
+      }
+
+      // The LAST click must stay "unanswered": no DOM mutation and no
+      // click-attributed request within 1s after it (analyzer.ts:231-257).
+      await page.waitForTimeout(1_500);
+
+      // Trigger an error: flushReplayBufferForError uploads the replay chunk
+      // (with the telemetry above) immediately instead of on the 30s cadence.
+      await page.click('[data-testid="nav-usercard"]');
+      await page.click('[data-testid="edit-profile-btn"]');
+
+      // Real chunk pipeline: presigned MinIO POST + commit, then the scrubber
+      // (eligible 30s after upload, swept every 15s).
+      const sessionId = await pollSessionForProject(tenant.projectId);
+      await pollScrubbedChunk(sessionId, 120_000);
+
+      // Batch 3 gap: drive the analysis ourselves (see file header).
+      await insertSessionAnalysisJob(tenant.projectId, sessionId);
+      const status = await pollSessionStatus(sessionId, ['analyzed', 'analysis_failed'], 90_000);
+      expect(status).toBe('analyzed');
+
+      const signals = await getActiveFrictionSignals(sessionId);
+      const rage = signals.find((s) => s.signal_type === 'rage_click');
+      expect(rage).toBeDefined();
+      expect(rage!.element_selector).toBe('[data-testid="dead-button"]');
+      await page.close();
+    }, 300_000);
+  }
+);
+```
+
+**Step 2: Run it** (stack still up from Task 5):
+
+```bash
+DATABASE_URL=postgres://opslane:opslane_dev@localhost:5434/opslane \
+INGESTION_URL=http://localhost:8082 \
+E2E_WORKER_NO_KEY=1 \
+pnpm --filter @opslane/test-e2e exec vitest run friction-smoke
+```
+
+Expected: PASS in roughly 60–120s (dominated by the scrubber's 30s+15s cadence).
+
+**Debugging guide if it fails, in causal order:**
+1. `waitForFunction` timeout → replay never became ready: check `page.on('console')` / `page.on('requestfailed')`; verify the injected config kept `replay: { enabled: true }` and `/sessions/init` returned `{recording: true}`.
+2. Session but no chunk row → presigned MinIO POST from the browser failed: log network with `page.on('response')`. Task 0 proved this surface works, so suspect a regression in compose/MinIO config since the spike.
+3. Chunk never scrubbed → scrubber not running or erroring: `docker compose logs ingestion | grep -i scrub`.
+4. `analysis_failed` → worker logs: `docker compose logs worker`.
+5. Signal missing or `dead_click` instead of `rage_click` → a mutation "answered" the last click (something in the fixture view isn't inert) or click gaps exceeded 1s (raise from 5 clicks / tighten the loop).
+
+**Step 3: Commit**
+
+```bash
+git add test-e2e/friction-smoke.test.ts
+git commit -m "Prove real rage clicks become a rage_click signal through the replay pipeline"
+```
+
+---
+
+### Task 8: CI wiring and skip enforcement
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `e2e-keyless` job, lines 153–218)
+
+**Step 1: Install Chromium in the keyless job.** After the `pnpm install --frozen-lockfile` step (`ci.yml:171`), add:
+
+```yaml
+      - name: Install Playwright chromium (browser smoke)
+        run: pnpm --filter @opslane/test-e2e exec playwright install --with-deps chromium
+```
+
+**Step 2: Raise the floor from a MEASURED baseline — do not do arithmetic on the old floor.** The current floor of 15 is stale: the suite already collects 24 tests (12 plain `it(` plus 12 expanded from `it.each(REASON_CODES)` in `needs-human-contract.test.ts:31-92`), so a floor of 15+3 would pass even with every browser test silently uncollected. Instead:
+
+1. Run the full suite locally with `--reporter=json` (Step 3 command) and read `numTotalTests` from the JSON — this is the authoritative baseline including the allowlisted skip. Expected: 27 (24 existing + 3 new).
+2. Set `E2E_MIN_TESTS` at `ci.yml:198` to exactly that measured number, and record the measurement in the commit message.
+
+Do NOT add the new tests to `E2E_ALLOWED_SKIP_PATTERN` — if they skip in CI (Playwright missing, gates wrong), `check-e2e-results.mjs` must fail the job. That guard is what makes silent-skip impossible.
+
+**Step 3: Verify the results-check locally** against the JSON from a full local run:
+
+```bash
+DATABASE_URL=postgres://opslane:opslane_dev@localhost:5434/opslane \
+INGESTION_URL=http://localhost:8082 \
+E2E_WORKER_NO_KEY=1 \
+pnpm --filter @opslane/test-e2e exec vitest run \
+  --reporter=default --reporter=json --outputFile=/tmp/e2e-results.json
+E2E_ALLOWED_SKIP_PATTERN='^pr_created pipeline \(full flow\)' E2E_MIN_TESTS=<measured> \
+  node scripts/check-e2e-results.mjs /tmp/e2e-results.json
+```
+
+Expected: `OK` line, `numTotalTests` matching the measured baseline (expected 27), only the allowed skip.
+
+**Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "Gate CI on the browser smoke tests actually running"
+```
+
+---
+
+### Task 9: Full verification and teardown
+
+**Step 1: Full repo gate** (root `AGENTS.md`):
+
+```bash
+pnpm install --frozen-lockfile
+pnpm -r build
+pnpm test
+(cd packages/ingestion && go build ./... && go test ./...)
+docker compose config --quiet
+node scripts/check-licenses.mjs
+```
+
+**Step 2: Full keyless lane end-to-end** (Task 8 Step 3 commands, from a clean stack: `docker compose down -v` first, then the boot recipe from Task 5 Step 1). All 18+ tests pass, results-check OK.
+
+**Step 3: Push the branch and confirm the `e2e-keyless` job passes in CI** — the local Docker environment and GitHub runners differ (this lane exists precisely to catch environment-shaped drift).
+
+**Step 4: Teardown:** `docker compose down -v`
+
+---
+
+## Explicitly out of scope (follow-ups, do not do here)
+
+1. **Auto-creating `session_analysis` jobs in the product** (ingestion, on session close or first scrub). When it lands, delete `insertSessionAnalysisJob` and let the friction test ride the product path — the test then gets strictly stronger.
+2. **Friction incident creation** (signals → `error_groups` with `kind='friction'`) — Batch 4+. When it exists, extend the friction test to poll the incidents API for `kind === 'friction'` instead of reading `friction_signals`.
+3. **AI-driven exploratory browser testing** — nightly, in `eval/`, never a merge gate.
+4. Dead-click and form-abandon browser scenarios — add after rage_click proves stable in CI for a week.

--- a/packages/sdk/src/replay.ts
+++ b/packages/sdk/src/replay.ts
@@ -329,6 +329,12 @@ export function stopReplayCapture(): void {
   }
 }
 
+/** Test-only: true once rrweb record() is active and the telemetry sink is
+ * installed — i.e. clicks from this point on land in replay chunks. */
+export function _replayStarted(): boolean {
+  return replayInstalled && stopFn !== null && streamReady;
+}
+
 function currentPageUrl(): string {
   try {
     return typeof window !== 'undefined' ? scrubUrl(window.location.href) : '';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,9 +231,21 @@ importers:
         specifier: ^8.13.0
         version: 8.18.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.40.0
+        version: 1.58.2
       '@types/pg':
         specifier: ^8.11.0
         version: 8.16.0
+      '@vitejs/plugin-react':
+        specifier: ^4.3.0
+        version: 4.7.0(vite@6.4.1(@types/node@25.3.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitejs/plugin-vue':
+        specifier: ^5.0.0
+        version: 5.2.4(vite@6.4.1(@types/node@25.3.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.28(typescript@5.9.3))
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@25.3.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.0
         version: 3.2.4(@types/node@25.3.0)(jiti@1.21.7)(jsdom@28.1.0)(tsx@4.21.0)(yaml@2.8.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,34 @@ importers:
         specifier: ^3.2.0
         version: 3.2.4(@types/node@25.3.0)(jiti@1.21.7)(jsdom@28.1.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  test-fixtures/react-app:
+    dependencies:
+      '@opslane/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      react:
+        specifier: ^18.3.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.0
+        version: 18.3.29
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.29)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.0
+        version: 4.7.0(vite@6.4.1(@types/node@25.3.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@25.3.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
+
   test-fixtures/vue-app:
     dependencies:
       '@opslane/sdk':
@@ -454,8 +482,46 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
@@ -466,17 +532,54 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bramus/specificity@2.4.2':
@@ -1196,6 +1299,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -1572,6 +1678,9 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -1984,6 +2093,18 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -2024,6 +2145,12 @@ packages:
 
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
@@ -2391,6 +2518,9 @@ packages:
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2638,6 +2768,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -2816,11 +2950,21 @@ packages:
       canvas:
         optional: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-with-bigint@3.5.3:
     resolution: {integrity: sha512-QObKu6nxy7NsxqR0VK4rkXnsNr5L9ElJaGEg+ucJ6J7/suoKZ0n+p76cu9aCqowytxEbwYNzvrMerfMkXneF5A==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -2868,6 +3012,9 @@ packages:
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -3227,6 +3374,10 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -3307,6 +3458,10 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
@@ -3766,6 +3921,9 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -4336,22 +4494,126 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
   '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -4908,6 +5170,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -5411,6 +5678,8 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rollup/pluginutils@5.3.0(rollup@4.57.1)':
     dependencies:
       '@types/estree': 1.0.8
@@ -5900,6 +6169,27 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -5944,6 +6234,18 @@ snapshots:
       csstype: 3.2.3
 
   '@types/shimmer@1.2.0': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.3.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.1(@types/node@25.3.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitejs/plugin-vue@5.2.4(vite@6.4.1(@types/node@25.3.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.28(typescript@5.9.3))':
     dependencies:
@@ -6336,6 +6638,8 @@ snapshots:
 
   confbox@0.2.4: {}
 
+  convert-source-map@2.0.0: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -6634,6 +6938,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
@@ -6838,9 +7144,13 @@ snapshots:
       - '@noble/hashes'
       - supports-color
 
+  jsesc@3.1.0: {}
+
   json-schema-traverse@1.0.0: {}
 
   json-with-bigint@3.5.3: {}
+
+  json5@2.2.3: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -6883,6 +7193,10 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@11.2.6: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   lru-cache@6.0.0:
     dependencies:
@@ -7195,6 +7509,8 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-refresh@0.17.0: {}
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -7314,6 +7630,8 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  semver@6.3.1: {}
 
   semver@7.5.4:
     dependencies:
@@ -7760,6 +8078,8 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yallist@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^5.0.0
         version: 5.2.4(vite@6.4.1(@types/node@25.3.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.28(typescript@5.9.3))
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@25.3.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)

--- a/scripts/check-e2e-results.mjs
+++ b/scripts/check-e2e-results.mjs
@@ -10,6 +10,10 @@
  *   E2E_ALLOWED_SKIP_PATTERN  regex of fully-qualified test names allowed to
  *                             skip (default: none)
  *   E2E_MIN_TESTS             minimum numTotalTests (default: 10)
+ *   E2E_REQUIRED_PATTERNS     newline-separated regexes; each must match at
+ *                             least one PASSED fully-qualified test name, so
+ *                             named suites cannot be deleted or filtered out
+ *                             without failing the check (default: none)
  */
 import { readFileSync } from 'node:fs';
 
@@ -23,8 +27,14 @@ const report = JSON.parse(readFileSync(file, 'utf8'));
 const allowedPattern = process.env.E2E_ALLOWED_SKIP_PATTERN;
 const allowed = allowedPattern ? new RegExp(allowedPattern) : null;
 const minTests = Number(process.env.E2E_MIN_TESTS ?? '10');
+const requiredPatterns = (process.env.E2E_REQUIRED_PATTERNS ?? '')
+  .split(/\r?\n/)
+  .map((s) => s.trim())
+  .filter(Boolean)
+  .map((p) => new RegExp(p));
 
 const problems = [];
+const passedNames = [];
 let passed = 0;
 let allowedSkips = 0;
 
@@ -33,6 +43,7 @@ for (const tf of report.testResults ?? []) {
     const name = [...(t.ancestorTitles ?? []), t.title].join(' > ');
     if (t.status === 'passed') {
       passed += 1;
+      passedNames.push(name);
     } else if (t.status === 'failed') {
       problems.push(`FAILED: ${name}`);
     } else if (allowed && allowed.test(name)) {
@@ -46,6 +57,11 @@ for (const tf of report.testResults ?? []) {
 const total = report.numTotalTests ?? 0;
 if (total < minTests) {
   problems.push(`Only ${total} tests were collected; expected at least ${minTests}`);
+}
+for (const re of requiredPatterns) {
+  if (!passedNames.some((name) => re.test(name))) {
+    problems.push(`REQUIRED TEST MISSING: no passed test matches ${re}`);
+  }
 }
 if (report.success === false && problems.length === 0) {
   problems.push('vitest reported overall failure');

--- a/test-e2e/browser-helpers.ts
+++ b/test-e2e/browser-helpers.ts
@@ -1,0 +1,92 @@
+/**
+ * Browser-smoke harness: boots a fixture app under Vite with the SDK aliased
+ * to source and init() config injected (real ingestion endpoint + seeded key).
+ */
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { PluginOption } from 'vite';
+
+const SDK_SRC = resolve(__dirname, '../packages/sdk/src');
+
+export interface FixtureServer {
+  url: string;
+  close(): Promise<void>;
+}
+
+export async function startFixture(opts: {
+  fixtureDir: string;
+  apiKey: string;
+  ingestionUrl: string;
+  entryPattern: RegExp;
+  plugins: PluginOption[];
+}): Promise<FixtureServer> {
+  const { createServer } = await import('vite');
+  const apiKey = JSON.stringify(opts.apiKey);
+  const ingestionUrl = JSON.stringify(opts.ingestionUrl);
+  const server = await createServer({
+    root: opts.fixtureDir,
+    configFile: false,
+    logLevel: 'error',
+    resolve: {
+      alias: [
+        // Order matters: subpaths before the bare specifier.
+        { find: '@opslane/sdk/react', replacement: resolve(SDK_SRC, 'react.tsx') },
+        { find: '@opslane/sdk/_replay', replacement: resolve(SDK_SRC, 'replay.ts') },
+        { find: '@opslane/sdk', replacement: resolve(SDK_SRC, 'index.ts') },
+      ],
+    },
+    server: { port: 0 },
+    plugins: [
+      ...opts.plugins,
+      {
+        name: 'inject-sdk-init',
+        transform(code: string, id: string) {
+          if (!opts.entryPattern.test(id)) return;
+
+          const replaced = code.replace(
+            /init\(\{[\s\S]*?\}\);/,
+            `init({
+              endpoint: ${ingestionUrl},
+              apiKey: ${apiKey},
+              flushInterval: 200,
+              maxBatchSize: 1,
+              replay: { enabled: true },
+            });`
+          );
+          if (replaced === code) {
+            throw new Error(`Fixture entry ${id} has no replaceable init() block`);
+          }
+
+          // Replay starts asynchronously (session registration + dynamic
+          // rrweb import), so expose readiness instead of sleeping.
+          return [
+            `import { _replayStarted as __opslaneReplayStarted } from '@opslane/sdk/_replay';`,
+            replaced,
+            `const __opslaneReadyTimer = setInterval(() => {`,
+            `  if (__opslaneReplayStarted()) {`,
+            `    Object.assign(window, { __opslaneReplayReady: true });`,
+            `    clearInterval(__opslaneReadyTimer);`,
+            `  }`,
+            `}, 50);`,
+          ].join('\n');
+        },
+      },
+    ],
+  });
+  await server.listen();
+  const port = server.config.server.port;
+  return {
+    url: `http://localhost:${port}`,
+    close: () => server.close(),
+  };
+}
+
+export async function isPlaywrightAvailable(): Promise<boolean> {
+  try {
+    const { chromium } = await import('@playwright/test');
+    const executablePath = chromium.executablePath();
+    return !!executablePath && existsSync(executablePath);
+  } catch {
+    return false;
+  }
+}

--- a/test-e2e/browser-helpers.ts
+++ b/test-e2e/browser-helpers.ts
@@ -2,8 +2,9 @@
  * Browser-smoke harness: boots a fixture app under Vite with the SDK aliased
  * to source and init() config injected (real ingestion endpoint + seeded key).
  */
-import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import type { PluginOption } from 'vite';
 
 const SDK_SRC = resolve(__dirname, '../packages/sdk/src');
@@ -23,13 +24,18 @@ export async function startFixture(opts: {
   const { createServer } = await import('vite');
   const apiKey = JSON.stringify(opts.apiKey);
   const ingestionUrl = JSON.stringify(opts.ingestionUrl);
+  // Parallel test files boot the same fixture concurrently; a shared default
+  // cache (node_modules/.vite) would have two optimizers racing over one dir.
+  const cacheDir = mkdtempSync(join(tmpdir(), 'opslane-vite-cache-'));
   const server = await createServer({
     root: opts.fixtureDir,
     configFile: false,
+    cacheDir,
     logLevel: 'error',
     resolve: {
       alias: [
-        // Order matters: subpaths before the bare specifier.
+        // Order matters: subpaths before the bare specifier. '_replay' is a
+        // test-only alias — the published SDK exports map has no './_replay'.
         { find: '@opslane/sdk/react', replacement: resolve(SDK_SRC, 'react.tsx') },
         { find: '@opslane/sdk/_replay', replacement: resolve(SDK_SRC, 'replay.ts') },
         { find: '@opslane/sdk', replacement: resolve(SDK_SRC, 'index.ts') },
@@ -43,9 +49,11 @@ export async function startFixture(opts: {
         transform(code: string, id: string) {
           if (!opts.entryPattern.test(id)) return;
 
+          // Replacer function, not a string: a '$' in the injected values
+          // would otherwise be interpreted as a replacement pattern ($&, $1).
           const replaced = code.replace(
             /init\(\{[\s\S]*?\}\);/,
-            `init({
+            () => `init({
               endpoint: ${ingestionUrl},
               apiKey: ${apiKey},
               flushInterval: 200,
@@ -77,7 +85,10 @@ export async function startFixture(opts: {
   const port = server.config.server.port;
   return {
     url: `http://localhost:${port}`,
-    close: () => server.close(),
+    close: async () => {
+      await server.close();
+      rmSync(cacheDir, { recursive: true, force: true });
+    },
   };
 }
 

--- a/test-e2e/browser-smoke.test.ts
+++ b/test-e2e/browser-smoke.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+/**
+ * Browser smoke: a real Chromium drives the fixture apps with the real SDK
+ * pointed at the real keyless stack. This covers real browser payload capture,
+ * ingestion grouping, and the worker's deterministic terminal state.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { resolve } from 'node:path';
+import {
+  cleanupTenant,
+  closePool,
+  getConfig,
+  listIncidents,
+  pollUntilTerminal,
+  seedTenant,
+  type Incident,
+  type TestTenant,
+} from './helpers.js';
+import {
+  isPlaywrightAvailable,
+  startFixture,
+  type FixtureServer,
+} from './browser-helpers.js';
+
+const hasLLMKey = !!process.env['ANTHROPIC_API_KEY'];
+const keylessWorkerRunning = process.env['E2E_WORKER_NO_KEY'] === '1';
+const playwrightAvailable = await isPlaywrightAvailable();
+
+const VUE_FIXTURE = resolve(__dirname, '../test-fixtures/vue-app');
+
+async function pollIncidentMatching(
+  tenant: TestTenant,
+  predicate: (incident: Incident) => boolean,
+  timeoutMs = 60_000
+): Promise<Incident> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const incidents = await listIncidents(tenant.apiKey, tenant.projectId);
+    const hit = incidents.find(predicate);
+    if (hit) return hit;
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  throw new Error(`No matching incident within ${timeoutMs}ms`);
+}
+
+describe.skipIf(hasLLMKey || !keylessWorkerRunning || !playwrightAvailable)(
+  'browser smoke: Vue error to needs_human',
+  () => {
+    let tenant: TestTenant;
+    let fixture: FixtureServer;
+    let browser: import('@playwright/test').Browser;
+
+    beforeAll(async () => {
+      tenant = await seedTenant();
+      const vue = (await import('@vitejs/plugin-vue')).default;
+      fixture = await startFixture({
+        fixtureDir: VUE_FIXTURE,
+        apiKey: tenant.apiKey,
+        ingestionUrl: getConfig().ingestionUrl,
+        entryPattern: /\/main\.ts$/,
+        plugins: [vue()],
+      });
+      const { chromium } = await import('@playwright/test');
+      browser = await chromium.launch();
+    }, 60_000);
+
+    afterAll(async () => {
+      await browser?.close();
+      await fixture?.close();
+      if (tenant) await cleanupTenant(tenant.orgId);
+      await closePool();
+    });
+
+    it('real Vue SDK error reaches needs_human with missing_llm_key', async () => {
+      const page = await browser.newPage();
+      try {
+        await page.goto(fixture.url);
+        await page.click('[data-testid="nav-usercard"]');
+        await page.click('[data-testid="edit-profile-btn"]');
+
+        const incident = await pollIncidentMatching(
+          tenant,
+          (candidate) => candidate.title.toLowerCase().includes('null')
+        );
+        expect(incident.status).toBeTruthy();
+
+        const terminal = await pollUntilTerminal(
+          tenant.apiKey,
+          tenant.projectId,
+          incident.id,
+          ['needs_human'],
+          90_000
+        );
+        expect(terminal.status).toBe('needs_human');
+        expect(terminal.reason?.reason_code).toBe('missing_llm_key');
+        expect(terminal.reason?.reason_message).toBeTruthy();
+        expect(terminal.reason?.remediation).toBeTruthy();
+      } finally {
+        await page.close();
+      }
+    }, 180_000);
+  }
+);

--- a/test-e2e/browser-smoke.test.ts
+++ b/test-e2e/browser-smoke.test.ts
@@ -27,6 +27,7 @@ const keylessWorkerRunning = process.env['E2E_WORKER_NO_KEY'] === '1';
 const playwrightAvailable = await isPlaywrightAvailable();
 
 const VUE_FIXTURE = resolve(__dirname, '../test-fixtures/vue-app');
+const REACT_FIXTURE = resolve(__dirname, '../test-fixtures/react-app');
 
 async function pollIncidentMatching(
   tenant: TestTenant,
@@ -95,6 +96,65 @@ describe.skipIf(hasLLMKey || !keylessWorkerRunning || !playwrightAvailable)(
         expect(terminal.reason?.reason_code).toBe('missing_llm_key');
         expect(terminal.reason?.reason_message).toBeTruthy();
         expect(terminal.reason?.remediation).toBeTruthy();
+      } finally {
+        await page.close();
+      }
+    }, 180_000);
+  }
+);
+
+describe.skipIf(hasLLMKey || !keylessWorkerRunning || !playwrightAvailable)(
+  'browser smoke: React error to needs_human',
+  () => {
+    let tenant: TestTenant;
+    let fixture: FixtureServer;
+    let browser: import('@playwright/test').Browser;
+
+    beforeAll(async () => {
+      tenant = await seedTenant();
+      const react = (await import('@vitejs/plugin-react')).default;
+      fixture = await startFixture({
+        fixtureDir: REACT_FIXTURE,
+        apiKey: tenant.apiKey,
+        ingestionUrl: getConfig().ingestionUrl,
+        entryPattern: /\/main\.tsx$/,
+        plugins: [react()],
+      });
+      const { chromium } = await import('@playwright/test');
+      browser = await chromium.launch();
+    }, 60_000);
+
+    afterAll(async () => {
+      await browser?.close();
+      await fixture?.close();
+      if (tenant) await cleanupTenant(tenant.orgId);
+      await closePool();
+    });
+
+    it('React error-boundary error reaches needs_human with missing_llm_key', async () => {
+      const page = await browser.newPage();
+      try {
+        await page.goto(fixture.url);
+        await page.click('[data-testid="nav-profile"]');
+        await page.click('[data-testid="load-profile-btn"]');
+        await page.waitForSelector('[data-testid="boundary-fallback"]');
+
+        const incident = await pollIncidentMatching(
+          tenant,
+          (candidate) => {
+            const title = candidate.title.toLowerCase();
+            return title.includes('displayname') || title.includes('null');
+          }
+        );
+        const terminal = await pollUntilTerminal(
+          tenant.apiKey,
+          tenant.projectId,
+          incident.id,
+          ['needs_human'],
+          90_000
+        );
+        expect(terminal.status).toBe('needs_human');
+        expect(terminal.reason?.reason_code).toBe('missing_llm_key');
       } finally {
         await page.close();
       }

--- a/test-e2e/friction-smoke.test.ts
+++ b/test-e2e/friction-smoke.test.ts
@@ -92,11 +92,11 @@ describe.skipIf(hasLLMKey || !keylessWorkerRunning || !playwrightAvailable)(
         await pollScrubbedChunk(sessionId, 120_000);
 
         await insertSessionAnalysisJob(tenant.projectId, sessionId);
-        const status = await pollSessionStatus(
-          sessionId,
-          ['analyzed', 'analysis_failed'],
-          90_000
-        );
+        // Poll for 'analyzed' only: on transient faults the worker writes
+        // 'analysis_failed' and rethrows, so the job retries and may still
+        // succeed. A genuine failure surfaces as a poll timeout that names
+        // the stuck status.
+        const status = await pollSessionStatus(sessionId, ['analyzed'], 90_000);
         expect(status).toBe('analyzed');
 
         const signals = await getActiveFrictionSignals(sessionId);

--- a/test-e2e/friction-smoke.test.ts
+++ b/test-e2e/friction-smoke.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+/**
+ * Friction smoke: real rage-clicks in Chromium produce rrweb telemetry inside
+ * replay chunks; the real scrubber and analyzer turn them into a rage_click
+ * friction signal.
+ *
+ * Batch 3 does not auto-create session_analysis jobs, so this test inserts the
+ * job directly. Remove that bridge when product scheduling lands.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { resolve } from 'node:path';
+import {
+  cleanupTenant,
+  closePool,
+  getActiveFrictionSignals,
+  getConfig,
+  insertSessionAnalysisJob,
+  pollScrubbedChunk,
+  pollSessionForProject,
+  pollSessionStatus,
+  seedTenant,
+  type TestTenant,
+} from './helpers.js';
+import {
+  isPlaywrightAvailable,
+  startFixture,
+  type FixtureServer,
+} from './browser-helpers.js';
+
+const hasLLMKey = !!process.env['ANTHROPIC_API_KEY'];
+const keylessWorkerRunning = process.env['E2E_WORKER_NO_KEY'] === '1';
+const playwrightAvailable = await isPlaywrightAvailable();
+
+const VUE_FIXTURE = resolve(__dirname, '../test-fixtures/vue-app');
+
+describe.skipIf(hasLLMKey || !keylessWorkerRunning || !playwrightAvailable)(
+  'browser smoke: rage click to friction signal',
+  () => {
+    let tenant: TestTenant;
+    let fixture: FixtureServer;
+    let browser: import('@playwright/test').Browser;
+
+    beforeAll(async () => {
+      tenant = await seedTenant();
+      const vue = (await import('@vitejs/plugin-vue')).default;
+      fixture = await startFixture({
+        fixtureDir: VUE_FIXTURE,
+        apiKey: tenant.apiKey,
+        ingestionUrl: getConfig().ingestionUrl,
+        entryPattern: /\/main\.ts$/,
+        plugins: [vue()],
+      });
+      const { chromium } = await import('@playwright/test');
+      browser = await chromium.launch();
+    }, 60_000);
+
+    afterAll(async () => {
+      await browser?.close();
+      await fixture?.close();
+      if (tenant) await cleanupTenant(tenant.orgId);
+      await closePool();
+    });
+
+    it('rage clicks on a dead button become a rage_click friction signal', async () => {
+      const page = await browser.newPage();
+      try {
+        await page.goto(fixture.url);
+
+        await page.waitForFunction(
+          () => (window as unknown as { __opslaneReplayReady?: boolean })
+            .__opslaneReplayReady === true,
+          undefined,
+          { timeout: 30_000 }
+        );
+
+        await page.click('[data-testid="nav-dead"]');
+        await page.waitForTimeout(500);
+
+        for (let click = 0; click < 5; click++) {
+          await page.click('[data-testid="dead-button"]');
+          await page.waitForTimeout(100);
+        }
+
+        // The last click must remain unanswered for the analyzer's full window.
+        await page.waitForTimeout(1_500);
+
+        // An accepted error immediately flushes the current replay chunk.
+        await page.click('[data-testid="nav-usercard"]');
+        await page.click('[data-testid="edit-profile-btn"]');
+
+        const sessionId = await pollSessionForProject(tenant.projectId);
+        await pollScrubbedChunk(sessionId, 120_000);
+
+        await insertSessionAnalysisJob(tenant.projectId, sessionId);
+        const status = await pollSessionStatus(
+          sessionId,
+          ['analyzed', 'analysis_failed'],
+          90_000
+        );
+        expect(status).toBe('analyzed');
+
+        const signals = await getActiveFrictionSignals(sessionId);
+        const rageClick = signals.find((signal) => signal.signal_type === 'rage_click');
+        expect(rageClick).toBeDefined();
+        expect(rageClick!.element_selector).toBe('[data-testid="dead-button"]');
+      } finally {
+        await page.close();
+      }
+    }, 300_000);
+  }
+);

--- a/test-e2e/helpers.ts
+++ b/test-e2e/helpers.ts
@@ -330,6 +330,102 @@ export async function seedUserWithJWT(orgId: string): Promise<{ userId: string; 
 }
 
 // ---------------------------------------------------------------------------
+// Session / friction helpers (browser smoke)
+// ---------------------------------------------------------------------------
+
+/** Polls until the project has a session (created by SDK /sessions/init). */
+export async function pollSessionForProject(
+  projectId: string,
+  timeoutMs = 30_000
+): Promise<string> {
+  const db = getPool();
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { rows } = await db.query<{ id: string }>(
+      `SELECT id FROM sessions WHERE project_id = $1 ORDER BY started_at DESC LIMIT 1`,
+      [projectId]
+    );
+    if (rows[0]) return rows[0].id;
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`No session appeared for project ${projectId} within ${timeoutMs}ms`);
+}
+
+/** Polls until at least one chunk for the session is scrubbed (analyzable).
+ * Scrubber cadence: eligible 30s after upload, swept every 15s — expect ~45-60s. */
+export async function pollScrubbedChunk(
+  sessionId: string,
+  timeoutMs = 120_000
+): Promise<void> {
+  const db = getPool();
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { rows } = await db.query(
+      `SELECT 1 FROM session_chunks WHERE session_id = $1 AND scrubbed_at IS NOT NULL LIMIT 1`,
+      [sessionId]
+    );
+    if (rows.length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  throw new Error(`No scrubbed chunk for session ${sessionId} within ${timeoutMs}ms`);
+}
+
+/** Batch 3 gap: the product does not yet auto-create session_analysis jobs.
+ * Delete this helper when automatic scheduling lands. */
+export async function insertSessionAnalysisJob(
+  projectId: string,
+  sessionId: string
+): Promise<void> {
+  const db = getPool();
+  await db.query(
+    `INSERT INTO error_group_jobs (project_id, session_id, job_type, status, triggered_by)
+     VALUES ($1, $2, 'session_analysis', 'pending', 'auto')`,
+    [projectId, sessionId]
+  );
+}
+
+/** Polls sessions.status until it reaches one of the given values. */
+export async function pollSessionStatus(
+  sessionId: string,
+  statuses: string[],
+  timeoutMs = 60_000
+): Promise<string> {
+  const db = getPool();
+  const deadline = Date.now() + timeoutMs;
+  let last = '';
+  while (Date.now() < deadline) {
+    const { rows } = await db.query<{ status: string }>(
+      `SELECT status FROM sessions WHERE id = $1`,
+      [sessionId]
+    );
+    last = rows[0]?.status ?? '(missing)';
+    if (statuses.includes(last)) return last;
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  throw new Error(`Session ${sessionId} stuck at '${last}' after ${timeoutMs}ms`);
+}
+
+export interface FrictionSignalRow {
+  signal_type: string;
+  element_selector: string | null;
+  occurrence_count: number;
+}
+
+/** Active (non-retracted, non-superseded) friction signals for a session. */
+export async function getActiveFrictionSignals(
+  sessionId: string
+): Promise<FrictionSignalRow[]> {
+  const db = getPool();
+  const { rows } = await db.query<FrictionSignalRow>(
+    `SELECT signal_type, element_selector, occurrence_count
+       FROM friction_signals
+      WHERE session_id = $1 AND retracted_at IS NULL AND superseded_by IS NULL`,
+    [sessionId]
+  );
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
 // Cleanup
 // ---------------------------------------------------------------------------
 
@@ -351,6 +447,11 @@ export async function cleanupTenant(orgId: string): Promise<void> {
 
   await db.query(
     `DELETE FROM error_group_jobs WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+    [orgId]
+  );
+  // Sessions cascade to session_chunks and friction_signals.
+  await db.query(
+    `DELETE FROM sessions WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
     [orgId]
   );
   await db.query(

--- a/test-e2e/package.json
+++ b/test-e2e/package.json
@@ -15,6 +15,7 @@
     "@types/pg": "^8.11.0",
     "@vitejs/plugin-react": "^4.3.0",
     "@vitejs/plugin-vue": "^5.0.0",
+    "typescript": "^5.4.0",
     "vite": "^6.0.0",
     "vitest": "^3.2.0"
   }

--- a/test-e2e/package.json
+++ b/test-e2e/package.json
@@ -11,7 +11,11 @@
     "pg": "^8.13.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.40.0",
     "@types/pg": "^8.11.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^6.0.0",
     "vitest": "^3.2.0"
   }
 }

--- a/test-fixtures/react-app/index.html
+++ b/test-fixtures/react-app/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Opslane React Fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/test-fixtures/react-app/package.json
+++ b/test-fixtures/react-app/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "opslane-fixture-react",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "license": "AGPL-3.0-only",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo ok"
+  },
+  "dependencies": {
+    "@opslane/sdk": "workspace:*",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.4.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/test-fixtures/react-app/src/App.tsx
+++ b/test-fixtures/react-app/src/App.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { BuggyProfile } from './BuggyProfile';
+
+export function App() {
+  const [view, setView] = useState('home');
+  return (
+    <div>
+      <nav>
+        <button data-testid="nav-home" onClick={() => setView('home')}>Home</button>
+        <button data-testid="nav-profile" onClick={() => setView('profile')}>Profile</button>
+      </nav>
+      <main>
+        {view === 'home' && <p>Select a bug to trigger</p>}
+        {view === 'profile' && <BuggyProfile />}
+      </main>
+    </div>
+  );
+}

--- a/test-fixtures/react-app/src/BuggyProfile.tsx
+++ b/test-fixtures/react-app/src/BuggyProfile.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+interface Profile {
+  displayName: string;
+}
+
+export function BuggyProfile() {
+  const [profile, setProfile] = useState<Profile | null | undefined>(undefined);
+  if (profile === null) {
+    // Render-phase throw: TypeError reading 'displayName' of null.
+    return <p>{(profile as unknown as Profile).displayName.toUpperCase()}</p>;
+  }
+  return (
+    <button data-testid="load-profile-btn" onClick={() => setProfile(null)}>
+      Load profile
+    </button>
+  );
+}

--- a/test-fixtures/react-app/src/main.tsx
+++ b/test-fixtures/react-app/src/main.tsx
@@ -1,0 +1,17 @@
+import { createRoot } from 'react-dom/client';
+import { init } from '@opslane/sdk';
+import { OpslaneErrorBoundary } from '@opslane/sdk/react';
+import { App } from './App';
+
+init({
+  endpoint: 'http://localhost:8082',
+  apiKey: 'e2e-test-key-plaintext',
+  release: 'e2e-react-fixture-v1',
+  replay: { enabled: true },
+});
+
+createRoot(document.getElementById('root')!).render(
+  <OpslaneErrorBoundary fallback={<p data-testid="boundary-fallback">Something broke</p>}>
+    <App />
+  </OpslaneErrorBoundary>
+);

--- a/test-fixtures/react-app/tsconfig.json
+++ b/test-fixtures/react-app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/test-fixtures/react-app/vite.config.ts
+++ b/test-fixtures/react-app/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/test-fixtures/vue-app/src/App.vue
+++ b/test-fixtures/vue-app/src/App.vue
@@ -4,6 +4,7 @@ import UserCard from './components/UserCard.vue';
 import AsyncLoader from './components/AsyncLoader.vue';
 import WatcherBug from './components/WatcherBug.vue';
 import FetchUser from './components/FetchUser.vue';
+import DeadEnd from './components/DeadEnd.vue';
 import type { User } from './types';
 
 const currentView = ref<string>('home');
@@ -18,6 +19,7 @@ const buggyUser: User = { id: 1, username: 'alice', profile: null };
       <button data-testid="nav-async" @click="currentView = 'async'">AsyncLoader</button>
       <button data-testid="nav-watcher" @click="currentView = 'watcher'">WatcherBug</button>
       <button data-testid="nav-fetch" @click="currentView = 'fetch'">FetchUser</button>
+      <button data-testid="nav-dead" @click="currentView = 'dead'">DeadEnd</button>
     </nav>
     <main>
       <p v-if="currentView === 'home'">Select a bug to trigger</p>
@@ -25,6 +27,7 @@ const buggyUser: User = { id: 1, username: 'alice', profile: null };
       <AsyncLoader v-if="currentView === 'async'" />
       <WatcherBug v-if="currentView === 'watcher'" />
       <FetchUser v-if="currentView === 'fetch'" />
+      <DeadEnd v-if="currentView === 'dead'" />
     </main>
   </div>
 </template>

--- a/test-fixtures/vue-app/src/components/DeadEnd.vue
+++ b/test-fixtures/vue-app/src/components/DeadEnd.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+// Intentionally inert: no handlers, no reactive state. Clicking must cause
+// zero DOM mutations or the friction analyzer treats the click as "answered".
+</script>
+
+<template>
+  <div>
+    <p>This button does nothing.</p>
+    <button data-testid="dead-button" type="button">Save changes</button>
+  </div>
+</template>


### PR DESCRIPTION
## What

A CI lane where a real Chromium drives the Vue and React fixture apps with the real SDK against the real keyless stack, deterministically asserting:

1. **Error path (Vue + React):** a real browser error → SDK capture → `POST /api/v1/events` → grouping → keyless worker → `error_groups.status = 'needs_human'` with `reason_code = 'missing_llm_key'`. The React test goes through `OpslaneErrorBoundary.componentDidCatch`, covering the React integration specifically.
2. **Friction path:** real rage clicks on an inert button → rrweb telemetry inside replay chunks → error-triggered flush → presigned MinIO upload → scrubber → analyzer → a `rage_click` friction signal with the exact selector `[data-testid="dead-button"]`.

Everything polls real state (incidents API, Postgres) — no sleep-and-hope.

## Why

The existing E2E suite proves the pipeline with hand-built payloads. Nothing exercised the seam in front of it: real SDK payload shapes, CORS, replay transport, and the browser-side capture paths. The friction pipeline had no end-to-end coverage at all.

## Pieces

- `test-fixtures/react-app` — new React 18 fixture with a render-phase `null` throw behind an error boundary.
- `test-fixtures/vue-app` — `DeadEnd.vue`, a deliberately inert button (any DOM mutation within 1s would make the analyzer treat the click as "answered").
- `packages/sdk/src/replay.ts` — the only production change: `_replayStarted()`, a test-only readiness hook (same precedent as `transport.ts` test hooks; not re-exported, not in the exports map).
- `test-e2e/browser-helpers.ts` — Vite harness: SDK aliased to source, `init()` swapped for test config with the seeded key, per-server optimizer cache, readiness marker, strict Chromium-binary detection.
- `test-e2e/browser-smoke.test.ts`, `test-e2e/friction-smoke.test.ts` — the three tests.
- `test-e2e/helpers.ts` — session/friction DB polling helpers. Known gap bridged honestly: nothing auto-creates `session_analysis` jobs yet (Batch 3), so the friction test inserts the job row itself and says so; delete when auto-scheduling lands.
- `.github/workflows/ci.yml` + `scripts/check-e2e-results.mjs` — the keyless job installs Chromium; `E2E_MIN_TESTS` raised to a **measured** 27; new `E2E_REQUIRED_PATTERNS` requires the three browser suites to pass **by name**, so neither a runtime skip nor a future edit can drop them silently.

## Verification

- Full suite against the live keyless compose stack: **26 passed + 1 allowlisted skip** (the with-secrets pipeline suite), all 3 browser tests executing for real; `check-e2e-results.mjs` OK on the run's JSON.
- The 27 floor was read from `numTotalTests` of that run, not computed (the old floor of 15 was stale and would have passed with every browser test uncollected).
- Name-pinned gate proven against synthetic results JSON: green with the suites present, three named `REQUIRED TEST MISSING` failures without them, no-op when unset.
- All new SQL verified column-by-column against `001–005` migrations (cleanup `DELETE` cannot be blocked by any FK; the job `INSERT` satisfies every constraint).
- `_replayStarted` confirmed unreachable from the published SDK surface.
- `pnpm --filter @opslane/test-e2e exec tsc --noEmit` clean; workflow YAML parses.
- Pre-landing review: 6 specialists + adversarial passes (Claude + Codex), 0 critical findings. One cross-model P1 claim (Vite `port: 0` returning `localhost:0`) was refuted with an executed probe — Vite mutates `config.server.port` to the bound port after `listen()`.
- Remaining proof this PR exists to provide: `e2e-keyless` green on GitHub-hosted runners.

## Follow-ups (out of scope)

- Auto-create `session_analysis` jobs in the product, then delete the test's manual insert.
- Friction incidents (signals → error groups); the test then polls the incidents API instead of `friction_signals`.
- Dead-click and form-abandon scenarios after `rage_click` proves stable in CI for a week.
