### PR TITLE
Admin observability dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ eval/results/
 !.verify/spec.md
 .claude/
 .omx/
+.gstack/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -16,6 +16,10 @@ paths = [
   # The read handler repeats that guarantee after fetching stored chunks; keep
   # its realistic canary scoped to this integration-test file as well.
   '''packages/ingestion/handler/session_read_test\.go''',
+  # The admin jobs redactor asserts realistic-shaped GitHub/npm/Slack/AWS/JWT
+  # tokens are stripped from last_error before operators see it; a token
+  # gitleaks ignores would prove nothing.
+  '''packages/ingestion/handler/admin_test\.go''',
   '''packages/sdk/src/__tests__/scrub\.test\.ts''',
   '''test-e2e/error-to-pr\.test\.ts''',
   '''test-e2e/replay-contract\.test\.ts''',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       GITHUB_WEBHOOK_SECRET: ${GITHUB_WEBHOOK_SECRET:-}
       DASHBOARD_ORIGIN: ${DASHBOARD_ORIGIN:-http://localhost:3000}
       INTERNAL_READ_TOKEN: ${INTERNAL_READ_TOKEN:-dev-internal-token}
+      ADMIN_EMAILS: ${OPSLANE_ADMIN_EMAILS:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/plans/2026-07-15-admin-observability-dashboard-design.md
+++ b/docs/plans/2026-07-15-admin-observability-dashboard-design.md
@@ -1,0 +1,132 @@
+# Admin observability dashboard — v1 design
+
+**Date:** 2026-07-15 (revised after review)
+**Status:** Proposed
+**Goal:** A cross-project, operator-only view that answers "is Opslane working?" — events flowing in, jobs completing, PRs going out — with Langfuse trace links for debugging investigations.
+
+## Scope decisions
+
+- **Cross-tenant operator view.** Aggregates across all orgs/projects. Normal customer sessions must never see it.
+- **Lives in the existing Vue dashboard** as a new `/admin` route. No separate app.
+- **Zero new dependencies.** Stat tiles + hand-rolled inline-SVG bar charts. No chart library, no Grafana, no new queue/metrics infra.
+- **One migration (`006_admin_observability.sql`).** Review killed the zero-migration goal twice over: the global time-range scans need indexes, and the headline lifecycle metrics ("PRs created", "needs human") cannot be derived reliably from mutable columns (`TransitionOnPRClose` clears `pr_url`; heartbeats and event recurrence churn `updated_at`). Decision: **lifecycle metrics are exact from deploy forward**; rows predating the migration have NULL timestamps and are excluded, which is acceptable for a "is it working now" dashboard.
+
+## Migration `006_admin_observability.sql`
+
+Idempotent (`IF NOT EXISTS` guards), append-only per ingestion AGENTS.md:
+
+- `ALTER TABLE error_groups ADD COLUMN IF NOT EXISTS pr_created_at TIMESTAMPTZ;`
+- `ALTER TABLE error_groups ADD COLUMN IF NOT EXISTS needs_human_at TIMESTAMPTZ;`
+- `CREATE INDEX IF NOT EXISTS idx_error_events_created_at ON error_events(created_at);`
+- `CREATE INDEX IF NOT EXISTS idx_error_group_jobs_created_at ON error_group_jobs(created_at DESC);`
+
+Verify per package AGENTS.md: apply to a disposable clean DB and a representative existing DB, then reapply for idempotency.
+
+## Lifecycle data producers (prerequisites for exact metrics)
+
+1. **Worker stamps transition times.** `updateGroupStatus` / `updateGroupInvestigation` (`packages/worker/src/db.ts`) set `pr_created_at = now()` when writing status `pr_created`, and `needs_human_at = now()` when writing `needs_human`. Timestamps are never cleared (PR close keeps `pr_created_at` so window counts survive `pr_url` being nulled). Known approximation: a group re-fixed after a closed PR overwrites `pr_created_at`, so the tile counts "incidents with a PR created in window", not raw PR count — label it that way.
+2. **Webhook writes `pr_outcomes` receipts.** Today `handler/webhook.go` only transitions group status; nothing ever inserts into `pr_outcomes`, so merged/closed counts would be permanently zero. Extend the webhook handler: after a successful `TransitionOnPRMerge`/`TransitionOnPRClose` (extend `RETURNING` to include `project_id`), insert a receipt with `outcome`, `pr_number`, `occurred_at = now()`, and `github_delivery_id` from the `X-GitHub-Delivery` header. Insert with `ON CONFLICT (github_delivery_id) DO NOTHING` for redelivery idempotency. Tests: merge inserts receipt, redelivery inserts nothing, `no_match` inserts nothing.
+
+## Backend (Go ingestion)
+
+### Admin auth
+
+- New env var **`ADMIN_EMAILS`** — comma-separated operator emails. Empty ⇒ admin API fully disabled (fail closed).
+- New **`RequireAdmin`** middleware (in `handler/auth.go`): runs after `AuthenticateSession`, loads the user via `UserIDFromCtx`, checks email against `ADMIN_EMAILS`. Non-admins get **404** (not 403) so the surface is invisible to customers.
+- Extend `GET /api/v1/auth/me` (`handler/auth_handlers.go:302`) with an `is_admin` boolean so the frontend can decide whether to render the Admin nav link.
+
+### New endpoints (both `AuthenticateSession` + `RequireAdmin`; handlers in new `handler/admin.go`, queries in `db/`)
+
+**`GET /api/v1/admin/overview`** — one payload for the whole page:
+
+- `events`: totals for last 1h / 24h / 7d; hourly buckets for the last 48h; top 10 projects by 24h volume (project + org name + count).
+  - **Bucket contract:** exactly 48 ordered UTC buckets over half-open hourly intervals `[hour, hour+1h)`, zero-filled via `generate_series` LEFT JOIN — `date_trunc` alone omits empty hours. Tests: empty DB (48 zeros), gaps, events exactly on a boundary land in the later bucket.
+- `jobs`: counts by `job_status`; counts by `job_type`; oldest pending job age; dead-letters in last 7d.
+- `workers`: **"workers with live claims"** = distinct `worker_id` where `status = 'claimed' AND lease_expires_at > now()` (excludes expired leases awaiting reaping); **"workers active in last 5m"** = distinct `worker_id` on rows with `updated_at > now() - interval '5 minutes'` (heartbeats update `updated_at`, so this is a liveness proxy that stays non-zero for busy workers; a fully idle fleet shows zero — acceptable for v1, noted in UI copy). Proxying the worker's own `/health` endpoint through ingestion is explicitly out of scope for v1.
+- `outcomes`: `error_groups` counts by current status; **incidents with PR created** in last 24h / 7d (`pr_created_at` in window); **needs human** in last 7d (`needs_human_at` in window); **merged / closed** in last 7d from `pr_outcomes.occurred_at`.
+
+**`GET /api/v1/admin/jobs?limit=50&status=&job_type=`** — recent jobs across all tenants. Precise contract:
+
+- **Joins:** LEFT JOIN to `error_groups` and `projects` — `setup_pr` and `session_analysis` jobs may have no incident; incident title and `pr_url` are nullable in the response.
+- **Filters:** `status` from the `job_status` enum values, `job_type` from `investigate|fix|error_fix|setup_pr|session_analysis`; reject unknown values with 400.
+- **Limit:** default 50, capped at 200.
+- **Ordering:** `created_at DESC, id DESC` (stable tie-break).
+- **Duration semantics:** `pending` → null; `claimed` → `now() - claimed_at` (elapsed so far); terminal → `updated_at - claimed_at` (final write sets `updated_at` at the terminal transition; heartbeats stop then).
+- **Fields:** job id, project name, `job_type`, `status`, `attempts`, `created_at`, duration (as above), redacted+truncated `last_error`, `trace_url` (Langfuse), nullable incident title + `pr_url`.
+
+### Safety
+
+- **`last_error` redaction:** it stores raw worker exception text which can embed credentials. Redact server-side before truncating (~300 chars): patterns for `ghp_`/`ghs_`/`github_pat_` tokens, `sk-` keys, `Bearer …`, and URL userinfo (`scheme://user:pass@`). Unit-test the redactor.
+- Query params validated against allowlists; all admin queries parameterized (existing pgx convention).
+
+### Conventions to respect
+
+- Cross-tenant queries violate the "scope every helper to project/org" rule by design. Name them `Admin*` in `db/`, document the exception in a comment, and rely on `RequireAdmin` as the sole gate.
+- Update `docs/reference/http-routes.md` (route-drift check fails `pnpm test` otherwise) and `docs/reference/environment-variables.md` (`ADMIN_EMAILS`).
+- **Performance budget:** overview endpoint p95 < 500ms on representative data. Verify each aggregate with `EXPLAIN (ANALYZE, BUFFERS)` and confirm the new indexes are used (no seq scan on `error_events` for windowed counts).
+
+## Frontend (packages/dashboard)
+
+- New route `/admin` → `AdminView.vue`.
+  - **Project-selection exemption:** the router guard (`router.ts:44-49`) redirects any authed route to `/setup` when `opslane_project_id` is unset, and `App.vue`'s `checkProject` does the same — exempt the `admin` route from both. Test: an operator with zero projects can load `/admin`.
+  - **Error handling:** preserve the existing 401 → `fetchWithAuth` refresh → login flow untouched; only a server-returned **404** from the overview call redirects a non-admin to `/`.
+- Nav link rendered only when `/auth/me` returns `is_admin: true` — customers never see the entry point.
+- Layout (top to bottom):
+  1. **Stat tiles:** Events 1h · Events 24h · Incidents w/ PR created 7d · Needs human 7d · Queue depth (pending) · Dead letters 7d · Workers w/ live claims.
+  2. **Ingestion chart:** 48 hourly bars, inline SVG (~60-line component), count on hover via `title`.
+  3. **Jobs by status** strip + **top projects by volume** table + **merged/closed 7d**.
+  4. **Recent jobs table:** time, project, type, status badge, attempts, duration, last error (**rendered as text only**, already redacted server-side), Langfuse ⧉ and PR ⧉ links — both passed through the existing `safeUrl` helper (`src/utils.ts:50`) and rendered with `rel="noopener noreferrer" target="_blank"`.
+  5. **Health card:** existing `GET /health` (ingestion, DB, MinIO). Worker health is represented by the heartbeat-derived tiles, not the worker's own `/health` endpoint (v2 candidate).
+- Auto-refresh every 60s. Types in `src/types/api.ts`, fetchers in `src/api.ts` (reuse `fetchWithAuth`).
+
+## Deployment wiring
+
+- `docker-compose.yml`: add `ADMIN_EMAILS: ${OPSLANE_ADMIN_EMAILS:-}` to the ingestion service environment; run `docker compose config --quiet` after editing.
+
+## Explicitly out of scope (v1)
+
+Alerting, historical rollups/retention, per-org drill-down, Prometheus/Grafana wiring, proxying worker `/health`, backfilling lifecycle timestamps for pre-migration rows, LLM cost tracking (Langfuse covers that once you're on the trace).
+
+## Implementation order
+
+1. Migration `006` + disposable-DB apply/reapply verification.
+2. Worker: stamp `pr_created_at` / `needs_human_at` in status writes (+ worker tests).
+3. Webhook: `pr_outcomes` receipt insertion with `X-GitHub-Delivery` idempotency (+ tests).
+4. `ADMIN_EMAILS` + `RequireAdmin` + `is_admin` in `/auth/me` (+ tests: admin 200, non-admin 404, unset env 404).
+5. `db/` admin queries + `/admin/overview` handler (+ tests incl. 48-bucket contract) + `EXPLAIN` check.
+6. `/admin/jobs` handler with redaction (+ tests incl. null-incident jobs, filter validation, duration cases).
+7. Docs: `http-routes.md`, `environment-variables.md`. Compose: `ADMIN_EMAILS` pass-through.
+8. Dashboard: API types/fetchers → router/App.vue exemptions → `AdminView` tiles → SVG bars → jobs table → nav gating.
+9. Live smoke.
+
+## Verification
+
+Rule: "done" means the checks below ran and their real output is in the completion report — command output, JSON responses, and screenshots. No claim rests on reading code alone.
+
+### Layer 1 — deterministic checks
+
+1. `cd packages/ingestion && go build ./... && go test ./...` (focused while iterating: `go test ./db ./handler`).
+2. `pnpm -r build && pnpm test` (includes the routes-doc drift check); worker tests for timestamp stamping.
+3. `docker compose config --quiet`.
+4. Migration `006`: apply to a disposable clean DB and a representative existing DB, then reapply to prove idempotency.
+5. `EXPLAIN (ANALYZE, BUFFERS)` on the windowed event count and recent-jobs queries against representative data; confirm the new indexes are used (no seq scan on `error_events`).
+
+### Layer 2 — API evidence (curl, before/after)
+
+Stack up via compose with `OPSLANE_ADMIN_EMAILS` set, migrations applied, `scripts/seed-e2e.sql` seeded:
+
+1. Curl `/api/v1/admin/overview` as admin → baseline JSON.
+2. POST events to `http://localhost:8082/api/v1/events`, run a worker job, curl overview again → show event totals and hourly buckets incrementing, job counts moving.
+3. Curl `/api/v1/admin/jobs` → job row present with correct status, attempts, and duration semantics.
+4. Curl both admin endpoints as a non-admin session → raw 404 body.
+
+### Layer 3 — browser evidence (headless browser, screenshots in the report)
+
+1. `/admin` as admin: every tile rendered and populated — events 1h/24h non-zero, ingestion bars showing the smoke-test spike, queue depth, jobs-by-status, top-projects table, recent-jobs table containing the triggered job.
+2. Langfuse link: with `LANGFUSE_*` keys set, the trace link renders and resolves; without them, the trace column renders empty. State in the report which case ran.
+3. Non-admin session: Admin nav link absent, and direct navigation to `/admin` redirects home (screenshot + the 404 in the network log).
+4. Admin with zero projects: `/admin` loads without a `/setup` redirect.
+
+### Evidence tiers for PR metrics
+
+"PRs created / merged / closed" tiles need a real fix-pipeline run (Anthropic key, GitHub repo, E2B) to light up end-to-end. If those credentials are available, run the full pipeline and screenshot the tiles. If not, prove them two ways and label the evidence as simulated: (a) worker/webhook unit tests covering `pr_created_at`/`needs_human_at` stamping and `pr_outcomes` receipt insertion (including redelivery idempotency), and (b) representative rows inserted into the disposable DB, with a screenshot of the tiles rendering them. The completion report must state per metric whether evidence was end-to-end or simulated.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -21,6 +21,7 @@ Every variable each service actually reads, from `os.Getenv` (ingestion) and `pr
 | `REPLAY_STORE_ACCESS_KEY` / `REPLAY_STORE_SECRET_KEY` | for replays | Storage credentials |
 | `REPLAY_STORE_BUCKET` / `REPLAY_STORE_REGION` | for replays | Bucket and region |
 | `INTERNAL_READ_TOKEN` | for worker replay evidence | Shared secret guarding worker-to-ingestion chunk reads. Unset disables the internal endpoint. |
+| `ADMIN_EMAILS` | no | Comma-separated operator email allowlist for the cross-tenant admin dashboard. Empty disables the admin API. Docker Compose maps it from the host-side `OPSLANE_ADMIN_EMAILS`. |
 | `VERSION` | no | Reported by `/health` |
 
 Ingestion reads **only** the `REPLAY_STORE_*` names; `MINIO_*` names appear in its test code, not runtime configuration.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -57,4 +57,5 @@ The worker starts with only `DATABASE_URL` and logs a warning for missing `ANTHR
 | Variable | Status |
 | --- | --- |
 | `ALLOW_REGISTRATION` | Read by nothing; there is no self-serve registration path (sign-in is GitHub OAuth). |
+| `OPSLANE_ADMIN_EMAILS` | Host-side name that docker-compose.yml maps into the ingestion service's `ADMIN_EMAILS`; consumed by Compose interpolation, not read by code directly. |
 | `ENCRYPTION_KEY` | Read by nothing except a sandbox scrub list; at-rest token encryption is not implemented (see [trust](../architecture/trust.md#honest-gaps-current-state)). |

--- a/docs/reference/http-routes.md
+++ b/docs/reference/http-routes.md
@@ -42,6 +42,8 @@ These are curated tables, not a stability contract — the API is early-stage an
 | GET | `/api/v1/auth/me` | Current user |
 | GET | `/api/v1/auth/verify` | Validate session |
 | POST | `/api/v1/auth/logout` | End session |
+| GET | `/api/v1/admin/overview` | Operator-only cross-tenant observability overview (404 unless allowlisted) |
+| GET | `/api/v1/admin/jobs` | Operator-only recent jobs (404 unless allowlisted) |
 | POST | `/api/v1/onboarding/setup` | First-run setup |
 | GET | `/api/v1/projects` | List projects |
 | POST | `/api/v1/projects` | Create project |

--- a/packages/dashboard/src/App.vue
+++ b/packages/dashboard/src/App.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { getMe, clearAuth, isAuthenticated, listProjects, type AuthUser, type Project } from './api';
+import { routeNeedsProject } from './route-project';
 
 const route = useRoute();
 const router = useRouter();
@@ -27,6 +28,9 @@ function navLinkClass(routeName: string): string {
 const showProjectPrompt = ref(false);
 const promptProjects = ref<Project[]>([]);
 const promptSelectedId = ref('');
+const shouldShowProjectPrompt = computed(
+  () => showProjectPrompt.value && routeNeedsProject(route.name),
+);
 
 async function loadUser(): Promise<void> {
   if (!isAuthenticated()) return;
@@ -40,6 +44,7 @@ async function loadUser(): Promise<void> {
 async function checkProject(): Promise<void> {
   if (!isAuthenticated()) return;
   if (fullPageRoutes.includes(route.name as string)) return;
+  if (!routeNeedsProject(route.name)) return;
 
   const pid = localStorage.getItem('opslane_project_id');
   if (pid) {
@@ -135,6 +140,9 @@ watch(
         <router-link to="/settings" :class="navLinkClass('settings')">
           Settings
         </router-link>
+        <router-link v-if="user?.is_admin" to="/admin" :class="navLinkClass('admin')">
+          Admin
+        </router-link>
         <span class="w-px h-5 bg-border"></span>
         <span v-if="user" class="text-sm text-text-muted" v-text="user.email"></span>
         <button
@@ -149,7 +157,7 @@ watch(
 
     <!-- Project selection prompt -->
     <div
-      v-if="showProjectPrompt && !isFullPage"
+      v-if="shouldShowProjectPrompt && !isFullPage"
       class="max-w-lg mx-auto mt-12 bg-surface rounded-md border border-border p-8"
     >
       <h2 class="text-base font-medium text-text mb-2">Select a project</h2>
@@ -184,7 +192,7 @@ watch(
     </div>
 
     <main
-      v-if="!showProjectPrompt"
+      v-if="!shouldShowProjectPrompt"
       :class="!isFullPage ? 'max-w-7xl mx-auto px-6 py-8' : ''"
     >
       <router-view :key="$route.fullPath" />

--- a/packages/dashboard/src/admin-format.test.ts
+++ b/packages/dashboard/src/admin-format.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { adminStatusBadgeClass, formatDuration } from './admin-format';
+
+describe('admin formatting', () => {
+  it('formats nullable job durations without implying pending jobs completed', () => {
+    expect(formatDuration(null)).toBe('\u2014');
+    expect(formatDuration(0.4)).toBe('<1s');
+    expect(formatDuration(75)).toBe('1m 15s');
+    expect(formatDuration(3_720)).toBe('1h 2m');
+  });
+
+  it('highlights dead letters as failures', () => {
+    expect(adminStatusBadgeClass('dead_letter')).toContain('text-red');
+  });
+});

--- a/packages/dashboard/src/admin-format.ts
+++ b/packages/dashboard/src/admin-format.ts
@@ -1,0 +1,38 @@
+export function formatDuration(seconds: number | null): string {
+  if (seconds === null || !Number.isFinite(seconds) || seconds < 0) return '\u2014';
+  if (seconds < 1) return '<1s';
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3_600) return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+  return `${Math.floor(seconds / 3_600)}h ${Math.round((seconds % 3_600) / 60)}m`;
+}
+
+// Keep the shared statuses aligned with statusBadgeClass in utils.ts so the
+// same status never renders a different color on the admin page.
+export function adminStatusBadgeClass(status: string): string {
+  switch (status) {
+    case 'completed':
+    case 'insight':
+    case 'resolved':
+      return 'bg-green-500/10 text-green';
+    case 'merged':
+    case 'pr_created':
+      return 'bg-emerald-500/10 text-green';
+    case 'claimed':
+    case 'analyzing':
+    case 'queued':
+      return 'bg-indigo-500/10 text-indigo';
+    case 'fixing':
+      return 'bg-indigo-500/10 text-indigo animate-pulse';
+    case 'awaiting_approval':
+    case 'investigated':
+      return 'bg-teal-500/10 text-teal';
+    case 'pending':
+    case 'needs_human':
+      return 'bg-amber-500/10 text-amber';
+    case 'failed':
+    case 'dead_letter':
+      return 'bg-red-500/10 text-red';
+    default:
+      return 'bg-surface-2 text-text-muted';
+  }
+}

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -2,6 +2,7 @@ import type {
   Incident, AffectedUser, Account, IncidentFilters,
   GitHubConfig, GitHubAppStatus, GitHubRepo, SetupPrStatus,
   SessionDetail, SessionFilters, SessionListResponse,
+  AdminOverview, AdminJobsResponse, HealthResponse,
 } from './types/api';
 import type { ChunkEnvelope } from './components/session-replay';
 
@@ -26,6 +27,7 @@ export interface AuthUser {
   org_id: string;
   email: string;
   name: string;
+  is_admin: boolean;
 }
 
 export function isAuthenticated(): boolean {
@@ -196,6 +198,40 @@ export interface ReplayRecording {
 
 export function getMe(): Promise<AuthUser> {
   return fetchJSON<AuthUser>('/auth/me');
+}
+
+// A hung admin request would otherwise wedge AdminView's poll loop forever
+// (its refreshing guard skips every later tick), so these calls carry a timeout.
+const ADMIN_FETCH_TIMEOUT_MS = 30_000;
+
+export function getAdminOverview(): Promise<AdminOverview> {
+  return fetchWithAuth<AdminOverview>('/admin/overview', {
+    signal: AbortSignal.timeout(ADMIN_FETCH_TIMEOUT_MS),
+  });
+}
+
+export function listAdminJobs(limit = 50): Promise<AdminJobsResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  return fetchWithAuth<AdminJobsResponse>(`/admin/jobs?${params}`, {
+    signal: AbortSignal.timeout(ADMIN_FETCH_TIMEOUT_MS),
+  });
+}
+
+export async function getHealth(): Promise<HealthResponse> {
+  const response = await fetch('/health', {
+    credentials: 'include',
+    signal: AbortSignal.timeout(ADMIN_FETCH_TIMEOUT_MS),
+  });
+  // The health endpoint intentionally returns its useful diagnostic payload with
+  // a 503 when the database is unhealthy, so callers should still render it.
+  if (!response.ok && response.status !== 503) {
+    throw new APIError(response.status, `Health API ${response.status}`);
+  }
+  try {
+    return await response.json() as HealthResponse;
+  } catch {
+    throw new APIError(response.status, `Health API ${response.status}: non-JSON response`);
+  }
 }
 
 export function listProjects(): Promise<Project[]> {

--- a/packages/dashboard/src/components/AdminHourlyChart.vue
+++ b/packages/dashboard/src/components/AdminHourlyChart.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { AdminHourlyEventBucket } from '../types/api';
+
+const props = defineProps<{ buckets: AdminHourlyEventBucket[] }>();
+
+const hourLabelFormat = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  timeZone: 'UTC',
+});
+
+const width = 960;
+const height = 190;
+const chartTop = 12;
+const chartBottom = 34;
+const chartHeight = height - chartTop - chartBottom;
+const maxCount = computed(() => Math.max(1, ...props.buckets.map((bucket) => bucket.count)));
+
+const bars = computed(() => {
+  const slotWidth = width / Math.max(1, props.buckets.length);
+  return props.buckets.map((bucket, index) => {
+    const scaledHeight = (bucket.count / maxCount.value) * chartHeight;
+    return {
+      ...bucket,
+      x: index * slotWidth + 2,
+      y: chartTop + chartHeight - Math.max(1, scaledHeight),
+      width: Math.max(1, slotWidth - 4),
+      height: Math.max(1, scaledHeight),
+      label: hourLabelFormat.format(new Date(bucket.hour)),
+    };
+  });
+});
+</script>
+
+<template>
+  <svg
+    :viewBox="`0 0 ${width} ${height}`"
+    class="block h-48 w-full"
+    role="img"
+    aria-label="Events ingested per hour over the last 48 hours"
+  >
+    <line
+      x1="0"
+      :y1="chartTop + chartHeight"
+      :x2="width"
+      :y2="chartTop + chartHeight"
+      class="stroke-border"
+    />
+    <g v-for="(bar, index) in bars" :key="bar.hour">
+      <rect
+        :x="bar.x"
+        :y="bar.y"
+        :width="bar.width"
+        :height="bar.height"
+        rx="2"
+        class="fill-teal/70 hover:fill-teal"
+      >
+        <title>{{ bar.label }} UTC: {{ bar.count.toLocaleString() }} events</title>
+      </rect>
+      <text
+        v-if="index % 6 === 0"
+        :x="bar.x"
+        :y="height - 8"
+        class="fill-text-muted text-[10px]"
+      >
+        {{ bar.label }}
+      </text>
+    </g>
+  </svg>
+</template>

--- a/packages/dashboard/src/main.ts
+++ b/packages/dashboard/src/main.ts
@@ -5,4 +5,6 @@ import './style.css';
 
 const app = createApp(App);
 app.use(router);
-app.mount('#app');
+// Wait for the initial navigation so route.name is resolved before App.vue's
+// mounted hooks run route-dependent checks (e.g. the /admin project exemption).
+void router.isReady().then(() => app.mount('#app'));

--- a/packages/dashboard/src/route-project.test.ts
+++ b/packages/dashboard/src/route-project.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { routeNeedsProject } from './route-project';
+
+describe('routeNeedsProject', () => {
+  it('lets an operator without a selected project open the admin dashboard', () => {
+    expect(routeNeedsProject('admin')).toBe(false);
+  });
+
+  it('still requires a project for tenant-scoped routes', () => {
+    expect(routeNeedsProject('activity')).toBe(true);
+    expect(routeNeedsProject('sessions')).toBe(true);
+  });
+});

--- a/packages/dashboard/src/route-project.ts
+++ b/packages/dashboard/src/route-project.ts
@@ -1,0 +1,5 @@
+const PROJECT_EXEMPT_ROUTES = new Set(['setup', 'login', 'auth-callback', 'admin']);
+
+export function routeNeedsProject(routeName: unknown): boolean {
+  return !PROJECT_EXEMPT_ROUTES.has(String(routeName));
+}

--- a/packages/dashboard/src/router.ts
+++ b/packages/dashboard/src/router.ts
@@ -8,6 +8,7 @@ import SetupWizard from './views/SetupWizard.vue';
 import Settings from './views/Settings.vue';
 import AccountsList from './views/AccountsList.vue';
 import AccountDetail from './views/AccountDetail.vue';
+import { routeNeedsProject } from './route-project';
 
 export const router = createRouter({
   history: createWebHistory(),
@@ -22,6 +23,7 @@ export const router = createRouter({
     { path: '/sessions', name: 'sessions', component: () => import('./views/SessionsList.vue') },
     { path: '/sessions/:sessionId', name: 'session-detail', component: () => import('./views/SessionDetail.vue') },
     { path: '/settings', name: 'settings', component: Settings },
+    { path: '/admin', name: 'admin', component: () => import('./views/AdminView.vue') },
     { path: '/:pathMatch(.*)*', redirect: '/' },
   ],
 });
@@ -41,7 +43,7 @@ router.beforeEach((to) => {
   }
 
   // Redirect to setup if authenticated but no project configured
-  if (authed && to.name !== 'setup' && to.name !== 'login' && to.name !== 'auth-callback') {
+  if (authed && routeNeedsProject(to.name)) {
     const hasProject = !!localStorage.getItem('opslane_project_id');
     if (!hasProject) {
       return { name: 'setup' };

--- a/packages/dashboard/src/types/api.ts
+++ b/packages/dashboard/src/types/api.ts
@@ -155,3 +155,90 @@ export interface SetupPrStatus {
   pr_number: number | null;
   error?: string;
 }
+
+// === Admin observability ===
+
+export type AdminJobStatus =
+  | 'pending'
+  | 'claimed'
+  | 'completed'
+  | 'failed'
+  | 'dead_letter';
+
+export type AdminJobType =
+  | 'investigate'
+  | 'fix'
+  | 'error_fix'
+  | 'setup_pr'
+  | 'session_analysis';
+
+export interface AdminHourlyEventBucket {
+  hour: string;
+  count: number;
+}
+
+export interface AdminTopProject {
+  project_id: string;
+  project_name: string;
+  org_name: string;
+  count: number;
+}
+
+export interface AdminOverview {
+  events: {
+    last_1h: number;
+    last_24h: number;
+    last_7d: number;
+    hourly: AdminHourlyEventBucket[];
+    top_projects: AdminTopProject[];
+  };
+  jobs: {
+    by_status: Partial<Record<AdminJobStatus, number>>;
+    by_type: Partial<Record<AdminJobType, number>>;
+    oldest_pending_age_seconds: number | null;
+    dead_letters_7d: number;
+  };
+  workers: {
+    live_claims: number;
+    active_5m: number;
+  };
+  outcomes: {
+    by_status: Record<string, number>;
+    pr_created_24h: number;
+    pr_created_7d: number;
+    needs_human_7d: number;
+    merged_7d: number;
+    closed_7d: number;
+  };
+}
+
+export interface AdminJob {
+  id: string;
+  project_name: string;
+  job_type: AdminJobType;
+  status: AdminJobStatus;
+  attempts: number;
+  created_at: string;
+  duration_seconds: number | null;
+  last_error: string | null;
+  trace_url: string | null;
+  incident_title: string | null;
+  pr_url: string | null;
+}
+
+export interface AdminJobsResponse {
+  jobs: AdminJob[];
+}
+
+export interface HealthCheckResult {
+  status: string;
+  latency_ms?: number;
+  error?: string;
+}
+
+export interface HealthResponse {
+  status: string;
+  checks: Record<string, HealthCheckResult>;
+  version: string;
+  uptime_seconds: number;
+}

--- a/packages/dashboard/src/views/AdminView.vue
+++ b/packages/dashboard/src/views/AdminView.vue
@@ -1,0 +1,334 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { APIError, getAdminOverview, getHealth, listAdminJobs } from '../api';
+import { adminStatusBadgeClass, formatDuration } from '../admin-format';
+import AdminHourlyChart from '../components/AdminHourlyChart.vue';
+import type { AdminJob, AdminOverview, HealthResponse } from '../types/api';
+import { formatDate, safeUrl } from '../utils';
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+const router = useRouter();
+const overview = ref<AdminOverview | null>(null);
+const jobs = ref<AdminJob[]>([]);
+const health = ref<HealthResponse | null>(null);
+const overviewError = ref<string | null>(null);
+const jobsError = ref<string | null>(null);
+const healthError = ref<string | null>(null);
+const loading = ref(true);
+const refreshing = ref(false);
+const refreshedAt = ref<Date | null>(null);
+let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+const jobStatuses = computed(() =>
+  Object.entries(overview.value?.jobs.by_status ?? {}).sort((a, b) => b[1] - a[1]),
+);
+const outcomeStatuses = computed(() =>
+  Object.entries(overview.value?.outcomes.by_status ?? {}).sort((a, b) => b[1] - a[1]),
+);
+const healthChecks = computed(() => Object.entries(health.value?.checks ?? {}));
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function loadDashboard(): Promise<void> {
+  if (refreshing.value) return;
+  refreshing.value = true;
+  overviewError.value = null;
+  jobsError.value = null;
+  healthError.value = null;
+
+  try {
+    const [overviewResult, jobsResult, healthResult] = await Promise.allSettled([
+      getAdminOverview(),
+      listAdminJobs(),
+      getHealth(),
+    ]);
+
+    if (overviewResult.status === 'rejected') {
+      if (overviewResult.reason instanceof APIError && overviewResult.reason.status === 404) {
+        await router.replace('/');
+        return;
+      }
+      overviewError.value = `Failed to load overview: ${errorMessage(overviewResult.reason)}`;
+    } else {
+      overview.value = overviewResult.value;
+    }
+
+    if (jobsResult.status === 'rejected') {
+      jobsError.value = `Failed to load recent jobs: ${errorMessage(jobsResult.reason)}`;
+    } else {
+      jobs.value = jobsResult.value.jobs;
+    }
+
+    if (healthResult.status === 'rejected') {
+      healthError.value = `Health check unavailable: ${errorMessage(healthResult.reason)}`;
+    } else {
+      health.value = healthResult.value;
+    }
+
+    refreshedAt.value = new Date();
+  } finally {
+    refreshing.value = false;
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  void loadDashboard();
+  refreshTimer = setInterval(() => void loadDashboard(), REFRESH_INTERVAL_MS);
+});
+
+onUnmounted(() => {
+  if (refreshTimer) clearInterval(refreshTimer);
+});
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h1 class="text-xl font-semibold text-text">System observability</h1>
+        <p class="mt-1 text-sm text-text-muted">
+          Cross-project event flow, investigation outcomes, and worker activity.
+        </p>
+      </div>
+      <div class="flex items-center gap-3">
+        <span v-if="refreshedAt" class="text-xs text-text-muted">
+          Updated {{ refreshedAt.toLocaleTimeString() }}
+        </span>
+        <button class="btn-secondary" :disabled="refreshing" @click="loadDashboard">
+          {{ refreshing ? 'Refreshing\u2026' : 'Refresh' }}
+        </button>
+      </div>
+    </div>
+
+    <div
+      v-if="overviewError"
+      class="rounded-md border border-red-500/20 bg-red-500/10 p-4 text-sm text-red"
+      v-text="overviewError"
+    ></div>
+
+    <div v-if="loading && !overview" class="py-12 text-center text-sm text-text-muted">
+      Loading operator metrics…
+    </div>
+
+    <template v-if="overview">
+      <section aria-label="Headline metrics" class="grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-7">
+        <div class="rounded-lg border border-border bg-surface p-4">
+          <p class="text-xs text-text-muted">Events 1h</p>
+          <p class="mt-2 text-2xl font-semibold tabular-nums">{{ overview.events.last_1h.toLocaleString() }}</p>
+        </div>
+        <div class="rounded-lg border border-border bg-surface p-4">
+          <p class="text-xs text-text-muted">Events 24h</p>
+          <p class="mt-2 text-2xl font-semibold tabular-nums">{{ overview.events.last_24h.toLocaleString() }}</p>
+        </div>
+        <div class="rounded-lg border border-border bg-surface p-4">
+          <p class="text-xs text-text-muted">Incidents w/ PR created 7d</p>
+          <p class="mt-2 text-2xl font-semibold tabular-nums">{{ overview.outcomes.pr_created_7d.toLocaleString() }}</p>
+        </div>
+        <div class="rounded-lg border border-border bg-surface p-4">
+          <p class="text-xs text-text-muted">Needs human 7d</p>
+          <p class="mt-2 text-2xl font-semibold tabular-nums">{{ overview.outcomes.needs_human_7d.toLocaleString() }}</p>
+        </div>
+        <div class="rounded-lg border border-border bg-surface p-4">
+          <p class="text-xs text-text-muted">Queue depth (pending)</p>
+          <p class="mt-2 text-2xl font-semibold tabular-nums">{{ (overview.jobs.by_status.pending ?? 0).toLocaleString() }}</p>
+        </div>
+        <div class="rounded-lg border border-border bg-surface p-4">
+          <p class="text-xs text-text-muted">Dead letters 7d</p>
+          <p class="mt-2 text-2xl font-semibold tabular-nums">{{ overview.jobs.dead_letters_7d.toLocaleString() }}</p>
+        </div>
+        <div class="rounded-lg border border-border bg-surface p-4">
+          <p class="text-xs text-text-muted">Workers w/ live claims</p>
+          <p class="mt-2 text-2xl font-semibold tabular-nums">{{ overview.workers.live_claims.toLocaleString() }}</p>
+        </div>
+      </section>
+
+      <section class="rounded-lg border border-border bg-surface p-5">
+        <div class="flex items-baseline justify-between gap-4">
+          <div>
+            <h2 class="text-base font-medium">Event ingestion</h2>
+            <p class="mt-1 text-xs text-text-muted">Hourly event volume over the last 48 hours (UTC)</p>
+          </div>
+          <span class="text-xs text-text-muted">7d total: {{ overview.events.last_7d.toLocaleString() }}</span>
+        </div>
+        <AdminHourlyChart :buckets="overview.events.hourly" />
+      </section>
+
+      <section class="grid gap-4 lg:grid-cols-3">
+        <div class="rounded-lg border border-border bg-surface p-5">
+          <h2 class="text-base font-medium">Jobs by status</h2>
+          <div v-if="jobStatuses.length" class="mt-4 flex flex-wrap gap-2">
+            <span
+              v-for="([status, count]) in jobStatuses"
+              :key="status"
+              class="inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-xs font-medium"
+              :class="adminStatusBadgeClass(status)"
+            >
+              {{ status.replace(/_/g, ' ') }} <strong class="tabular-nums">{{ count }}</strong>
+            </span>
+          </div>
+          <p v-else class="mt-4 text-sm text-text-muted">No jobs recorded.</p>
+          <dl class="mt-5 border-t border-border pt-4 text-xs">
+            <div class="flex justify-between gap-4">
+              <dt class="text-text-muted">Oldest pending</dt>
+              <dd class="tabular-nums">{{ formatDuration(overview.jobs.oldest_pending_age_seconds) }}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div class="rounded-lg border border-border bg-surface p-5">
+          <h2 class="text-base font-medium">Top projects · 24h</h2>
+          <div class="mt-3 overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-border text-left text-xs text-text-muted">
+                  <th class="py-2 pr-3 font-medium">Project</th>
+                  <th class="py-2 pr-3 font-medium">Organization</th>
+                  <th class="py-2 text-right font-medium">Events</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="project in overview.events.top_projects" :key="project.project_id" class="border-b border-border-subtle last:border-0">
+                  <td class="py-2 pr-3" v-text="project.project_name"></td>
+                  <td class="py-2 pr-3 text-text-muted" v-text="project.org_name"></td>
+                  <td class="py-2 text-right tabular-nums">{{ project.count.toLocaleString() }}</td>
+                </tr>
+                <tr v-if="overview.events.top_projects.length === 0">
+                  <td colspan="3" class="py-4 text-center text-text-muted">No events in the last 24 hours.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="rounded-lg border border-border bg-surface p-5">
+          <h2 class="text-base font-medium">Incident outcomes</h2>
+          <div class="mt-4 grid grid-cols-2 gap-3">
+            <div class="rounded-md bg-surface-2 p-3">
+              <p class="text-xs text-text-muted">Merged 7d</p>
+              <p class="mt-1 text-xl font-semibold tabular-nums">{{ overview.outcomes.merged_7d }}</p>
+            </div>
+            <div class="rounded-md bg-surface-2 p-3">
+              <p class="text-xs text-text-muted">Closed 7d</p>
+              <p class="mt-1 text-xl font-semibold tabular-nums">{{ overview.outcomes.closed_7d }}</p>
+            </div>
+          </div>
+          <div class="mt-4 flex flex-wrap gap-2">
+            <span
+              v-for="([status, count]) in outcomeStatuses"
+              :key="status"
+              class="inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-xs font-medium"
+              :class="adminStatusBadgeClass(status)"
+            >
+              {{ status.replace(/_/g, ' ') }} <strong>{{ count }}</strong>
+            </span>
+          </div>
+        </div>
+      </section>
+    </template>
+
+    <section class="rounded-lg border border-border bg-surface">
+      <div class="border-b border-border px-5 py-4">
+        <h2 class="text-base font-medium">Recent jobs</h2>
+        <p class="mt-1 text-xs text-text-muted">Latest work across all projects</p>
+      </div>
+      <p v-if="jobsError" class="m-5 rounded-md bg-red-500/10 p-3 text-sm text-red" v-text="jobsError"></p>
+      <div v-else class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead>
+            <tr class="border-b border-border text-left text-xs uppercase tracking-wide text-text-muted">
+              <th class="px-4 py-2.5 font-medium">Time</th>
+              <th class="px-4 py-2.5 font-medium">Project / incident</th>
+              <th class="px-4 py-2.5 font-medium">Type</th>
+              <th class="px-4 py-2.5 font-medium">Status</th>
+              <th class="px-4 py-2.5 text-right font-medium">Attempts</th>
+              <th class="px-4 py-2.5 text-right font-medium">Duration</th>
+              <th class="px-4 py-2.5 font-medium">Last error</th>
+              <th class="px-4 py-2.5 text-right font-medium">Links</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="job in jobs" :key="job.id" class="border-b border-border-subtle align-top last:border-0">
+              <td class="whitespace-nowrap px-4 py-3 text-text-muted">{{ formatDate(job.created_at) }}</td>
+              <td class="max-w-56 px-4 py-3">
+                <p class="truncate" v-text="job.project_name"></p>
+                <p v-if="job.incident_title" class="mt-0.5 truncate text-xs text-text-muted" v-text="job.incident_title"></p>
+              </td>
+              <td class="whitespace-nowrap px-4 py-3 font-mono text-xs" v-text="job.job_type"></td>
+              <td class="px-4 py-3">
+                <span class="inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium" :class="adminStatusBadgeClass(job.status)">
+                  {{ job.status.replace(/_/g, ' ') }}
+                </span>
+              </td>
+              <td class="px-4 py-3 text-right tabular-nums">{{ job.attempts }}</td>
+              <td class="whitespace-nowrap px-4 py-3 text-right tabular-nums text-text-muted">{{ formatDuration(job.duration_seconds) }}</td>
+              <td class="max-w-80 px-4 py-3 text-xs text-text-muted">
+                <span class="line-clamp-3 break-words" v-text="job.last_error ?? '\u2014'"></span>
+              </td>
+              <td class="whitespace-nowrap px-4 py-3 text-right">
+                <a
+                  v-if="safeUrl(job.trace_url ?? undefined)"
+                  :href="safeUrl(job.trace_url ?? undefined)"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-teal hover:underline"
+                  aria-label="Open Langfuse trace"
+                >Trace ⧉</a>
+                <a
+                  v-if="safeUrl(job.pr_url ?? undefined)"
+                  :href="safeUrl(job.pr_url ?? undefined)"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="ml-3 text-teal hover:underline"
+                  aria-label="Open pull request"
+                >PR ⧉</a>
+                <span v-if="!safeUrl(job.trace_url ?? undefined) && !safeUrl(job.pr_url ?? undefined)" class="text-text-faint">—</span>
+              </td>
+            </tr>
+            <tr v-if="jobs.length === 0 && !loading">
+              <td colspan="8" class="px-4 py-8 text-center text-text-muted">No jobs recorded.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="rounded-lg border border-border bg-surface p-5">
+      <div class="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h2 class="text-base font-medium">Service health</h2>
+          <p class="mt-1 text-xs text-text-muted">Ingestion, database, and object storage</p>
+        </div>
+        <span
+          v-if="health"
+          class="inline-flex rounded-full px-2.5 py-1 text-xs font-medium"
+          :class="health.status === 'ok' ? 'bg-green-500/10 text-green' : health.status === 'degraded' ? 'bg-amber-500/10 text-amber' : 'bg-red-500/10 text-red'"
+          v-text="health.status"
+        ></span>
+      </div>
+      <p v-if="healthError" class="mt-4 text-sm text-red" v-text="healthError"></p>
+      <div v-else-if="health" class="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div class="rounded-md bg-surface-2 p-3">
+          <p class="text-xs text-text-muted">Ingestion</p>
+          <p class="mt-1 text-sm font-medium" v-text="health.status"></p>
+          <p class="mt-1 text-xs text-text-faint">v{{ health.version }} · up {{ formatDuration(health.uptime_seconds) }}</p>
+        </div>
+        <div v-for="([name, check]) in healthChecks" :key="name" class="rounded-md bg-surface-2 p-3">
+          <p class="text-xs capitalize text-text-muted" v-text="name"></p>
+          <p class="mt-1 text-sm font-medium" :class="check.status === 'ok' ? 'text-green' : 'text-red'" v-text="check.status"></p>
+          <p v-if="check.latency_ms !== undefined" class="mt-1 text-xs text-text-faint">{{ check.latency_ms.toFixed(1) }}ms</p>
+          <p v-if="check.error" class="mt-1 break-words text-xs text-red" v-text="check.error"></p>
+        </div>
+        <div v-if="overview" class="rounded-md bg-surface-2 p-3">
+          <p class="text-xs text-text-muted">Workers active in last 5m</p>
+          <p class="mt-1 text-sm font-medium tabular-nums">{{ overview.workers.active_5m }}</p>
+          <p class="mt-1 text-xs text-text-faint">Heartbeat-derived; an idle fleet may show zero.</p>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/packages/dashboard/vite.config.ts
+++ b/packages/dashboard/vite.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
         target: process.env.VITE_API_URL || 'http://localhost:8082',
         changeOrigin: true,
       },
+      '/health': {
+        target: process.env.VITE_API_URL || 'http://localhost:8082',
+        changeOrigin: true,
+      },
     },
   },
 })

--- a/packages/ingestion/db/admin.go
+++ b/packages/ingestion/db/admin.go
@@ -251,6 +251,9 @@ func (q *Queries) AdminOverviewData(ctx context.Context) (*AdminOverview, error)
 // AdminRecentJobs intentionally returns jobs across all tenants. The caller must
 // validate status/jobType against the public allowlists before calling.
 func (q *Queries) AdminRecentJobs(ctx context.Context, limit int, status, jobType string) ([]AdminJob, error) {
+	// The handler clamps limit too; bound it here as well so the slice
+	// allocation and query LIMIT can never depend on an unchecked caller.
+	limit = max(1, min(limit, 200))
 	rows, err := q.pool.Query(ctx, `
 		SELECT
 			j.id, coalesce(p.name, ''), j.job_type, j.status::text, j.attempts, j.created_at,

--- a/packages/ingestion/db/admin.go
+++ b/packages/ingestion/db/admin.go
@@ -251,9 +251,16 @@ func (q *Queries) AdminOverviewData(ctx context.Context) (*AdminOverview, error)
 // AdminRecentJobs intentionally returns jobs across all tenants. The caller must
 // validate status/jobType against the public allowlists before calling.
 func (q *Queries) AdminRecentJobs(ctx context.Context, limit int, status, jobType string) ([]AdminJob, error) {
-	// The handler clamps limit too; bound it here as well so the slice
-	// allocation and query LIMIT can never depend on an unchecked caller.
-	limit = max(1, min(limit, 200))
+	// The handler clamps limit too; bound it here as well so the query LIMIT
+	// can never depend on an unchecked caller. Explicit comparisons rather
+	// than the min/max builtins: CodeQL's taint analysis only recognizes
+	// branch guards as allocation-size barriers.
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 200 {
+		limit = 200
+	}
 	rows, err := q.pool.Query(ctx, `
 		SELECT
 			j.id, coalesce(p.name, ''), j.job_type, j.status::text, j.attempts, j.created_at,
@@ -275,7 +282,9 @@ func (q *Queries) AdminRecentJobs(ctx context.Context, limit int, status, jobTyp
 	}
 	defer rows.Close()
 
-	jobs := make([]AdminJob, 0, limit)
+	// Non-nil so an empty result serializes as [] not null; grown by append
+	// so the allocation size never derives from request input.
+	jobs := []AdminJob{}
 	for rows.Next() {
 		var job AdminJob
 		if err := rows.Scan(

--- a/packages/ingestion/db/admin.go
+++ b/packages/ingestion/db/admin.go
@@ -1,0 +1,290 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type AdminHourlyEventBucket struct {
+	Hour  time.Time `json:"hour"`
+	Count int64     `json:"count"`
+}
+
+type AdminTopProject struct {
+	ProjectID   string `json:"project_id"`
+	ProjectName string `json:"project_name"`
+	OrgName     string `json:"org_name"`
+	Count       int64  `json:"count"`
+}
+
+type AdminEventOverview struct {
+	Last1H      int64                    `json:"last_1h"`
+	Last24H     int64                    `json:"last_24h"`
+	Last7D      int64                    `json:"last_7d"`
+	Hourly      []AdminHourlyEventBucket `json:"hourly"`
+	TopProjects []AdminTopProject        `json:"top_projects"`
+}
+
+type AdminJobOverview struct {
+	ByStatus                map[string]int64 `json:"by_status"`
+	ByType                  map[string]int64 `json:"by_type"`
+	OldestPendingAgeSeconds *float64         `json:"oldest_pending_age_seconds"`
+	DeadLetters7D           int64            `json:"dead_letters_7d"`
+}
+
+type AdminWorkerOverview struct {
+	LiveClaims int64 `json:"live_claims"`
+	Active5M   int64 `json:"active_5m"`
+}
+
+type AdminOutcomeOverview struct {
+	ByStatus     map[string]int64 `json:"by_status"`
+	PRCreated24H int64            `json:"pr_created_24h"`
+	PRCreated7D  int64            `json:"pr_created_7d"`
+	NeedsHuman7D int64            `json:"needs_human_7d"`
+	Merged7D     int64            `json:"merged_7d"`
+	Closed7D     int64            `json:"closed_7d"`
+}
+
+type AdminOverview struct {
+	Events   AdminEventOverview   `json:"events"`
+	Jobs     AdminJobOverview     `json:"jobs"`
+	Workers  AdminWorkerOverview  `json:"workers"`
+	Outcomes AdminOutcomeOverview `json:"outcomes"`
+}
+
+type AdminJob struct {
+	ID              string    `json:"id"`
+	ProjectName     string    `json:"project_name"`
+	JobType         string    `json:"job_type"`
+	Status          string    `json:"status"`
+	Attempts        int       `json:"attempts"`
+	CreatedAt       time.Time `json:"created_at"`
+	DurationSeconds *float64  `json:"duration_seconds"`
+	LastError       *string   `json:"last_error"`
+	TraceURL        *string   `json:"trace_url"`
+	IncidentTitle   *string   `json:"incident_title"`
+	PRURL           *string   `json:"pr_url"`
+}
+
+// AdminOverviewData intentionally crosses every tenant. RequireAdmin is the sole
+// HTTP gate; keep the Admin prefix on every cross-tenant helper for auditability.
+func (q *Queries) AdminOverviewData(ctx context.Context) (*AdminOverview, error) {
+	result := &AdminOverview{
+		Events: AdminEventOverview{Hourly: make([]AdminHourlyEventBucket, 0, 48), TopProjects: make([]AdminTopProject, 0, 10)},
+		Jobs: AdminJobOverview{
+			ByStatus: map[string]int64{"pending": 0, "claimed": 0, "completed": 0, "failed": 0, "dead_letter": 0},
+			ByType:   map[string]int64{"investigate": 0, "fix": 0, "error_fix": 0, "setup_pr": 0, "session_analysis": 0},
+		},
+		Outcomes: AdminOutcomeOverview{ByStatus: make(map[string]int64)},
+	}
+
+	if err := q.pool.QueryRow(ctx, `
+		SELECT
+			count(*) FILTER (WHERE created_at >= now() - interval '1 hour'),
+			count(*) FILTER (WHERE created_at >= now() - interval '24 hours'),
+			count(*) FILTER (WHERE created_at >= now() - interval '7 days')
+		FROM error_events
+		WHERE created_at >= now() - interval '7 days'`).Scan(&result.Events.Last1H, &result.Events.Last24H, &result.Events.Last7D); err != nil {
+		return nil, fmt.Errorf("admin event totals: %w", err)
+	}
+
+	rows, err := q.pool.Query(ctx, `
+		WITH buckets AS (
+			SELECT generate_series(
+				date_trunc('hour', now(), 'UTC') - interval '47 hours',
+				date_trunc('hour', now(), 'UTC'),
+				interval '1 hour'
+			) AS hour
+		), counts AS (
+			SELECT date_trunc('hour', created_at, 'UTC') AS hour, count(*) AS count
+			FROM error_events
+			WHERE created_at >= date_trunc('hour', now(), 'UTC') - interval '47 hours'
+			  AND created_at < date_trunc('hour', now(), 'UTC') + interval '1 hour'
+			GROUP BY 1
+		)
+		SELECT b.hour, coalesce(c.count, 0)
+		FROM buckets b LEFT JOIN counts c USING (hour)
+		ORDER BY b.hour`)
+	if err != nil {
+		return nil, fmt.Errorf("admin hourly events: %w", err)
+	}
+	for rows.Next() {
+		var bucket AdminHourlyEventBucket
+		if err := rows.Scan(&bucket.Hour, &bucket.Count); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan admin hourly events: %w", err)
+		}
+		result.Events.Hourly = append(result.Events.Hourly, bucket)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, fmt.Errorf("iterate admin hourly events: %w", err)
+	}
+	rows.Close()
+
+	rows, err = q.pool.Query(ctx, `
+		SELECT p.id, p.name, o.name, count(*) AS count
+		FROM error_events e
+		JOIN projects p ON p.id = e.project_id
+		JOIN orgs o ON o.id = p.org_id
+		WHERE e.created_at >= now() - interval '24 hours'
+		GROUP BY p.id, p.name, o.name
+		ORDER BY count DESC, p.id
+		LIMIT 10`)
+	if err != nil {
+		return nil, fmt.Errorf("admin top projects: %w", err)
+	}
+	for rows.Next() {
+		var project AdminTopProject
+		if err := rows.Scan(&project.ProjectID, &project.ProjectName, &project.OrgName, &project.Count); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan admin top projects: %w", err)
+		}
+		result.Events.TopProjects = append(result.Events.TopProjects, project)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, fmt.Errorf("iterate admin top projects: %w", err)
+	}
+	rows.Close()
+
+	rows, err = q.pool.Query(ctx, `SELECT status::text, count(*) FROM error_group_jobs GROUP BY status`)
+	if err != nil {
+		return nil, fmt.Errorf("admin jobs by status: %w", err)
+	}
+	for rows.Next() {
+		var key string
+		var count int64
+		if err := rows.Scan(&key, &count); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan admin jobs by status: %w", err)
+		}
+		result.Jobs.ByStatus[key] = count
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, fmt.Errorf("iterate admin jobs by status: %w", err)
+	}
+	rows.Close()
+
+	rows, err = q.pool.Query(ctx, `SELECT job_type, count(*) FROM error_group_jobs GROUP BY job_type`)
+	if err != nil {
+		return nil, fmt.Errorf("admin jobs by type: %w", err)
+	}
+	for rows.Next() {
+		var key string
+		var count int64
+		if err := rows.Scan(&key, &count); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan admin jobs by type: %w", err)
+		}
+		result.Jobs.ByType[key] = count
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, fmt.Errorf("iterate admin jobs by type: %w", err)
+	}
+	rows.Close()
+
+	if err := q.pool.QueryRow(ctx, `
+		SELECT
+			extract(epoch FROM now() - min(created_at) FILTER (WHERE status = 'pending'))::double precision,
+			count(*) FILTER (WHERE status = 'dead_letter' AND updated_at >= now() - interval '7 days')
+		FROM error_group_jobs
+		WHERE status = 'pending' OR (status = 'dead_letter' AND updated_at >= now() - interval '7 days')`).Scan(
+		&result.Jobs.OldestPendingAgeSeconds, &result.Jobs.DeadLetters7D,
+	); err != nil {
+		return nil, fmt.Errorf("admin job health: %w", err)
+	}
+
+	if err := q.pool.QueryRow(ctx, `
+		SELECT
+			count(DISTINCT worker_id) FILTER (WHERE status = 'claimed' AND lease_expires_at > now()),
+			count(DISTINCT worker_id) FILTER (WHERE worker_id IS NOT NULL AND updated_at > now() - interval '5 minutes')
+		FROM error_group_jobs`).Scan(&result.Workers.LiveClaims, &result.Workers.Active5M); err != nil {
+		return nil, fmt.Errorf("admin worker health: %w", err)
+	}
+
+	rows, err = q.pool.Query(ctx, `SELECT status::text, count(*) FROM error_groups GROUP BY status`)
+	if err != nil {
+		return nil, fmt.Errorf("admin outcomes by status: %w", err)
+	}
+	for rows.Next() {
+		var key string
+		var count int64
+		if err := rows.Scan(&key, &count); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan admin outcomes by status: %w", err)
+		}
+		result.Outcomes.ByStatus[key] = count
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, fmt.Errorf("iterate admin outcomes by status: %w", err)
+	}
+	rows.Close()
+
+	if err := q.pool.QueryRow(ctx, `
+		SELECT
+			count(*) FILTER (WHERE pr_created_at >= now() - interval '24 hours'),
+			count(*) FILTER (WHERE pr_created_at >= now() - interval '7 days'),
+			count(*) FILTER (WHERE needs_human_at >= now() - interval '7 days')
+		FROM error_groups`).Scan(
+		&result.Outcomes.PRCreated24H, &result.Outcomes.PRCreated7D, &result.Outcomes.NeedsHuman7D,
+	); err != nil {
+		return nil, fmt.Errorf("admin lifecycle outcomes: %w", err)
+	}
+
+	if err := q.pool.QueryRow(ctx, `
+		SELECT
+			count(*) FILTER (WHERE outcome = 'merged' AND occurred_at >= now() - interval '7 days'),
+			count(*) FILTER (WHERE outcome = 'closed' AND occurred_at >= now() - interval '7 days')
+		FROM pr_outcomes`).Scan(&result.Outcomes.Merged7D, &result.Outcomes.Closed7D); err != nil {
+		return nil, fmt.Errorf("admin PR outcomes: %w", err)
+	}
+
+	return result, nil
+}
+
+// AdminRecentJobs intentionally returns jobs across all tenants. The caller must
+// validate status/jobType against the public allowlists before calling.
+func (q *Queries) AdminRecentJobs(ctx context.Context, limit int, status, jobType string) ([]AdminJob, error) {
+	rows, err := q.pool.Query(ctx, `
+		SELECT
+			j.id, coalesce(p.name, ''), j.job_type, j.status::text, j.attempts, j.created_at,
+			CASE
+				WHEN j.status = 'pending' THEN NULL
+				WHEN j.status = 'claimed' THEN extract(epoch FROM now() - j.claimed_at)::double precision
+				ELSE extract(epoch FROM j.updated_at - j.claimed_at)::double precision
+			END,
+			j.last_error, j.trace_url, g.title, g.pr_url
+		FROM error_group_jobs j
+		LEFT JOIN error_groups g ON g.id = j.error_group_id
+		LEFT JOIN projects p ON p.id = j.project_id
+		WHERE ($1::text = '' OR j.status::text = $1)
+		  AND ($2::text = '' OR j.job_type = $2)
+		ORDER BY j.created_at DESC, j.id DESC
+		LIMIT $3`, status, jobType, limit)
+	if err != nil {
+		return nil, fmt.Errorf("admin recent jobs: %w", err)
+	}
+	defer rows.Close()
+
+	jobs := make([]AdminJob, 0, limit)
+	for rows.Next() {
+		var job AdminJob
+		if err := rows.Scan(
+			&job.ID, &job.ProjectName, &job.JobType, &job.Status, &job.Attempts, &job.CreatedAt,
+			&job.DurationSeconds, &job.LastError, &job.TraceURL, &job.IncidentTitle, &job.PRURL,
+		); err != nil {
+			return nil, fmt.Errorf("scan admin recent jobs: %w", err)
+		}
+		jobs = append(jobs, job)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate admin recent jobs: %w", err)
+	}
+	return jobs, nil
+}

--- a/packages/ingestion/db/admin_test.go
+++ b/packages/ingestion/db/admin_test.go
@@ -1,0 +1,173 @@
+package db_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/opslane/opslane/packages/ingestion/db"
+)
+
+func TestAdminOverviewHourlyBucketsAreZeroFilledAndBoundarySafe(t *testing.T) {
+	admin := testPool(t)
+	psql := findPsql(t)
+	pool, dsn := disposableDB(t, admin)
+	for _, file := range migrationFiles(t) {
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("apply migration %s: %v", file, err)
+		}
+	}
+	q := db.New(pool)
+	ctx := context.Background()
+
+	org, err := q.CreateOrg(ctx, "admin-overview-"+fmt.Sprint(time.Now().UnixNano()))
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	t.Cleanup(func() { cleanupTenant(t, pool, org.ID) })
+	repo := "example/admin-overview"
+	project, err := q.CreateProject(ctx, org.ID, "Admin Overview", &repo)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	env, err := q.CreateEnvironment(ctx, project.ID, "production")
+	if err != nil {
+		t.Fatalf("create environment: %v", err)
+	}
+
+	before, err := q.AdminOverviewData(ctx)
+	if err != nil {
+		t.Fatalf("admin overview before inserts: %v", err)
+	}
+	if len(before.Events.Hourly) != 48 {
+		t.Fatalf("got %d hourly buckets, want 48", len(before.Events.Hourly))
+	}
+	for i := 1; i < len(before.Events.Hourly); i++ {
+		if before.Events.Hourly[i].Hour.Sub(before.Events.Hourly[i-1].Hour) != time.Hour {
+			t.Fatalf("buckets %d and %d are not one hour apart", i-1, i)
+		}
+	}
+	for _, bucket := range before.Events.Hourly {
+		if bucket.Count != 0 {
+			t.Fatalf("empty database bucket %s count = %d, want 0", bucket.Hour, bucket.Count)
+		}
+	}
+
+	currentHour := time.Now().UTC().Truncate(time.Hour)
+	createdTimes := []time.Time{currentHour, currentHour.Add(-time.Hour), currentHour.Add(-3 * time.Hour)}
+	for i, createdAt := range createdTimes {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO error_events
+				(project_id, environment_id, timestamp, error_type, error_message, stack_trace_raw, created_at)
+			VALUES ($1, $2, $3, 'AdminTest', $4, 'stack', $3)`,
+			project.ID, env.ID, createdAt, fmt.Sprintf("admin event %d", i)); err != nil {
+			t.Fatalf("insert event %d: %v", i, err)
+		}
+	}
+
+	after, err := q.AdminOverviewData(ctx)
+	if err != nil {
+		t.Fatalf("admin overview after inserts: %v", err)
+	}
+	if len(after.Events.Hourly) != 48 {
+		t.Fatalf("got %d hourly buckets after inserts, want 48", len(after.Events.Hourly))
+	}
+	beforeCounts := make(map[int64]int64, len(before.Events.Hourly))
+	for _, bucket := range before.Events.Hourly {
+		beforeCounts[bucket.Hour.Unix()] = bucket.Count
+	}
+	for _, createdAt := range createdTimes {
+		var got *db.AdminHourlyEventBucket
+		for i := range after.Events.Hourly {
+			if after.Events.Hourly[i].Hour.Equal(createdAt) {
+				got = &after.Events.Hourly[i]
+				break
+			}
+		}
+		if got == nil {
+			t.Fatalf("missing bucket at %s", createdAt)
+		}
+		if delta := got.Count - beforeCounts[createdAt.Unix()]; delta != 1 {
+			t.Fatalf("bucket %s delta = %d, want 1", createdAt, delta)
+		}
+	}
+	// The deliberately skipped -2h bucket proves gaps remain present.
+	gap := currentHour.Add(-2 * time.Hour)
+	if _, ok := beforeCounts[gap.Unix()]; !ok {
+		t.Fatalf("missing zero-fill gap bucket at %s", gap)
+	}
+	for _, bucket := range after.Events.Hourly {
+		if bucket.Hour.Equal(gap) && bucket.Count != 0 {
+			t.Fatalf("gap bucket %s count = %d, want 0", gap, bucket.Count)
+		}
+	}
+}
+
+func TestAdminRecentJobsDurationAndNullableIncident(t *testing.T) {
+	pool := testPool(t)
+	q := db.New(pool)
+	ctx := context.Background()
+
+	org, err := q.CreateOrg(ctx, "admin-jobs-"+fmt.Sprint(time.Now().UnixNano()))
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	t.Cleanup(func() { cleanupTenant(t, pool, org.ID) })
+	repo := "example/admin-jobs"
+	project, err := q.CreateProject(ctx, org.ID, "Admin Jobs", &repo)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	ids := make(map[string]string)
+	for _, tc := range []struct {
+		name   string
+		status string
+		setup  string
+	}{
+		{name: "pending", status: "pending", setup: "created_at = now() - interval '10 minutes'"},
+		{name: "claimed", status: "claimed", setup: "claimed_at = now() - interval '30 seconds', lease_expires_at = now() + interval '1 minute', worker_id = 'admin-test-worker'"},
+		{name: "completed", status: "completed", setup: "claimed_at = now() - interval '2 minutes', updated_at = now() - interval '1 minute'"},
+	} {
+		query := `INSERT INTO error_group_jobs (project_id, job_type, status) VALUES ($1, 'setup_pr', $2) RETURNING id`
+		var id string
+		if err := pool.QueryRow(ctx, query, project.ID, tc.status).Scan(&id); err != nil {
+			t.Fatalf("insert %s job: %v", tc.name, err)
+		}
+		if _, err := pool.Exec(ctx, "UPDATE error_group_jobs SET "+tc.setup+" WHERE id = $1", id); err != nil {
+			t.Fatalf("configure %s job: %v", tc.name, err)
+		}
+		ids[tc.name] = id
+	}
+
+	jobs, err := q.AdminRecentJobs(ctx, 200, "", "setup_pr")
+	if err != nil {
+		t.Fatalf("admin recent jobs: %v", err)
+	}
+	found := make(map[string]db.AdminJob)
+	for _, job := range jobs {
+		for name, id := range ids {
+			if job.ID == id {
+				found[name] = job
+			}
+		}
+	}
+	if len(found) != len(ids) {
+		t.Fatalf("found %d test jobs, want %d", len(found), len(ids))
+	}
+	if found["pending"].DurationSeconds != nil {
+		t.Errorf("pending duration = %v, want nil", *found["pending"].DurationSeconds)
+	}
+	if duration := found["claimed"].DurationSeconds; duration == nil || *duration < 29 || *duration > 40 {
+		t.Errorf("claimed duration = %v, want about 30 seconds", duration)
+	}
+	if duration := found["completed"].DurationSeconds; duration == nil || *duration < 59 || *duration > 61 {
+		t.Errorf("completed duration = %v, want 60 seconds", duration)
+	}
+	for name, job := range found {
+		if job.ProjectName != project.Name || job.IncidentTitle != nil || job.PRURL != nil {
+			t.Errorf("%s nullable-incident job fields = %+v", name, job)
+		}
+	}
+}

--- a/packages/ingestion/db/migrations/006_admin_observability.sql
+++ b/packages/ingestion/db/migrations/006_admin_observability.sql
@@ -1,0 +1,11 @@
+-- 006_admin_observability.sql — operator dashboard indexes and lifecycle timestamps.
+-- Lifecycle timestamps are exact from this migration forward; legacy rows remain NULL.
+
+ALTER TABLE error_groups ADD COLUMN IF NOT EXISTS pr_created_at TIMESTAMPTZ;
+ALTER TABLE error_groups ADD COLUMN IF NOT EXISTS needs_human_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_error_events_created_at
+  ON error_events(created_at);
+
+CREATE INDEX IF NOT EXISTS idx_error_group_jobs_created_at
+  ON error_group_jobs(created_at DESC);

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -1087,55 +1087,106 @@ func (q *Queries) UpdateErrorGroupStatus(ctx context.Context, u StatusUpdate) er
 
 // === Resolution lifecycle ===
 
+// PRTransition identifies the incident and project changed by a pull-request
+// lifecycle transition. A zero value means no matching pr_created incident.
+type PRTransition struct {
+	ErrorGroupID string
+	ProjectID    string
+}
+
+// Assumption for both transitions: github_repo + pr_number + status='pr_created'
+// is unique in practice. If multiple projects share the same repo, only one
+// arbitrary match is updated. At pilot scale (3-4 partners) this is acceptable;
+// revisit if multi-project-per-repo is needed.
+const transitionOnPRMergeSQL = `UPDATE error_groups eg
+	 SET status = 'merged', merged_at = now(), updated_at = now()
+	 FROM projects p
+	 WHERE eg.project_id = p.id
+	   AND p.github_repo = $1
+	   AND eg.pr_number = $2
+	   AND eg.status = 'pr_created'
+	 RETURNING eg.id, eg.project_id`
+
+const transitionOnPRCloseSQL = `UPDATE error_groups eg
+	 SET status = 'investigated', pr_url = NULL, pr_number = NULL, updated_at = now()
+	 FROM projects p
+	 WHERE eg.project_id = p.id
+	   AND p.github_repo = $1
+	   AND eg.pr_number = $2
+	   AND eg.status = 'pr_created'
+	 RETURNING eg.id, eg.project_id`
+
+const insertPROutcomeSQL = `INSERT INTO pr_outcomes
+	    (error_group_id, project_id, pr_number, outcome, github_delivery_id, occurred_at)
+	 VALUES ($1, $2, $3, $4, $5, now())
+	 ON CONFLICT (github_delivery_id) DO NOTHING`
+
 // TransitionOnPRMerge transitions an error group from pr_created to merged.
-// Matches by github_repo (owner/repo) + pr_number. Returns the group ID or empty string if no match.
-// Assumption: github_repo + pr_number + status='pr_created' is unique in practice.
-// If multiple projects share the same repo, only one arbitrary match is updated.
-// At pilot scale (3-4 partners) this is acceptable; revisit if multi-project-per-repo is needed.
-func (q *Queries) TransitionOnPRMerge(ctx context.Context, githubRepo string, prNumber int) (string, error) {
-	var groupID string
-	err := q.pool.QueryRow(ctx,
-		`UPDATE error_groups eg
-		 SET status = 'merged', merged_at = now(), updated_at = now()
-		 FROM projects p
-		 WHERE eg.project_id = p.id
-		   AND p.github_repo = $1
-		   AND eg.pr_number = $2
-		   AND eg.status = 'pr_created'
-		 RETURNING eg.id`,
-		githubRepo, prNumber,
-	).Scan(&groupID)
-	if err == pgx.ErrNoRows {
-		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("transition on PR merge: %w", err)
-	}
-	return groupID, nil
+// Matches by github_repo (owner/repo) + pr_number. Returns the changed group and
+// project IDs, or a zero-value PRTransition if no incident matches.
+func (q *Queries) TransitionOnPRMerge(ctx context.Context, githubRepo string, prNumber int) (PRTransition, error) {
+	return scanPRTransition(q.pool.QueryRow(ctx, transitionOnPRMergeSQL, githubRepo, prNumber), "merge")
 }
 
 // TransitionOnPRClose transitions an error group from pr_created back to investigated
 // when a PR is closed without merging. Clears PR fields.
-func (q *Queries) TransitionOnPRClose(ctx context.Context, githubRepo string, prNumber int) (string, error) {
-	var groupID string
-	err := q.pool.QueryRow(ctx,
-		`UPDATE error_groups eg
-		 SET status = 'investigated', pr_url = NULL, pr_number = NULL, updated_at = now()
-		 FROM projects p
-		 WHERE eg.project_id = p.id
-		   AND p.github_repo = $1
-		   AND eg.pr_number = $2
-		   AND eg.status = 'pr_created'
-		 RETURNING eg.id`,
-		githubRepo, prNumber,
-	).Scan(&groupID)
+func (q *Queries) TransitionOnPRClose(ctx context.Context, githubRepo string, prNumber int) (PRTransition, error) {
+	return scanPRTransition(q.pool.QueryRow(ctx, transitionOnPRCloseSQL, githubRepo, prNumber), "close")
+}
+
+func scanPRTransition(row pgx.Row, action string) (PRTransition, error) {
+	var result PRTransition
+	err := row.Scan(&result.ErrorGroupID, &result.ProjectID)
 	if err == pgx.ErrNoRows {
-		return "", nil
+		return PRTransition{}, nil
 	}
 	if err != nil {
-		return "", fmt.Errorf("transition on PR close: %w", err)
+		return PRTransition{}, fmt.Errorf("transition on PR %s: %w", action, err)
 	}
-	return groupID, nil
+	return result, nil
+}
+
+// RecordPRLifecycleEvent transitions the matching pr_created incident and inserts
+// its immutable pr_outcomes receipt in ONE transaction. outcome must be "merged"
+// or "closed". Atomicity matters: if the receipt insert fails, the transition
+// rolls back too, so a webhook redelivery can repair the partial failure instead
+// of hitting no_match with the receipt permanently lost (004_friction.sql
+// documents the receipts log as loss-free under redelivery). The delivery ID is
+// the receipt idempotency key for duplicate deliveries.
+func (q *Queries) RecordPRLifecycleEvent(ctx context.Context, githubRepo string, prNumber int, outcome, githubDeliveryID string) (PRTransition, error) {
+	var transitionSQL string
+	switch outcome {
+	case "merged":
+		transitionSQL = transitionOnPRMergeSQL
+	case "closed":
+		transitionSQL = transitionOnPRCloseSQL
+	default:
+		return PRTransition{}, fmt.Errorf("record PR lifecycle event: unknown outcome %q", outcome)
+	}
+
+	tx, err := q.pool.Begin(ctx)
+	if err != nil {
+		return PRTransition{}, fmt.Errorf("begin PR lifecycle tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	result, err := scanPRTransition(tx.QueryRow(ctx, transitionSQL, githubRepo, prNumber), outcome)
+	if err != nil {
+		return PRTransition{}, err
+	}
+	if result.ErrorGroupID == "" {
+		return PRTransition{}, nil
+	}
+
+	if _, err := tx.Exec(ctx, insertPROutcomeSQL,
+		result.ErrorGroupID, result.ProjectID, prNumber, outcome, githubDeliveryID,
+	); err != nil {
+		return PRTransition{}, fmt.Errorf("insert PR outcome receipt: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return PRTransition{}, fmt.Errorf("commit PR lifecycle tx: %w", err)
+	}
+	return result, nil
 }
 
 // ResolveErrorGroup manually transitions an error group to resolved.

--- a/packages/ingestion/db/queries_test.go
+++ b/packages/ingestion/db/queries_test.go
@@ -199,28 +199,28 @@ func TestTransitionOnPRMergeAndClose(t *testing.T) {
 	}
 
 	// Wrong repo/PR: no transition, no error.
-	if id, err := q.TransitionOnPRMerge(ctx, "org/other-repo", 7); err != nil || id != "" {
-		t.Fatalf("TransitionOnPRMerge(wrong repo) = (%q, %v), want empty", id, err)
+	if result, err := q.TransitionOnPRMerge(ctx, "org/other-repo", 7); err != nil || result != (db.PRTransition{}) {
+		t.Fatalf("TransitionOnPRMerge(wrong repo) = (%+v, %v), want empty", result, err)
 	}
-	if id, err := q.TransitionOnPRMerge(ctx, "org/pr-lifecycle", 999); err != nil || id != "" {
-		t.Fatalf("TransitionOnPRMerge(wrong PR) = (%q, %v), want empty", id, err)
+	if result, err := q.TransitionOnPRMerge(ctx, "org/pr-lifecycle", 999); err != nil || result != (db.PRTransition{}) {
+		t.Fatalf("TransitionOnPRMerge(wrong PR) = (%+v, %v), want empty", result, err)
 	}
 
 	// Matching merge transitions to merged.
-	id, err := q.TransitionOnPRMerge(ctx, "org/pr-lifecycle", 7)
+	result, err := q.TransitionOnPRMerge(ctx, "org/pr-lifecycle", 7)
 	if err != nil {
 		t.Fatalf("TransitionOnPRMerge: %v", err)
 	}
-	if id != groupID {
-		t.Fatalf("TransitionOnPRMerge returned %q, want %q", id, groupID)
+	if result != (db.PRTransition{ErrorGroupID: groupID, ProjectID: projID}) {
+		t.Fatalf("TransitionOnPRMerge returned %+v, want group %q and project %q", result, groupID, projID)
 	}
 	if got := groupStatus(t, pool, groupID); got != "merged" {
 		t.Fatalf("group status = %q, want merged", got)
 	}
 
 	// A merged group is terminal for the PR lifecycle: close is a no-op.
-	if id, err := q.TransitionOnPRClose(ctx, "org/pr-lifecycle", 7); err != nil || id != "" {
-		t.Fatalf("TransitionOnPRClose after merge = (%q, %v), want empty", id, err)
+	if result, err := q.TransitionOnPRClose(ctx, "org/pr-lifecycle", 7); err != nil || result != (db.PRTransition{}) {
+		t.Fatalf("TransitionOnPRClose after merge = (%+v, %v), want empty", result, err)
 	}
 }
 
@@ -242,12 +242,12 @@ func TestTransitionOnPRClose_RevertsToInvestigated(t *testing.T) {
 		t.Fatalf("set pr_number: %v", err)
 	}
 
-	id, err := q.TransitionOnPRClose(ctx, "org/pr-close", 3)
+	result, err := q.TransitionOnPRClose(ctx, "org/pr-close", 3)
 	if err != nil {
 		t.Fatalf("TransitionOnPRClose: %v", err)
 	}
-	if id != groupID {
-		t.Fatalf("TransitionOnPRClose returned %q, want %q", id, groupID)
+	if result != (db.PRTransition{ErrorGroupID: groupID, ProjectID: projID}) {
+		t.Fatalf("TransitionOnPRClose returned %+v, want group %q and project %q", result, groupID, projID)
 	}
 	if got := groupStatus(t, pool, groupID); got != "investigated" {
 		t.Fatalf("group status = %q, want investigated", got)

--- a/packages/ingestion/handler/admin.go
+++ b/packages/ingestion/handler/admin.go
@@ -1,0 +1,95 @@
+package handler
+
+import (
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strconv"
+)
+
+var adminJobStatuses = map[string]struct{}{
+	"pending": {}, "claimed": {}, "completed": {}, "failed": {}, "dead_letter": {},
+}
+
+var adminJobTypes = map[string]struct{}{
+	"investigate": {}, "fix": {}, "error_fix": {}, "setup_pr": {}, "session_analysis": {},
+}
+
+var secretRedactors = []struct {
+	re          *regexp.Regexp
+	replacement string
+}{
+	{regexp.MustCompile(`github_pat_[A-Za-z0-9_]+`), "[REDACTED]"},
+	{regexp.MustCompile(`gh[opsur]_[A-Za-z0-9]+`), "[REDACTED]"},
+	{regexp.MustCompile(`npm_[A-Za-z0-9]+`), "[REDACTED]"},
+	{regexp.MustCompile(`xox[a-z]-[A-Za-z0-9-]+`), "[REDACTED]"},
+	{regexp.MustCompile(`AKIA[0-9A-Z]{16}`), "[REDACTED]"},
+	// \b keeps hyphenated words like "disk-space" intact while still catching keys.
+	{regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{6,}`), "[REDACTED]"},
+	{regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`), "[REDACTED]"},
+	{regexp.MustCompile(`(?i)Bearer\s+[^\s]+`), "Bearer [REDACTED]"},
+	{regexp.MustCompile(`(?i)\b(password|passwd|secret|token|api[_-]?key)(\s*[=:]\s*)\S+`), "${1}${2}[REDACTED]"},
+	{regexp.MustCompile(`([A-Za-z][A-Za-z0-9+.-]*://)[^/@\s]+@`), "${1}[REDACTED]@"},
+}
+
+func redactAdminError(value string) string {
+	for _, redactor := range secretRedactors {
+		value = redactor.re.ReplaceAllString(value, redactor.replacement)
+	}
+	runes := []rune(value)
+	if len(runes) > 300 {
+		return string(runes[:300]) + "…"
+	}
+	return value
+}
+
+func (d *Dependencies) AdminOverview(w http.ResponseWriter, r *http.Request) {
+	overview, err := d.Queries.AdminOverviewData(r.Context())
+	if err != nil {
+		slog.Error("admin: overview query failed", "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to load admin overview")
+		return
+	}
+	writeJSON(w, http.StatusOK, overview)
+}
+
+func (d *Dependencies) AdminJobs(w http.ResponseWriter, r *http.Request) {
+	limit := 50
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 {
+			writeJSONError(w, http.StatusBadRequest, "limit must be a positive integer")
+			return
+		}
+		limit = min(parsed, 200)
+	}
+
+	status := r.URL.Query().Get("status")
+	if status != "" {
+		if _, ok := adminJobStatuses[status]; !ok {
+			writeJSONError(w, http.StatusBadRequest, "invalid status")
+			return
+		}
+	}
+	jobType := r.URL.Query().Get("job_type")
+	if jobType != "" {
+		if _, ok := adminJobTypes[jobType]; !ok {
+			writeJSONError(w, http.StatusBadRequest, "invalid job_type")
+			return
+		}
+	}
+
+	jobs, err := d.Queries.AdminRecentJobs(r.Context(), limit, status, jobType)
+	if err != nil {
+		slog.Error("admin: recent jobs query failed", "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to load admin jobs")
+		return
+	}
+	for i := range jobs {
+		if jobs[i].LastError != nil {
+			redacted := redactAdminError(*jobs[i].LastError)
+			jobs[i].LastError = &redacted
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"jobs": jobs})
+}

--- a/packages/ingestion/handler/admin_integration_test.go
+++ b/packages/ingestion/handler/admin_integration_test.go
@@ -1,0 +1,74 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opslane/opslane/packages/ingestion/auth"
+	"github.com/opslane/opslane/packages/ingestion/db"
+	"github.com/opslane/opslane/packages/ingestion/handler"
+)
+
+func TestAdminRoutesFailClosedAndAuthMeSignalsAllowlist(t *testing.T) {
+	_, q, pool := authTestRouter(t)
+	ctx := context.Background()
+	uniq := fmt.Sprint(time.Now().UnixNano())
+	org, err := q.CreateOrg(ctx, "admin-auth-"+uniq)
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	user, err := q.CreateUserGitHub(ctx, org.ID, "admin+"+uniq+"@example.com", "Admin", time.Now().UnixNano(), "admin-"+uniq, "")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, user.ID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM orgs WHERE id = $1`, org.ID)
+	})
+
+	token, err := auth.SignAccessToken([]byte(authTestJWTSecret), user.ID, org.ID, user.Email)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	authz := map[string]string{"Authorization": "Bearer " + token}
+
+	adminDeps := &handler.Dependencies{
+		Queries:     db.New(pool),
+		JWTSecret:   []byte(authTestJWTSecret),
+		AdminEmails: handler.ParseAdminEmails(strings.ToUpper(user.Email)),
+	}
+	adminRouter := handler.NewRouter(adminDeps)
+	if w := doRequest(adminRouter, http.MethodGet, "/api/v1/admin/overview", authz); w.Code != http.StatusOK {
+		t.Fatalf("admin overview = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	me := doRequest(adminRouter, http.MethodGet, "/api/v1/auth/me", authz)
+	if me.Code != http.StatusOK {
+		t.Fatalf("auth me = %d, want 200: %s", me.Code, me.Body.String())
+	}
+	var meBody map[string]any
+	if err := json.Unmarshal(me.Body.Bytes(), &meBody); err != nil {
+		t.Fatalf("decode auth me: %v", err)
+	}
+	if meBody["is_admin"] != true {
+		t.Fatalf("auth me is_admin = %v, want true", meBody["is_admin"])
+	}
+
+	nonAdminDeps := &handler.Dependencies{
+		Queries:     db.New(pool),
+		JWTSecret:   []byte(authTestJWTSecret),
+		AdminEmails: handler.ParseAdminEmails("someone-else@example.com"),
+	}
+	if w := doRequest(handler.NewRouter(nonAdminDeps), http.MethodGet, "/api/v1/admin/overview", authz); w.Code != http.StatusNotFound {
+		t.Fatalf("non-admin overview = %d, want 404: %s", w.Code, w.Body.String())
+	}
+
+	disabledDeps := &handler.Dependencies{Queries: db.New(pool), JWTSecret: []byte(authTestJWTSecret)}
+	if w := doRequest(handler.NewRouter(disabledDeps), http.MethodGet, "/api/v1/admin/jobs", authz); w.Code != http.StatusNotFound {
+		t.Fatalf("disabled admin jobs = %d, want 404: %s", w.Code, w.Body.String())
+	}
+}

--- a/packages/ingestion/handler/admin_test.go
+++ b/packages/ingestion/handler/admin_test.go
@@ -1,0 +1,77 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseAdminEmails(t *testing.T) {
+	emails := ParseAdminEmails(" Admin@Example.com, operator@example.com, ,ADMIN@example.com ")
+	if len(emails) != 2 {
+		t.Fatalf("got %d emails, want 2", len(emails))
+	}
+	for _, email := range []string{"admin@example.com", "operator@example.com"} {
+		if _, ok := emails[email]; !ok {
+			t.Errorf("missing normalized email %q", email)
+		}
+	}
+}
+
+func TestAdminJobsRejectsInvalidFiltersBeforeQuerying(t *testing.T) {
+	deps := &Dependencies{}
+	for _, path := range []string{
+		"/api/v1/admin/jobs?limit=zero",
+		"/api/v1/admin/jobs?limit=0",
+		"/api/v1/admin/jobs?status=unknown",
+		"/api/v1/admin/jobs?job_type=unknown",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		deps.AdminJobs(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("GET %s = %d, want 400", path, w.Code)
+		}
+	}
+}
+
+func TestRedactAdminError(t *testing.T) {
+	raw := "ghp_abcdefghijklmnopqrstuvwxyz github_pat_abc_DEF123 sk-secret Bearer top-secret https://user:pass@example.com/path"
+	got := redactAdminError(raw)
+	for _, secret := range []string{"ghp_", "github_pat_", "sk-secret", "top-secret", "user:pass"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("redacted error still contains %q: %s", secret, got)
+		}
+	}
+	if !strings.Contains(got, "https://[REDACTED]@example.com/path") {
+		t.Errorf("URL userinfo was not redacted correctly: %s", got)
+	}
+}
+
+func TestRedactAdminErrorCoversCommonCredentialShapes(t *testing.T) {
+	raw := "gho_16C7e42F292c6912E7710c838347Ae178B4a " +
+		"npm_AbCdEf1234567890 xoxb-1234-5678-abcdef " +
+		"AKIAIOSFODNN7EXAMPLE eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.dGVzdHNpZw " +
+		"password=hunter2 api_key: abc123"
+	got := redactAdminError(raw)
+	for _, secret := range []string{"gho_16C", "npm_AbC", "xoxb-1234", "AKIAIOSFODNN7EXAMPLE", "eyJhbGciOiJIUzI1NiJ9", "hunter2", "abc123"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("redacted error still contains %q: %s", secret, got)
+		}
+	}
+}
+
+func TestRedactAdminErrorPreservesBenignText(t *testing.T) {
+	in := "disk-space exhausted while writing task-output to /var/tmp"
+	if got := redactAdminError(in); got != in {
+		t.Errorf("benign text was mangled: %q", got)
+	}
+}
+
+func TestRedactAdminErrorTruncatesRunesAfterRedaction(t *testing.T) {
+	got := redactAdminError(strings.Repeat("界", 301))
+	if len([]rune(got)) != 301 || !strings.HasSuffix(got, "…") {
+		t.Fatalf("got %d runes and suffix %q", len([]rune(got)), got[len(got)-3:])
+	}
+}

--- a/packages/ingestion/handler/auth.go
+++ b/packages/ingestion/handler/auth.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -67,6 +68,52 @@ type Dependencies struct {
 	GitHubAppPrivateKey   []byte // PEM-encoded RSA private key
 	GitHubAppSlug         string
 	DashboardOrigin       string // e.g. "http://localhost:3000"
+	AdminEmails           map[string]struct{}
+}
+
+// ParseAdminEmails normalizes the comma-separated ADMIN_EMAILS allowlist.
+// An empty result disables all admin-only routes.
+func ParseAdminEmails(value string) map[string]struct{} {
+	emails := make(map[string]struct{})
+	for _, email := range strings.Split(value, ",") {
+		email = strings.ToLower(strings.TrimSpace(email))
+		if email != "" {
+			emails[email] = struct{}{}
+		}
+	}
+	return emails
+}
+
+func (d *Dependencies) isAdminEmail(email string) bool {
+	if len(d.AdminEmails) == 0 {
+		return false
+	}
+	_, ok := d.AdminEmails[strings.ToLower(strings.TrimSpace(email))]
+	return ok
+}
+
+// RequireAdmin hides the cross-tenant operator surface from normal users.
+// It must run after AuthenticateSession so ctxUserID is trustworthy.
+// A DB failure is a 500, not a 404: the client treats 404 as "not an admin"
+// and would silently evict a real operator on a transient database blip.
+func (d *Dependencies) RequireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(d.AdminEmails) == 0 {
+			writeJSONError(w, http.StatusNotFound, "not found")
+			return
+		}
+		user, err := d.Queries.GetUserByID(r.Context(), UserIDFromCtx(r.Context()))
+		if err != nil {
+			slog.Error("admin: load user for allowlist check failed", "error", err)
+			writeJSONError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		if user == nil || !d.isAdminEmail(user.Email) {
+			writeJSONError(w, http.StatusNotFound, "not found")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // AuthenticateSDK resolves environment API key -> environment -> project -> org.

--- a/packages/ingestion/handler/auth_handlers.go
+++ b/packages/ingestion/handler/auth_handlers.go
@@ -154,10 +154,11 @@ type tokenResponse struct {
 }
 
 type userJSON struct {
-	ID    string `json:"id"`
-	OrgID string `json:"org_id"`
-	Email string `json:"email"`
-	Name  string `json:"name"`
+	ID      string `json:"id"`
+	OrgID   string `json:"org_id"`
+	Email   string `json:"email"`
+	Name    string `json:"name"`
+	IsAdmin bool   `json:"is_admin"`
 }
 
 // issueTokenPair creates a JWT + refresh token and stores the refresh token hash.
@@ -186,10 +187,11 @@ func (d *Dependencies) issueTokenPair(w http.ResponseWriter, r *http.Request, us
 		RefreshToken: rawRefresh,
 		ExpiresIn:    int(auth.DefaultAccessTokenTTL.Seconds()),
 		User: userJSON{
-			ID:    userID,
-			OrgID: orgID,
-			Email: email,
-			Name:  name,
+			ID:      userID,
+			OrgID:   orgID,
+			Email:   email,
+			Name:    name,
+			IsAdmin: d.isAdminEmail(email),
 		},
 	})
 }
@@ -219,10 +221,11 @@ func (d *Dependencies) issueTokenPairCookie(w http.ResponseWriter, r *http.Reque
 	json.NewEncoder(w).Encode(map[string]any{
 		"expires_in": int(auth.DefaultAccessTokenTTL.Seconds()),
 		"user": userJSON{
-			ID:    userID,
-			OrgID: orgID,
-			Email: email,
-			Name:  name,
+			ID:      userID,
+			OrgID:   orgID,
+			Email:   email,
+			Name:    name,
+			IsAdmin: d.isAdminEmail(email),
 		},
 	})
 }
@@ -309,10 +312,11 @@ func (d *Dependencies) AuthMe(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(userJSON{
-		ID:    user.ID,
-		OrgID: user.OrgID,
-		Email: user.Email,
-		Name:  user.Name,
+		ID:      user.ID,
+		OrgID:   user.OrgID,
+		Email:   user.Email,
+		Name:    user.Name,
+		IsAdmin: d.isAdminEmail(user.Email),
 	})
 }
 

--- a/packages/ingestion/handler/routes.go
+++ b/packages/ingestion/handler/routes.go
@@ -85,6 +85,10 @@ func NewRouterWithPool(deps *Dependencies, pool *pgxpool.Pool) *chi.Mux {
 		r.With(deps.AuthenticateSession).Get("/auth/verify", deps.AuthVerify)
 		r.With(deps.AuthenticateSession).Post("/auth/logout", deps.Logout)
 
+		// Cross-tenant operator observability. RequireAdmin deliberately returns 404.
+		r.With(deps.AuthenticateSession, deps.RequireAdmin).Get("/admin/overview", deps.AdminOverview)
+		r.With(deps.AuthenticateSession, deps.RequireAdmin).Get("/admin/jobs", deps.AdminJobs)
+
 		// Onboarding
 		r.With(deps.AuthenticateSession).Post("/onboarding/setup", deps.OnboardingSetup)
 

--- a/packages/ingestion/handler/webhook.go
+++ b/packages/ingestion/handler/webhook.go
@@ -71,36 +71,32 @@ func (d *Dependencies) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 
 	repo := event.Repository.FullName
 	prNumber := event.PullRequest.Number
-
-	if event.PullRequest.Merged {
-		groupID, err := d.Queries.TransitionOnPRMerge(r.Context(), repo, prNumber)
-		if err != nil {
-			slog.Error("webhook: transition on PR merge failed", "repo", repo, "pr", prNumber, "error", err)
-			writeJSONError(w, http.StatusInternalServerError, "failed to process merge event")
-			return
-		}
-		status := "processed"
-		if groupID == "" {
-			status = "no_match"
-		}
-		slog.Info("webhook: PR merged", "repo", repo, "pr", prNumber, "group_id", groupID, "status", status)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": status, "action": "merged", "group_id": groupID})
-	} else {
-		groupID, err := d.Queries.TransitionOnPRClose(r.Context(), repo, prNumber)
-		if err != nil {
-			slog.Error("webhook: transition on PR close failed", "repo", repo, "pr", prNumber, "error", err)
-			writeJSONError(w, http.StatusInternalServerError, "failed to process close event")
-			return
-		}
-		status := "processed"
-		if groupID == "" {
-			status = "no_match"
-		}
-		slog.Info("webhook: PR closed without merge", "repo", repo, "pr", prNumber, "group_id", groupID, "status", status)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": status, "action": "closed", "group_id": groupID})
+	deliveryID := strings.TrimSpace(r.Header.Get("X-GitHub-Delivery"))
+	if deliveryID == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing X-GitHub-Delivery header")
+		return
 	}
+
+	outcome := "closed"
+	if event.PullRequest.Merged {
+		outcome = "merged"
+	}
+
+	// Transition + receipt insert are one transaction: a partial failure rolls
+	// both back so a redelivery can complete them together.
+	transition, err := d.Queries.RecordPRLifecycleEvent(r.Context(), repo, prNumber, outcome, deliveryID)
+	if err != nil {
+		slog.Error("webhook: record PR lifecycle event failed", "repo", repo, "pr", prNumber, "outcome", outcome, "delivery_id", deliveryID, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to process "+outcome+" event")
+		return
+	}
+	status := "processed"
+	if transition.ErrorGroupID == "" {
+		status = "no_match"
+	}
+	slog.Info("webhook: PR "+outcome, "repo", repo, "pr", prNumber, "group_id", transition.ErrorGroupID, "status", status)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": status, "action": outcome, "group_id": transition.ErrorGroupID})
 }
 
 // verifyWebhookSignature validates the X-Hub-Signature-256 header.

--- a/packages/ingestion/handler/webhook_test.go
+++ b/packages/ingestion/handler/webhook_test.go
@@ -1,11 +1,24 @@
 package handler
 
 import (
+	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/opslane/opslane/packages/ingestion/db"
 )
+
+const webhookTestDSN = "postgres://opslane:opslane_dev@localhost:5434/opslane?sslmode=disable"
 
 func TestVerifyWebhookSignature_Valid(t *testing.T) {
 	secret := "test-secret"
@@ -49,5 +62,208 @@ func TestVerifyWebhookSignature_WrongSecret(t *testing.T) {
 
 	if verifyWebhookSignature(payload, "wrong-secret", sig) {
 		t.Error("expected wrong secret to fail verification")
+	}
+}
+
+func TestHandleWebhook_MissingDeliveryHeaderRejected(t *testing.T) {
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "receipt-test-secret")
+	deps := &Dependencies{}
+	body := []byte(`{"action":"closed","pull_request":{"number":1,"merged":true},"repository":{"full_name":"org/x"}}`)
+	mac := hmac.New(sha256.New, []byte("receipt-test-secret"))
+	_, _ = mac.Write(body)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/github/webhook", bytes.NewReader(body))
+	request.Header.Set("X-Hub-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	request.Header.Set("X-GitHub-Event", "pull_request")
+	response := httptest.NewRecorder()
+	deps.HandleWebhook(response, request)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body: %s)", response.Code, response.Body.String())
+	}
+}
+
+func TestHandleWebhook_PROutcomeReceipts(t *testing.T) {
+	pool := webhookTestPool(t)
+	queries := db.New(pool)
+	repo, projectID, groupID := seedWebhookPR(t, pool, queries)
+	deps := &Dependencies{Queries: queries}
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "receipt-test-secret")
+
+	mergedBody := []byte(fmt.Sprintf(
+		`{"action":"closed","pull_request":{"number":42,"merged":true},"repository":{"full_name":%q}}`,
+		repo,
+	))
+	mergeDeliveryID := "delivery-" + uuid.NewString()
+
+	t.Run("merge inserts receipt", func(t *testing.T) {
+		response := sendSignedWebhook(t, deps, mergedBody, mergeDeliveryID)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+		}
+		assertWebhookStatus(t, response, "processed")
+
+		var gotGroupID, gotProjectID, outcome, deliveryID string
+		var prNumber int
+		var occurredAtNonNull bool
+		err := pool.QueryRow(context.Background(),
+			`SELECT error_group_id, project_id, pr_number, outcome, github_delivery_id,
+			        occurred_at IS NOT NULL
+			 FROM pr_outcomes WHERE github_delivery_id = $1`,
+			mergeDeliveryID,
+		).Scan(&gotGroupID, &gotProjectID, &prNumber, &outcome, &deliveryID, &occurredAtNonNull)
+		if err != nil {
+			t.Fatalf("query PR outcome: %v", err)
+		}
+		if gotGroupID != groupID || gotProjectID != projectID || prNumber != 42 || outcome != "merged" || deliveryID != mergeDeliveryID || !occurredAtNonNull {
+			t.Fatalf("unexpected PR outcome: group=%q project=%q pr=%d outcome=%q delivery=%q occurred_at_non_null=%v",
+				gotGroupID, gotProjectID, prNumber, outcome, deliveryID, occurredAtNonNull)
+		}
+	})
+
+	t.Run("redelivery does not duplicate receipt", func(t *testing.T) {
+		response := sendSignedWebhook(t, deps, mergedBody, mergeDeliveryID)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+		}
+		assertWebhookStatus(t, response, "no_match")
+
+		var count int
+		if err := pool.QueryRow(context.Background(),
+			`SELECT count(*) FROM pr_outcomes WHERE github_delivery_id = $1`,
+			mergeDeliveryID,
+		).Scan(&count); err != nil {
+			t.Fatalf("count PR outcomes: %v", err)
+		}
+		if count != 1 {
+			t.Fatalf("receipt count = %d, want 1", count)
+		}
+	})
+
+	t.Run("no match inserts no receipt", func(t *testing.T) {
+		body := []byte(`{"action":"closed","pull_request":{"number":999,"merged":true},"repository":{"full_name":"org/not-managed"}}`)
+		noMatchDeliveryID := "delivery-" + uuid.NewString()
+		response := sendSignedWebhook(t, deps, body, noMatchDeliveryID)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+		}
+		assertWebhookStatus(t, response, "no_match")
+
+		var count int
+		if err := pool.QueryRow(context.Background(),
+			`SELECT count(*) FROM pr_outcomes WHERE github_delivery_id = $1`,
+			noMatchDeliveryID,
+		).Scan(&count); err != nil {
+			t.Fatalf("count PR outcomes: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("receipt count = %d, want 0", count)
+		}
+	})
+}
+
+func webhookTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = webhookTestDSN
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Skipf("skipping webhook DB test: cannot connect to postgres: %v", err)
+	}
+	if err := pool.Ping(context.Background()); err != nil {
+		pool.Close()
+		t.Skipf("skipping webhook DB test: postgres not reachable: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func seedWebhookPR(t *testing.T, pool *pgxpool.Pool, queries *db.Queries) (repo, projectID, groupID string) {
+	t.Helper()
+	ctx := context.Background()
+	suffix := uuid.NewString()
+	org, err := queries.CreateOrg(ctx, "webhook-receipt-"+suffix)
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	t.Cleanup(func() {
+		statements := []string{
+			`DELETE FROM pr_outcomes WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+			`DELETE FROM error_group_jobs WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+			`DELETE FROM error_events WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+			`DELETE FROM error_groups WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+			`DELETE FROM environment_api_keys WHERE environment_id IN (SELECT e.id FROM environments e JOIN projects p ON e.project_id = p.id WHERE p.org_id = $1)`,
+			`DELETE FROM environments WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+			`DELETE FROM projects WHERE org_id = $1`,
+			`DELETE FROM orgs WHERE id = $1`,
+		}
+		for _, statement := range statements {
+			if _, err := pool.Exec(context.Background(), statement, org.ID); err != nil {
+				t.Logf("cleanup warning: %v", err)
+			}
+		}
+	})
+
+	repo = "org/webhook-" + suffix
+	project, err := queries.CreateProject(ctx, org.ID, "webhook-project", &repo)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	environment, err := queries.CreateEnvironment(ctx, project.ID, "production")
+	if err != nil {
+		t.Fatalf("create environment: %v", err)
+	}
+	result, err := queries.InsertErrorEventAndGroup(ctx, db.IngestParams{
+		ProjectID:     project.ID,
+		EnvironmentID: environment.ID,
+		ErrorType:     "TypeError",
+		ErrorMessage:  "webhook receipt test",
+		StackTraceRaw: "at app.js:1:1",
+		Fingerprint:   "webhook-" + suffix,
+		Title:         "Webhook receipt test",
+	})
+	if err != nil {
+		t.Fatalf("insert error event and group: %v", err)
+	}
+	prURL := "https://github.com/" + repo + "/pull/42"
+	if err := queries.UpdateErrorGroupStatus(ctx, db.StatusUpdate{
+		ProjectID: project.ID,
+		GroupID:   result.GroupID,
+		Status:    "pr_created",
+		PrURL:     &prURL,
+	}); err != nil {
+		t.Fatalf("mark group pr_created: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE error_groups SET pr_number = 42 WHERE id = $1`, result.GroupID); err != nil {
+		t.Fatalf("set PR number: %v", err)
+	}
+	return repo, project.ID, result.GroupID
+}
+
+func sendSignedWebhook(t *testing.T, deps *Dependencies, body []byte, deliveryID string) *httptest.ResponseRecorder {
+	t.Helper()
+	mac := hmac.New(sha256.New, []byte("receipt-test-secret"))
+	_, _ = mac.Write(body)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/github/webhook", bytes.NewReader(body))
+	request.Header.Set("X-Hub-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	request.Header.Set("X-GitHub-Event", "pull_request")
+	request.Header.Set("X-GitHub-Delivery", deliveryID)
+	response := httptest.NewRecorder()
+	deps.HandleWebhook(response, request)
+	return response
+}
+
+func assertWebhookStatus(t *testing.T, response *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	var body struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Status != want {
+		t.Fatalf("response status = %q, want %q (body: %s)", body.Status, want, response.Body.String())
 	}
 }

--- a/packages/ingestion/main.go
+++ b/packages/ingestion/main.go
@@ -96,6 +96,7 @@ func main() {
 		GitHubAppPrivateKey:   githubAppPrivateKey,
 		GitHubAppSlug:         githubAppSlug,
 		DashboardOrigin:       dashboardOrigin,
+		AdminEmails:           handler.ParseAdminEmails(os.Getenv("ADMIN_EMAILS")),
 	}
 	r := handler.NewRouterWithPool(deps, pool)
 

--- a/packages/worker/src/__tests__/db-queries.test.ts
+++ b/packages/worker/src/__tests__/db-queries.test.ts
@@ -22,7 +22,60 @@ import {
   getSessionForAnalysis,
   setSessionAnalysisStatus,
   claimJob,
+  updateGroupStatus,
+  updateGroupInvestigation,
 } from '../db.js';
+
+describe('group lifecycle timestamp queries', () => {
+  beforeEach(() => mockQuery.mockReset());
+
+  it('stamps PR-created and needs-human transitions without clearing prior timestamps', async () => {
+    mockQuery.mockResolvedValue({ rowCount: 1, rows: [{ id: 'g1' }] });
+
+    await updateGroupStatus('g1', 'p1', 'pr_created');
+    await updateGroupStatus('g1', 'p1', 'needs_human', {
+      reason: {
+        reason_code: 'missing_llm_key',
+        reason_message: 'API key not configured',
+        remediation: 'Configure the worker API key',
+      },
+    });
+
+    for (const call of mockQuery.mock.calls) {
+      const query = String(call[0]);
+      expect(query).toContain("WHEN $3::error_group_status = 'pr_created'");
+      expect(query).toContain("AND status IS DISTINCT FROM 'pr_created' THEN now()");
+      expect(query).toContain('ELSE pr_created_at');
+      expect(query).toContain("WHEN $3::error_group_status = 'needs_human'");
+      expect(query).toContain("AND status IS DISTINCT FROM 'needs_human' THEN now()");
+      expect(query).toContain('ELSE needs_human_at');
+    }
+    expect(mockQuery.mock.calls[0]?.[1]?.[2]).toBe('pr_created');
+    expect(mockQuery.mock.calls[1]?.[1]?.[2]).toBe('needs_human');
+  });
+
+  it('stamps needs-human investigation results without clearing lifecycle timestamps', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'g1' }] });
+
+    await updateGroupInvestigation('g1', 'p1', 'needs_human', {
+      rootCause: 'External dependency failed',
+      reason: {
+        reason_code: 'worker_runtime_error',
+        reason_message: 'The investigation could not complete',
+        remediation: 'Review the incident manually',
+      },
+    });
+
+    const query = String(mockQuery.mock.calls[0]?.[0]);
+    expect(query).toContain("WHEN $3::error_group_status = 'pr_created'");
+      expect(query).toContain("AND status IS DISTINCT FROM 'pr_created' THEN now()");
+    expect(query).toContain('ELSE pr_created_at');
+    expect(query).toContain("WHEN $3::error_group_status = 'needs_human'");
+      expect(query).toContain("AND status IS DISTINCT FROM 'needs_human' THEN now()");
+    expect(query).toContain('ELSE needs_human_at');
+    expect(mockQuery.mock.calls[0]?.[1]?.[2]).toBe('needs_human');
+  });
+});
 
 describe('getErrorGroup', () => {
   beforeEach(() => mockQuery.mockReset());

--- a/packages/worker/src/__tests__/db.test.ts
+++ b/packages/worker/src/__tests__/db.test.ts
@@ -135,6 +135,113 @@ describeDb('db.ts integration tests', () => {
     await testPool.query(`DELETE FROM error_groups WHERE project_id = $1`, [testProjectId]);
   });
 
+  describe('group lifecycle timestamps', () => {
+    const reason = {
+      reason_code: 'worker_runtime_error' as const,
+      reason_message: 'The worker could not complete the incident',
+      remediation: 'Review the incident manually',
+    };
+
+    it('stamps PR creation and retains it across later status changes', async () => {
+      const { errorGroupId } = await seedErrorGroupAndJob();
+
+      await updateGroupStatus(errorGroupId, testProjectId, 'pr_created', {
+        pr_url: 'https://github.com/octocat/hello/pull/42',
+        pr_number: 42,
+      });
+      const stamped = await testPool.query<{ pr_created_at: Date | null }>(
+        `SELECT pr_created_at FROM error_groups WHERE id = $1`,
+        [errorGroupId],
+      );
+      expect(stamped.rows[0]?.pr_created_at).toBeInstanceOf(Date);
+
+      await updateGroupStatus(errorGroupId, testProjectId, 'analyzing');
+      const retained = await testPool.query<{ pr_created_at: Date | null }>(
+        `SELECT pr_created_at FROM error_groups WHERE id = $1`,
+        [errorGroupId],
+      );
+      expect(retained.rows[0]?.pr_created_at).toEqual(stamped.rows[0]?.pr_created_at);
+    });
+
+    it('stamps needs-human status updates and retains the timestamp later', async () => {
+      const { errorGroupId } = await seedErrorGroupAndJob();
+
+      await updateGroupStatus(errorGroupId, testProjectId, 'needs_human', { reason });
+      const stamped = await testPool.query<{ needs_human_at: Date | null }>(
+        `SELECT needs_human_at FROM error_groups WHERE id = $1`,
+        [errorGroupId],
+      );
+      expect(stamped.rows[0]?.needs_human_at).toBeInstanceOf(Date);
+
+      await updateGroupStatus(errorGroupId, testProjectId, 'queued');
+      const retained = await testPool.query<{ needs_human_at: Date | null }>(
+        `SELECT needs_human_at FROM error_groups WHERE id = $1`,
+        [errorGroupId],
+      );
+      expect(retained.rows[0]?.needs_human_at).toEqual(stamped.rows[0]?.needs_human_at);
+    });
+
+    it('stamps needs-human investigation results', async () => {
+      const { errorGroupId } = await seedErrorGroupAndJob();
+
+      await updateGroupInvestigation(errorGroupId, testProjectId, 'needs_human', {
+        rootCause: 'External dependency failed',
+        reason,
+      });
+
+      const result = await testPool.query<{
+        status: string;
+        needs_human_at: Date | null;
+      }>(
+        `SELECT status, needs_human_at FROM error_groups WHERE id = $1`,
+        [errorGroupId],
+      );
+      expect(result.rows[0]?.status).toBe('needs_human');
+      expect(result.rows[0]?.needs_human_at).toBeInstanceOf(Date);
+    });
+
+    it('does not move pr_created_at when the same status is written again', async () => {
+      const { errorGroupId } = await seedErrorGroupAndJob();
+
+      await updateGroupStatus(errorGroupId, testProjectId, 'pr_created', {
+        pr_url: 'https://github.com/octocat/hello/pull/43',
+        pr_number: 43,
+      });
+      const first = await testPool.query<{ pr_created_at: Date | null }>(
+        `SELECT pr_created_at FROM error_groups WHERE id = $1`,
+        [errorGroupId],
+      );
+
+      // Retried terminal writes happen under the at-least-once job model; they
+      // must not drag the stamp forward and inflate windowed admin metrics.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await updateGroupStatus(errorGroupId, testProjectId, 'pr_created', {
+        pr_url: 'https://github.com/octocat/hello/pull/43',
+        pr_number: 43,
+      });
+      const second = await testPool.query<{ pr_created_at: Date | null }>(
+        `SELECT pr_created_at FROM error_groups WHERE id = $1`,
+        [errorGroupId],
+      );
+      expect(second.rows[0]?.pr_created_at).toEqual(first.rows[0]?.pr_created_at);
+    });
+
+    it('stamps pr_created_at through investigation updates', async () => {
+      const { errorGroupId } = await seedErrorGroupAndJob();
+
+      await updateGroupInvestigation(errorGroupId, testProjectId, 'pr_created', {
+        rootCause: 'Fix PR opened after investigation',
+      });
+
+      const result = await testPool.query<{ status: string; pr_created_at: Date | null }>(
+        `SELECT status, pr_created_at FROM error_groups WHERE id = $1`,
+        [errorGroupId],
+      );
+      expect(result.rows[0]?.status).toBe('pr_created');
+      expect(result.rows[0]?.pr_created_at).toBeInstanceOf(Date);
+    });
+  });
+
   describe('claimJob', () => {
     it('should claim a pending job and set claimed status', async () => {
       const { jobId } = await seedErrorGroupAndJob();

--- a/packages/worker/src/db.ts
+++ b/packages/worker/src/db.ts
@@ -374,6 +374,16 @@ export async function updateGroupStatus(
          reason_code = $7,
          reason_message = $8,
          remediation = $9,
+         pr_created_at = CASE
+           WHEN $3::error_group_status = 'pr_created'
+                AND status IS DISTINCT FROM 'pr_created' THEN now()
+           ELSE pr_created_at
+         END,
+         needs_human_at = CASE
+           WHEN $3::error_group_status = 'needs_human'
+                AND status IS DISTINCT FROM 'needs_human' THEN now()
+           ELSE needs_human_at
+         END,
          updated_at = now()
      WHERE id = $1 AND project_id = $2
        ${lease ? 'AND EXISTS (SELECT 1 FROM owned)' : ''}
@@ -720,7 +730,7 @@ export async function getSourceMaps(projectId: string, release: string): Promise
 export async function updateGroupInvestigation(
   errorGroupId: string,
   projectId: string,
-  status: 'investigated' | 'fixing' | 'needs_human' | 'insight' | 'awaiting_approval',
+  status: 'investigated' | 'fixing' | 'pr_created' | 'needs_human' | 'insight' | 'awaiting_approval',
   fields: {
     rootCause?: string;
     suggestedMitigation?: string;
@@ -762,6 +772,16 @@ export async function updateGroupInvestigation(
          reason_code = $7,
          reason_message = $8,
          remediation = $9,
+         pr_created_at = CASE
+           WHEN $3::error_group_status = 'pr_created'
+                AND status IS DISTINCT FROM 'pr_created' THEN now()
+           ELSE pr_created_at
+         END,
+         needs_human_at = CASE
+           WHEN $3::error_group_status = 'needs_human'
+                AND status IS DISTINCT FROM 'needs_human' THEN now()
+           ELSE needs_human_at
+         END,
          updated_at = now()
      WHERE id = $1 AND project_id = $2
        ${lease ? 'AND EXISTS (SELECT 1 FROM owned)' : ''}


### PR DESCRIPTION
## What

Cross-tenant, operator-only view answering "is Opslane working?" — events flowing in, jobs completing, PRs going out. Design doc: `docs/plans/2026-07-15-admin-observability-dashboard-design.md`.

- **Migration 006**: `pr_created_at` / `needs_human_at` on `error_groups` + indexes for windowed scans. Lifecycle metrics are exact from deploy forward; legacy rows stay NULL.
- **Worker**: stamps both timestamps on status writes, guarded so retried same-status writes can't inflate windowed tiles.
- **Webhook**: writes immutable `pr_outcomes` receipts atomically with the status transition (`RecordPRLifecycleEvent`), keyed on `X-GitHub-Delivery` for redelivery idempotency.
- **Auth**: `ADMIN_EMAILS` allowlist + `RequireAdmin` middleware. Non-admins get 404 (surface invisible); empty allowlist disables the API (fail closed); DB errors are 500 + logged, not 404. `is_admin` on every `userJSON` emitter.
- **API**: `GET /api/v1/admin/overview` (48 zero-filled UTC hourly buckets, tiles, outcomes) and `GET /api/v1/admin/jobs` (validated filters, 200-row cap, per-state duration semantics, server-side secret redaction on `last_error`).
- **Dashboard**: `/admin` route with tiles, inline-SVG 48h chart, recent-jobs table, health card; 60s polling with request timeouts; nav link gated on `is_admin`; project-selection exemption that survives hard loads (`router.isReady()`).

## Review

Ran `/review` with 10 passes (7 specialists, Claude adversarial, Red Team, Codex — GATE: PASS). 19 findings fixed, including: non-atomic receipt insert (receipt loss on partial failure), `RequireAdmin` masking DB errors as 404, a mount race defeating the zero-project `/admin` exemption, timestamp re-stamping inflating metrics, unanchored redaction regex mangling benign text, and raw `\uXXXX` escapes rendering literally in the UI.

## Verification

- `go build && go vet && go test ./...` — all ingestion packages pass
- Worker: 375 passed / 0 failed on a clean disposable DB (incl. new lifecycle tests)
- Dashboard: build + 44 tests; `docker compose config` clean
- Migration 006 applied to a clean DB and reapplied (idempotent)
- Live smoke on a fresh compose stack: admin overview returns exactly 48 buckets with correct tile counts; a live `POST /api/v1/events` moved `last_1h` 6→7 and its job appeared in the recent-jobs table; `last_error` shows `[REDACTED]` for `ghp_`/`Bearer`/userinfo secrets; non-admin gets raw 404 on both endpoints and `is_admin: false`
- Browser walkthrough (headless, screenshots): admin sees nav link + fully rendered dashboard, zero console errors; non-admin has no link and deep-linking `/admin` redirects home on the 404

Not yet run: `EXPLAIN (ANALYZE, BUFFERS)` index verification against representative data volume.
