### PR TITLE
Batch 5 — The ladder: act on friction (#57)

### DIFF
--- a/docs/plans/2026-07-15-batch-5-the-ladder.md
+++ b/docs/plans/2026-07-15-batch-5-the-ladder.md
@@ -1,0 +1,1267 @@
+# Batch 5 — The Ladder ("act on it") Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship issue #57: insight cards + Generate-fix from `awaiting_approval`, the per-project friction-autonomy ladder, idempotent + attributable PR receipts, honest Suggestion labeling in the PR body, and a conditional lift of the friction auto-fix gate.
+
+**Architecture:** Batch 3 already shipped all the schema (`004_friction.sql`: `pr_outcomes`, `projects.friction_autonomy`, `error_group_jobs.triggered_by`, the `candidate`/`awaiting_approval`/`insight` statuses) and Suggestion PR titles/headings. Batch 5 is wiring: the Go webhook writes receipts *before* state transitions (keyed on GitHub's delivery id), the worker records the fix-job id on the group at PR creation and consults `friction_autonomy` before auto-fixing friction, the ingestion API exposes autonomy settings + a fix-stats aggregation, and the Vue dashboard grows the `awaiting_approval` Generate-fix affordance, the insight card, and the autonomy settings panel with receipts beside it.
+
+**Tech Stack:** Go 1.24 + chi + pgx (`packages/ingestion`), Node 22 + TypeScript + Vitest (`packages/worker`), Vue 3 + Vite (`packages/dashboard`), Postgres migrations in `packages/ingestion/db/migrations/` applied by `scripts/run-migrations.sh`.
+
+**Design source:** `docs/plans/2026-07-13-unified-incidents-replay-friction-design.md` §4 (ladder), §5 (receipts), Batch 5 definition. Issue: #57.
+
+---
+
+## Current state (verified 2026-07-15 — do NOT rebuild these)
+
+| Piece | State | Where |
+|---|---|---|
+| Statuses `candidate`/`awaiting_approval`/`insight` | DONE | `004_friction.sql:10-12`; `candidate` hidden at `packages/ingestion/db/queries.go:541,728` |
+| `pr_outcomes` table (UNIQUE `github_delivery_id`, `fix_job_id`) | DONE (schema only, zero writers) | `004_friction.sql:74-84` |
+| `error_group_jobs.triggered_by` | DONE; `'human'` written by `TriggerFixJob` (`queries.go:803-804`), `'auto'` by `updateGroupAndCreateFixJob` (`packages/worker/src/db.ts:938-941`) | |
+| `projects.friction_autonomy` (`ask_first`/`auto_fix`/`auto_fix_ux`) | DONE (column only; nothing reads or writes it) | `004_friction.sql:96-106` |
+| TriggerFix accepts friction+`awaiting_approval`, error+`investigated` | DONE + tested | `queries.go:772-817`, `friction_test.go:101` |
+| Worker friction investigate → `awaiting_approval`/`insight` | DONE | `packages/worker/src/index.ts:468,478` |
+| Friction auto-fix hard gate | ACTIVE (unconditional) | `packages/worker/src/index.ts:545-549`, test `__tests__/index.test.ts:366` |
+| Suggestion PR title + body heading | DONE + tested | `packages/worker/src/pr.ts:268-270,410-412`; `pr.test.ts:143,252` |
+| Webhook handler | Transitions state, no receipts, no delivery id, `closed` always reverts to `investigated` (wrong for friction) | `packages/ingestion/handler/webhook.go` |
+| Dashboard fix button | `investigated`-only | `IncidentDetail.vue:373` |
+| Batch 4 (#56, auto-created friction incidents) | NOT LANDED | Batch 5 does not require it to implement; the organic dogfood gate does (Task 11 seeds manually) |
+
+Branch: `abhishekray07/session-replay-batch-5` (this worktree). Commit after every task.
+
+---
+
+### Task 1: Migration 007 — `pr_fix_job_id` on `error_groups`
+
+The design (v4-17) requires recording the fix-job id **at PR creation** so a later webhook outcome is attributable. `pr_outcomes.fix_job_id` exists but nothing can populate it — the group row must carry the link between PR creation and the webhook.
+
+**Files:**
+- Create: `packages/ingestion/db/migrations/007_receipts_wiring.sql`
+
+**Step 1: Write the migration**
+
+```sql
+-- 007_receipts_wiring.sql — Batch 5 (epic #31, issue #57): attributable receipts.
+-- Append-only after 001-006. IDEMPOTENCY IS MANDATORY: run-migrations.sh
+-- re-applies every file on every start.
+--
+-- The fix job that produced a PR, recorded at PR creation (design v4-17) so the
+-- merge/close webhook can copy it into pr_outcomes.fix_job_id. NULL for PRs
+-- created before Batch 5 and for setup PRs. Cleared when a PR closes unmerged.
+ALTER TABLE error_groups ADD COLUMN IF NOT EXISTS pr_fix_job_id UUID
+  REFERENCES error_group_jobs(id) ON DELETE SET NULL;
+```
+
+**Step 2: Verify idempotency against a disposable database**
+
+Two traps here: `scripts/run-migrations.sh` defaults `MIGRATION_DIR` to `/app/db/migrations` and **exits 0 when that directory is absent** — so running it bare on the host succeeds without applying anything. And the Compose postgres keeps a retained `pgdata` volume, so it is not disposable. Create a scratch database inside the container and apply every migration there twice, running `psql` inside the container (the host may not have it):
+
+```bash
+docker compose up -d postgres
+docker compose exec -T postgres psql -U opslane -d postgres \
+  -c 'DROP DATABASE IF EXISTS migration_check;' -c 'CREATE DATABASE migration_check;'
+for run in 1 2; do
+  for f in packages/ingestion/db/migrations/*.sql; do
+    echo "run $run: $f"
+    docker compose exec -T postgres psql -U opslane -d migration_check -v ON_ERROR_STOP=1 < "$f" || exit 1
+  done
+done
+docker compose exec -T postgres psql -U opslane -d postgres -c 'DROP DATABASE migration_check;'
+```
+
+Expected: both passes apply all 7 files with no errors (`ON_ERROR_STOP=1` makes any failure exit non-zero). The "representative existing database" check from ingestion `AGENTS.md` happens in Task 11's live smoke, where migrations run against the retained dev DB.
+
+**Step 3: Verify Go still builds and db tests pass**
+
+```bash
+cd packages/ingestion && go build ./... && go test ./db
+```
+
+Expected: PASS (no code references the column yet).
+
+**Step 4: Commit**
+
+```bash
+git add packages/ingestion/db/migrations/007_receipts_wiring.sql
+git commit -m "feat: add pr_fix_job_id column for attributable PR receipts (#57)"
+```
+
+---
+
+### Task 2: Worker records the fix-job id at PR creation
+
+**Files:**
+- Modify: `packages/worker/src/db.ts:380-450` (`updateGroupStatus`)
+- Modify: `packages/worker/src/index.ts:766-770` (fix-job success path)
+- Test: `packages/worker/src/__tests__/index.test.ts`
+- Test (update): `packages/worker/src/__tests__/db-queries.test.ts:300-307` — this test pins `updateGroupStatus`'s parameter array by index (`[1][6]` = reason_code, `[1][7]`, `[1][8]`); the shift below moves those to `[1][7]/[1][8]/[1][9]`. Update the assertions or the suite fails mechanically.
+
+**Step 1: Write the failing test**
+
+In `index.test.ts`, find the `processFixJob` success-path test (the one that mocks `runPipeline` returning `{ status: 'pr_created', ... }`; if none exists, add one next to the `describe` at line 196 using the same `fixJob()`/mock helpers). Assert the new field:
+
+```ts
+it('records the fix job id on the group at PR creation', async () => {
+  // arrange mocks so runPipeline resolves { status: 'pr_created', pr_url, pr_number, confidence }
+  const job = fixJob();
+  await processFixJob(job, new AbortController().signal);
+
+  expect(mockUpdateGroupStatus).toHaveBeenCalledWith(
+    'grp-1', 'proj-1', 'pr_created',
+    expect.objectContaining({ pr_fix_job_id: job.id }),
+    job,
+  );
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @opslane/worker test -- index.test.ts`
+Expected: FAIL — `pr_fix_job_id` not in the call.
+
+**Step 3: Implement**
+
+In `db.ts` `updateGroupStatus`, add to the `fields` type:
+
+```ts
+    pr_fix_job_id?: string;
+```
+
+Rewrite the UPDATE so `pr_fix_job_id` becomes `$7` and everything after shifts by one (reason columns → `$8/$9/$10`, lease params in `ownedCte` → `$11/$12/$13`):
+
+```ts
+     UPDATE error_groups
+     SET status = $3::error_group_status,
+         confidence = $4,
+         pr_url = $5,
+         pr_number = $6,
+         pr_fix_job_id = COALESCE($7, pr_fix_job_id),
+         reason_code = $8,
+         reason_message = $9,
+         remediation = $10,
+         updated_at = now()
+```
+
+(`COALESCE` so the many other `updateGroupStatus` callers that omit the field don't null out an existing link.) Add `fields?.pr_fix_job_id ?? null,` to the params array after `pr_number`, and update the three `ownedCte` placeholders (`$10/$11/$12` → `$11/$12/$13`).
+
+In `index.ts:766`, add the field:
+
+```ts
+      await updateGroupStatus(job.errorGroupId, job.projectId, 'pr_created', {
+        confidence: result.confidence,
+        pr_url: result.pr_url,
+        pr_number: result.pr_number,
+        pr_fix_job_id: job.id,
+      }, job);
+```
+
+(`job.id` for a fix job IS the fix-job id — the lease is the job row.)
+
+**Step 4: Run tests**
+
+Run: `pnpm --filter @opslane/worker test`
+Expected: PASS (all worker tests, not just the new one — the param renumbering can silently break other `updateGroupStatus` paths).
+
+**Step 5: Commit**
+
+```bash
+git add packages/worker/src/db.ts packages/worker/src/index.ts packages/worker/src/__tests__/index.test.ts
+git commit -m "feat: record fix job id on the group at PR creation (#57)"
+```
+
+---
+
+### Task 3: `ProcessPRWebhook` — receipt before transition, idempotent, kind-aware
+
+Replaces `TransitionOnPRMerge`/`TransitionOnPRClose` (`packages/ingestion/db/queries.go:1104-1155`) with one transactional method that (a) writes the `pr_outcomes` receipt **first**, (b) no-ops on a redelivered `github_delivery_id`, (c) sends a closed-unmerged **friction** group back to `awaiting_approval` (not `investigated` — today's close path is wrong for friction), and (d) clears `pr_fix_job_id` on close.
+
+**Files:**
+- Modify: `packages/ingestion/db/queries.go` (delete the two old methods, add `ProcessPRWebhook`)
+- Test: `packages/ingestion/db/queries_test.go` (rewrite `TestTransitionOnPRMergeAndClose` at line 182)
+
+**Step 0: Fix test cleanup first**
+
+`cleanupTenant` (`packages/ingestion/db/testhelper_test.go:40`) deletes `error_group_jobs` and `error_groups` — but `pr_outcomes` has FKs to both, so any receipt-writing test would leave FK-protected rows and poison later runs. Add as the FIRST delete in the list:
+
+```go
+		`DELETE FROM pr_outcomes WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+```
+
+**Step 1: Write the failing tests**
+
+Rewrite/replace `TestTransitionOnPRMergeAndClose` with tests for the new method. Reuse the existing seeding helpers in `queries_test.go`/`friction_test.go` (`createFrictionTestProject`, `insertIncident` — `friction_test.go:12-40`). Set `pr_number`/`status='pr_created'` with a direct `q.Pool().Exec` UPDATE, as `insertIncident` doesn't take PR fields.
+
+```go
+func TestProcessPRWebhook_ReceiptBeforeTransition_Idempotent(t *testing.T) {
+	q, projectID := createFrictionTestProject(t, "pr-webhook-merge")
+	ctx := context.Background()
+	groupID := insertIncident(t, q, projectID, "fp-webhook-1", "error", "pr_created")
+	mustExec(t, q, `UPDATE error_groups SET pr_number = 41, pr_url = 'https://x/41' WHERE id = $1`, groupID)
+
+	res, err := q.ProcessPRWebhook(ctx, "org/repo", 41, true, "delivery-aaa", time.Now())
+	if err != nil || res.GroupID != groupID || res.Duplicate {
+		t.Fatalf("ProcessPRWebhook = (%+v, %v), want group %s, not duplicate", res, err, groupID)
+	}
+	// Receipt exists with the right outcome
+	var outcome string
+	if err := q.Pool().QueryRow(ctx,
+		`SELECT outcome FROM pr_outcomes WHERE error_group_id = $1 AND github_delivery_id = 'delivery-aaa'`,
+		groupID).Scan(&outcome); err != nil || outcome != "merged" {
+		t.Fatalf("receipt = (%q, %v), want merged", outcome, err)
+	}
+	// Group transitioned
+	assertGroupStatus(t, q, groupID, "merged")
+
+	// Redelivery: same delivery id → duplicate, still exactly one receipt
+	res, err = q.ProcessPRWebhook(ctx, "org/repo", 41, true, "delivery-aaa", time.Now())
+	if err != nil || !res.Duplicate {
+		t.Fatalf("redelivery = (%+v, %v), want duplicate", res, err)
+	}
+	var n int
+	q.Pool().QueryRow(ctx, `SELECT count(*) FROM pr_outcomes WHERE error_group_id = $1`, groupID).Scan(&n)
+	if n != 1 {
+		t.Fatalf("receipts = %d, want 1", n)
+	}
+}
+
+func TestProcessPRWebhook_FrictionCloseAttributesAndReturnsToAwaitingApproval(t *testing.T) {
+	q, projectID := createFrictionTestProject(t, "pr-webhook-close")
+	ctx := context.Background()
+	groupID := insertIncident(t, q, projectID, "fp-webhook-2", "friction", "pr_created")
+
+	// A real fix job, attached at "PR creation" — attribution must survive the webhook.
+	var fixJob string
+	if err := q.Pool().QueryRow(ctx,
+		`INSERT INTO error_group_jobs (error_group_id, project_id, job_type, triggered_by)
+		 VALUES ($1, $2, 'fix', 'human') RETURNING id`, groupID, projectID).Scan(&fixJob); err != nil {
+		t.Fatalf("insert fix job: %v", err)
+	}
+	mustExec(t, q, `UPDATE error_groups SET pr_number = 42, pr_url = 'https://x/42', pr_fix_job_id = $2 WHERE id = $1`,
+		groupID, fixJob)
+
+	res, err := q.ProcessPRWebhook(ctx, "org/repo", 42, false, "delivery-bbb", time.Now())
+	if err != nil || res.GroupID != groupID {
+		t.Fatalf("ProcessPRWebhook = (%+v, %v)", res, err)
+	}
+	// The receipt carries the exact fix job id (design v4-17: attributable).
+	var receiptJob *string
+	if err := q.Pool().QueryRow(ctx,
+		`SELECT fix_job_id FROM pr_outcomes WHERE github_delivery_id = 'delivery-bbb'`).Scan(&receiptJob); err != nil {
+		t.Fatalf("receipt: %v", err)
+	}
+	if receiptJob == nil || *receiptJob != fixJob {
+		t.Fatalf("receipt fix_job_id = %v, want %s", receiptJob, fixJob)
+	}
+	// Friction returns to awaiting_approval (not investigated) and PR fields clear.
+	assertGroupStatus(t, q, groupID, "awaiting_approval")
+	var prURL, groupFixJob *string
+	q.Pool().QueryRow(ctx, `SELECT pr_url, pr_fix_job_id FROM error_groups WHERE id = $1`, groupID).Scan(&prURL, &groupFixJob)
+	if prURL != nil || groupFixJob != nil {
+		t.Fatalf("pr fields not cleared: url=%v fixJob=%v", prURL, groupFixJob)
+	}
+}
+
+func TestProcessPRWebhook_NoMatch(t *testing.T) {
+	q, _ := createFrictionTestProject(t, "pr-webhook-nomatch")
+	res, err := q.ProcessPRWebhook(context.Background(), "org/repo", 999, true, "delivery-ccc", time.Now())
+	if err != nil || res.GroupID != "" {
+		t.Fatalf("no-match = (%+v, %v), want empty group", res, err)
+	}
+}
+```
+
+Add small helpers `mustExec` / `assertGroupStatus` if they don't already exist in the test package (grep first). Keep the error-kind close case from the old test: error + close → `investigated`.
+
+**Step 2: Run to verify failure**
+
+Run: `cd packages/ingestion && go test ./db -run TestProcessPRWebhook`
+Expected: FAIL — `ProcessPRWebhook` undefined.
+
+**Step 3: Implement**
+
+Delete `TransitionOnPRMerge` and `TransitionOnPRClose`; add (near the "Resolution lifecycle" section, keeping the multi-project caveat comment):
+
+```go
+// PRWebhookResult reports how a pull_request webhook was applied.
+type PRWebhookResult struct {
+	GroupID   string
+	Duplicate bool // receipt for this github_delivery_id already existed; no transition performed
+}
+
+// ProcessPRWebhook records an immutable pr_outcomes receipt and then transitions
+// the matched group — receipt BEFORE state clearing, idempotent on GitHub's
+// delivery id (design v4-17). A closed-unmerged friction group returns to
+// awaiting_approval; an error group returns to investigated.
+// Matches by github_repo + pr_number + status='pr_created' (see the
+// multi-project-per-repo caveat that applied to the old transition methods).
+//
+// Idempotency MUST be checked against pr_outcomes before matching the group:
+// the first delivery moves the group out of pr_created (or clears pr_number),
+// so a redelivery would otherwise look like no_match and never reach the
+// unique-constraint conflict. The ON CONFLICT on the insert remains as the
+// backstop for two concurrent deliveries of the same id racing this check.
+func (q *Queries) ProcessPRWebhook(ctx context.Context, githubRepo string, prNumber int, merged bool, deliveryID string, occurredAt time.Time) (PRWebhookResult, error) {
+	tx, err := q.pool.Begin(ctx)
+	if err != nil {
+		return PRWebhookResult{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Redelivery fast-path: this delivery id was already counted.
+	var seenGroup string
+	err = tx.QueryRow(ctx,
+		`SELECT error_group_id FROM pr_outcomes WHERE github_delivery_id = $1`,
+		deliveryID,
+	).Scan(&seenGroup)
+	if err == nil {
+		return PRWebhookResult{GroupID: seenGroup, Duplicate: true}, nil // read-only; deferred rollback is fine
+	}
+	if err != pgx.ErrNoRows {
+		return PRWebhookResult{}, fmt.Errorf("check delivery id: %w", err)
+	}
+
+	var groupID, projectID, kind string
+	var fixJobID *string
+	err = tx.QueryRow(ctx,
+		`SELECT eg.id, eg.project_id, eg.kind, eg.pr_fix_job_id
+		 FROM error_groups eg
+		 JOIN projects p ON eg.project_id = p.id
+		 WHERE p.github_repo = $1 AND eg.pr_number = $2 AND eg.status = 'pr_created'
+		 FOR UPDATE OF eg`,
+		githubRepo, prNumber,
+	).Scan(&groupID, &projectID, &kind, &fixJobID)
+	if err == pgx.ErrNoRows {
+		return PRWebhookResult{}, nil
+	}
+	if err != nil {
+		return PRWebhookResult{}, fmt.Errorf("match pr webhook group: %w", err)
+	}
+
+	outcome := "closed"
+	if merged {
+		outcome = "merged"
+	}
+	ct, err := tx.Exec(ctx,
+		`INSERT INTO pr_outcomes (error_group_id, project_id, pr_number, outcome, github_delivery_id, fix_job_id, occurred_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)
+		 ON CONFLICT (github_delivery_id) DO NOTHING`,
+		groupID, projectID, prNumber, outcome, deliveryID, fixJobID, occurredAt,
+	)
+	if err != nil {
+		return PRWebhookResult{}, fmt.Errorf("insert pr outcome: %w", err)
+	}
+	if ct.RowsAffected() == 0 {
+		// Redelivered webhook: the outcome is already counted; do not transition again.
+		if err := tx.Commit(ctx); err != nil {
+			return PRWebhookResult{}, fmt.Errorf("commit tx: %w", err)
+		}
+		return PRWebhookResult{GroupID: groupID, Duplicate: true}, nil
+	}
+
+	if merged {
+		_, err = tx.Exec(ctx,
+			`UPDATE error_groups SET status = 'merged', merged_at = now(), updated_at = now() WHERE id = $1`,
+			groupID)
+	} else {
+		_, err = tx.Exec(ctx,
+			`UPDATE error_groups
+			 SET status = CASE WHEN kind = 'friction'
+			                   THEN 'awaiting_approval'::error_group_status
+			                   ELSE 'investigated'::error_group_status END,
+			     pr_url = NULL, pr_number = NULL, pr_fix_job_id = NULL, updated_at = now()
+			 WHERE id = $1`,
+			groupID)
+	}
+	if err != nil {
+		return PRWebhookResult{}, fmt.Errorf("transition on pr %s: %w", outcome, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return PRWebhookResult{}, fmt.Errorf("commit tx: %w", err)
+	}
+	return PRWebhookResult{GroupID: groupID}, nil
+}
+```
+
+Note: `webhook.go` still calls the deleted methods — the package won't compile until Task 4. Do Task 4 before running the full build; run only `go vet ./db` here if needed, or fold Steps 4-5 of this task into Task 4's verification. Preferred: implement Task 3 + Task 4 code, then run tests for both.
+
+**Step 4: Commit** (after Task 4's tests pass — single commit is fine, or commit both tasks together)
+
+---
+
+### Task 4: Webhook handler reads `X-GitHub-Delivery` and calls `ProcessPRWebhook`
+
+**Files:**
+- Modify: `packages/ingestion/handler/webhook.go`
+- Test: `packages/ingestion/handler/webhook_test.go`
+
+**Step 1: Write the failing test**
+
+`webhook_test.go` currently only unit-tests `verifyWebhookSignature`. Add an httptest for the missing-delivery-id guard (no DB needed — the guard fires before any query):
+
+```go
+func TestHandleWebhook_MissingDeliveryID(t *testing.T) {
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+	payload := []byte(`{"action":"closed","pull_request":{"number":1,"merged":true},"repository":{"full_name":"org/repo"}}`)
+	mac := hmac.New(sha256.New, []byte("test-secret"))
+	mac.Write(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/github/webhook", bytes.NewReader(payload))
+	req.Header.Set("X-Hub-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	// no X-GitHub-Delivery header
+
+	rec := httptest.NewRecorder()
+	(&Dependencies{}).HandleWebhook(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+```
+
+**Step 2: Run to verify failure**
+
+Run: `cd packages/ingestion && go test ./handler -run TestHandleWebhook_MissingDeliveryID`
+Expected: FAIL (currently processes without the header, panics on nil Queries or returns non-400).
+
+**Step 3: Implement**
+
+In `webhook.go`:
+
+1. Add `"time"` to imports; extend the payload struct:
+
+```go
+type pullRequestEvent struct {
+	Action      string `json:"action"`
+	PullRequest struct {
+		Number   int        `json:"number"`
+		Merged   bool       `json:"merged"`
+		ClosedAt *time.Time `json:"closed_at"`
+	} `json:"pull_request"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+```
+
+2. After the event-type check (line 57) and before unmarshal, read the delivery id:
+
+```go
+	deliveryID := r.Header.Get("X-GitHub-Delivery")
+	if deliveryID == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing X-GitHub-Delivery header")
+		return
+	}
+```
+
+3. Replace the entire merged/closed branch (lines 72-103) with one call:
+
+```go
+	repo := event.Repository.FullName
+	prNumber := event.PullRequest.Number
+	occurredAt := time.Now()
+	if event.PullRequest.ClosedAt != nil {
+		occurredAt = *event.PullRequest.ClosedAt
+	}
+	action := "closed"
+	if event.PullRequest.Merged {
+		action = "merged"
+	}
+
+	result, err := d.Queries.ProcessPRWebhook(r.Context(), repo, prNumber, event.PullRequest.Merged, deliveryID, occurredAt)
+	if err != nil {
+		slog.Error("webhook: process PR event failed", "repo", repo, "pr", prNumber, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to process pull_request event")
+		return
+	}
+	status := "processed"
+	switch {
+	case result.Duplicate:
+		status = "duplicate"
+	case result.GroupID == "":
+		status = "no_match"
+	}
+	slog.Info("webhook: PR "+action, "repo", repo, "pr", prNumber, "group_id", result.GroupID, "status", status, "delivery_id", deliveryID)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": status, "action": action, "group_id": result.GroupID})
+```
+
+**Step 4: Run tests to verify pass**
+
+```bash
+cd packages/ingestion && go build ./... && go test ./db ./handler
+```
+Expected: PASS, including Task 3's `TestProcessPRWebhook_*`.
+
+**Step 5: Commit**
+
+```bash
+git add packages/ingestion/db/queries.go packages/ingestion/db/queries_test.go packages/ingestion/handler/webhook.go packages/ingestion/handler/webhook_test.go
+git commit -m "feat: idempotent, attributable PR receipts before state transitions (#57)"
+```
+
+---
+
+### Task 5: Autonomy settings API (read + PATCH)
+
+**Files:**
+- Modify: `packages/ingestion/db/queries.go` (`Project` struct :58, `UpdateProject` :1539, and **every** query that scans a `Project` — grep `github_repo, default_branch, created_at` and add `friction_autonomy` to each RETURNING/SELECT + Scan: `CreateProject`, `GetProjectByID`, `ListProjectsByOrg`, `UpdateProject`, and any others the grep finds)
+- Modify: `packages/ingestion/handler/read_api.go` (`projectJSON`/`toProjectJSON` :93-107, `UpdateProjectEndpoint` :426-456)
+- Test: `packages/ingestion/db/friction_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestUpdateProjectFrictionAutonomy(t *testing.T) {
+	q, projectID := createFrictionTestProject(t, "autonomy-settings")
+	ctx := context.Background()
+
+	var orgID string
+	if err := q.Pool().QueryRow(ctx, `SELECT org_id FROM projects WHERE id = $1`, projectID).Scan(&orgID); err != nil {
+		t.Fatalf("get org: %v", err)
+	}
+
+	// Default surfaces on the struct
+	autoFix := "auto_fix"
+	p, err := q.UpdateProject(ctx, orgID, projectID, nil, &autoFix)
+	if err != nil || p == nil {
+		t.Fatalf("UpdateProject: %v", err)
+	}
+	if p.FrictionAutonomy != "auto_fix" {
+		t.Fatalf("FrictionAutonomy = %q, want auto_fix", p.FrictionAutonomy)
+	}
+	// Omitted field is preserved (COALESCE semantics)
+	if p.GithubRepo == nil || *p.GithubRepo != "org/repo" {
+		t.Fatalf("GithubRepo clobbered: %v", p.GithubRepo)
+	}
+	// CHECK constraint rejects garbage
+	bad := "yolo"
+	if _, err := q.UpdateProject(ctx, orgID, projectID, nil, &bad); err == nil {
+		t.Fatal("expected CHECK violation for invalid autonomy value")
+	}
+}
+```
+
+**Step 2: Run to verify failure**
+
+Run: `cd packages/ingestion && go test ./db -run TestUpdateProjectFrictionAutonomy`
+Expected: FAIL — `UpdateProject` takes 4 args; `FrictionAutonomy` undefined.
+
+**Step 3: Implement**
+
+`Project` struct gains `FrictionAutonomy string`. New `UpdateProject`:
+
+```go
+// UpdateProject updates a project's settings. Only non-nil fields are changed
+// (COALESCE), so PATCH callers can send a single field. Tenant-scoped by orgID.
+func (q *Queries) UpdateProject(ctx context.Context, orgID, projectID string, githubRepo, frictionAutonomy *string) (*Project, error) {
+	var p Project
+	err := q.pool.QueryRow(ctx,
+		`UPDATE projects
+		 SET github_repo = COALESCE($3, github_repo),
+		     friction_autonomy = COALESCE($4, friction_autonomy)
+		 WHERE id = $2 AND org_id = $1
+		 RETURNING id, org_id, name, github_repo, default_branch, friction_autonomy, created_at`,
+		orgID, projectID, githubRepo, frictionAutonomy,
+	).Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.FrictionAutonomy, &p.CreatedAt)
+	...
+```
+
+(Behavior note, deliberate: `github_repo` can no longer be nulled via PATCH — the dashboard never does that; document in the commit message.)
+
+Update every other `Project` scan site found by the grep the same way. `projectJSON`:
+
+```go
+type projectJSON struct {
+	ID               string  `json:"id"`
+	Name             string  `json:"name"`
+	GithubRepo       *string `json:"github_repo"`
+	FrictionAutonomy string  `json:"friction_autonomy"`
+	CreatedAt        string  `json:"created_at"`
+}
+```
+
+`UpdateProjectEndpoint` request + validation (validate in the handler so the client gets a 400, not a 500 from the CHECK):
+
+```go
+	var req struct {
+		GithubRepo       *string `json:"github_repo"`
+		FrictionAutonomy *string `json:"friction_autonomy"`
+	}
+	...
+	if req.FrictionAutonomy != nil {
+		switch *req.FrictionAutonomy {
+		case "ask_first", "auto_fix", "auto_fix_ux":
+		default:
+			writeJSONError(w, http.StatusBadRequest, "friction_autonomy must be one of ask_first, auto_fix, auto_fix_ux")
+			return
+		}
+	}
+	project, err := d.Queries.UpdateProject(r.Context(), orgID, projectID, req.GithubRepo, req.FrictionAutonomy)
+```
+
+**Step 4: Handler-layer test (validation + serialization)**
+
+A DB-backed httptest harness already exists in this package — read `packages/ingestion/handler/read_api_test.go` and follow its setup pattern (Dependencies + real Queries + authenticated session). Add to it:
+
+```go
+// TestUpdateProjectEndpoint_FrictionAutonomy:
+//  1. PATCH {"friction_autonomy":"yolo"}      → 400 (handler validation, not a 500 from the CHECK)
+//  2. PATCH {"friction_autonomy":"auto_fix"}  → 200; response JSON has "friction_autonomy":"auto_fix"
+//  3. PATCH {"github_repo":"org/other"}       → 200; response still has "friction_autonomy":"auto_fix" (COALESCE preserved)
+```
+
+**Step 5: Run tests**
+
+```bash
+cd packages/ingestion && go build ./... && go test ./db ./handler
+```
+Expected: PASS (fix any other `UpdateProject` caller the compiler flags, e.g. in `Settings`/onboarding paths — pass `nil` for autonomy).
+
+**Step 6: Commit**
+
+```bash
+git add packages/ingestion
+git commit -m "feat: expose friction_autonomy on the project settings API (#57)"
+```
+
+---
+
+### Task 6: Fix-stats endpoint (receipts beside the toggle)
+
+Design §5: per category — generated (by `triggered_by`) → merged/closed (from `pr_outcomes`).
+
+**Files:**
+- Modify: `packages/ingestion/db/queries.go` (add `FixStats` + `GetFixStats`)
+- Modify: `packages/ingestion/handler/read_api.go` (add `GetFixStatsEndpoint`)
+- Modify: `packages/ingestion/handler/routes.go` (add route near line 117)
+- Test: `packages/ingestion/db/friction_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestGetFixStats(t *testing.T) {
+	q, projectID := createFrictionTestProject(t, "fix-stats")
+	ctx := context.Background()
+
+	errGroup := insertIncident(t, q, projectID, "fp-stats-err", "error", "merged")
+	fricGroup := insertIncident(t, q, projectID, "fp-stats-fric", "friction", "pr_created")
+
+	var errJob, fricJob string
+	q.Pool().QueryRow(ctx, `INSERT INTO error_group_jobs (error_group_id, project_id, job_type, triggered_by)
+		VALUES ($1, $2, 'fix', 'auto') RETURNING id`, errGroup, projectID).Scan(&errJob)
+	q.Pool().QueryRow(ctx, `INSERT INTO error_group_jobs (error_group_id, project_id, job_type, triggered_by)
+		VALUES ($1, $2, 'fix', 'human') RETURNING id`, fricGroup, projectID).Scan(&fricJob)
+	mustExec(t, q, `INSERT INTO pr_outcomes (error_group_id, project_id, pr_number, outcome, github_delivery_id, fix_job_id, occurred_at)
+		VALUES ($1, $2, 41, 'merged', 'stats-d1', $3, now())`, errGroup, projectID, errJob)
+	mustExec(t, q, `INSERT INTO pr_outcomes (error_group_id, project_id, pr_number, outcome, github_delivery_id, fix_job_id, occurred_at)
+		VALUES ($1, $2, 42, 'closed', 'stats-d2', $3, now())`, fricGroup, projectID, fricJob)
+
+	stats, err := q.GetFixStats(ctx, projectID)
+	if err != nil {
+		t.Fatalf("GetFixStats: %v", err)
+	}
+	if s := stats["error"]; s.GeneratedAuto != 1 || s.PRsMerged != 1 {
+		t.Fatalf("error stats = %+v", s)
+	}
+	if s := stats["friction"]; s.GeneratedHuman != 1 || s.PRsClosed != 1 {
+		t.Fatalf("friction stats = %+v", s)
+	}
+}
+```
+
+**Step 2: Run to verify failure** — `go test ./db -run TestGetFixStats` → FAIL, undefined.
+
+**Step 3: Implement**
+
+```go
+// FixStats are the receipts shown beside each autonomy toggle (design §5).
+type FixStats struct {
+	GeneratedAuto  int `json:"generated_auto"`
+	GeneratedHuman int `json:"generated_human"`
+	PRsMerged      int `json:"prs_merged"`
+	PRsClosed      int `json:"prs_closed"`
+}
+
+// GetFixStats aggregates fix generation and PR outcomes per incident kind. Tenant-scoped.
+func (q *Queries) GetFixStats(ctx context.Context, projectID string) (map[string]FixStats, error) {
+	stats := map[string]FixStats{"error": {}, "friction": {}}
+
+	rows, err := q.pool.Query(ctx,
+		`SELECT eg.kind, j.triggered_by, count(*)
+		 FROM error_group_jobs j JOIN error_groups eg ON j.error_group_id = eg.id
+		 WHERE j.project_id = $1 AND j.job_type IN ('fix', 'error_fix') AND j.triggered_by IS NOT NULL
+		 GROUP BY 1, 2`, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("fix stats jobs: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var kind, trigger string
+		var n int
+		if err := rows.Scan(&kind, &trigger, &n); err != nil {
+			return nil, fmt.Errorf("scan fix stats jobs: %w", err)
+		}
+		s := stats[kind]
+		if trigger == "human" {
+			s.GeneratedHuman = n
+		} else {
+			s.GeneratedAuto = n
+		}
+		stats[kind] = s
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate fix stats jobs: %w", err)
+	}
+
+	rows2, err := q.pool.Query(ctx,
+		`SELECT eg.kind, o.outcome, count(*)
+		 FROM pr_outcomes o JOIN error_groups eg ON o.error_group_id = eg.id
+		 WHERE o.project_id = $1
+		 GROUP BY 1, 2`, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("fix stats outcomes: %w", err)
+	}
+	defer rows2.Close()
+	for rows2.Next() {
+		var kind, outcome string
+		var n int
+		if err := rows2.Scan(&kind, &outcome, &n); err != nil {
+			return nil, fmt.Errorf("scan fix stats outcomes: %w", err)
+		}
+		s := stats[kind]
+		if outcome == "merged" {
+			s.PRsMerged = n
+		} else {
+			s.PRsClosed = n
+		}
+		stats[kind] = s
+	}
+	if err := rows2.Err(); err != nil {
+		return nil, fmt.Errorf("iterate fix stats outcomes: %w", err)
+	}
+	return stats, nil
+}
+```
+
+Handler (mirror `ListEnvironmentsEndpoint`'s shape, `read_api.go:459+`):
+
+```go
+// GetFixStatsEndpoint returns per-kind fix generation and PR outcome counts.
+// GET /api/v1/projects/{projectID}/fix-stats
+func (d *Dependencies) GetFixStatsEndpoint(w http.ResponseWriter, r *http.Request) {
+	projectID := chi.URLParam(r, "projectID")
+	if !d.verifyProjectAccess(w, r, projectID) {
+		return
+	}
+	stats, err := d.Queries.GetFixStats(r.Context(), projectID)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to load fix stats")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(stats)
+}
+```
+
+Route (`routes.go`, with the other project GETs): `r.With(deps.AuthenticateSession).Get("/projects/{projectID}/fix-stats", deps.GetFixStatsEndpoint)`
+
+**Step 4: Handler-layer test** — in the `read_api_test.go`-style harness: `GET /projects/{id}/fix-stats` returns 200 with both `"error"` and `"friction"` keys and all four counters (assert the JSON shape, not just status), and an unauthenticated request is rejected. This also proves the route is actually wired in `routes.go`.
+
+**Step 5: Run** — `go build ./... && go test ./db ./handler` → PASS.
+
+**Step 6: Commit** — `git commit -m "feat: fix-stats receipts aggregation endpoint (#57)"`
+
+---
+
+### Task 7: Worker lifts the friction auto-fix gate behind the autonomy ladder
+
+Two touch points: (a) the friction **investigate** path auto-triggers a fix for code-caused, high-confidence friction when autonomy allows; (b) the **fix-job** gate (`index.ts:545-549`) re-checks autonomy at execution time (settings may change between enqueue and claim) instead of refusing unconditionally. `auto_fix_ux` behaves like `auto_fix` for now — there is no UX-suggestion fix category yet (`insight` never gets a PR); the rung exists so opting in is a one-time setting.
+
+**Files:**
+- Modify: `packages/worker/src/db.ts:551-566` (`ProjectData` + `getProject`), `:504-524` (`ErrorGroupData` + `getErrorGroup` gain `confidence`)
+- Modify: `packages/worker/src/index.ts:465-490` (friction investigate routing), `:545-549` (gate)
+- Test: `packages/worker/src/__tests__/index.test.ts` (new cases + update the existing refusal test at :366, which expects `undefined` fields)
+
+**Pre-existing bug fixed in passing:** today's refusal path (`index.ts:546`) passes `undefined` fields to `updateGroupStatus`, which writes `confidence = NULL` (`db.ts:425,439`) — so refusing a job erases the investigation's confidence. The gate below preserves it. This matters for the settings-change race: autonomy can be downgraded to `ask_first` between enqueue and claim, and the refusal must not degrade the parked incident.
+
+**Step 1: Write the failing tests**
+
+First extend the `db.getProject` mock's default return with `friction_autonomy: 'ask_first'` (find the existing mock; every existing test must keep passing on the ask-first default — including the line-366 refusal test). Then:
+
+```ts
+it('auto-triggers a friction fix when autonomy is auto_fix and confidence is high', async () => {
+  mockGetProject.mockResolvedValue({ ...baseProject, friction_autonomy: 'auto_fix' });
+  // arrange investigateFriction mock → { codeCause: true, confidence: 'high', reason, remediation }
+  await processInvestigateJob(makeFrictionJob(), new AbortController().signal);
+
+  expect(db.updateGroupAndCreateFixJob).toHaveBeenCalledWith(
+    'grp-1', 'proj-1',
+    expect.objectContaining({ confidence: 'high' }),
+    expect.anything(),
+  );
+  expect(db.updateGroupInvestigation).not.toHaveBeenCalledWith(
+    'grp-1', 'proj-1', 'awaiting_approval', expect.anything(), expect.anything(),
+  );
+});
+
+it('parks medium-confidence friction in awaiting_approval even with auto_fix autonomy', async () => {
+  mockGetProject.mockResolvedValue({ ...baseProject, friction_autonomy: 'auto_fix' });
+  // investigateFriction mock → { codeCause: true, confidence: 'medium', ... }
+  await processInvestigateJob(makeFrictionJob(), new AbortController().signal);
+
+  expect(db.updateGroupInvestigation).toHaveBeenCalledWith(
+    'grp-1', 'proj-1', 'awaiting_approval', expect.anything(), expect.anything(),
+  );
+  expect(db.updateGroupAndCreateFixJob).not.toHaveBeenCalled();
+});
+
+it('processes an auto friction fix job when autonomy allows it', async () => {
+  mockGetProject.mockResolvedValue({ ...baseProject, friction_autonomy: 'auto_fix' });
+  const job = { ...makeJob(), jobType: 'fix' as const, triggeredBy: 'auto' as const };
+
+  await processFixJob(job, new AbortController().signal);
+
+  expect(mockCloneRepo).toHaveBeenCalled(); // gate did not refuse
+});
+
+it('still refuses an auto friction fix job under ask_first, preserving confidence', async () => {
+  // The settings-change race: autonomy was auto_fix at enqueue, downgraded before claim.
+  mockGetProject.mockResolvedValue({ ...baseProject, friction_autonomy: 'ask_first' });
+  mockGetErrorGroup.mockResolvedValue({ ...baseFrictionGroup, confidence: 'high' });
+  const job = { ...makeJob(), jobType: 'fix' as const, triggeredBy: 'auto' as const };
+
+  await processFixJob(job, new AbortController().signal);
+
+  expect(mockUpdateGroupStatus).toHaveBeenCalledWith(
+    'grp-1', 'proj-1', 'awaiting_approval',
+    expect.objectContaining({ confidence: 'high' }), // NOT undefined — see pre-existing bug note
+    job,
+  );
+  expect(mockCloneRepo).not.toHaveBeenCalled();
+});
+```
+
+Also update the existing refusal test (`index.test.ts:366-375`): its `toHaveBeenCalledWith(..., 'awaiting_approval', undefined, job)` expectation becomes the fields object above.
+
+Adapt helper names (`makeJob`, `fixJob`, mock handles) to what the file actually uses — read the existing friction tests around lines 330-380 first.
+
+**Step 2: Run to verify failure** — `pnpm --filter @opslane/worker test -- index.test.ts` → new tests FAIL.
+
+**Step 3: Implement**
+
+`db.ts`:
+
+```ts
+export type FrictionAutonomy = 'ask_first' | 'auto_fix' | 'auto_fix_ux';
+
+export interface ProjectData {
+  id: string;
+  name: string;
+  github_repo: string;
+  default_branch: string;
+  friction_autonomy: FrictionAutonomy;
+}
+```
+and add `friction_autonomy` to `getProject`'s SELECT. Also add `confidence` to `ErrorGroupData` and `getErrorGroup`'s SELECT (`db.ts:504-524`) so the gate can preserve it:
+
+```ts
+export interface ErrorGroupData {
+  // ...existing fields...
+  confidence: ConfidenceLevel | null;
+}
+```
+
+`index.ts` — friction investigate routing (the `result.codeCause` branch at :467; `project` is already in scope from :425):
+
+```ts
+    if (result.codeCause) {
+      // Autonomy ladder (design §4): code-caused, high-confidence friction may
+      // route straight to a fix once the project has opted past ask-first.
+      // auto_fix_ux currently behaves like auto_fix — insight never gets a PR,
+      // so there is no separate UX-suggestion fix category yet.
+      if (result.confidence === 'high' && project.friction_autonomy !== 'ask_first') {
+        const fixJobId = await updateGroupAndCreateFixJob(job.errorGroupId, job.projectId, {
+          rootCause: result.reason,
+          suggestedMitigation: result.remediation,
+          confidence: result.confidence,
+        }, job);
+        logger.info('Friction investigation: auto-triggering fix (autonomy ladder)', {
+          job_id: job.id, fix_job_id: fixJobId, autonomy: project.friction_autonomy,
+        });
+      } else {
+        await updateGroupInvestigation(job.errorGroupId, job.projectId, 'awaiting_approval', {
+          rootCause: result.reason,
+          suggestedMitigation: result.remediation,
+          confidence: result.confidence,
+        }, job);
+        logger.info('Friction investigation: awaiting human approval', {
+          job_id: job.id, confidence: result.confidence,
+        });
+      }
+    } else {
+```
+
+(`updateGroupAndCreateFixJob` requires the group to be in `analyzing` — it is: `processInvestigateJob` sets `analyzing` at `index.ts:202` before branching into the friction path. It inserts the fix job with `triggered_by='auto'`.)
+
+`index.ts` — the gate in `processFixJob` (:545):
+
+```ts
+  if (group.kind === 'friction' && job.triggeredBy !== 'human') {
+    // Re-check autonomy at execution time: settings may have changed between
+    // enqueue and claim, and legacy jobs (triggeredBy null) are never auto-run.
+    const gateProject = await db.getProject(job.projectId);
+    const autonomy = gateProject?.friction_autonomy ?? 'ask_first';
+    if (job.triggeredBy !== 'auto' || autonomy === 'ask_first') {
+      // Preserve the investigation's confidence — updateGroupStatus writes
+      // omitted fields as NULL (db.ts:425,439).
+      await updateGroupStatus(job.errorGroupId, job.projectId, 'awaiting_approval', {
+        confidence: group.confidence ?? undefined,
+      }, job);
+      logger.warn('Refused non-human friction fix job', { job_id: job.id, autonomy });
+      return;
+    }
+  }
+```
+
+**Step 4: Run all worker tests** — `pnpm --filter @opslane/worker test` → PASS (the pre-existing refusal test must still pass via the ask-first default mock).
+
+**Step 5: Commit** — `git commit -m "feat: lift the friction auto-fix gate behind the autonomy ladder (#57)"`
+
+---
+
+### Task 8: Honest Suggestion line in the friction PR body
+
+The title/heading already say Suggestion; the body's confidence line (`packages/worker/src/pr.ts:278`) still claims `✅ Tests passing` identically for both kinds. Design: the gate proves "nothing broke," not "the friction is gone."
+
+**Files:**
+- Modify: `packages/worker/src/pr.ts:278` area (`buildPRBody`)
+- Test: `packages/worker/src/__tests__/pr.test.ts`
+
+**Step 1: Write the failing test** (next to the existing friction tests at :143):
+
+```ts
+it('marks the friction body as unverified against the original friction', () => {
+  const body = buildPRBody({ ...baseInput, kind: 'friction' });
+  expect(body).toContain('friction itself was not re-verified');
+  expect(body).not.toContain('**Confidence:** High · ✅ Tests passing');
+});
+```
+
+(Adapt `baseInput` to the fixture the file already uses.)
+
+**Step 2: Run to verify failure** — `pnpm --filter @opslane/worker test -- pr.test.ts` → FAIL.
+
+**Step 3: Implement** — read `pr.ts:270-285`, then branch the line:
+
+```ts
+  const confidenceLine = input.kind === 'friction'
+    ? '**Confidence:** Suggestion · ✅ Repo tests passing · ⚠️ The friction itself was not re-verified — review before merging'
+    : '**Confidence:** High · ✅ Tests passing';
+```
+
+and use `confidenceLine` where the literal was.
+
+**Step 4: Run** — `pnpm --filter @opslane/worker test -- pr.test.ts` → PASS (all, including the two existing Suggestion tests).
+
+**Step 5: Commit** — `git commit -m "feat: friction PR body states the suggestion is unverified (#57)"`
+
+---
+
+### Task 9: Dashboard — Generate fix from `awaiting_approval` + insight card
+
+**Files:**
+- Modify: `packages/dashboard/src/views/IncidentDetail.vue` (root-cause card :347, fix button :371-405)
+
+No component test harness exists for the dashboard; verification is typecheck/build (Step 3) plus the live smoke in Task 11.
+
+**Step 1: Root-cause card also renders for `awaiting_approval`**
+
+Change the `v-if` at :348 to:
+
+```
+v-if="(incident.status === 'investigated' || incident.status === 'awaiting_approval' || incident.status === 'fixing' || incident.status === 'needs_human') && incident.root_cause"
+```
+
+**Step 2: Add the insight card and extend the fix button**
+
+Insert after the root-cause card (before the Find Fix block):
+
+```html
+        <!-- Insight card (friction, no code cause — terminal, never a PR; design v4-4) -->
+        <div
+          v-if="incident.status === 'insight'"
+          class="p-4 bg-purple-500/10 border border-purple-500/20 border-l-2 border-l-purple-500 rounded-lg space-y-3"
+        >
+          <p class="text-sm font-medium text-purple-400">Insight — no code cause</p>
+          <p class="text-xs text-text-muted">
+            Opslane investigated this friction and found no code change that would fix it.
+            No PR will be created; use the findings below to guide a product or UX change.
+          </p>
+          <div v-if="incident.root_cause">
+            <p class="text-xs font-medium text-purple-400 uppercase tracking-wide">What users hit</p>
+            <pre
+              class="mt-1 text-sm bg-surface border border-border p-3 rounded overflow-x-auto whitespace-pre-wrap text-text"
+              v-text="incident.root_cause"
+            ></pre>
+          </div>
+        </div>
+```
+
+Change the fix block's `v-if` (:373) and button label:
+
+```
+v-if="incident.status === 'investigated' || incident.status === 'awaiting_approval'"
+```
+
+Inside the block, above the guidance label, add the Suggestion note:
+
+```html
+          <p v-if="incident.status === 'awaiting_approval'" class="text-xs text-text-muted">
+            This friction fix has a code cause and is waiting for your approval.
+            It will open a <strong>Suggestion</strong> PR — repo tests must pass,
+            but the friction itself is not re-verified.
+          </p>
+```
+
+and the button text:
+
+```html
+              <span v-if="fixLoading">Triggering...</span>
+              <span v-else>{{ incident.status === 'awaiting_approval' ? 'Generate fix' : 'Find Fix' }}</span>
+```
+
+`handleTriggerFix` and the polling logic need no changes — the backend already accepts friction+`awaiting_approval` (`queries.go:785-789`).
+
+**Step 3: Verify build/typecheck**
+
+Run: `pnpm --filter @opslane/dashboard build` (check the exact package name in `packages/dashboard/package.json` first)
+Expected: builds clean.
+
+**Step 4: Commit** — `git commit -m "feat: insight card and Generate-fix from awaiting_approval (#57)"`
+
+---
+
+### Task 10: Dashboard — autonomy settings with receipts beside the toggle
+
+**Files:**
+- Modify: `packages/dashboard/src/api.ts` (`Project` :143, `updateProject` :209; add `FixStats` + `getFixStats`)
+- Modify: `packages/dashboard/src/views/Settings.vue`
+
+**Step 1: API client**
+
+```ts
+export interface Project {
+  id: string;
+  name: string;
+  github_repo: string | null;
+  friction_autonomy: 'ask_first' | 'auto_fix' | 'auto_fix_ux';
+  created_at: string;
+}
+
+export function updateProject(
+  projectId: string,
+  data: { github_repo?: string; friction_autonomy?: Project['friction_autonomy'] }
+): Promise<Project> {
+  return patchJSON<Project>(`/projects/${projectId}`, data);
+}
+
+export interface FixStats {
+  generated_auto: number;
+  generated_human: number;
+  prs_merged: number;
+  prs_closed: number;
+}
+
+export function getFixStats(projectId: string): Promise<Record<'error' | 'friction', FixStats>> {
+  return fetchJSON<Record<'error' | 'friction', FixStats>>(`/projects/${projectId}/fix-stats`);
+}
+```
+
+**Step 2: Settings panel**
+
+Read `Settings.vue` fully first and copy its existing card/section markup and save-feedback pattern. Important: the view has **no `selectedProject` object** — only `projects: Ref<Project[]>` and `selectedProjectId: Ref<string>` (`Settings.vue:26-28`), and the ID can be a manually-typed one that isn't in the list. Add a computed, a watcher-driven loader with a stale-request guard, and per-option receipts (the design says stats beside **each** toggle, not one summary line):
+
+```html
+    <!-- Friction autonomy (Batch 5, issue #57) -->
+    <section class="p-4 bg-surface border border-border rounded-lg space-y-3">
+      <div>
+        <h2 class="text-sm font-medium text-text">Friction autonomy</h2>
+        <p class="mt-1 text-xs text-text-muted">
+          How Opslane acts on friction incidents (rage clicks, dead clicks, form abandonment)
+          that have a code cause. Error fixes are unaffected.
+        </p>
+      </div>
+      <p v-if="!selectedProject" class="text-xs text-text-faint">
+        Select one of your projects above to manage autonomy.
+        (Manually entered project IDs can't be managed here.)
+      </p>
+      <div v-else class="space-y-2">
+        <label
+          v-for="opt in autonomyOptions"
+          :key="opt.value"
+          class="flex items-start gap-3 p-3 border rounded-lg cursor-pointer"
+          :class="autonomy === opt.value ? 'border-teal bg-teal-500/5' : 'border-border'"
+        >
+          <input
+            type="radio"
+            name="friction-autonomy"
+            class="mt-0.5"
+            :value="opt.value"
+            :checked="autonomy === opt.value"
+            :disabled="autonomySaving"
+            @change="saveAutonomy(opt.value)"
+          />
+          <span>
+            <span class="block text-sm text-text">{{ opt.label }}</span>
+            <span class="block text-xs text-text-muted">{{ opt.description }}</span>
+            <!-- Receipts beside each toggle (design §5) -->
+            <span v-if="fixStats" class="block mt-1 text-xs text-text-faint">{{ optionStats(opt.value) }}</span>
+          </span>
+        </label>
+      </div>
+      <p v-if="autonomyError" class="text-sm text-red" v-text="autonomyError"></p>
+    </section>
+```
+
+Script additions (adapt to the file's existing composition-API style and selected-project ref):
+
+```ts
+const autonomyOptions = [
+  { value: 'ask_first', label: 'Ask first (default)', description: 'Friction fixes wait in awaiting-approval until you click Generate fix.' },
+  { value: 'auto_fix', label: 'Auto-fix', description: 'High-confidence, code-caused friction goes straight to a Suggestion PR.' },
+  { value: 'auto_fix_ux', label: 'Auto-fix incl. UX suggestions', description: 'Same as auto-fix today; reserved for UX-suggestion fixes when they ship.' },
+] as const;
+
+const selectedProject = computed(() =>
+  projects.value.find((p) => p.id === selectedProjectId.value) ?? null,
+);
+
+const autonomy = ref<Project['friction_autonomy']>('ask_first');
+const autonomySaving = ref(false);
+const autonomyError = ref('');
+const fixStats = ref<Record<'error' | 'friction', FixStats> | null>(null);
+let statsRequestToken = 0; // stale-response guard when switching projects quickly
+
+watch(selectedProjectId, loadAutonomyAndStats, { immediate: true });
+// projects load async on mount — re-derive the toggle once they arrive
+watch(projects, () => {
+  autonomy.value = selectedProject.value?.friction_autonomy ?? 'ask_first';
+});
+
+async function loadAutonomyAndStats() {
+  autonomyError.value = '';
+  fixStats.value = null;
+  autonomy.value = selectedProject.value?.friction_autonomy ?? 'ask_first';
+  const id = selectedProjectId.value;
+  if (!id || !selectedProject.value) return; // manual IDs: card shows the hint instead
+  const token = ++statsRequestToken;
+  try {
+    const stats = await getFixStats(id);
+    if (token === statsRequestToken) fixStats.value = stats; // drop stale responses
+  } catch {
+    // stats are best-effort; the toggle works without them
+  }
+}
+
+async function saveAutonomy(value: Project['friction_autonomy']) {
+  if (!selectedProject.value) return;
+  const prev = autonomy.value;
+  autonomy.value = value;
+  autonomySaving.value = true;
+  autonomyError.value = '';
+  try {
+    const updated = await updateProject(selectedProject.value.id, { friction_autonomy: value });
+    // keep the local list in sync so switching away and back shows the saved value
+    projects.value = projects.value.map((p) => (p.id === updated.id ? updated : p));
+  } catch (err) {
+    autonomy.value = prev; // roll back the optimistic flip
+    autonomyError.value = err instanceof Error ? err.message : 'Failed to save autonomy setting';
+  } finally {
+    autonomySaving.value = false;
+  }
+}
+
+function optionStats(value: Project['friction_autonomy']): string {
+  const f = fixStats.value?.friction;
+  if (!f) return '';
+  switch (value) {
+    case 'ask_first':
+      return `${f.generated_human} friction fixes generated on request`;
+    case 'auto_fix':
+      return `${f.generated_auto} auto-generated · ${f.prs_merged} merged · ${f.prs_closed} closed without merge`;
+    case 'auto_fix_ux':
+      return 'No UX-suggestion fixes yet';
+  }
+}
+```
+
+(Import `computed`/`watch` from `vue` if the file doesn't already; import `getFixStats` and the `FixStats` type from `../api`.)
+
+**Step 3: Verify** — `pnpm --filter @opslane/dashboard build` → clean.
+
+**Step 4: Commit** — `git commit -m "feat: autonomy ladder settings with fix receipts (#57)"`
+
+---### Task 11: Full gate, live smoke, and the dogfood gate
+
+**Step 1: Full repository gate** (AGENTS.md order — fix at each step):
+
+```bash
+pnpm install --frozen-lockfile
+pnpm -r build
+pnpm test
+(cd packages/ingestion && go build ./... && go test ./...)
+docker compose config --quiet
+```
+
+**Step 2: Live smoke (required — pipeline behavior changed).** Two setup traps: Compose defaults `GITHUB_WEBHOOK_SECRET` to empty (`docker-compose.yml:65`), which makes the webhook return 500 — export a secret **before** starting; and there is no host-side `DATABASE_URL`/psql — run SQL through the container. Migrations apply on ingestion container start (that's the "representative existing database" check from ingestion `AGENTS.md`).
+
+```bash
+export GITHUB_WEBHOOK_SECRET=smoke-secret
+docker compose up -d --build
+docker compose exec -T postgres psql -U opslane -d opslane < scripts/seed-e2e.sql
+```
+
+Then exercise the four new paths against the running stack:
+
+1. **TriggerFix from awaiting_approval:** insert a friction group (`kind='friction'`, `status='awaiting_approval'`, a `root_cause`) for the seeded project via psql; open the dashboard incident page → the Suggestion note + **Generate fix** button render; click it → group flips to `fixing`, an `error_group_jobs` row exists with `triggered_by='human'`. (Keyless worker will land it in `needs_human` with `missing_llm_key` — that still proves the route.)
+2. **Webhook receipts:** insert a group with `status='pr_created'`, `pr_number`, a real fix-job row and its id in `pr_fix_job_id`; POST a signed `pull_request` closed payload (HMAC with `smoke-secret`, recipe in `webhook_test.go`) with an `X-GitHub-Delivery` header → `pr_outcomes` has one row with that delivery id **and that fix job id**; POST the identical payload again → response `"status":"duplicate"`, still one row; friction group is back in `awaiting_approval`.
+3. **Autonomy settings:** in Settings, flip the project to Auto-fix → PATCH succeeds, per-option receipt lines render from `/fix-stats`; confirm `projects.friction_autonomy='auto_fix'` in psql.
+4. **The auto_fix gate path (the headline behavior — must be smoked, not just unit-tested):** with the project set to `auto_fix`, insert a friction group and a pending fix job with `triggered_by='auto'` → the keyless worker passes the gate (log shows no "Refused non-human friction fix job") and proceeds until the missing LLM key lands it in `needs_human` — proving the gate opens. Flip the project back to `ask_first`, repeat → the job is refused, the group returns to `awaiting_approval`, and its `confidence` is unchanged in psql (the settings-change race).
+
+**Step 3: The issue #57 gate — do not check it off from seeded data.** Issue #57 names #56 (Batch 4) as a dependency and its gate demands a **real dogfood** friction incident. Two runs:
+- **Implementation proof (now, seeded):** with `ANTHROPIC_API_KEY` + a GitHub-connected repo, seed `friction_signals` from a real `test-fixtures/vue-app` rage-click session (the `test-e2e/friction-smoke.test.ts` flow), create the friction group by hand, run the keyed worker: investigation → `awaiting_approval` → click **Generate fix** → a PR titled `[Opslane] Suggestion: …` with the unverified-friction line and the tests+judge gate intact. Comment the PR link on #57 as implementation evidence.
+- **Gate check-off (after #56 lands):** re-run organically — real detection creates the incident, no manual SQL — and only then check off #57's gate. If Abhishek decides seeded proof should suffice instead, amend the issue text explicitly; don't quietly reinterpret the gate.
+
+**Step 4: Update docs if drift-checked.** Run `node scripts/check-docs-drift.mjs` (CI runs it); update `docs/contracts/` or package `AGENTS.md` files if the webhook response shape or settings API is documented there (grep `docs/contracts` for `webhook`, `projects`).
+
+**Step 5: Final commit + PR**
+
+```bash
+git push -u origin abhishekray07/session-replay-batch-5
+gh pr create --title "Batch 5 — The ladder: act on friction (#57)" --body "Closes #57. ..."
+```
+
+---
+
+## Verification strategy while Batch 4 (#56) is developed in parallel
+
+Batch 5 consumes incidents in `awaiting_approval`/`insight`; Batch 4 only automates *producing* them. So nothing here waits on Batch 4:
+
+1. **Unit layer (no Batch 4):** worker Vitest proves gate/autonomy/labeling/attribution logic; Go tests against real Postgres prove the receipts guarantees (receipt-before-transition, delivery-id idempotency, kind-aware close) — these are DB semantics and are fully provable now.
+2. **Live smoke (seeded):** insert `awaiting_approval` friction groups by SQL — the same bridge `test-e2e/friction-smoke.test.ts` already uses for the missing scheduler. Observe the button → `fixing` → `triggered_by='human'`; signed webhook curl → one receipt, duplicate redelivery → still one; settings PATCH → column + stats.
+3. **Dogfood proof (keyed, seeded):** the full `awaiting_approval` → Suggestion-PR flow runs today with a seeded incident — implementation evidence, posted to #57. It is **not** the issue's gate: #57 names #56 as a dependency and demands a real dogfood incident.
+4. **Gate check-off (post-merge, both branches):** organic path — rage-click fixture → Batch 4 creates the incident → Batch 5 affordances, zero manual SQL. Only this run checks off #57's gate (or Abhishek explicitly amends the issue to accept seeded proof).
+
+Coordination with the Batch 4 branch:
+- **Migration numbers:** this plan claims `007_receipts_wiring.sql`. Agree now that Batch 4 takes `008+`; whoever merges second renumbers (runner applies lexically).
+- **`packages/worker/src/index.ts`:** both branches touch it (Batch 5: investigate routing + fix gate; Batch 4: enqueueing upstream). Expect textual conflicts; rebase before merge and re-run the full worker suite after resolving.
+- **Safety across the merge gap:** the gate is autonomy-aware with `ask_first` as the column default, so if Batch 4's detection turns on before or after Batch 5 merges, nothing auto-PRs until a project explicitly opts in. Merge order does not matter for safety.
+
+## Out of scope (deliberately)
+
+- **Batch 4 (#56)** adjudicate→fold→aggregate and auto-created friction incidents — separate issue; Batch 5 works against manually-seeded incidents.
+- **Kind badges on the inbox** — Batch 4 scope (design §6).
+- **Pricing decision** ("does a friction fix bill like an error fix") — flagged in the design as decide-before-Batch-5; a product call, not code. Raise it with Abhishek before shipping the autonomy toggle publicly.
+- **A distinct behavior for `auto_fix_ux`** — no UX-suggestion fix category exists yet (`insight` never produces a PR); the rung is settings-only until then.

--- a/docs/reference/http-routes.md
+++ b/docs/reference/http-routes.md
@@ -19,7 +19,7 @@ These are curated tables, not a stability contract — the API is early-stage an
 | GET | `/api/v1/agent/poll/{sessionID}` | none | Agent onboarding poll |
 | GET | `/agent/auth/{sessionID}` | none | Agent onboarding browser auth |
 | GET | `/agent/auth/callback` | none | Agent onboarding callback |
-| POST | `/api/v1/github/webhook` | HMAC | GitHub webhook receiver |
+| POST | `/api/v1/github/webhook` | HMAC | GitHub webhook receiver — requires `X-GitHub-Delivery` (400 without it); responds `processed`, `no_match`, or `duplicate` (idempotent on redelivery) |
 
 ## SDK (X-API-Key)
 
@@ -45,7 +45,8 @@ These are curated tables, not a stability contract — the API is early-stage an
 | POST | `/api/v1/onboarding/setup` | First-run setup |
 | GET | `/api/v1/projects` | List projects |
 | POST | `/api/v1/projects` | Create project |
-| PATCH | `/api/v1/projects/{projectID}` | Update project |
+| PATCH | `/api/v1/projects/{projectID}` | Update project (partial: omitted/null fields are preserved, so `github_repo` can no longer be cleared here) |
+| GET | `/api/v1/projects/{projectID}/fix-stats` | Per-kind fix generation and PR outcome receipts |
 | GET | `/api/v1/projects/{projectID}/environments` | List environments |
 | POST | `/api/v1/projects/{projectID}/environments` | Create environment |
 | POST | `/api/v1/environments/{envID}/api-keys` | Create ingest key |
@@ -55,7 +56,7 @@ These are curated tables, not a stability contract — the API is early-stage an
 | GET | `/api/v1/projects/{projectID}/sessions/{sessionID}` | Session detail and scrubbed chunk manifest |
 | GET | `/api/v1/projects/{projectID}/sessions/{sessionID}/chunks/{seq}` | Fetch one decoded, re-redacted scrubbed chunk |
 | GET | `/api/v1/projects/{projectID}/incidents/{incidentID}/affected-users` | Affected users |
-| POST | `/api/v1/projects/{projectID}/incidents/{incidentID}/fix` | Trigger fix from an `investigated` analysis |
+| POST | `/api/v1/projects/{projectID}/incidents/{incidentID}/fix` | Trigger an eligible error or approved friction fix |
 | POST | `/api/v1/projects/{projectID}/incidents/{incidentID}/resolve` | Resolve incident |
 | POST | `/api/v1/projects/{projectID}/incidents/{incidentID}/archive` | Archive incident |
 | POST | `/api/v1/projects/{projectID}/incidents/{incidentID}/unarchive` | Unarchive incident |

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -144,7 +144,18 @@ export interface Project {
   id: string;
   name: string;
   github_repo: string | null;
+  friction_autonomy: 'ask_first' | 'auto_fix' | 'auto_fix_ux';
   created_at: string;
+}
+
+export interface FixStats {
+  generated_auto: number;
+  generated_human: number;
+  prs_merged: number;
+  prs_closed: number;
+  /** Outcomes attributed to auto-triggered fix jobs only. */
+  prs_merged_auto: number;
+  prs_closed_auto: number;
 }
 
 export interface Environment {
@@ -208,9 +219,13 @@ export function createProject(name: string, githubRepo: string): Promise<Project
 
 export function updateProject(
   projectId: string,
-  data: { github_repo?: string }
+  data: { github_repo?: string; friction_autonomy?: Project['friction_autonomy'] }
 ): Promise<Project> {
   return patchJSON<Project>(`/projects/${projectId}`, data);
+}
+
+export function getFixStats(projectId: string): Promise<Record<'error' | 'friction', FixStats>> {
+  return fetchJSON<Record<'error' | 'friction', FixStats>>(`/projects/${projectId}/fix-stats`);
 }
 
 export function listEnvironments(projectId: string): Promise<Environment[]> {

--- a/packages/dashboard/src/style.css
+++ b/packages/dashboard/src/style.css
@@ -37,6 +37,7 @@
   --color-green: #4ade80;
   --color-amber: #f5a623;
   --color-red: #ff4d4d;
+  --color-purple: #c084fc; /* insight status */
 
   /* Typography */
   --font-sans: 'DM Sans', system-ui, sans-serif;

--- a/packages/dashboard/src/views/IncidentDetail.vue
+++ b/packages/dashboard/src/views/IncidentDetail.vue
@@ -343,9 +343,9 @@ onMounted(async () => {
           </a>
         </div>
 
-        <!-- Investigation results (investigated, fixing, or preserved on needs_human) -->
+        <!-- Investigation results (investigated, awaiting approval, fixing, or preserved on needs_human) -->
         <div
-          v-if="(incident.status === 'investigated' || incident.status === 'fixing' || incident.status === 'needs_human') && incident.root_cause"
+          v-if="(incident.status === 'investigated' || incident.status === 'awaiting_approval' || incident.status === 'fixing' || incident.status === 'needs_human') && incident.root_cause"
           class="p-4 bg-teal-500/10 border border-teal-500/20 border-l-2 border-l-teal rounded-lg space-y-3"
         >
           <div>
@@ -368,11 +368,35 @@ onMounted(async () => {
           </div>
         </div>
 
-        <!-- Find Fix button (investigated state) -->
+        <!-- Insight card (friction, no code cause — terminal, never a PR; design v4-4) -->
         <div
-          v-if="incident.status === 'investigated'"
+          v-if="incident.status === 'insight'"
+          class="p-4 bg-purple-500/10 border border-purple-500/20 border-l-2 border-l-purple rounded-lg space-y-3"
+        >
+          <p class="text-sm font-medium text-purple">Insight — no code cause</p>
+          <p class="text-xs text-text-muted">
+            Opslane investigated this friction and found no code change that would fix it.
+            No PR will be created; use the findings below to guide a product or UX change.
+          </p>
+          <div v-if="incident.root_cause">
+            <p class="text-xs font-medium text-purple uppercase tracking-wide">What users hit</p>
+            <pre
+              class="mt-1 text-sm bg-surface border border-border p-3 rounded overflow-x-auto whitespace-pre-wrap text-text"
+              v-text="incident.root_cause"
+            ></pre>
+          </div>
+        </div>
+
+        <!-- Find Fix / Generate fix button -->
+        <div
+          v-if="incident.status === 'investigated' || incident.status === 'awaiting_approval'"
           class="p-4 bg-surface border border-border rounded-lg space-y-3"
         >
+          <p v-if="incident.status === 'awaiting_approval'" class="text-xs text-text-muted">
+            This friction fix has a code cause and is waiting for your approval.
+            It will open a <strong>Suggestion</strong> PR — repo tests must pass,
+            but the friction itself is not re-verified.
+          </p>
           <div>
             <label for="guidance" class="block text-sm font-medium text-text-muted">
               Guide the agent (optional)
@@ -394,7 +418,7 @@ onMounted(async () => {
               @click="handleTriggerFix"
             >
               <span v-if="fixLoading">Triggering...</span>
-              <span v-else>Find Fix</span>
+              <span v-else>{{ incident.status === 'awaiting_approval' ? 'Generate fix' : 'Find Fix' }}</span>
             </button>
             <p
               v-if="fixError"

--- a/packages/dashboard/src/views/Settings.vue
+++ b/packages/dashboard/src/views/Settings.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { computed, ref, onMounted, watch } from 'vue';
 import {
   listProjects,
+  updateProject,
+  getFixStats,
   listEnvironments,
   createEnvironment,
   listAPIKeys,
@@ -14,6 +16,7 @@ import {
   type Environment,
   type APIKey,
   type APIKeyCreated,
+  type FixStats,
 } from '../api';
 import type { GitHubConfig, GitHubAppStatus } from '../types/api';
 import { formatDate, safeUrl } from '../utils';
@@ -29,6 +32,36 @@ const manualId = ref('');
 const showManual = ref(false);
 const saved = ref(false);
 const loadingProjects = ref(true);
+
+// Friction autonomy
+const autonomyOptions = [
+  {
+    value: 'ask_first',
+    label: 'Ask first (default)',
+    description: 'Friction fixes wait in awaiting-approval until you click Generate fix.',
+  },
+  {
+    value: 'auto_fix',
+    label: 'Auto-fix',
+    description: 'High-confidence, code-caused friction goes straight to a Suggestion PR.',
+  },
+  {
+    value: 'auto_fix_ux',
+    label: 'Auto-fix incl. UX suggestions',
+    description: 'Same as auto-fix today; reserved for UX-suggestion fixes when they ship.',
+  },
+] as const;
+
+const selectedProject = computed(() =>
+  projects.value.find((project) => project.id === selectedProjectId.value) ?? null,
+);
+const autonomy = ref<Project['friction_autonomy']>('ask_first');
+const autonomySaving = ref(false);
+const autonomyError = ref('');
+const fixStats = ref<Record<'error' | 'friction', FixStats> | null>(null);
+let statsRequestToken = 0;
+let autonomySaveToken = 0;
+let lastLoadedProjectId: string | null = null;
 
 // Environments tab
 const environments = ref<Environment[]>([]);
@@ -72,10 +105,93 @@ onMounted(async () => {
   }
 });
 
+watch(selectedProjectId, () => {
+  // Invalidate an in-flight save for the previously selected project so its
+  // completion cannot overwrite the new project's displayed state.
+  autonomySaveToken += 1;
+  autonomySaving.value = false;
+  void loadAutonomyAndStats();
+}, { immediate: true });
+watch(projects, () => {
+  // The projects list changes in two ways: the async load on mount (the
+  // selected project appears — fetch its stats) and a completed save (same
+  // project, only friction_autonomy changed — re-sync the toggle without
+  // refetching stats, which would flicker the receipts for nothing).
+  autonomy.value = selectedProject.value?.friction_autonomy ?? 'ask_first';
+  if ((selectedProject.value?.id ?? null) !== lastLoadedProjectId) {
+    void loadAutonomyAndStats();
+  }
+});
+
+async function loadAutonomyAndStats(): Promise<void> {
+  const token = ++statsRequestToken;
+  autonomyError.value = '';
+  fixStats.value = null;
+  autonomy.value = selectedProject.value?.friction_autonomy ?? 'ask_first';
+
+  const id = selectedProjectId.value;
+  lastLoadedProjectId = selectedProject.value?.id ?? null;
+  if (!id || !selectedProject.value) return;
+
+  try {
+    const stats = await getFixStats(id);
+    if (token === statsRequestToken) {
+      fixStats.value = stats;
+    }
+  } catch {
+    // Stats are best-effort; the autonomy setting works without them.
+  }
+}
+
+async function saveAutonomy(value: Project['friction_autonomy']): Promise<void> {
+  if (!selectedProject.value) return;
+
+  const projectId = selectedProject.value.id;
+  const saveToken = ++autonomySaveToken;
+  const previous = autonomy.value;
+  autonomy.value = value;
+  autonomySaving.value = true;
+  autonomyError.value = '';
+  try {
+    const updated = await updateProject(projectId, { friction_autonomy: value });
+    projects.value = projects.value.map((project) =>
+      project.id === updated.id ? updated : project,
+    );
+  } catch (err: unknown) {
+    if (saveToken === autonomySaveToken && selectedProjectId.value === projectId) {
+      autonomy.value = previous;
+      autonomyError.value = err instanceof Error
+        ? err.message
+        : 'Failed to save autonomy setting';
+    }
+  } finally {
+    if (saveToken === autonomySaveToken) {
+      autonomySaving.value = false;
+    }
+  }
+}
+
+function optionStats(value: Project['friction_autonomy']): string {
+  const stats = fixStats.value?.friction;
+  if (!stats) return '';
+
+  switch (value) {
+    case 'ask_first':
+      return `${stats.generated_human} friction fixes requested by you`;
+    case 'auto_fix':
+      // Attempts, not delivered PRs: a job can park or dead-end before a PR.
+      // The merged/closed splits count auto-triggered PRs only.
+      return `${stats.generated_auto} auto fix attempts · ${stats.prs_merged_auto} merged · ${stats.prs_closed_auto} closed without merge`;
+    case 'auto_fix_ux':
+      return 'Shares the auto-fix path today — activity is counted under Auto-fix';
+  }
+}
+
 function save(): void {
   const id = showManual.value ? manualId.value.trim() : selectedProjectId.value;
   if (!id) return;
 
+  selectedProjectId.value = id;
   localStorage.setItem('opslane_project_id', id);
 
   const project = projects.value.find((p) => p.id === id);
@@ -382,6 +498,60 @@ async function handleCreateKey(): Promise<void> {
           </div>
         </div>
       </div>
+
+      <!-- Friction autonomy (Batch 5, issue #57) -->
+      <section class="mt-8 p-4 bg-surface border border-border rounded-lg space-y-3">
+        <div>
+          <h3 id="friction-autonomy-heading" class="text-sm font-medium text-text">Friction autonomy</h3>
+          <p id="friction-autonomy-desc" class="mt-1 text-xs text-text-muted">
+            How Opslane acts on friction incidents (rage clicks, dead clicks, form abandonment)
+            that have a code cause. Error fixes are unaffected.
+          </p>
+        </div>
+        <p v-if="!selectedProject" class="text-xs text-text-faint">
+          Select one of your projects above to manage autonomy.
+          (Manually entered project IDs can't be managed here.)
+        </p>
+        <div
+          v-else
+          class="space-y-2"
+          role="radiogroup"
+          aria-labelledby="friction-autonomy-heading"
+          aria-describedby="friction-autonomy-desc"
+        >
+          <label
+            v-for="option in autonomyOptions"
+            :key="option.value"
+            class="flex items-start gap-3 p-3 border rounded-lg transition-colors focus-within:ring-1 focus-within:ring-teal"
+            :class="[
+              autonomy === option.value
+                ? 'border-teal bg-teal-500/5'
+                : 'border-border hover:border-text-faint hover:bg-surface-2',
+              autonomySaving ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer',
+            ]"
+          >
+            <input
+              type="radio"
+              name="friction-autonomy"
+              class="mt-0.5"
+              :value="option.value"
+              :checked="autonomy === option.value"
+              :disabled="autonomySaving"
+              @change="saveAutonomy(option.value)"
+            />
+            <span>
+              <span class="block text-sm text-text" v-text="option.label"></span>
+              <span class="block text-xs text-text-muted" v-text="option.description"></span>
+              <span
+                v-if="fixStats"
+                class="block mt-1 text-xs text-text-faint"
+                v-text="optionStats(option.value)"
+              ></span>
+            </span>
+          </label>
+        </div>
+        <p v-if="autonomyError" class="text-sm text-red" v-text="autonomyError"></p>
+      </section>
     </div>
 
     <!-- Environments tab -->

--- a/packages/dashboard/tailwind.config.js
+++ b/packages/dashboard/tailwind.config.js
@@ -17,6 +17,7 @@ export default {
         green: 'var(--color-green)',
         amber: 'var(--color-amber)',
         red: 'var(--color-red)',
+        purple: 'var(--color-purple)',
       },
       fontFamily: {
         sans: ['var(--font-sans)'],

--- a/packages/ingestion/db/friction_test.go
+++ b/packages/ingestion/db/friction_test.go
@@ -203,3 +203,136 @@ func TestUnarchiveIncidentRestoresKindSafeStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateProjectFrictionAutonomy(t *testing.T) {
+	q, projectID := createFrictionTestProject(t, "autonomy-settings")
+	ctx := context.Background()
+
+	var orgID string
+	if err := q.Pool().QueryRow(ctx,
+		`SELECT org_id FROM projects WHERE id = $1`, projectID,
+	).Scan(&orgID); err != nil {
+		t.Fatalf("get project org: %v", err)
+	}
+
+	autoFix := "auto_fix"
+	project, err := q.UpdateProject(ctx, orgID, projectID, nil, &autoFix)
+	if err != nil || project == nil {
+		t.Fatalf("UpdateProject = (%+v, %v)", project, err)
+	}
+	if project.FrictionAutonomy != autoFix {
+		t.Fatalf("FrictionAutonomy = %q, want %q", project.FrictionAutonomy, autoFix)
+	}
+	if project.GithubRepo == nil || *project.GithubRepo != "org/repo" {
+		t.Fatalf("GithubRepo was clobbered: %v", project.GithubRepo)
+	}
+
+	project, err = q.UpdateProject(ctx, orgID, projectID, nil, nil)
+	if err != nil || project == nil || project.FrictionAutonomy != autoFix {
+		t.Fatalf("omitted autonomy was not preserved: project=%+v err=%v", project, err)
+	}
+
+	invalid := "yolo"
+	if _, err := q.UpdateProject(ctx, orgID, projectID, nil, &invalid); err == nil {
+		t.Fatal("expected invalid autonomy to violate the database constraint")
+	}
+}
+
+func TestGetFixStats(t *testing.T) {
+	q, projectID := createFrictionTestProject(t, "fix-stats")
+	ctx := context.Background()
+
+	errorGroupID := insertIncident(t, q, projectID, "fp-stats-error", "error", "merged")
+	frictionGroupID := insertIncident(t, q, projectID, "fp-stats-friction", "friction", "pr_created")
+
+	var errorJobID, frictionJobID string
+	if err := q.Pool().QueryRow(ctx,
+		`INSERT INTO error_group_jobs (error_group_id, project_id, job_type, triggered_by)
+		 VALUES ($1, $2, 'fix', 'auto') RETURNING id`,
+		errorGroupID, projectID,
+	).Scan(&errorJobID); err != nil {
+		t.Fatalf("insert auto fix job: %v", err)
+	}
+	if err := q.Pool().QueryRow(ctx,
+		`INSERT INTO error_group_jobs (error_group_id, project_id, job_type, triggered_by)
+		 VALUES ($1, $2, 'fix', 'human') RETURNING id`,
+		frictionGroupID, projectID,
+	).Scan(&frictionJobID); err != nil {
+		t.Fatalf("insert human fix job: %v", err)
+	}
+
+	for _, receipt := range []struct {
+		groupID  string
+		prNumber int
+		outcome  string
+		delivery string
+		fixJobID string
+	}{
+		{errorGroupID, 41, "merged", "fix-stats-merged", errorJobID},
+		{frictionGroupID, 42, "closed", "fix-stats-closed", frictionJobID},
+	} {
+		if _, err := q.Pool().Exec(ctx,
+			`INSERT INTO pr_outcomes
+			   (error_group_id, project_id, pr_number, outcome, github_delivery_id, fix_job_id, occurred_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, now())`,
+			receipt.groupID, projectID, receipt.prNumber, receipt.outcome, receipt.delivery, receipt.fixJobID,
+		); err != nil {
+			t.Fatalf("insert %s receipt: %v", receipt.outcome, err)
+		}
+	}
+
+	stats, err := q.GetFixStats(ctx, projectID)
+	if err != nil {
+		t.Fatalf("GetFixStats: %v", err)
+	}
+	if stat := stats["error"]; stat.GeneratedAuto != 1 || stat.GeneratedHuman != 0 || stat.PRsMerged != 1 || stat.PRsClosed != 0 {
+		t.Fatalf("error stats = %+v", stat)
+	}
+	// The error merge came from an auto job, so it counts in the auto split.
+	if stat := stats["error"]; stat.PRsMergedAuto != 1 || stat.PRsClosedAuto != 0 {
+		t.Fatalf("error auto splits = %+v", stat)
+	}
+	if stat := stats["friction"]; stat.GeneratedAuto != 0 || stat.GeneratedHuman != 1 || stat.PRsMerged != 0 || stat.PRsClosed != 1 {
+		t.Fatalf("friction stats = %+v", stat)
+	}
+	// The friction close came from a human-requested job: total counts it, the
+	// auto split must not.
+	if stat := stats["friction"]; stat.PRsMergedAuto != 0 || stat.PRsClosedAuto != 0 {
+		t.Fatalf("friction auto splits = %+v", stat)
+	}
+}
+
+func TestGetFixStats_TenantScoped(t *testing.T) {
+	q, projectID := createFrictionTestProject(t, "fix-stats-scope-a")
+	_, otherProjectID := createFrictionTestProject(t, "fix-stats-scope-b")
+	ctx := context.Background()
+
+	otherGroupID := insertIncident(t, q, otherProjectID, "fp-stats-other", "error", "merged")
+	var otherJobID string
+	if err := q.Pool().QueryRow(ctx,
+		`INSERT INTO error_group_jobs (error_group_id, project_id, job_type, triggered_by)
+		 VALUES ($1, $2, 'fix', 'auto') RETURNING id`,
+		otherGroupID, otherProjectID,
+	).Scan(&otherJobID); err != nil {
+		t.Fatalf("insert other project's fix job: %v", err)
+	}
+	if _, err := q.Pool().Exec(ctx,
+		`INSERT INTO pr_outcomes
+		   (error_group_id, project_id, pr_number, outcome, github_delivery_id, fix_job_id, occurred_at)
+		 VALUES ($1, $2, 99, 'merged', 'fix-stats-scope-d1', $3, now())`,
+		otherGroupID, otherProjectID, otherJobID,
+	); err != nil {
+		t.Fatalf("insert other project's receipt: %v", err)
+	}
+
+	stats, err := q.GetFixStats(ctx, projectID)
+	if err != nil {
+		t.Fatalf("GetFixStats: %v", err)
+	}
+	if stat := stats["error"]; stat != (db.FixStats{}) {
+		t.Fatalf("leaked another project's error stats: %+v", stat)
+	}
+	if stat := stats["friction"]; stat != (db.FixStats{}) {
+		t.Fatalf("leaked another project's friction stats: %+v", stat)
+	}
+}

--- a/packages/ingestion/db/migrations/008_receipts_wiring.sql
+++ b/packages/ingestion/db/migrations/008_receipts_wiring.sql
@@ -1,0 +1,16 @@
+-- 008_receipts_wiring.sql — Batch 5 (epic #31, issue #57): attributable receipts.
+-- Append-only after 001-007. IDEMPOTENCY IS MANDATORY: run-migrations.sh
+-- re-applies every file on every start.
+--
+-- The fix job that produced a PR, recorded at PR creation (design v4-17) so the
+-- merge/close webhook can copy it into pr_outcomes.fix_job_id. NULL for PRs
+-- created before Batch 5 and for setup PRs. Cleared when a PR closes unmerged.
+ALTER TABLE error_groups ADD COLUMN IF NOT EXISTS pr_fix_job_id UUID
+  REFERENCES error_group_jobs(id) ON DELETE SET NULL;
+
+-- GetFixStats aggregates both tables by project_id; neither had an index
+-- serving that filter (error_group_jobs is the highest-churn table).
+CREATE INDEX IF NOT EXISTS idx_error_group_jobs_project_type
+  ON error_group_jobs(project_id, job_type);
+CREATE INDEX IF NOT EXISTS idx_pr_outcomes_project
+  ON pr_outcomes(project_id);

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -56,12 +56,13 @@ type Org struct {
 }
 
 type Project struct {
-	ID            string
-	OrgID         string
-	Name          string
-	GithubRepo    *string
-	DefaultBranch string
-	CreatedAt     time.Time
+	ID               string
+	OrgID            string
+	Name             string
+	GithubRepo       *string
+	DefaultBranch    string
+	FrictionAutonomy string
+	CreatedAt        time.Time
 }
 
 type Environment struct {
@@ -113,9 +114,9 @@ func (q *Queries) CreateProject(ctx context.Context, orgID, name string, githubR
 	err := q.pool.QueryRow(ctx,
 		`INSERT INTO projects (org_id, name, github_repo)
 		 VALUES ($1, $2, $3)
-		 RETURNING id, org_id, name, github_repo, default_branch, created_at`,
+		 RETURNING id, org_id, name, github_repo, default_branch, friction_autonomy, created_at`,
 		orgID, name, githubRepo,
-	).Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.CreatedAt)
+	).Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.FrictionAutonomy, &p.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("create project: %w", err)
 	}
@@ -1101,55 +1102,199 @@ func (q *Queries) UpdateErrorGroupStatus(ctx context.Context, u StatusUpdate) er
 
 // === Resolution lifecycle ===
 
-// TransitionOnPRMerge transitions an error group from pr_created to merged.
-// Matches by github_repo (owner/repo) + pr_number. Returns the group ID or empty string if no match.
-// Assumption: github_repo + pr_number + status='pr_created' is unique in practice.
-// If multiple projects share the same repo, only one arbitrary match is updated.
-// At pilot scale (3-4 partners) this is acceptable; revisit if multi-project-per-repo is needed.
-func (q *Queries) TransitionOnPRMerge(ctx context.Context, githubRepo string, prNumber int) (string, error) {
-	var groupID string
-	err := q.pool.QueryRow(ctx,
-		`UPDATE error_groups eg
-		 SET status = 'merged', merged_at = now(), updated_at = now()
-		 FROM projects p
-		 WHERE eg.project_id = p.id
-		   AND p.github_repo = $1
-		   AND eg.pr_number = $2
-		   AND eg.status = 'pr_created'
-		 RETURNING eg.id`,
-		githubRepo, prNumber,
-	).Scan(&groupID)
-	if err == pgx.ErrNoRows {
-		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("transition on PR merge: %w", err)
-	}
-	return groupID, nil
+// PRWebhookResult reports how a pull_request webhook was applied.
+type PRWebhookResult struct {
+	GroupID   string
+	Duplicate bool // receipt for this github_delivery_id already existed; no transition performed
 }
 
-// TransitionOnPRClose transitions an error group from pr_created back to investigated
-// when a PR is closed without merging. Clears PR fields.
-func (q *Queries) TransitionOnPRClose(ctx context.Context, githubRepo string, prNumber int) (string, error) {
-	var groupID string
-	err := q.pool.QueryRow(ctx,
-		`UPDATE error_groups eg
-		 SET status = 'investigated', pr_url = NULL, pr_number = NULL, updated_at = now()
-		 FROM projects p
-		 WHERE eg.project_id = p.id
-		   AND p.github_repo = $1
+// ProcessPRWebhook records an immutable pr_outcomes receipt before transitioning
+// the matched group. GitHub delivery IDs make redeliveries idempotent. A
+// closed-unmerged friction group returns to awaiting_approval; an error group
+// returns to investigated.
+//
+// A merge for a PR whose group already left pr_created (closed unmerged, then
+// reopened and merged) is recovered through the earlier close receipt, which
+// still links repo+pr_number to the group. Without that, the merge would be
+// silently dropped and the incident would stay fix-eligible. A close/merge
+// arriving before the worker records pr_created still no-matches — recovering
+// that needs a delivery inbox and is deliberately out of scope here.
+//
+// Matching by github_repo + pr_number + status='pr_created' assumes that tuple
+// is unique in practice. If multiple projects share the same repo, one arbitrary
+// match is used; revisit this for multi-project-per-repo support.
+func (q *Queries) ProcessPRWebhook(ctx context.Context, githubRepo string, prNumber int, merged bool, deliveryID string, occurredAt time.Time) (PRWebhookResult, error) {
+	tx, err := q.pool.Begin(ctx)
+	if err != nil {
+		return PRWebhookResult{}, fmt.Errorf("begin PR webhook transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Check idempotency before matching the group: the first delivery moves the
+	// group out of pr_created or clears its PR fields.
+	var seenGroupID string
+	err = tx.QueryRow(ctx,
+		`SELECT error_group_id FROM pr_outcomes WHERE github_delivery_id = $1`,
+		deliveryID,
+	).Scan(&seenGroupID)
+	if err == nil {
+		return PRWebhookResult{GroupID: seenGroupID, Duplicate: true}, nil
+	}
+	if err != pgx.ErrNoRows {
+		return PRWebhookResult{}, fmt.Errorf("check PR webhook delivery id: %w", err)
+	}
+
+	var groupID, projectID, kind string
+	var fixJobID *string
+	err = tx.QueryRow(ctx,
+		`SELECT eg.id, eg.project_id, eg.kind, eg.pr_fix_job_id
+		 FROM error_groups eg
+		 JOIN projects p ON eg.project_id = p.id
+		 WHERE p.github_repo = $1
 		   AND eg.pr_number = $2
 		   AND eg.status = 'pr_created'
-		 RETURNING eg.id`,
+		 FOR UPDATE OF eg`,
 		githubRepo, prNumber,
-	).Scan(&groupID)
+	).Scan(&groupID, &projectID, &kind, &fixJobID)
 	if err == pgx.ErrNoRows {
-		return "", nil
+		// A concurrent delivery can pass the first receipt check, wait on the
+		// group's row lock, then find that the winner already transitioned it.
+		// Recheck the immutable receipt so that race still reports duplicate.
+		err = tx.QueryRow(ctx,
+			`SELECT error_group_id FROM pr_outcomes WHERE github_delivery_id = $1`,
+			deliveryID,
+		).Scan(&seenGroupID)
+		if err == nil {
+			return PRWebhookResult{GroupID: seenGroupID, Duplicate: true}, nil
+		}
+		if err != pgx.ErrNoRows {
+			return PRWebhookResult{}, fmt.Errorf("recheck PR webhook delivery id: %w", err)
+		}
+		if !merged {
+			return PRWebhookResult{}, nil
+		}
+		return recoverReopenedMerge(ctx, tx, githubRepo, prNumber, deliveryID, occurredAt)
 	}
 	if err != nil {
-		return "", fmt.Errorf("transition on PR close: %w", err)
+		return PRWebhookResult{}, fmt.Errorf("match PR webhook group: %w", err)
 	}
-	return groupID, nil
+
+	outcome := "closed"
+	if merged {
+		outcome = "merged"
+	}
+	ct, err := tx.Exec(ctx,
+		`INSERT INTO pr_outcomes
+		   (error_group_id, project_id, pr_number, outcome, github_delivery_id, fix_job_id, occurred_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)
+		 ON CONFLICT (github_delivery_id) DO NOTHING`,
+		groupID, projectID, prNumber, outcome, deliveryID, fixJobID, occurredAt,
+	)
+	if err != nil {
+		return PRWebhookResult{}, fmt.Errorf("insert PR outcome: %w", err)
+	}
+	if ct.RowsAffected() == 0 {
+		if err := tx.Commit(ctx); err != nil {
+			return PRWebhookResult{}, fmt.Errorf("commit duplicate PR webhook: %w", err)
+		}
+		return PRWebhookResult{GroupID: groupID, Duplicate: true}, nil
+	}
+
+	if merged {
+		// merged_at anchors the silence checker's post-merge window, so use the
+		// PR's actual closed_at rather than webhook-processing time: a delayed
+		// delivery must not reclassify post-merge regressions as pre-merge noise.
+		_, err = tx.Exec(ctx,
+			`UPDATE error_groups
+			 SET status = 'merged', merged_at = $2, updated_at = now()
+			 WHERE id = $1`,
+			groupID, occurredAt,
+		)
+	} else {
+		_, err = tx.Exec(ctx,
+			`UPDATE error_groups
+			 SET status = CASE WHEN kind = 'friction'
+			                   THEN 'awaiting_approval'::error_group_status
+			                   ELSE 'investigated'::error_group_status END,
+			     pr_url = NULL,
+			     pr_number = NULL,
+			     pr_fix_job_id = NULL,
+			     updated_at = now()
+			 WHERE id = $1`,
+			groupID,
+		)
+	}
+	if err != nil {
+		return PRWebhookResult{}, fmt.Errorf("transition on PR %s: %w", outcome, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return PRWebhookResult{}, fmt.Errorf("commit PR webhook transaction: %w", err)
+	}
+	return PRWebhookResult{GroupID: groupID}, nil
+}
+
+// recoverReopenedMerge handles a merge webhook for a PR whose group already
+// left pr_created: the unmerged close wrote a receipt and cleared the group's
+// PR fields, then the PR was reopened and merged. The earlier receipt still
+// links repo+pr_number to the group, so the merge receipt is recorded (with the
+// close receipt's fix_job_id for attribution) and — only if the group is still
+// parked where the close left it — the group transitions to merged. Any other
+// status means the incident moved on (a newer fix may be in flight); the
+// receipt is still written so outcome counts stay accurate, but state is left
+// alone.
+func recoverReopenedMerge(ctx context.Context, tx pgx.Tx, githubRepo string, prNumber int, deliveryID string, occurredAt time.Time) (PRWebhookResult, error) {
+	var groupID, projectID, status string
+	var fixJobID *string
+	err := tx.QueryRow(ctx,
+		`SELECT eg.id, eg.project_id, eg.status, o.fix_job_id
+		 FROM pr_outcomes o
+		 JOIN error_groups eg ON o.error_group_id = eg.id
+		 JOIN projects p ON eg.project_id = p.id
+		 WHERE p.github_repo = $1
+		   AND o.pr_number = $2
+		 ORDER BY o.occurred_at DESC, o.created_at DESC
+		 LIMIT 1
+		 FOR UPDATE OF eg`,
+		githubRepo, prNumber,
+	).Scan(&groupID, &projectID, &status, &fixJobID)
+	if err == pgx.ErrNoRows {
+		return PRWebhookResult{}, nil
+	}
+	if err != nil {
+		return PRWebhookResult{}, fmt.Errorf("recover reopened PR merge: %w", err)
+	}
+
+	ct, err := tx.Exec(ctx,
+		`INSERT INTO pr_outcomes
+		   (error_group_id, project_id, pr_number, outcome, github_delivery_id, fix_job_id, occurred_at)
+		 VALUES ($1, $2, $3, 'merged', $4, $5, $6)
+		 ON CONFLICT (github_delivery_id) DO NOTHING`,
+		groupID, projectID, prNumber, deliveryID, fixJobID, occurredAt,
+	)
+	if err != nil {
+		return PRWebhookResult{}, fmt.Errorf("insert recovered PR outcome: %w", err)
+	}
+	if ct.RowsAffected() == 0 {
+		if err := tx.Commit(ctx); err != nil {
+			return PRWebhookResult{}, fmt.Errorf("commit duplicate recovered PR webhook: %w", err)
+		}
+		return PRWebhookResult{GroupID: groupID, Duplicate: true}, nil
+	}
+
+	if status == "investigated" || status == "awaiting_approval" {
+		if _, err := tx.Exec(ctx,
+			`UPDATE error_groups
+			 SET status = 'merged', merged_at = $2, updated_at = now()
+			 WHERE id = $1`,
+			groupID, occurredAt,
+		); err != nil {
+			return PRWebhookResult{}, fmt.Errorf("transition recovered PR merge: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return PRWebhookResult{}, fmt.Errorf("commit recovered PR webhook: %w", err)
+	}
+	return PRWebhookResult{GroupID: groupID}, nil
 }
 
 // ResolveErrorGroup manually transitions an error group to resolved.
@@ -1495,7 +1640,7 @@ func (q *Queries) ConsumeAuthorizationCode(ctx context.Context, codeHash string)
 // ListProjectsByOrg returns all projects for a given org. Tenant-scoped.
 func (q *Queries) ListProjectsByOrg(ctx context.Context, orgID string) ([]Project, error) {
 	rows, err := q.pool.Query(ctx,
-		`SELECT id, org_id, name, github_repo, default_branch, created_at
+		`SELECT id, org_id, name, github_repo, default_branch, friction_autonomy, created_at
 		 FROM projects
 		 WHERE org_id = $1
 		 ORDER BY created_at ASC`,
@@ -1509,7 +1654,7 @@ func (q *Queries) ListProjectsByOrg(ctx context.Context, orgID string) ([]Projec
 	var projects []Project
 	for rows.Next() {
 		var p Project
-		if err := rows.Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.CreatedAt); err != nil {
+		if err := rows.Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.FrictionAutonomy, &p.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan project: %w", err)
 		}
 		projects = append(projects, p)
@@ -1522,10 +1667,10 @@ func (q *Queries) ListProjectsByOrg(ctx context.Context, orgID string) ([]Projec
 func (q *Queries) GetProjectByOrgID(ctx context.Context, orgID, projectID string) (*Project, error) {
 	var p Project
 	err := q.pool.QueryRow(ctx,
-		`SELECT id, org_id, name, github_repo, default_branch, created_at
+		`SELECT id, org_id, name, github_repo, default_branch, friction_autonomy, created_at
 		 FROM projects WHERE id = $1 AND org_id = $2`,
 		projectID, orgID,
-	).Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.CreatedAt)
+	).Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.FrictionAutonomy, &p.CreatedAt)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}
@@ -1535,15 +1680,18 @@ func (q *Queries) GetProjectByOrgID(ctx context.Context, orgID, projectID string
 	return &p, nil
 }
 
-// UpdateProject updates a project's github_repo. Tenant-scoped by orgID.
-func (q *Queries) UpdateProject(ctx context.Context, orgID, projectID string, githubRepo *string) (*Project, error) {
+// UpdateProject updates a project's settings. Only non-nil fields are changed.
+// Tenant-scoped by orgID.
+func (q *Queries) UpdateProject(ctx context.Context, orgID, projectID string, githubRepo, frictionAutonomy *string) (*Project, error) {
 	var p Project
 	err := q.pool.QueryRow(ctx,
-		`UPDATE projects SET github_repo = $3
+		`UPDATE projects
+		 SET github_repo = COALESCE($3, github_repo),
+		     friction_autonomy = COALESCE($4, friction_autonomy)
 		 WHERE id = $2 AND org_id = $1
-		 RETURNING id, org_id, name, github_repo, default_branch, created_at`,
-		orgID, projectID, githubRepo,
-	).Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.CreatedAt)
+		 RETURNING id, org_id, name, github_repo, default_branch, friction_autonomy, created_at`,
+		orgID, projectID, githubRepo, frictionAutonomy,
+	).Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.FrictionAutonomy, &p.CreatedAt)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}
@@ -1551,6 +1699,102 @@ func (q *Queries) UpdateProject(ctx context.Context, orgID, projectID string, gi
 		return nil, fmt.Errorf("update project: %w", err)
 	}
 	return &p, nil
+}
+
+// FixStats are the receipts shown beside each autonomy option.
+type FixStats struct {
+	GeneratedAuto  int `json:"generated_auto"`
+	GeneratedHuman int `json:"generated_human"`
+	PRsMerged      int `json:"prs_merged"`
+	PRsClosed      int `json:"prs_closed"`
+	// Auto-only outcome splits, attributed via pr_outcomes.fix_job_id →
+	// error_group_jobs.triggered_by, so the auto-fix receipt line never counts
+	// human-requested PRs. Receipts without a fix_job_id (pre-receipts PRs)
+	// count only in the totals above.
+	PRsMergedAuto int `json:"prs_merged_auto"`
+	PRsClosedAuto int `json:"prs_closed_auto"`
+}
+
+// GetFixStats aggregates fix generation and PR outcomes per incident kind.
+// The project ID scopes both source queries to a single tenant project.
+func (q *Queries) GetFixStats(ctx context.Context, projectID string) (map[string]FixStats, error) {
+	stats := map[string]FixStats{
+		"error":    {},
+		"friction": {},
+	}
+
+	rows, err := q.pool.Query(ctx,
+		`SELECT eg.kind, j.triggered_by, count(*)
+		 FROM error_group_jobs j
+		 JOIN error_groups eg ON j.error_group_id = eg.id
+		 WHERE j.project_id = $1
+		   AND j.job_type IN ('fix', 'error_fix')
+		   AND j.triggered_by IS NOT NULL
+		 GROUP BY eg.kind, j.triggered_by`,
+		projectID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get fix stats jobs: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var kind, triggeredBy string
+		var count int
+		if err := rows.Scan(&kind, &triggeredBy, &count); err != nil {
+			return nil, fmt.Errorf("scan fix stats jobs: %w", err)
+		}
+		stat := stats[kind]
+		switch triggeredBy {
+		case "human":
+			stat.GeneratedHuman = count
+		case "auto":
+			stat.GeneratedAuto = count
+		}
+		stats[kind] = stat
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate fix stats jobs: %w", err)
+	}
+
+	outcomeRows, err := q.pool.Query(ctx,
+		`SELECT eg.kind, o.outcome, COALESCE(j.triggered_by, '') AS triggered_by, count(*)
+		 FROM pr_outcomes o
+		 JOIN error_groups eg ON o.error_group_id = eg.id
+		 LEFT JOIN error_group_jobs j ON o.fix_job_id = j.id
+		 WHERE o.project_id = $1
+		 GROUP BY eg.kind, o.outcome, COALESCE(j.triggered_by, '')`,
+		projectID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get fix stats outcomes: %w", err)
+	}
+	defer outcomeRows.Close()
+	for outcomeRows.Next() {
+		var kind, outcome, triggeredBy string
+		var count int
+		if err := outcomeRows.Scan(&kind, &outcome, &triggeredBy, &count); err != nil {
+			return nil, fmt.Errorf("scan fix stats outcomes: %w", err)
+		}
+		stat := stats[kind]
+		switch outcome {
+		case "merged":
+			stat.PRsMerged += count
+			if triggeredBy == "auto" {
+				stat.PRsMergedAuto += count
+			}
+		case "closed":
+			stat.PRsClosed += count
+			if triggeredBy == "auto" {
+				stat.PRsClosedAuto += count
+			}
+		}
+		stats[kind] = stat
+	}
+	if err := outcomeRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate fix stats outcomes: %w", err)
+	}
+
+	return stats, nil
 }
 
 // ListEnvironments returns all environments for a project. Tenant-scoped.
@@ -1653,9 +1897,9 @@ func (q *Queries) CreateProjectTx(ctx context.Context, tx pgx.Tx, orgID, name st
 	err := tx.QueryRow(ctx,
 		`INSERT INTO projects (org_id, name, github_repo)
 		 VALUES ($1, $2, $3)
-		 RETURNING id, org_id, name, github_repo, default_branch, created_at`,
+		 RETURNING id, org_id, name, github_repo, default_branch, friction_autonomy, created_at`,
 		orgID, name, githubRepo,
-	).Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.CreatedAt)
+	).Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.FrictionAutonomy, &p.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("create project tx: %w", err)
 	}
@@ -1868,13 +2112,13 @@ func (q *Queries) ExpireAgentSessions(ctx context.Context) (int64, error) {
 func (q *Queries) FindProjectByRepoURL(ctx context.Context, repoURL string) (*Project, error) {
 	var p Project
 	err := q.pool.QueryRow(ctx,
-		`SELECT id, org_id, name, github_repo, default_branch, created_at
+		`SELECT id, org_id, name, github_repo, default_branch, friction_autonomy, created_at
 		 FROM projects
 		 WHERE github_repo = $1
 		 ORDER BY created_at ASC
 		 LIMIT 1`,
 		repoURL,
-	).Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.CreatedAt)
+	).Scan(&p.ID, &p.OrgID, &p.Name, &p.GithubRepo, &p.DefaultBranch, &p.FrictionAutonomy, &p.CreatedAt)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}

--- a/packages/ingestion/db/queries_test.go
+++ b/packages/ingestion/db/queries_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -179,7 +180,7 @@ func TestTriggerFixJob_IsTenantScoped(t *testing.T) {
 	}
 }
 
-func TestTransitionOnPRMergeAndClose(t *testing.T) {
+func TestProcessPRWebhook_ReceiptBeforeTransition_Idempotent(t *testing.T) {
 	pool := testPool(t)
 	ctx := context.Background()
 	q := db.New(pool)
@@ -198,33 +199,154 @@ func TestTransitionOnPRMergeAndClose(t *testing.T) {
 		t.Fatalf("set pr_number: %v", err)
 	}
 
-	// Wrong repo/PR: no transition, no error.
-	if id, err := q.TransitionOnPRMerge(ctx, "org/other-repo", 7); err != nil || id != "" {
-		t.Fatalf("TransitionOnPRMerge(wrong repo) = (%q, %v), want empty", id, err)
-	}
-	if id, err := q.TransitionOnPRMerge(ctx, "org/pr-lifecycle", 999); err != nil || id != "" {
-		t.Fatalf("TransitionOnPRMerge(wrong PR) = (%q, %v), want empty", id, err)
-	}
-
-	// Matching merge transitions to merged.
-	id, err := q.TransitionOnPRMerge(ctx, "org/pr-lifecycle", 7)
-	if err != nil {
-		t.Fatalf("TransitionOnPRMerge: %v", err)
-	}
-	if id != groupID {
-		t.Fatalf("TransitionOnPRMerge returned %q, want %q", id, groupID)
+	result, err := q.ProcessPRWebhook(ctx, "org/pr-lifecycle", 7, true, "delivery-merge", time.Now())
+	if err != nil || result.GroupID != groupID || result.Duplicate {
+		t.Fatalf("ProcessPRWebhook = (%+v, %v), want group %s, not duplicate", result, err, groupID)
 	}
 	if got := groupStatus(t, pool, groupID); got != "merged" {
 		t.Fatalf("group status = %q, want merged", got)
 	}
 
-	// A merged group is terminal for the PR lifecycle: close is a no-op.
-	if id, err := q.TransitionOnPRClose(ctx, "org/pr-lifecycle", 7); err != nil || id != "" {
-		t.Fatalf("TransitionOnPRClose after merge = (%q, %v), want empty", id, err)
+	var outcome string
+	if err := pool.QueryRow(ctx,
+		`SELECT outcome FROM pr_outcomes
+		 WHERE error_group_id = $1 AND github_delivery_id = 'delivery-merge'`,
+		groupID,
+	).Scan(&outcome); err != nil || outcome != "merged" {
+		t.Fatalf("receipt = (%q, %v), want merged", outcome, err)
+	}
+
+	result, err = q.ProcessPRWebhook(ctx, "org/pr-lifecycle", 7, true, "delivery-merge", time.Now())
+	if err != nil || !result.Duplicate || result.GroupID != groupID {
+		t.Fatalf("redelivery = (%+v, %v), want duplicate for group %s", result, err, groupID)
+	}
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM pr_outcomes WHERE error_group_id = $1`, groupID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count receipts: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("receipts = %d, want 1", count)
 	}
 }
 
-func TestTransitionOnPRClose_RevertsToInvestigated(t *testing.T) {
+func TestProcessPRWebhook_ConcurrentRedeliveryReportsDuplicate(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	_, _, _, groupID := seedGroup(t, pool, q, "pr-webhook-concurrent")
+	if _, err := pool.Exec(ctx,
+		`UPDATE error_groups
+		 SET status = 'pr_created', pr_number = 71, pr_url = 'https://example.test/pull/71'
+		 WHERE id = $1`,
+		groupID,
+	); err != nil {
+		t.Fatalf("set PR fields: %v", err)
+	}
+
+	type callResult struct {
+		result db.PRWebhookResult
+		err    error
+	}
+	start := make(chan struct{})
+	results := make(chan callResult, 2)
+	for range 2 {
+		go func() {
+			<-start
+			result, err := q.ProcessPRWebhook(
+				ctx, "org/pr-webhook-concurrent", 71, true, "delivery-concurrent", time.Now(),
+			)
+			results <- callResult{result: result, err: err}
+		}()
+	}
+	close(start)
+
+	duplicates := 0
+	processed := 0
+	for range 2 {
+		call := <-results
+		if call.err != nil {
+			t.Fatalf("ProcessPRWebhook: %v", call.err)
+		}
+		if call.result.GroupID != groupID {
+			t.Fatalf("result group = %q, want %q", call.result.GroupID, groupID)
+		}
+		if call.result.Duplicate {
+			duplicates++
+		} else {
+			processed++
+		}
+	}
+	if processed != 1 || duplicates != 1 {
+		t.Fatalf("processed=%d duplicates=%d, want one of each", processed, duplicates)
+	}
+
+	var receiptCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM pr_outcomes WHERE github_delivery_id = 'delivery-concurrent'`,
+	).Scan(&receiptCount); err != nil {
+		t.Fatalf("count receipts: %v", err)
+	}
+	if receiptCount != 1 {
+		t.Fatalf("receipt count = %d, want 1", receiptCount)
+	}
+}
+
+func TestProcessPRWebhook_FrictionCloseAttributesAndReturnsToAwaitingApproval(t *testing.T) {
+	q, projectID := createFrictionTestProject(t, "pr-webhook-friction-close")
+	ctx := context.Background()
+	groupID := insertIncident(t, q, projectID, "fp-webhook-friction-close", "friction", "pr_created")
+
+	var fixJobID string
+	if err := q.Pool().QueryRow(ctx,
+		`INSERT INTO error_group_jobs (error_group_id, project_id, job_type, triggered_by)
+		 VALUES ($1, $2, 'fix', 'human') RETURNING id`,
+		groupID, projectID,
+	).Scan(&fixJobID); err != nil {
+		t.Fatalf("insert fix job: %v", err)
+	}
+	if _, err := q.Pool().Exec(ctx,
+		`UPDATE error_groups
+		 SET pr_number = 42, pr_url = 'https://github.com/org/repo/pull/42', pr_fix_job_id = $2
+		 WHERE id = $1`,
+		groupID, fixJobID,
+	); err != nil {
+		t.Fatalf("set PR fields: %v", err)
+	}
+
+	result, err := q.ProcessPRWebhook(ctx, "org/repo", 42, false, "delivery-friction-close", time.Now())
+	if err != nil || result.GroupID != groupID || result.Duplicate {
+		t.Fatalf("ProcessPRWebhook = (%+v, %v), want group %s", result, err, groupID)
+	}
+	if got := groupStatus(t, q.Pool(), groupID); got != "awaiting_approval" {
+		t.Fatalf("group status = %q, want awaiting_approval", got)
+	}
+
+	var receiptJobID *string
+	if err := q.Pool().QueryRow(ctx,
+		`SELECT fix_job_id FROM pr_outcomes WHERE github_delivery_id = 'delivery-friction-close'`,
+	).Scan(&receiptJobID); err != nil {
+		t.Fatalf("query receipt: %v", err)
+	}
+	if receiptJobID == nil || *receiptJobID != fixJobID {
+		t.Fatalf("receipt fix_job_id = %v, want %s", receiptJobID, fixJobID)
+	}
+
+	var prURL *string
+	var prNumber *int
+	var groupFixJobID *string
+	if err := q.Pool().QueryRow(ctx,
+		`SELECT pr_url, pr_number, pr_fix_job_id FROM error_groups WHERE id = $1`, groupID,
+	).Scan(&prURL, &prNumber, &groupFixJobID); err != nil {
+		t.Fatalf("query PR fields: %v", err)
+	}
+	if prURL != nil || prNumber != nil || groupFixJobID != nil {
+		t.Fatalf("PR fields not cleared: url=%v number=%v fix_job_id=%v", prURL, prNumber, groupFixJobID)
+	}
+}
+
+func TestProcessPRWebhook_ErrorCloseRevertsToInvestigated(t *testing.T) {
 	pool := testPool(t)
 	ctx := context.Background()
 	q := db.New(pool)
@@ -242,12 +364,9 @@ func TestTransitionOnPRClose_RevertsToInvestigated(t *testing.T) {
 		t.Fatalf("set pr_number: %v", err)
 	}
 
-	id, err := q.TransitionOnPRClose(ctx, "org/pr-close", 3)
-	if err != nil {
-		t.Fatalf("TransitionOnPRClose: %v", err)
-	}
-	if id != groupID {
-		t.Fatalf("TransitionOnPRClose returned %q, want %q", id, groupID)
+	result, err := q.ProcessPRWebhook(ctx, "org/pr-close", 3, false, "delivery-error-close", time.Now())
+	if err != nil || result.GroupID != groupID {
+		t.Fatalf("ProcessPRWebhook = (%+v, %v), want group %s", result, err, groupID)
 	}
 	if got := groupStatus(t, pool, groupID); got != "investigated" {
 		t.Fatalf("group status = %q, want investigated", got)
@@ -261,6 +380,94 @@ func TestTransitionOnPRClose_RevertsToInvestigated(t *testing.T) {
 	}
 	if prURL != nil || prNumber != nil {
 		t.Fatalf("PR fields not cleared on close: pr_url=%v pr_number=%v", prURL, prNumber)
+	}
+}
+
+func TestProcessPRWebhook_ReopenedMergeRecoversViaReceipt(t *testing.T) {
+	q, projectID := createFrictionTestProject(t, "pr-webhook-reopen-merge")
+	ctx := context.Background()
+	groupID := insertIncident(t, q, projectID, "fp-webhook-reopen", "friction", "pr_created")
+
+	var fixJobID string
+	if err := q.Pool().QueryRow(ctx,
+		`INSERT INTO error_group_jobs (error_group_id, project_id, job_type, triggered_by)
+		 VALUES ($1, $2, 'fix', 'human') RETURNING id`,
+		groupID, projectID,
+	).Scan(&fixJobID); err != nil {
+		t.Fatalf("insert fix job: %v", err)
+	}
+	if _, err := q.Pool().Exec(ctx,
+		`UPDATE error_groups
+		 SET pr_number = 55, pr_url = 'https://github.com/org/repo/pull/55', pr_fix_job_id = $2
+		 WHERE id = $1`,
+		groupID, fixJobID,
+	); err != nil {
+		t.Fatalf("set PR fields: %v", err)
+	}
+
+	// Close unmerged: receipt written, PR fields cleared, group parked.
+	if _, err := q.ProcessPRWebhook(ctx, "org/repo", 55, false, "delivery-reopen-close", time.Now()); err != nil {
+		t.Fatalf("close delivery: %v", err)
+	}
+	if got := groupStatus(t, q.Pool(), groupID); got != "awaiting_approval" {
+		t.Fatalf("group status after close = %q, want awaiting_approval", got)
+	}
+
+	// Reopen + merge: no pr_created match remains, but the close receipt still
+	// links repo+pr_number to the group — the merge must be recovered.
+	mergedAt := time.Now().Add(-2 * time.Minute).UTC().Truncate(time.Second)
+	result, err := q.ProcessPRWebhook(ctx, "org/repo", 55, true, "delivery-reopen-merge", mergedAt)
+	if err != nil || result.GroupID != groupID || result.Duplicate {
+		t.Fatalf("recovered merge = (%+v, %v), want group %s", result, err, groupID)
+	}
+	if got := groupStatus(t, q.Pool(), groupID); got != "merged" {
+		t.Fatalf("group status after recovered merge = %q, want merged", got)
+	}
+
+	// The recovered receipt keeps the fix-job attribution and the PR's actual
+	// merge time (not webhook-processing time) lands in merged_at.
+	var receiptJobID *string
+	if err := q.Pool().QueryRow(ctx,
+		`SELECT fix_job_id FROM pr_outcomes WHERE github_delivery_id = 'delivery-reopen-merge'`,
+	).Scan(&receiptJobID); err != nil {
+		t.Fatalf("query recovered receipt: %v", err)
+	}
+	if receiptJobID == nil || *receiptJobID != fixJobID {
+		t.Fatalf("recovered receipt fix_job_id = %v, want %s", receiptJobID, fixJobID)
+	}
+	var mergedAtDB time.Time
+	if err := q.Pool().QueryRow(ctx,
+		`SELECT merged_at FROM error_groups WHERE id = $1`, groupID,
+	).Scan(&mergedAtDB); err != nil {
+		t.Fatalf("query merged_at: %v", err)
+	}
+	if !mergedAtDB.UTC().Truncate(time.Second).Equal(mergedAt) {
+		t.Fatalf("merged_at = %v, want %v", mergedAtDB.UTC(), mergedAt)
+	}
+
+	// Redelivery of the recovered merge stays idempotent.
+	result, err = q.ProcessPRWebhook(ctx, "org/repo", 55, true, "delivery-reopen-merge", time.Now())
+	if err != nil || !result.Duplicate || result.GroupID != groupID {
+		t.Fatalf("recovered-merge redelivery = (%+v, %v), want duplicate", result, err)
+	}
+	var receipts int
+	if err := q.Pool().QueryRow(ctx,
+		`SELECT count(*) FROM pr_outcomes WHERE error_group_id = $1`, groupID,
+	).Scan(&receipts); err != nil {
+		t.Fatalf("count receipts: %v", err)
+	}
+	if receipts != 2 {
+		t.Fatalf("receipts = %d, want 2 (close + recovered merge)", receipts)
+	}
+}
+
+func TestProcessPRWebhook_NoMatch(t *testing.T) {
+	q, _ := createFrictionTestProject(t, "pr-webhook-no-match")
+	result, err := q.ProcessPRWebhook(
+		context.Background(), "org/repo", 999, true, "delivery-no-match", time.Now(),
+	)
+	if err != nil || result.GroupID != "" || result.Duplicate {
+		t.Fatalf("no match = (%+v, %v), want empty result", result, err)
 	}
 }
 

--- a/packages/ingestion/db/testhelper_test.go
+++ b/packages/ingestion/db/testhelper_test.go
@@ -44,6 +44,7 @@ func cleanupTenant(t *testing.T, pool *pgxpool.Pool, orgID string) {
 
 	// Delete in dependency order
 	queries := []string{
+		`DELETE FROM pr_outcomes WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 		`DELETE FROM error_group_jobs WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 		`DELETE FROM error_events WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 		`DELETE FROM error_group_affected_users WHERE error_group_id IN (SELECT id FROM error_groups WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1))`,

--- a/packages/ingestion/handler/auth_middleware_test.go
+++ b/packages/ingestion/handler/auth_middleware_test.go
@@ -1,10 +1,16 @@
 package handler_test
 
 import (
+	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -163,11 +169,161 @@ func TestAuthenticateSession_ValidTokenAndOrgScope(t *testing.T) {
 	}
 }
 
+func TestUpdateProjectEndpoint_FrictionAutonomy(t *testing.T) {
+	router, q, pool := authTestRouter(t)
+	orgID, projectID, _, _ := seedTenant(t, q)
+	t.Cleanup(func() { cleanupTenantHandler(t, pool, orgID) })
+
+	token, err := auth.SignAccessToken(
+		[]byte(authTestJWTSecret), "autonomy-user", orgID, "autonomy@example.com",
+	)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	patch := func(body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(
+			http.MethodPatch, "/api/v1/projects/"+projectID, strings.NewReader(body),
+		)
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, req)
+		return response
+	}
+
+	if response := patch(`{"friction_autonomy":"yolo"}`); response.Code != http.StatusBadRequest {
+		t.Fatalf("invalid autonomy status = %d, want 400: %s", response.Code, response.Body.String())
+	}
+
+	response := patch(`{"friction_autonomy":"auto_fix"}`)
+	if response.Code != http.StatusOK {
+		t.Fatalf("valid autonomy status = %d, want 200: %s", response.Code, response.Body.String())
+	}
+	var project struct {
+		GithubRepo       *string `json:"github_repo"`
+		FrictionAutonomy string  `json:"friction_autonomy"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&project); err != nil {
+		t.Fatalf("decode project response: %v", err)
+	}
+	if project.FrictionAutonomy != "auto_fix" {
+		t.Fatalf("friction_autonomy = %q, want auto_fix", project.FrictionAutonomy)
+	}
+
+	response = patch(`{"github_repo":"org/other"}`)
+	if response.Code != http.StatusOK {
+		t.Fatalf("github-only PATCH status = %d, want 200: %s", response.Code, response.Body.String())
+	}
+	if err := json.NewDecoder(response.Body).Decode(&project); err != nil {
+		t.Fatalf("decode github-only response: %v", err)
+	}
+	if project.FrictionAutonomy != "auto_fix" {
+		t.Fatalf("github-only PATCH reset autonomy to %q", project.FrictionAutonomy)
+	}
+	if project.GithubRepo == nil || *project.GithubRepo != "org/other" {
+		t.Fatalf("github_repo = %v, want org/other", project.GithubRepo)
+	}
+}
+
+func TestGetFixStatsEndpoint_AuthenticatedShape(t *testing.T) {
+	router, q, pool := authTestRouter(t)
+	orgID, projectID, _, _ := seedTenant(t, q)
+	t.Cleanup(func() { cleanupTenantHandler(t, pool, orgID) })
+	path := "/api/v1/projects/" + projectID + "/fix-stats"
+
+	if response := doRequest(router, http.MethodGet, path, nil); response.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want 401", response.Code)
+	}
+
+	token, err := auth.SignAccessToken(
+		[]byte(authTestJWTSecret), "stats-user", orgID, "stats@example.com",
+	)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	response := doRequest(router, http.MethodGet, path,
+		map[string]string{"Authorization": "Bearer " + token})
+	if response.Code != http.StatusOK {
+		t.Fatalf("authenticated status = %d, want 200: %s", response.Code, response.Body.String())
+	}
+
+	var payload map[string]map[string]int
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode fix stats: %v", err)
+	}
+	for _, kind := range []string{"error", "friction"} {
+		stat, ok := payload[kind]
+		if !ok {
+			t.Fatalf("response missing %q stats: %#v", kind, payload)
+		}
+		for _, field := range []string{
+			"generated_auto", "generated_human",
+			"prs_merged", "prs_closed", "prs_merged_auto", "prs_closed_auto",
+		} {
+			if _, ok := stat[field]; !ok {
+				t.Fatalf("%s stats missing %q: %#v", kind, field, stat)
+			}
+		}
+	}
+}
+
+func TestHandleWebhook_StatusMapping(t *testing.T) {
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "handler-test-secret")
+	router, q, pool := authTestRouter(t)
+	orgID, projectID, _, _ := seedTenant(t, q)
+	t.Cleanup(func() { cleanupTenantHandler(t, pool, orgID) })
+	ctx := context.Background()
+
+	var groupID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO error_groups (project_id, fingerprint, title, first_seen, last_seen, kind, status, pr_number, pr_url)
+		 VALUES ($1, 'fp-webhook-mapping', 'fp-webhook-mapping', now(), now(), 'error', 'pr_created', 77, 'https://github.com/owner/repo/pull/77')
+		 RETURNING id`,
+		projectID,
+	).Scan(&groupID); err != nil {
+		t.Fatalf("insert pr_created group: %v", err)
+	}
+
+	post := func(payload []byte, deliveryID string) map[string]string {
+		t.Helper()
+		mac := hmac.New(sha256.New, []byte("handler-test-secret"))
+		mac.Write(payload)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/github/webhook", bytes.NewReader(payload))
+		req.Header.Set("X-Hub-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+		req.Header.Set("X-GitHub-Event", "pull_request")
+		req.Header.Set("X-GitHub-Delivery", deliveryID)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("webhook status = %d, want 200: %s", w.Code, w.Body.String())
+		}
+		var body map[string]string
+		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+			t.Fatalf("decode webhook response: %v", err)
+		}
+		return body
+	}
+
+	merged := []byte(`{"action":"closed","pull_request":{"number":77,"merged":true},"repository":{"full_name":"owner/repo"}}`)
+	if body := post(merged, "mapping-d1"); body["status"] != "processed" || body["action"] != "merged" || body["group_id"] != groupID {
+		t.Fatalf("first delivery = %v, want processed/merged/%s", body, groupID)
+	}
+	if body := post(merged, "mapping-d1"); body["status"] != "duplicate" || body["group_id"] != groupID {
+		t.Fatalf("redelivery = %v, want duplicate", body)
+	}
+	noMatch := []byte(`{"action":"closed","pull_request":{"number":9999,"merged":false},"repository":{"full_name":"owner/repo"}}`)
+	if body := post(noMatch, "mapping-d2"); body["status"] != "no_match" || body["action"] != "closed" {
+		t.Fatalf("unknown PR = %v, want no_match/closed", body)
+	}
+}
+
 // cleanupTenantHandler mirrors db_test.cleanupTenant for handler tests.
 func cleanupTenantHandler(t *testing.T, pool *pgxpool.Pool, orgID string) {
 	t.Helper()
 	ctx := context.Background()
 	for _, q := range []string{
+		`DELETE FROM pr_outcomes WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 		`DELETE FROM error_group_jobs WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 		`DELETE FROM error_events WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 		`DELETE FROM error_groups WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,

--- a/packages/ingestion/handler/read_api.go
+++ b/packages/ingestion/handler/read_api.go
@@ -91,18 +91,20 @@ func toIncidentJSON(g db.ErrorGroup) incidentJSON {
 
 // projectJSON is the JSON representation of a project for the dashboard API.
 type projectJSON struct {
-	ID         string  `json:"id"`
-	Name       string  `json:"name"`
-	GithubRepo *string `json:"github_repo"`
-	CreatedAt  string  `json:"created_at"`
+	ID               string  `json:"id"`
+	Name             string  `json:"name"`
+	GithubRepo       *string `json:"github_repo"`
+	FrictionAutonomy string  `json:"friction_autonomy"`
+	CreatedAt        string  `json:"created_at"`
 }
 
 func toProjectJSON(p db.Project) projectJSON {
 	return projectJSON{
-		ID:         p.ID,
-		Name:       p.Name,
-		GithubRepo: p.GithubRepo,
-		CreatedAt:  p.CreatedAt.Format(time.RFC3339),
+		ID:               p.ID,
+		Name:             p.Name,
+		GithubRepo:       p.GithubRepo,
+		FrictionAutonomy: p.FrictionAutonomy,
+		CreatedAt:        p.CreatedAt.Format(time.RFC3339),
 	}
 }
 
@@ -434,14 +436,27 @@ func (d *Dependencies) UpdateProjectEndpoint(w http.ResponseWriter, r *http.Requ
 
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
 	var req struct {
-		GithubRepo *string `json:"github_repo"`
+		GithubRepo       *string `json:"github_repo"`
+		FrictionAutonomy *string `json:"friction_autonomy"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 
-	project, err := d.Queries.UpdateProject(r.Context(), orgID, projectID, req.GithubRepo)
+	if req.FrictionAutonomy != nil {
+		switch *req.FrictionAutonomy {
+		case "ask_first", "auto_fix", "auto_fix_ux":
+		default:
+			writeJSONError(w, http.StatusBadRequest,
+				"friction_autonomy must be one of ask_first, auto_fix, auto_fix_ux")
+			return
+		}
+	}
+
+	project, err := d.Queries.UpdateProject(
+		r.Context(), orgID, projectID, req.GithubRepo, req.FrictionAutonomy,
+	)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to update project")
 		return
@@ -453,6 +468,24 @@ func (d *Dependencies) UpdateProjectEndpoint(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(toProjectJSON(*project))
+}
+
+// GetFixStatsEndpoint returns per-kind fix generation and PR outcome counts.
+// GET /api/v1/projects/{projectID}/fix-stats
+func (d *Dependencies) GetFixStatsEndpoint(w http.ResponseWriter, r *http.Request) {
+	projectID := chi.URLParam(r, "projectID")
+	if !d.verifyProjectAccess(w, r, projectID) {
+		return
+	}
+
+	stats, err := d.Queries.GetFixStats(r.Context(), projectID)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to load fix stats")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(stats)
 }
 
 // ListEnvironmentsEndpoint returns environments for a project.

--- a/packages/ingestion/handler/routes.go
+++ b/packages/ingestion/handler/routes.go
@@ -103,6 +103,9 @@ func NewRouterWithPool(deps *Dependencies, pool *pgxpool.Pool) *chi.Mux {
 
 		// Stats (session or SDK auth — CLI uses API key, dashboard uses JWT)
 		r.With(deps.AuthenticateSessionOrSDK).Get("/projects/{projectID}/event-count", deps.GetEventCountEndpoint)
+		// Fix-stats is dashboard-only (session auth): it backs the autonomy
+		// settings receipts, which no SDK/CLI caller consumes.
+		r.With(deps.AuthenticateSession).Get("/projects/{projectID}/fix-stats", deps.GetFixStatsEndpoint)
 
 		// Incidents (session or SDK auth — CLI uses API key, dashboard uses JWT)
 		r.With(deps.AuthenticateSessionOrSDK).Get("/projects/{projectID}/incidents", deps.ListIncidents)

--- a/packages/ingestion/handler/webhook.go
+++ b/packages/ingestion/handler/webhook.go
@@ -10,14 +10,16 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 )
 
 // pullRequestEvent represents the relevant fields from a GitHub pull_request webhook payload.
 type pullRequestEvent struct {
 	Action      string `json:"action"`
 	PullRequest struct {
-		Number int  `json:"number"`
-		Merged bool `json:"merged"`
+		Number   int        `json:"number"`
+		Merged   bool       `json:"merged"`
+		ClosedAt *time.Time `json:"closed_at"`
 	} `json:"pull_request"`
 	Repository struct {
 		FullName string `json:"full_name"`
@@ -56,6 +58,12 @@ func (d *Dependencies) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	deliveryID := r.Header.Get("X-GitHub-Delivery")
+	if deliveryID == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing X-GitHub-Delivery header")
+		return
+	}
+
 	var event pullRequestEvent
 	if err := json.Unmarshal(body, &event); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON payload")
@@ -71,36 +79,41 @@ func (d *Dependencies) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 
 	repo := event.Repository.FullName
 	prNumber := event.PullRequest.Number
-
-	if event.PullRequest.Merged {
-		groupID, err := d.Queries.TransitionOnPRMerge(r.Context(), repo, prNumber)
-		if err != nil {
-			slog.Error("webhook: transition on PR merge failed", "repo", repo, "pr", prNumber, "error", err)
-			writeJSONError(w, http.StatusInternalServerError, "failed to process merge event")
-			return
-		}
-		status := "processed"
-		if groupID == "" {
-			status = "no_match"
-		}
-		slog.Info("webhook: PR merged", "repo", repo, "pr", prNumber, "group_id", groupID, "status", status)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": status, "action": "merged", "group_id": groupID})
-	} else {
-		groupID, err := d.Queries.TransitionOnPRClose(r.Context(), repo, prNumber)
-		if err != nil {
-			slog.Error("webhook: transition on PR close failed", "repo", repo, "pr", prNumber, "error", err)
-			writeJSONError(w, http.StatusInternalServerError, "failed to process close event")
-			return
-		}
-		status := "processed"
-		if groupID == "" {
-			status = "no_match"
-		}
-		slog.Info("webhook: PR closed without merge", "repo", repo, "pr", prNumber, "group_id", groupID, "status", status)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": status, "action": "closed", "group_id": groupID})
+	occurredAt := time.Now()
+	if event.PullRequest.ClosedAt != nil {
+		occurredAt = *event.PullRequest.ClosedAt
 	}
+	action := "closed"
+	if event.PullRequest.Merged {
+		action = "merged"
+	}
+
+	result, err := d.Queries.ProcessPRWebhook(
+		r.Context(), repo, prNumber, event.PullRequest.Merged, deliveryID, occurredAt,
+	)
+	if err != nil {
+		slog.Error("webhook: process PR event failed", "repo", repo, "pr", prNumber, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to process pull_request event")
+		return
+	}
+	status := "processed"
+	switch {
+	case result.Duplicate:
+		status = "duplicate"
+	case result.GroupID == "":
+		status = "no_match"
+	}
+	slog.Info("webhook: PR "+action,
+		"repo", repo,
+		"pr", prNumber,
+		"group_id", result.GroupID,
+		"status", status,
+		"delivery_id", deliveryID,
+	)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status": status, "action": action, "group_id": result.GroupID,
+	})
 }
 
 // verifyWebhookSignature validates the X-Hub-Signature-256 header.

--- a/packages/ingestion/handler/webhook_test.go
+++ b/packages/ingestion/handler/webhook_test.go
@@ -1,11 +1,32 @@
 package handler
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
+
+func TestHandleWebhook_MissingDeliveryID(t *testing.T) {
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+	payload := []byte(`{"action":"closed","pull_request":{"number":1,"merged":true},"repository":{"full_name":"org/repo"}}`)
+	mac := hmac.New(sha256.New, []byte("test-secret"))
+	mac.Write(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/github/webhook", bytes.NewReader(payload))
+	req.Header.Set("X-Hub-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	req.Header.Set("X-GitHub-Event", "pull_request")
+
+	rec := httptest.NewRecorder()
+	(&Dependencies{}).HandleWebhook(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
 
 func TestVerifyWebhookSignature_Valid(t *testing.T) {
 	secret := "test-secret"

--- a/packages/test-reliability/src/system/friction-ladder.system.test.ts
+++ b/packages/test-reliability/src/system/friction-ladder.system.test.ts
@@ -1,0 +1,308 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { scanReliabilityInvariants } from '../invariant-scanner.js';
+import {
+  createFixtureRepository,
+  startProviderRecorders,
+  type ProviderRecorders,
+} from '../../../worker/src/__tests__/reliability-fixture.js';
+import type { TestTenant } from '../../../../test-e2e/helpers.js';
+
+const databaseUrl = process.env['DATABASE_URL'];
+if (!databaseUrl) {
+  throw new Error(
+    'DATABASE_URL is required for the friction-ladder system test; run it against a disposable migrated database',
+  );
+}
+
+const ingestionUrl = process.env['INGESTION_URL'] ?? 'http://localhost:8082';
+const webhookSecret = process.env['GITHUB_WEBHOOK_SECRET'] ?? 'reliability-webhook-secret';
+const envKeys = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_BASE_URL',
+  'GITHUB_TOKEN',
+  'OPSLANE_GITHUB_API_URL',
+  'OPSLANE_GITHUB_URL',
+  'OPSLANE_SANDBOX_BACKEND',
+  'OPSLANE_RELIABILITY_HARNESS',
+] as const;
+
+/**
+ * The keyed friction dogfood loop against provider twins (no real
+ * credentials): friction incident → autonomy ladder auto-triggers a fix →
+ * real agent pipeline against the Anthropic twin → real git push → Suggestion
+ * PR on the GitHub twin → twin merges/closes → signed pull_request webhook →
+ * attributable pr_outcomes receipt.
+ */
+describe('friction ladder system tracer (provider twins)', () => {
+  const savedEnv = new Map<string, string | undefined>();
+  let root: string | undefined;
+  let providers: ProviderRecorders | undefined;
+  let tenant: TestTenant | undefined;
+
+  afterAll(async () => {
+    const helpers = await import('../../../../test-e2e/helpers.js');
+    const workerDb = await import('../../../worker/src/db.js');
+    if (tenant) await helpers.cleanupTenant(tenant.orgId).catch(() => undefined);
+    await Promise.all([
+      workerDb.closePool(),
+      helpers.closePool(),
+      providers?.close(),
+    ]);
+    if (root) await rm(root, { recursive: true, force: true });
+    for (const key of envKeys) {
+      const value = savedEnv.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('walks friction from investigation to a merged, attributed Suggestion PR', async () => {
+    for (const key of envKeys) savedEnv.set(key, process.env[key]);
+
+    const health = await fetch(`${ingestionUrl}/health`);
+    expect(health.ok, `Ingestion is not healthy at ${ingestionUrl}`).toBe(true);
+
+    const helpers = await import('../../../../test-e2e/helpers.js');
+    const db = helpers.getPool();
+    const liveBefore = await db.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM error_group_jobs WHERE status IN ('pending', 'claimed')`,
+    );
+    if (liveBefore.rows[0]?.count !== '0') {
+      throw new Error(
+        `Friction-ladder system test requires a disposable database with no live jobs; found ${liveBefore.rows[0]?.count}`,
+      );
+    }
+
+    root = await mkdtemp(join(tmpdir(), 'opslane-friction-ladder-'));
+    const githubRepo = `e2e/friction-ladder-${Date.now()}`;
+    const remoteRoot = join(root, 'remotes');
+    await createFixtureRepository(root, join(remoteRoot, `${githubRepo}.git`));
+
+    providers = await startProviderRecorders({ ingestionUrl, webhookSecret });
+    process.env['ANTHROPIC_API_KEY'] = 'test-anthropic-key';
+    process.env['ANTHROPIC_BASE_URL'] = providers.anthropicBaseUrl;
+    process.env['GITHUB_TOKEN'] = 'test-github-token';
+    process.env['OPSLANE_GITHUB_API_URL'] = providers.githubBaseUrl;
+    process.env['OPSLANE_GITHUB_URL'] = pathToFileURL(remoteRoot).href;
+    process.env['OPSLANE_SANDBOX_BACKEND'] = 'local';
+    process.env['OPSLANE_RELIABILITY_HARNESS'] = '1';
+
+    tenant = await helpers.seedTenant(githubRepo);
+    // The ladder's opt-in rung: high-confidence, code-caused friction may fix
+    // without a human click.
+    await db.query(
+      `UPDATE projects SET friction_autonomy = 'auto_fix' WHERE id = $1`,
+      [tenant.projectId],
+    );
+
+    const group = await db.query<{ id: string }>(
+      `INSERT INTO error_groups
+         (project_id, fingerprint, title, first_seen, last_seen, kind, status,
+          signal_type, element_selector, page_url_normalized)
+       VALUES ($1, 'fp-friction-ladder', 'Rage click on save', now(), now(), 'friction', 'queued',
+               'rage_click', '[data-testid="save"]', 'https://fixture.invalid/settings')
+       RETURNING id`,
+      [tenant.projectId],
+    );
+    const groupId = group.rows[0]!.id;
+    await db.query(
+      `INSERT INTO error_group_jobs (error_group_id, project_id, job_type) VALUES ($1, $2, 'investigate')`,
+      [groupId, tenant.projectId],
+    );
+
+    const workerDb = await import('../../../worker/src/db.js');
+    const worker = await import('../../../worker/src/index.js');
+    const workerId = `friction-ladder-worker-${Date.now()}`;
+    const signal = new AbortController().signal;
+
+    // Investigation: the Anthropic twin classifies the friction as code-caused
+    // at high confidence, so the ladder must enqueue an auto fix job itself.
+    const investigateJob = await workerDb.claimJob(workerId, 120_000);
+    expect(investigateJob).toMatchObject({
+      errorGroupId: groupId,
+      projectId: tenant.projectId,
+      jobType: 'investigate',
+    });
+    await worker.processInvestigateJob(
+      investigateJob as NonNullable<typeof investigateJob> & { errorGroupId: string },
+      signal,
+    );
+    expect(
+      await workerDb.completeJob(investigateJob!.id, workerId, investigateJob!.leaseGeneration),
+    ).toBe(true);
+
+    const autoFixJob = await db.query<{ id: string; triggered_by: string; status: string }>(
+      `SELECT id, triggered_by, status FROM error_group_jobs
+       WHERE error_group_id = $1 AND job_type = 'fix'`,
+      [groupId],
+    );
+    expect(autoFixJob.rows).toHaveLength(1);
+    expect(autoFixJob.rows[0]).toMatchObject({ triggered_by: 'auto', status: 'pending' });
+
+    // Fix: the claim-time gate re-reads friction_autonomy and lets the auto
+    // job through; the real pipeline clones, edits (twin script), runs the
+    // fixture's tests, pushes, and opens the PR on the GitHub twin.
+    const fixJob = await workerDb.claimJob(workerId, 300_000);
+    expect(fixJob).toMatchObject({
+      id: autoFixJob.rows[0]!.id,
+      errorGroupId: groupId,
+      jobType: 'fix',
+      triggeredBy: 'auto',
+    });
+    await worker.processFixJob(
+      fixJob as NonNullable<typeof fixJob> & { errorGroupId: string },
+      signal,
+    );
+    expect(await workerDb.completeJob(fixJob!.id, workerId, fixJob!.leaseGeneration)).toBe(true);
+
+    // The Suggestion contract: honest title, honest unverified-friction body.
+    expect(providers.pullRequests).toHaveLength(1);
+    const pull = providers.pullRequests[0]!;
+    expect(pull.title).toMatch(/^\[Opslane\] Suggestion:/);
+    expect(pull.body).toContain('friction itself was not re-verified');
+    expect(pull.base).toBe('main');
+
+    const afterFix = await db.query<{
+      status: string;
+      pr_number: number | null;
+      pr_fix_job_id: string | null;
+    }>(
+      `SELECT status, pr_number, pr_fix_job_id FROM error_groups WHERE id = $1`,
+      [groupId],
+    );
+    expect(afterFix.rows[0]).toEqual({
+      status: 'pr_created',
+      pr_number: pull.number,
+      pr_fix_job_id: fixJob!.id,
+    });
+    expect(await scanReliabilityInvariants(db)).toEqual([]);
+
+    // Merge on the twin → signed webhook → receipt BEFORE transition, fully
+    // attributed to the fix job recorded at PR creation.
+    const mergedAt = new Date(Date.now() - 60_000);
+    mergedAt.setMilliseconds(0);
+    const merge = await providers.mergePullRequest(pull.number, mergedAt);
+    expect(merge.status).toBe(200);
+    expect(await merge.json()).toMatchObject({ status: 'processed', action: 'merged' });
+
+    const afterMerge = await db.query<{
+      status: string;
+      merged_at: Date | null;
+    }>(
+      `SELECT status, merged_at FROM error_groups WHERE id = $1`,
+      [groupId],
+    );
+    expect(afterMerge.rows[0]?.status).toBe('merged');
+    expect(afterMerge.rows[0]?.merged_at?.toISOString()).toBe(mergedAt.toISOString());
+
+    const receipts = await db.query<{
+      outcome: string;
+      fix_job_id: string | null;
+      pr_number: number;
+    }>(
+      `SELECT outcome, fix_job_id, pr_number FROM pr_outcomes WHERE error_group_id = $1`,
+      [groupId],
+    );
+    expect(receipts.rows).toEqual([
+      { outcome: 'merged', fix_job_id: fixJob!.id, pr_number: pull.number },
+    ]);
+
+    // The receipts surface: this merge counts as ONE auto-attributed merge —
+    // the same join GetFixStats uses for the Settings toggle numbers.
+    const stats = await db.query<{ kind: string; outcome: string; triggered_by: string | null }>(
+      `SELECT eg.kind, o.outcome, j.triggered_by
+       FROM pr_outcomes o
+       JOIN error_groups eg ON o.error_group_id = eg.id
+       LEFT JOIN error_group_jobs j ON o.fix_job_id = j.id
+       WHERE o.project_id = $1`,
+      [tenant.projectId],
+    );
+    expect(stats.rows).toEqual([
+      { kind: 'friction', outcome: 'merged', triggered_by: 'auto' },
+    ]);
+    expect(await scanReliabilityInvariants(db)).toEqual([]);
+  }, 300_000);
+
+  it('returns a close-unmerged Suggestion to awaiting_approval with its receipt', async () => {
+    const helpers = await import('../../../../test-e2e/helpers.js');
+    const db = helpers.getPool();
+    expect(tenant && providers && root, 'first test must have run').toBeTruthy();
+
+    // A second friction incident already holding an open Suggestion PR: seed
+    // the state the first test produced organically, then exercise only the
+    // close leg through the twin.
+    const group = await db.query<{ id: string }>(
+      `INSERT INTO error_groups
+         (project_id, fingerprint, title, first_seen, last_seen, kind, status,
+          signal_type, page_url_normalized, confidence)
+       VALUES ($1, 'fp-friction-ladder-close', 'Dead click on export', now(), now(), 'friction', 'pr_created',
+               'dead_click', 'https://fixture.invalid/export', 'high')
+       RETURNING id`,
+      [tenant!.projectId],
+    );
+    const groupId = group.rows[0]!.id;
+    const fixJob = await db.query<{ id: string }>(
+      `INSERT INTO error_group_jobs (error_group_id, project_id, job_type, status, triggered_by)
+       VALUES ($1, $2, 'fix', 'completed', 'auto') RETURNING id`,
+      [groupId, tenant!.projectId],
+    );
+    const fixJobId = fixJob.rows[0]!.id;
+
+    // Register the PR with the twin the same way the worker would.
+    const [owner, repo] = (await db.query<{ github_repo: string }>(
+      `SELECT github_repo FROM projects WHERE id = $1`,
+      [tenant!.projectId],
+    )).rows[0]!.github_repo.split('/') as [string, string];
+    const create = await fetch(`${process.env['OPSLANE_GITHUB_API_URL']}/repos/${owner}/${repo}/pulls`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'token test-github-token' },
+      body: JSON.stringify({
+        title: '[Opslane] Suggestion: reconnect the export handler',
+        body: 'The friction itself was not re-verified — review before merging',
+        head: 'opslane/fix-export',
+        base: 'main',
+      }),
+    });
+    const created = await create.json() as { number: number };
+    await db.query(
+      `UPDATE error_groups
+       SET pr_number = $2, pr_url = $3, pr_fix_job_id = $4
+       WHERE id = $1`,
+      [groupId, created.number, `https://github.test/${owner}/${repo}/pull/${created.number}`, fixJobId],
+    );
+
+    const closeResponse = await providers!.closePullRequest(created.number);
+    expect(closeResponse.status).toBe(200);
+    expect(await closeResponse.json()).toMatchObject({ status: 'processed', action: 'closed' });
+
+    const afterClose = await db.query<{
+      status: string;
+      confidence: string | null;
+      pr_number: number | null;
+      pr_fix_job_id: string | null;
+    }>(
+      `SELECT status, confidence, pr_number, pr_fix_job_id FROM error_groups WHERE id = $1`,
+      [groupId],
+    );
+    // Friction returns to the approval queue — not 'investigated' — with the
+    // PR fields cleared and the investigation's confidence intact.
+    expect(afterClose.rows[0]).toEqual({
+      status: 'awaiting_approval',
+      confidence: 'high',
+      pr_number: null,
+      pr_fix_job_id: null,
+    });
+
+    const receipt = await db.query<{ outcome: string; fix_job_id: string | null }>(
+      `SELECT outcome, fix_job_id FROM pr_outcomes WHERE error_group_id = $1`,
+      [groupId],
+    );
+    expect(receipt.rows).toEqual([{ outcome: 'closed', fix_job_id: fixJobId }]);
+    expect(await scanReliabilityInvariants(db)).toEqual([]);
+  }, 60_000);
+});

--- a/packages/test-reliability/src/system/worker-success.system.test.ts
+++ b/packages/test-reliability/src/system/worker-success.system.test.ts
@@ -235,7 +235,7 @@ describe('event-to-pr reliability system tracer', () => {
       project_id: tenant.projectId,
       status: 'pr_created',
       confidence: 'high',
-      pr_url: 'https://github.test/e2e/reliability/pull/42',
+      pr_url: `https://github.test/${githubRepo}/pull/42`,
     });
     expect(await scanReliabilityInvariants(db)).toEqual([]);
 

--- a/packages/worker/src/__tests__/db-queries.test.ts
+++ b/packages/worker/src/__tests__/db-queries.test.ts
@@ -177,6 +177,7 @@ describe('getProject', () => {
     });
     const project = await getProject('p1');
     expect(project?.github_repo).toBe('org/repo');
+    expect(mockQuery.mock.calls[0][0]).toContain('friction_autonomy');
   });
 });
 
@@ -302,9 +303,9 @@ describe('requeueStaleJobs — reconcile dead-lettered fix jobs', () => {
     );
     expect(statusCall, 'expected a needs_human reconciliation update').toBeTruthy();
     expect(statusCall![1][0]).toBe('g1');         // errorGroupId
-    expect(statusCall![1][6]).toBe('lease_lost'); // reason_code
-    expect(statusCall![1][7]).toBeTruthy();        // reason_message
-    expect(statusCall![1][8]).toBeTruthy();        // remediation
+    expect(statusCall![1][7]).toBe('lease_lost'); // reason_code
+    expect(statusCall![1][8]).toBeTruthy();        // reason_message
+    expect(statusCall![1][9]).toBeTruthy();        // remediation
   });
 
   it('leaves requeued (non-dead-letter) and non-fix dead-letter jobs alone', async () => {

--- a/packages/worker/src/__tests__/index.test.ts
+++ b/packages/worker/src/__tests__/index.test.ts
@@ -366,12 +366,13 @@ describe('friction worker path', () => {
       vi.mocked(investigateFriction).mockResolvedValue({
         codeCause: true, confidence: 'high', reason: 'save handler is disconnected', remediation: 'wire the handler',
       });
-      vi.mocked(db.updateGroupAndCreateFixJob).mockResolvedValue('fix-job-1');
+      vi.mocked(db.updateGroupAndCreateFixJob).mockResolvedValue({ created: true, fixJobId: 'fix-job-1' });
 
       await processInvestigateJob(makeJob(), new AbortController().signal);
 
       expect(db.updateGroupAndCreateFixJob).toHaveBeenCalledWith(
         'grp-1', 'proj-1', expect.objectContaining({ confidence: 'high' }), makeJob(),
+        { allowFriction: true },
       );
       expect(db.updateGroupInvestigation).not.toHaveBeenCalledWith(
         'grp-1', 'proj-1', 'awaiting_approval', expect.anything(), expect.anything(),

--- a/packages/worker/src/__tests__/index.test.ts
+++ b/packages/worker/src/__tests__/index.test.ts
@@ -108,6 +108,7 @@ function makeGroup(overrides?: Partial<ErrorGroupData>): ErrorGroupData {
     signal_type: null,
     element_selector: null,
     page_url_normalized: null,
+    confidence: null,
     ...overrides,
   };
 }
@@ -207,7 +208,9 @@ describe('processFixJob — preserves writeup on failure (no revert/null)', () =
       stack_trace_raw: 'at App.vue:42', stack_trace_resolved: null,
       breadcrumbs: '[]', context: '{}', release: null, session_id: null,
     } as ErrorEventData);
-    mockGetProject.mockResolvedValue({ id: 'p1', name: 'app', github_repo: 'org/app', default_branch: 'main' } as ProjectData);
+    mockGetProject.mockResolvedValue({
+      id: 'p1', name: 'app', github_repo: 'org/app', default_branch: 'main', friction_autonomy: 'ask_first',
+    } as ProjectData);
     mockCloneRepo.mockResolvedValue({ repoDir: '/tmp/r', cleanup: vi.fn() } as never);
     vi.mocked(db.getProjectGitHubInstallation).mockResolvedValue(null as never);
     vi.mocked(db.getReplayForGroup).mockResolvedValue(null as never);
@@ -271,6 +274,7 @@ describe('processFixJob — preserves writeup on failure (no revert/null)', () =
     const call = mockUpdateGroupStatus.mock.calls.find((c) => c[2] === 'pr_created');
     expect(call).toBeTruthy();
     expect(call![3]?.pr_url).toBe('https://github.com/org/app/pull/7');
+    expect(call![3]?.pr_fix_job_id).toBe('j1');
   });
 
   it('prefers session-pointer evidence fetched through ingestion', async () => {
@@ -325,14 +329,14 @@ describe('friction worker path', () => {
       page_url_normalized: 'https://app.example.com/settings',
     }));
     mockGetProject.mockResolvedValue({
-      id: 'proj-1', name: 'app', github_repo: 'org/app', default_branch: 'main',
+      id: 'proj-1', name: 'app', github_repo: 'org/app', default_branch: 'main', friction_autonomy: 'ask_first',
     });
     vi.mocked(db.getProjectGitHubInstallation).mockResolvedValue(null);
     mockCloneRepo.mockResolvedValue({ repoDir: '/tmp/repo', cleanup: vi.fn() } as never);
     vi.mocked(gatherFrictionEvidence).mockResolvedValue({ signals: [], timeline: '', truncated: false });
   });
 
-  it('skips error-only guards and never auto-fixes a code-caused friction incident', async () => {
+  it('parks code-caused friction under ask-first autonomy', async () => {
     vi.mocked(investigateFriction).mockResolvedValue({
       codeCause: true, confidence: 'high', reason: 'save handler is disconnected', remediation: 'wire the handler',
     });
@@ -349,6 +353,43 @@ describe('friction worker path', () => {
     );
   });
 
+  it.each(['auto_fix', 'auto_fix_ux'] as const)(
+    'auto-triggers a high-confidence friction fix under %s autonomy', async (frictionAutonomy) => {
+      mockGetProject.mockResolvedValue({
+        id: 'proj-1', name: 'app', github_repo: 'org/app', default_branch: 'main', friction_autonomy: frictionAutonomy,
+      });
+      vi.mocked(investigateFriction).mockResolvedValue({
+        codeCause: true, confidence: 'high', reason: 'save handler is disconnected', remediation: 'wire the handler',
+      });
+      vi.mocked(db.updateGroupAndCreateFixJob).mockResolvedValue('fix-job-1');
+
+      await processInvestigateJob(makeJob(), new AbortController().signal);
+
+      expect(db.updateGroupAndCreateFixJob).toHaveBeenCalledWith(
+        'grp-1', 'proj-1', expect.objectContaining({ confidence: 'high' }), makeJob(),
+      );
+      expect(db.updateGroupInvestigation).not.toHaveBeenCalledWith(
+        'grp-1', 'proj-1', 'awaiting_approval', expect.anything(), expect.anything(),
+      );
+    },
+  );
+
+  it('parks medium-confidence friction even when autonomy allows auto-fix', async () => {
+    mockGetProject.mockResolvedValue({
+      id: 'proj-1', name: 'app', github_repo: 'org/app', default_branch: 'main', friction_autonomy: 'auto_fix',
+    });
+    vi.mocked(investigateFriction).mockResolvedValue({
+      codeCause: true, confidence: 'medium', reason: 'save handler is disconnected', remediation: 'wire the handler',
+    });
+
+    await processInvestigateJob(makeJob(), new AbortController().signal);
+
+    expect(db.updateGroupInvestigation).toHaveBeenCalledWith(
+      'grp-1', 'proj-1', 'awaiting_approval', expect.objectContaining({ confidence: 'medium' }), makeJob(),
+    );
+    expect(db.updateGroupAndCreateFixJob).not.toHaveBeenCalled();
+  });
+
   it('records friction without a code cause as an insight', async () => {
     vi.mocked(investigateFriction).mockResolvedValue({
       codeCause: false, confidence: 'medium', reason: 'The workflow is confusing but functional.',
@@ -363,16 +404,50 @@ describe('friction worker path', () => {
     expect(db.updateGroupAndCreateFixJob).not.toHaveBeenCalled();
   });
 
-  it('refuses a non-human friction fix before cloning or running the pipeline', async () => {
+  it('refuses an auto friction fix under ask-first while preserving confidence', async () => {
+    mockGetErrorGroup.mockResolvedValue(makeGroup({
+      kind: 'friction', status: 'fixing', sample_event_id: '', confidence: 'high',
+    }));
     const job = { ...makeJob(), jobType: 'fix' as const, triggeredBy: 'auto' as const };
 
     await processFixJob(job, new AbortController().signal);
 
     expect(mockUpdateGroupStatus).toHaveBeenCalledWith(
-      'grp-1', 'proj-1', 'awaiting_approval', undefined, job,
+      'grp-1', 'proj-1', 'awaiting_approval', expect.objectContaining({ confidence: 'high' }), job,
     );
     expect(mockCloneRepo).not.toHaveBeenCalled();
     expect(mockRunPipeline).not.toHaveBeenCalled();
+  });
+
+  it('processes an auto friction fix when autonomy allows it', async () => {
+    mockGetErrorGroup.mockResolvedValue(makeGroup({
+      kind: 'friction', status: 'fixing', sample_event_id: '', confidence: 'high',
+    }));
+    mockGetProject.mockResolvedValue({
+      id: 'proj-1', name: 'app', github_repo: 'org/app', default_branch: 'main', friction_autonomy: 'auto_fix',
+    });
+    const job = { ...makeJob(), jobType: 'fix' as const, triggeredBy: 'auto' as const };
+
+    await processFixJob(job, new AbortController().signal);
+
+    expect(mockCloneRepo).toHaveBeenCalled();
+  });
+
+  it('parks a legacy friction fix job with no attribution even under auto_fix', async () => {
+    mockGetErrorGroup.mockResolvedValue(makeGroup({
+      kind: 'friction', status: 'fixing', sample_event_id: '', confidence: 'high',
+    }));
+    mockGetProject.mockResolvedValue({
+      id: 'proj-1', name: 'app', github_repo: 'org/app', default_branch: 'main', friction_autonomy: 'auto_fix',
+    });
+    const job = { ...makeJob(), jobType: 'fix' as const, triggeredBy: null };
+
+    await processFixJob(job, new AbortController().signal);
+
+    expect(mockUpdateGroupStatus).toHaveBeenCalledWith(
+      'grp-1', 'proj-1', 'awaiting_approval', expect.objectContaining({ confidence: 'high' }), job,
+    );
+    expect(mockCloneRepo).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/worker/src/__tests__/pr.test.ts
+++ b/packages/worker/src/__tests__/pr.test.ts
@@ -255,6 +255,13 @@ describe('buildPRBody', () => {
     expect(body).not.toContain('Opslane fixed');
   });
 
+  it('marks friction as unverified against the original friction', () => {
+    const body = buildPRBody(makeInput({ kind: 'friction' }));
+
+    expect(body).toContain('friction itself was not re-verified');
+    expect(body).not.toContain('**Confidence:** High · ✅ Tests passing');
+  });
+
   it('uses the explicit human summary as a header-free lede', () => {
     const body = buildPRBody(makeInput({
       humanSummary: '### The user submitted the form. The app crashed on submit. The fix guards the missing value.',

--- a/packages/worker/src/__tests__/reliability-fixture.ts
+++ b/packages/worker/src/__tests__/reliability-fixture.ts
@@ -1,4 +1,5 @@
 import { execFile as execFileCallback } from 'node:child_process';
+import { createHmac, randomUUID } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { createServer, type IncomingMessage, type Server } from 'node:http';
 import { dirname, join } from 'node:path';
@@ -24,11 +25,37 @@ export interface FixtureRepository {
   deliveryClone: string;
 }
 
+/** A pull request held by the GitHub twin, created by the real worker. */
+export interface TwinPullRequest {
+  number: number;
+  owner: string;
+  repo: string;
+  title: string;
+  body: string;
+  head: string;
+  base: string;
+  state: 'open' | 'closed';
+  merged: boolean;
+}
+
+export interface ProviderTwinOptions {
+  /** Ingestion base URL that receives signed pull_request webhooks on merge/close. */
+  ingestionUrl?: string;
+  /** Shared HMAC secret — must equal ingestion's GITHUB_WEBHOOK_SECRET. */
+  webhookSecret?: string;
+}
+
 export interface ProviderRecorders {
   anthropicBaseUrl: string;
   githubBaseUrl: string;
   anthropicJournal: RecordedRequest[];
   githubJournal: RecordedRequest[];
+  /** PRs the worker created against the GitHub twin, in creation order. */
+  pullRequests: TwinPullRequest[];
+  /** Merge a twin PR and deliver the signed pull_request webhook to ingestion. */
+  mergePullRequest(number: number, closedAt?: Date): Promise<Response>;
+  /** Close a twin PR unmerged and deliver the signed webhook to ingestion. */
+  closePullRequest(number: number, closedAt?: Date): Promise<Response>;
   close(): Promise<void>;
 }
 
@@ -132,7 +159,7 @@ export async function createFixtureRepository(
   return { remote, deliveryClone };
 }
 
-export async function startProviderRecorders(): Promise<ProviderRecorders> {
+export async function startProviderRecorders(options: ProviderTwinOptions = {}): Promise<ProviderRecorders> {
   const anthropicJournal: RecordedRequest[] = [];
   const anthropicServer = createServer(async (request, response) => {
     const body = await readJsonRequest(request);
@@ -143,7 +170,19 @@ export async function startProviderRecorders(): Promise<ProviderRecorders> {
     });
     const names = toolNames(body);
     let message: Record<string, unknown>;
-    if (names.includes('classify_error')) {
+    if (names.includes('classify_friction')) {
+      message = anthropicMessage(body, [{
+        type: 'tool_use',
+        id: 'tool_classify_friction',
+        name: 'classify_friction',
+        input: {
+          codeCause: true,
+          confidence: 'high',
+          reason: 'The value renderer dereferences missing input, so the control appears dead.',
+          remediation: 'Guard the missing value with a narrow fallback.',
+        },
+      }], 'tool_use');
+    } else if (names.includes('classify_error')) {
       message = anthropicMessage(body, [{
         type: 'tool_use',
         id: 'tool_classify',
@@ -205,6 +244,8 @@ export async function startProviderRecorders(): Promise<ProviderRecorders> {
   const anthropicBaseUrl = await listen(anthropicServer);
 
   const githubJournal: RecordedRequest[] = [];
+  const pullRequests: TwinPullRequest[] = [];
+  let nextPullNumber = 42;
   const githubServer = createServer(async (request, response) => {
     const body = await readJsonRequest(request);
     githubJournal.push({
@@ -212,19 +253,94 @@ export async function startProviderRecorders(): Promise<ProviderRecorders> {
       authorization: request.headers.authorization,
       body,
     });
-    response.writeHead(201, { 'content-type': 'application/json' });
-    response.end(JSON.stringify({
-      html_url: 'https://github.test/e2e/reliability/pull/42',
-      number: 42,
-    }));
+    // Stateful slice of GitHub's REST API: pulls.create. Response shape from
+    // GitHub's spec — the twin remembers the PR so a later merge/close can
+    // deliver the matching webhook.
+    const pullsMatch = /^\/repos\/([^/]+)\/([^/]+)\/pulls$/.exec(request.url ?? '');
+    if (request.method === 'POST' && pullsMatch) {
+      const pull: TwinPullRequest = {
+        number: nextPullNumber++,
+        owner: pullsMatch[1]!,
+        repo: pullsMatch[2]!,
+        title: String(body['title'] ?? ''),
+        body: String(body['body'] ?? ''),
+        head: String(body['head'] ?? ''),
+        base: String(body['base'] ?? ''),
+        state: 'open',
+        merged: false,
+      };
+      pullRequests.push(pull);
+      response.writeHead(201, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        html_url: `https://github.test/${pull.owner}/${pull.repo}/pull/${pull.number}`,
+        number: pull.number,
+        state: pull.state,
+        title: pull.title,
+      }));
+      return;
+    }
+    // Anything else the worker probes (e.g. repo contents) is absent.
+    response.writeHead(404, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ message: 'Not Found' }));
   });
   const githubBaseUrl = await listen(githubServer);
+
+  // Deliver a spec-shaped, HMAC-signed pull_request webhook, exactly as GitHub
+  // would. Shapes come from GitHub's webhook spec, not from what ingestion
+  // expects — that's what makes the twin catch bugs instead of confirming them.
+  async function deliverClosed(pull: TwinPullRequest, merged: boolean, closedAt: Date): Promise<Response> {
+    const { ingestionUrl, webhookSecret } = options;
+    if (!ingestionUrl || !webhookSecret) {
+      throw new Error('GitHub twin webhooks need ingestionUrl + webhookSecret in startProviderRecorders options');
+    }
+    pull.state = 'closed';
+    pull.merged = merged;
+    const payload = JSON.stringify({
+      action: 'closed',
+      number: pull.number,
+      pull_request: {
+        number: pull.number,
+        state: 'closed',
+        title: pull.title,
+        merged,
+        merged_at: merged ? closedAt.toISOString() : null,
+        closed_at: closedAt.toISOString(),
+        head: { ref: pull.head },
+        base: { ref: pull.base },
+      },
+      repository: {
+        full_name: `${pull.owner}/${pull.repo}`,
+        name: pull.repo,
+        owner: { login: pull.owner },
+      },
+    });
+    const signature = createHmac('sha256', webhookSecret).update(payload).digest('hex');
+    return fetch(`${ingestionUrl.replace(/\/$/, '')}/api/v1/github/webhook`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-hub-signature-256': `sha256=${signature}`,
+        'x-github-event': 'pull_request',
+        'x-github-delivery': randomUUID(),
+      },
+      body: payload,
+    });
+  }
+
+  function findPull(number: number): TwinPullRequest {
+    const pull = pullRequests.find((candidate) => candidate.number === number);
+    if (!pull) throw new Error(`GitHub twin has no pull request #${number}`);
+    return pull;
+  }
 
   return {
     anthropicBaseUrl,
     githubBaseUrl,
     anthropicJournal,
     githubJournal,
+    pullRequests,
+    mergePullRequest: (number, closedAt = new Date()) => deliverClosed(findPull(number), true, closedAt),
+    closePullRequest: (number, closedAt = new Date()) => deliverClosed(findPull(number), false, closedAt),
     close: async () => Promise.all([close(anthropicServer), close(githubServer)]).then(() => undefined),
   };
 }

--- a/packages/worker/src/db.ts
+++ b/packages/worker/src/db.ts
@@ -926,9 +926,12 @@ export async function updateGroupInvestigation(
  * confidence and auto-triggers a fix.
  */
 /** Result of an automatic investigate→fix transition attempt. Friction
- * incidents are refused at this layer (issue #56 defense in depth): even a
- * future caller that skips the route-level kind check cannot auto-create a
- * fix job for kind='friction'. */
+ * incidents are refused at this layer by default (issue #56 defense in
+ * depth): even a future caller that skips the route-level kind check cannot
+ * auto-create a fix job for kind='friction'. The one sanctioned exception is
+ * the autonomy ladder (issue #57), which must opt in explicitly via
+ * allowFriction after checking projects.friction_autonomy — and the fix-job
+ * gate in processFixJob re-checks autonomy at claim time as a second layer. */
 export type FixJobResult =
   | { created: true; fixJobId: string }
   | { created: false; reason: 'kind_not_error' };
@@ -942,6 +945,7 @@ export async function updateGroupAndCreateFixJob(
     confidence?: ConfidenceLevel;
   },
   lease: JobLease,
+  opts?: { allowFriction?: boolean },
 ): Promise<FixJobResult> {
   const db = getPool();
   const client = await db.connect();
@@ -978,8 +982,10 @@ export async function updateGroupAndCreateFixJob(
     if ((group.rowCount ?? 0) !== 1) {
       throw new Error(`Cannot create fix job: group ${errorGroupId} was not found`);
     }
-    if (group.rows[0]!.kind !== 'error') {
+    const kind = group.rows[0]!.kind;
+    if (kind !== 'error' && !(kind === 'friction' && opts?.allowFriction)) {
       // Typed no-transition result: nothing changed, nothing enqueued.
+      // Friction passes only via the autonomy ladder's explicit opt-in.
       await client.query('COMMIT');
       return { created: false, reason: 'kind_not_error' };
     }

--- a/packages/worker/src/db.ts
+++ b/packages/worker/src/db.ts
@@ -385,6 +385,7 @@ export async function updateGroupStatus(
     confidence?: ConfidenceLevel;
     pr_url?: string;
     pr_number?: number;
+    pr_fix_job_id?: string;
     reason?: NeedsHumanReason;
   },
   lease?: JobLease,
@@ -408,9 +409,9 @@ export async function updateGroupStatus(
   const ownedCte = lease
     ? `WITH owned AS (
          SELECT id FROM error_group_jobs
-         WHERE id = $10
-           AND worker_id = $11
-           AND lease_generation = $12::bigint
+         WHERE id = $11
+           AND worker_id = $12
+           AND lease_generation = $13::bigint
            AND project_id = $2
            AND error_group_id = $1
            AND status = 'claimed'
@@ -425,9 +426,10 @@ export async function updateGroupStatus(
          confidence = $4,
          pr_url = $5,
          pr_number = $6,
-         reason_code = $7,
-         reason_message = $8,
-         remediation = $9,
+         pr_fix_job_id = COALESCE($7, pr_fix_job_id),
+         reason_code = $8,
+         reason_message = $9,
+         remediation = $10,
          updated_at = now()
      WHERE id = $1 AND project_id = $2
        ${lease ? 'AND EXISTS (SELECT 1 FROM owned)' : ''}
@@ -439,6 +441,7 @@ export async function updateGroupStatus(
       fields?.confidence ?? null,
       fields?.pr_url ?? null,
       fields?.pr_number ?? null,
+      fields?.pr_fix_job_id ?? null,
       reason?.reason_code ?? null,
       reason?.reason_message ?? null,
       reason?.remediation ?? null,
@@ -512,13 +515,14 @@ export interface ErrorGroupData {
   signal_type: string | null;
   element_selector: string | null;
   page_url_normalized: string | null;
+  confidence: ConfidenceLevel | null;
 }
 
 export async function getErrorGroup(groupId: string, projectId: string): Promise<ErrorGroupData | null> {
   const pool = getPool();
   const { rows } = await pool.query<ErrorGroupData>(
     `SELECT id, title, fingerprint, sample_event_id, occurrence_count, status,
-            kind, signal_type, element_selector, page_url_normalized
+            kind, signal_type, element_selector, page_url_normalized, confidence
      FROM error_groups WHERE id = $1 AND project_id = $2`,
     [groupId, projectId],
   );
@@ -548,17 +552,20 @@ export async function getErrorEvent(eventId: string, projectId: string): Promise
   return rows[0] ?? null;
 }
 
+export type FrictionAutonomy = 'ask_first' | 'auto_fix' | 'auto_fix_ux';
+
 export interface ProjectData {
   id: string;
   name: string;
   github_repo: string;
   default_branch: string;
+  friction_autonomy: FrictionAutonomy;
 }
 
 export async function getProject(projectId: string): Promise<ProjectData | null> {
   const pool = getPool();
   const { rows } = await pool.query<ProjectData>(
-    `SELECT id, name, github_repo, default_branch
+    `SELECT id, name, github_repo, default_branch, friction_autonomy
      FROM projects WHERE id = $1`,
     [projectId],
   );

--- a/packages/worker/src/friction/__tests__/investigate-friction.test.ts
+++ b/packages/worker/src/friction/__tests__/investigate-friction.test.ts
@@ -18,7 +18,7 @@ function group(): ErrorGroupData {
     id: 'g1', title: 'Rage click on save', fingerprint: 'fp', sample_event_id: '',
     occurrence_count: 1, status: 'queued', kind: 'friction',
     signal_type: 'rage_click', element_selector: '[data-testid="save"]',
-    page_url_normalized: 'https://app.example.com/checkout/:id',
+    page_url_normalized: 'https://app.example.com/checkout/:id', confidence: null,
   };
 }
 

--- a/packages/worker/src/friction/investigate-friction.ts
+++ b/packages/worker/src/friction/investigate-friction.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { createAnthropicClient } from '../anthropic-client.js';
 import { executeListFiles, executeReadFile, executeSearch } from '../investigate.js';
 import { logger } from '../logger.js';
 import type { ErrorGroupData } from '../db.js';
@@ -65,7 +66,10 @@ export async function investigateFriction(
   evidence: FrictionEvidence | null,
   repoPath: string,
 ): Promise<FrictionInvestigationResult> {
-  const client = new Anthropic({ apiKey });
+  // Shared factory so ANTHROPIC_BASE_URL is honored — investigate.ts already
+  // routes through it; a divergent direct client here would bypass provider
+  // twins and any configured proxy.
+  const client = createAnthropicClient(apiKey);
   const evidenceText = evidence
     ? JSON.stringify({ signals: evidence.signals, timeline: evidence.timeline, truncated: evidence.truncated })
     : 'No folded signal evidence is available; investigate from the incident descriptors only.';

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -493,16 +493,31 @@ export async function processFrictionInvestigateJob(
       const autonomyAllowsFix = project.friction_autonomy === 'auto_fix'
         || project.friction_autonomy === 'auto_fix_ux';
       if (result.confidence === 'high' && autonomyAllowsFix) {
-        const fixJobId = await updateGroupAndCreateFixJob(job.errorGroupId, job.projectId, {
+        // allowFriction is the ladder's explicit opt-in past the kind gate;
+        // refuse-by-default stays intact for every other caller (issue #56).
+        const fixResult = await updateGroupAndCreateFixJob(job.errorGroupId, job.projectId, {
           rootCause: result.reason,
           suggestedMitigation: result.remediation,
           confidence: result.confidence,
-        }, job);
-        logger.info('Friction investigation: auto-triggering fix (autonomy ladder)', {
-          job_id: job.id,
-          fix_job_id: fixJobId,
-          autonomy: project.friction_autonomy,
-        });
+        }, job, { allowFriction: true });
+        if (fixResult.created) {
+          logger.info('Friction investigation: auto-triggering fix (autonomy ladder)', {
+            job_id: job.id,
+            fix_job_id: fixResult.fixJobId,
+            autonomy: project.friction_autonomy,
+          });
+        } else {
+          // Never drop the investigation: park it for human approval instead.
+          await updateGroupInvestigation(job.errorGroupId, job.projectId, 'awaiting_approval', {
+            rootCause: result.reason,
+            suggestedMitigation: result.remediation,
+            confidence: result.confidence,
+          }, job);
+          logger.warn('Friction investigation: auto-fix refused by kind gate — parked for approval', {
+            job_id: job.id,
+            reason: fixResult.reason,
+          });
+        }
       } else {
         await updateGroupInvestigation(job.errorGroupId, job.projectId, 'awaiting_approval', {
           rootCause: result.reason,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -465,15 +465,32 @@ export async function processFrictionInvestigateJob(
     const result = await investigateFriction(apiKey, group, evidence, clone.repoDir);
     checkAbort(signal);
     if (result.codeCause) {
-      await updateGroupInvestigation(job.errorGroupId, job.projectId, 'awaiting_approval', {
-        rootCause: result.reason,
-        suggestedMitigation: result.remediation,
-        confidence: result.confidence,
-      }, job);
-      logger.info('Friction investigation: awaiting human approval', {
-        job_id: job.id,
-        confidence: result.confidence,
-      });
+      // auto_fix_ux shares the code-caused auto-fix path until UX-suggestion
+      // fixes exist; insights remain terminal and never produce a PR.
+      const autonomyAllowsFix = project.friction_autonomy === 'auto_fix'
+        || project.friction_autonomy === 'auto_fix_ux';
+      if (result.confidence === 'high' && autonomyAllowsFix) {
+        const fixJobId = await updateGroupAndCreateFixJob(job.errorGroupId, job.projectId, {
+          rootCause: result.reason,
+          suggestedMitigation: result.remediation,
+          confidence: result.confidence,
+        }, job);
+        logger.info('Friction investigation: auto-triggering fix (autonomy ladder)', {
+          job_id: job.id,
+          fix_job_id: fixJobId,
+          autonomy: project.friction_autonomy,
+        });
+      } else {
+        await updateGroupInvestigation(job.errorGroupId, job.projectId, 'awaiting_approval', {
+          rootCause: result.reason,
+          suggestedMitigation: result.remediation,
+          confidence: result.confidence,
+        }, job);
+        logger.info('Friction investigation: awaiting human approval', {
+          job_id: job.id,
+          confidence: result.confidence,
+        });
+      }
     } else {
       await updateGroupInvestigation(job.errorGroupId, job.projectId, 'insight', {
         rootCause: result.reason,
@@ -543,9 +560,17 @@ export async function processFixJob(job: ClaimedJob & { errorGroupId: string }, 
   if (!group) throw new Error(`Error group ${job.errorGroupId} not found`);
 
   if (group.kind === 'friction' && job.triggeredBy !== 'human') {
-    await updateGroupStatus(job.errorGroupId, job.projectId, 'awaiting_approval', undefined, job);
-    logger.warn('Refused non-human friction fix job', { job_id: job.id });
-    return;
+    // Settings can change after enqueue, so enforce the current project rung
+    // when the job is claimed. Legacy jobs without attribution stay parked.
+    const gateProject = await db.getProject(job.projectId);
+    const autonomy = gateProject?.friction_autonomy ?? 'ask_first';
+    if (job.triggeredBy !== 'auto' || autonomy === 'ask_first') {
+      await updateGroupStatus(job.errorGroupId, job.projectId, 'awaiting_approval', {
+        confidence: group.confidence ?? undefined,
+      }, job);
+      logger.warn('Refused non-human friction fix job', { job_id: job.id, autonomy });
+      return;
+    }
   }
 
   const event = group.sample_event_id
@@ -767,6 +792,7 @@ export async function processFixJob(job: ClaimedJob & { errorGroupId: string }, 
         confidence: result.confidence,
         pr_url: result.pr_url,
         pr_number: result.pr_number,
+        pr_fix_job_id: job.id,
       }, job);
       jobsProcessed++;
       logger.info('Fix job completed: pr_created', {

--- a/packages/worker/src/pr.ts
+++ b/packages/worker/src/pr.ts
@@ -263,6 +263,9 @@ export function buildPRBody(input: PRInput): string {
   );
   const fence = '`'.repeat(maxBacktickRun + 1);
   const replayLink = buildReplayLink(input.errorGroupId, input.projectId);
+  const confidenceLine = input.kind === 'friction'
+    ? '**Confidence:** Suggestion · ✅ Repo tests passing · ⚠️ The friction itself was not re-verified — review before merging'
+    : '**Confidence:** High · ✅ Tests passing';
 
   return [
     input.kind === 'friction'
@@ -275,7 +278,7 @@ export function buildPRBody(input: PRInput): string {
     `${fence}diff`,
     input.diff.trim(),
     fence,
-    '**Confidence:** High · ✅ Tests passing',
+    confidenceLine,
     replayLink ? `📊 [Full investigation & session replay →](${replayLink})` : null,
     buildTechnicalDetails(input),
     '---',

--- a/scripts/run-reliability-system.sh
+++ b/scripts/run-reliability-system.sh
@@ -6,6 +6,10 @@ RELIABILITY_DATABASE="opslane_reliability"
 LOCAL_RELIABILITY_DATABASE_URL="postgres://opslane:opslane_dev@localhost:5434/${RELIABILITY_DATABASE}"
 export INGESTION_PORT
 export OPSLANE_COMPOSE_DATABASE_URL="postgres://opslane:opslane_dev@postgres:5432/${RELIABILITY_DATABASE}?sslmode=disable"
+# The GitHub twin signs pull_request webhooks with this; ingestion must verify
+# them, so both sides share the secret (friction-ladder system test).
+GITHUB_WEBHOOK_SECRET="${GITHUB_WEBHOOK_SECRET:-reliability-webhook-secret}"
+export GITHUB_WEBHOOK_SECRET
 
 docker compose stop ingestion >/dev/null 2>&1 || true
 docker compose up -d --wait postgres


### PR DESCRIPTION
Part of #57 (deliberately not `Closes` — see gate note below). Plan: `docs/plans/2026-07-15-batch-5-the-ladder.md`. Design: `docs/plans/2026-07-13-unified-incidents-replay-friction-design.md` §4–5.

## What ships

**Idempotent, attributable PR receipts.** `ProcessPRWebhook` writes an immutable `pr_outcomes` receipt keyed on `X-GitHub-Delivery` *before* any state transition, with a redelivery fast-path, a post-lock race recheck, and `ON CONFLICT` backstop. The worker records `pr_fix_job_id` on the group at PR creation so the eventual merge/close receipt is attributed to the exact fix job. A close→reopen→merge is recovered through the prior receipt (previously the merge was silently dropped and the incident stayed fix-eligible). `merged_at` now uses GitHub's `closed_at`, not webhook-arrival time, so the silence checker can't mis-window delayed deliveries. Friction closes return to `awaiting_approval` (not `investigated`). Migration `008_receipts_wiring.sql` (renumbered from 007 after #66 claimed it) adds the column plus `project_id` indexes for the stats queries.

**The friction-autonomy ladder.** `projects.friction_autonomy` (`ask_first`/`auto_fix`/`auto_fix_ux`) is now readable/settable via PATCH `/projects/{id}` (validated in the handler) and consulted twice: at investigation time (high-confidence, code-caused friction auto-routes to a fix once opted past ask-first) and re-checked at fix-job claim time, so a settings downgrade between enqueue and claim parks the job in `awaiting_approval` — now preserving the investigation's confidence (previously refusal nulled it). Batch 4's kind gate in `updateGroupAndCreateFixJob` stays refuse-by-default; the ladder is the one sanctioned caller via an explicit `allowFriction` opt-in.

**Receipts beside the toggle.** New GET `/projects/{id}/fix-stats` aggregates fix generation (by `triggered_by`) and PR outcomes per kind, with outcomes split by attribution so the Auto-fix row never counts human-requested PRs.

**Honest Suggestion labeling.** The friction PR body states repo tests passed but the friction itself was not re-verified.

**Dashboard.** Generate-fix from `awaiting_approval` (with the Suggestion caveat), the insight card (semantic purple token), the autonomy settings panel with per-option receipts (a11y radiogroup, hover/focus states, no refetch flicker on save).

**Provider twins (henry-style).** The reliability fixture's GitHub recorder is now a stateful twin: it remembers PRs the real worker opens and can merge/close them, delivering HMAC-signed spec-shaped `pull_request` webhooks to ingestion. `friction-ladder.system.test.ts` walks the entire keyed dogfood loop with zero real credentials — investigation → ladder auto-fix → real agent pipeline pushes the fix branch → Suggestion PR → twin merge → attributed receipt. Also fixes `investigateFriction` silently ignoring `ANTHROPIC_BASE_URL`.

## Verification

- Full gate: `pnpm -r build`, `pnpm test` (81 files across 6 packages), Go `./...` (10 packages, incl. migration apply/idempotency/roll-forward with 008), `docker compose config`, docs-drift clean.
- E2E (isolated compose stack, keyless worker, real Chromium): **31 passed, 1 skipped** (`error-to-pr`, needs live credentials by design) — includes the friction browser smoke and Batch 4's promotion-gate suite.
- Live smoke over real HTTP: signed close webhook → receipt with exact `fix_job_id` + `closed_at`, redelivery → `duplicate` with one receipt; reopen→merge recovered with correct `merged_at`; PATCH validation (400/200/persisted); fix-stats shape + 401; gate open under `auto_fix` (no refusal, keyless terminal state) and refusal under mid-flight `ask_first` downgrade with confidence preserved.
- System tracers (provider twins, disposable DB): friction-ladder (merge + close legs) and the existing event-to-pr tracer — 3/3.
- Multi-agent pre-landing review ran (7 specialists + adversarial Claude/Codex + Red Team); all confirmed findings fixed in-branch.

## Gate note (#57)

The issue gate demands an **organic** dogfood friction incident (real detection → incident → ladder → Suggestion PR, no manual SQL). Batch 4 (#66) just landed, so that run is now possible post-merge; this PR intentionally does not auto-close #57. Known deferred item (documented in `ProcessPRWebhook`'s comment): a close/merge arriving in the seconds before the worker records `pr_created` still no-matches — needs a delivery-inbox design, tracked as follow-up. The pricing decision for friction fixes (flagged in the design as decide-before-public) is also still open.