### PR TITLE
Enforce POST /api/v1/events wire backward-compatibility in CI

### DIFF
--- a/.github/workflows/wire-fixtures.yml
+++ b/.github/workflows/wire-fixtures.yml
@@ -2,8 +2,10 @@ name: Wire fixtures
 
 # SECURITY: pull_request_target runs the workflow and scripts from the trusted
 # base branch. A PR therefore cannot weaken this gate by editing the workflow or
-# checker in the same PR. This job only reads the PR's Git metadata. Never check
-# out or execute the PR head in this workflow: this trigger has elevated trust.
+# checker in the same PR. This job reads only PR metadata: the checker asks the
+# GitHub API for the PR's changed-file list (names + status). The PR head is
+# never fetched, checked out, or executed, so no untrusted code enters this
+# privileged context. Keep it that way: this trigger has elevated trust.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
@@ -11,6 +13,7 @@ on:
 permissions:
   contents: read
   statuses: write
+  pull-requests: read
 
 jobs:
   publish-wire-fixture-status:
@@ -38,19 +41,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-          fetch-depth: 0
-      - name: Fetch PR head commit (metadata only; never checked out)
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'contract-change') }}
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: git fetch --no-tags origin "refs/pull/${PR_NUMBER}/head"
       - name: Evaluate wire-fixture immutability
         id: policy
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'contract-change') }}
         continue-on-error: true
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: node scripts/check-wire-fixtures.mjs
       - name: Publish final required status on PR head
         if: ${{ always() }}

--- a/.github/workflows/wire-fixtures.yml
+++ b/.github/workflows/wire-fixtures.yml
@@ -1,0 +1,80 @@
+name: Wire fixtures
+
+# SECURITY: pull_request_target runs the workflow and scripts from the trusted
+# base branch. A PR therefore cannot weaken this gate by editing the workflow or
+# checker in the same PR. This job only reads the PR's Git metadata. Never check
+# out or execute the PR head in this workflow: this trigger has elevated trust.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  publish-wire-fixture-status:
+    # This job's Actions check is attached to the pull_request_target base SHA.
+    # The required `wire-fixtures` context is instead published explicitly as a
+    # commit status on the PR head SHA below.
+    name: Trusted wire-fixture policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Publish pending status on PR head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state=pending \
+            -f context=wire-fixtures \
+            -f description="Checking frozen wire fixtures" \
+            -f target_url="$TARGET_URL"
+      - name: Check out base branch (trusted workflow and script)
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'contract-change') }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Fetch PR head commit (metadata only; never checked out)
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'contract-change') }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: git fetch --no-tags origin "refs/pull/${PR_NUMBER}/head"
+      - name: Evaluate wire-fixture immutability
+        id: policy
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'contract-change') }}
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/check-wire-fixtures.mjs
+      - name: Publish final required status on PR head
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CONTRACT_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'contract-change') }}
+          POLICY_OUTCOME: ${{ steps.policy.outcome }}
+        run: |
+          if [[ "$CONTRACT_CHANGE" == "true" ]]; then
+            state=success
+            description="Approved contract-change bypass"
+          elif [[ "$POLICY_OUTCOME" == "success" ]]; then
+            state=success
+            description="Frozen wire fixtures are append-only"
+          else
+            state=failure
+            description="Frozen wire fixture policy failed"
+          fi
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state="$state" \
+            -f context=wire-fixtures \
+            -f description="$description" \
+            -f target_url="$TARGET_URL"
+          [[ "$state" == "success" ]]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ docker compose config --quiet
 - Do not introduce Redis, BullMQ, or another queue without an architectural decision; use the existing Postgres job queue.
 - Do not persist production credentials in plaintext; use deployment environment variables or GitHub App credentials until encrypted storage is implemented.
 - Do not add legacy shims by default; preserve documented public contracts or change them explicitly.
+- The `POST /api/v1/events` wire contract is append-only and backward-compatible. Add optional fields only; never edit or delete a frozen fixture under `test-fixtures/wire/`. See `docs/contracts/events.md`.
 - Keep the change inside the current issue instead of expanding the product scope.
 - Reuse existing utilities before adding a dependency, and review any new dependency's license.
 - Preserve terminal-status and lease contracts; fix the implementation or test setup instead of weakening them.

--- a/docs/contracts/events.md
+++ b/docs/contracts/events.md
@@ -1,0 +1,39 @@
+# Event API contract
+
+`POST /api/v1/events` is **append-only and backward-compatible, forever.**
+
+The SDK ships to npm and runs in customers' apps on their upgrade schedule; the
+ingestion API deploys on ours. Old SDK versions POST to our newest server
+indefinitely and we cannot force-upgrade them. A break is a silent customer
+outage we cannot hotfix.
+
+## Rules
+
+- **Add only optional fields.** Never remove a field the SDK may send, never make
+  an existing field required, never stop reading a field an old SDK sends.
+- **Never tighten decoding.** The events decoder must keep tolerating unknown
+  fields (no `DisallowUnknownFields`) so a *newer* SDK's extra fields are ignored,
+  not rejected.
+- **Fixtures are frozen.** `test-fixtures/wire/events/` holds the exact wire JSON
+  for every released SDK version. Add a new `v<version>-*.json` pair for every
+  SDK release, even when no other field changes; never edit or delete an existing
+  file.
+
+## Enforcement
+
+- `packages/ingestion/handler/wire_compat_test.go` (`go` CI job) replays every
+  fixture and asserts `202` plus full field round-trip, stable grouping, and
+  unknown-field tolerance.
+- `packages/sdk/src/__tests__/wire-shape.test.ts` (`js` CI job) asserts the SDK's
+  real transport output still matches the current version's pair.
+- `.github/workflows/wire-fixtures.yml` (trusted-base `pull_request_target`)
+  publishes the required `wire-fixtures` status on the PR head and fails it when
+  a PR modifies or deletes a frozen fixture, unless the PR carries the
+  `contract-change` label: the one deliberate, reviewed way to change the
+  contract.
+
+## Making a deliberate change
+
+Adding a field: add a new fixture pair, keep the field optional server-side, and
+the old fixtures still pass. Editing or removing an existing fixture: apply the
+`contract-change` label, a conscious acknowledgement that live clients may break.

--- a/docs/plans/2026-07-16-wire-fixtures-backward-compat-design.md
+++ b/docs/plans/2026-07-16-wire-fixtures-backward-compat-design.md
@@ -1,0 +1,269 @@
+# Enforce SDK↔event-API backward compatibility
+
+Design for [issue #75](https://github.com/opslane/opslane-oss/issues/75). Status: approved 2026-07-16 (revised after design review).
+
+## Problem
+
+The SDK ships to npm and runs in customers' apps. The ingestion API deploys on
+our own schedule. We cannot force-upgrade an SDK sitting in someone else's app,
+so **old SDK versions POST to our newest server indefinitely**. The
+`POST /api/v1/events` event contract must therefore stay backward-compatible
+forever.
+
+CI is currently blind to this class of break. Every existing test
+(`e2e-keyless`, `reliability-system`) builds the SDK and the server from the
+*same commit* — it only proves HEAD-SDK works with HEAD-server. A contract break
+manifests as old-SDK-vs-new-server, which HEAD-vs-HEAD cannot exercise. A break
+is a silent customer outage we cannot hotfix, so this warrants a hard CI gate.
+
+### Verified current state (2026-07-16)
+
+- The ingestion events decoder (`packages/ingestion/handler/error_event.go`)
+  uses plain `json.Unmarshal` with **no `DisallowUnknownFields`**. Forward-compat
+  (new SDK → old server) is already safe — the old server ignores unknown
+  fields. We only need a guard that keeps it that way.
+- **Backward-compat (old SDK → new server) is unguarded.** A future change that
+  tightens validation, makes a field required, or stops reading a field the old
+  SDK sends would break live clients with no signal.
+- The wire shape has two definitions that can drift: TS `ErrorEventPayload` in
+  `shared/src/types.ts:37-58` and the anonymous Go request struct in
+  `error_event.go:56-68`.
+
+## Decisions
+
+Resolved during brainstorming and design review:
+
+1. **Immutability detection: git-diff script** (not the GitHub API). A local
+   `scripts/check-wire-fixtures.mjs` runs `git diff --name-status` and fails on
+   any modify/delete under `test-fixtures/wire/`. Self-contained, runnable on a
+   laptop before pushing, no network or `gh` dependency.
+2. **Override scope: PR-only, `contract-change` label bypasses.** The check runs
+   only on `pull_request`, diffs against the PR base. A `contract-change` label
+   skips it for the rare legitimate edit. Push-to-main is not checked at the
+   workflow level — see *Prerequisites* for how the push path is closed instead.
+3. **The gate lives in its own workflow.** `.github/workflows/wire-fixtures.yml`
+   triggers on `pull_request` with explicit
+   `types: [opened, synchronize, reopened, labeled, unlabeled]` and runs *only*
+   the fixture check. Adding or removing the label re-runs this check in seconds
+   instead of re-running the whole `ci.yml` pipeline. It becomes its own required
+   status check (it is **not** part of `ci-ok`).
+4. **SDK assertion: normalized deep equality.** Capture the SDK's true wire
+   output, sentinel-replace volatile fields (`timestamp`, `stack`, `sdk_version`,
+   `session_id`), then compare the *complete* serialized JSON to the fixture.
+   Key-and-type matching was rejected — two same-typed fields could be swapped
+   undetected.
+
+### Verified review findings
+
+- `buildPayload()` (`packages/sdk/src/core.ts:62-94`) **always** calls
+  `addBreadcrumb(breadcrumb)` (line 70), so `breadcrumbs: []` is only reachable
+  with an explicit `maxBreadcrumbs: 0` config. It also returns
+  `release`/`session_id` as keys holding `undefined` (lines 91-92); those keys
+  disappear only at `JSON.stringify` in `transport.ts`. Fixtures must therefore
+  be captured from the **wire form**, not from the raw object.
+- `ci.yml` (`:3-6`) uses `pull_request:` with no `types:`, so the default
+  activity types (`opened, synchronize, reopened`) exclude `labeled`/`unlabeled`.
+  Applying the label after a failure would not re-fire CI, and a manual re-run
+  replays the original label-less event. This is why the gate needs its own
+  workflow with explicit label activity types (decision 3).
+
+## Prerequisites (ops, not code)
+
+These make the "hard gate" real. Without them the gate is advisory.
+
+1. **Create the `contract-change` label** in the repo
+   (`gh label create contract-change`). It does not exist today.
+2. **Enforced PR-only branch protection on `main`, including administrators.**
+   The gate only runs on pull requests. An admin direct push to `main` bypasses
+   it. Branch protection must require the `wire-fixtures` status check and apply
+   to admins, or the gate has a hole. Documented here as an explicit prerequisite.
+   Residual risk if this is not configured: a direct push can still edit a frozen
+   fixture. Push-side verification is intentionally not built — on a direct push
+   there is no base PR and no label to express the legitimate-edit escape hatch,
+   so the branch-protection route is the correct fix.
+
+## Wire shape (reference)
+
+`ErrorEventPayload` — `shared/src/types.ts:37-58`. Built by `buildPayload()` at
+`packages/sdk/src/core.ts:62-94`; sent by `flushEvents()` at
+`packages/sdk/src/transport.ts:119-126` as one JSON object per request.
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `timestamp` | yes | ISO 8601 |
+| `error.{type,message,stack}` | yes | strings; only `message` validated server-side |
+| `breadcrumbs` | yes | array, may be empty |
+| `context` | yes | object; all sub-fields optional |
+| `context.user.{id,email,account_id,account_name}` | no | `user` added only when set |
+| `sdk_version` | yes | |
+| `release` | no | key **dropped** from wire when unset |
+| `session_id` | no | key **dropped** from wire when unset |
+
+Current SDK version is `1.0.0` (`packages/sdk/package.json`), so fixtures are
+named `v1.0.0-*`.
+
+## What to build
+
+### 1. Frozen wire fixtures
+
+```
+test-fixtures/wire/events/v1.0.0-minimal.json
+test-fixtures/wire/events/v1.0.0-full.json
+test-fixtures/wire/events/README.md
+```
+
+Captured from the **actual wire body** the SDK sends (intercept the `fetch` body
+in a test harness, or `JSON.parse(JSON.stringify(buildPayload(...)))`), so the
+`undefined`-key drop and breadcrumb behavior are represented truthfully.
+
+- **Minimal** — SDK configured with `maxBreadcrumbs: 0`, no user, no `release`,
+  no `session_id`. Wire body: `timestamp`, `error{type,message,stack}`,
+  `breadcrumbs:[]`, `context{url,user_agent}`, `sdk_version`. No `release`/
+  `session_id` keys.
+- **Full** — user set (`id`,`email`,`account_id`,`account_name`), `release` set,
+  `session_id` present, at least one real breadcrumb. Wire body includes
+  `context.user`, `release`, `session_id`, and a populated `breadcrumbs`.
+- `README.md` documents the exact SDK setup used to produce each file, and the
+  rule: **append-only — add new files for new SDK versions, never edit or delete
+  an existing file.**
+
+Adding a new SDK field is done by adding a *new* fixture and keeping the field
+optional server-side; old fixtures still pass.
+
+### 2. Ingestion backward-compat test (`go` job)
+
+New `packages/ingestion/handler/wire_compat_test.go`, package `handler_test`,
+modeled on `handler/error_event_test.go`.
+
+- Reuse helpers `testDeps(t)` (`error_event_test.go:25`) and `seedTenant(t,q)`
+  (`:46`). Drive requests in-process via `httptest.NewRecorder` +
+  `handler.NewRouter(deps).ServeHTTP`.
+- Loop **every** `test-fixtures/wire/events/*.json` (relative path
+  `../../../test-fixtures/wire/events`): POST each → assert **202** → capture the
+  returned `event_id` → `SELECT` that row and assert the **full** contract:
+  `timestamp`, `error.type`, `error.message`, `error.stack`, `breadcrumbs` and
+  `context` as semantic JSON, `release`, `session_id`, and the event→group
+  linkage. For the full fixture, assert user extraction (the documented
+  `context.user` side effect).
+- **Correct-grouping proof:** POST the same fixture twice and assert the second
+  response's `group_id` equals the first — substantiates grouping, not just
+  storage.
+- **Unknown-field-tolerance case:** load a fixture, inject a top-level
+  `future_field` and a nested unknown, POST → still **202**. Locks in
+  forward-compat so nobody adds `DisallowUnknownFields` to this endpoint.
+- Runs under the existing `go test ./...` step (`ci.yml:84-88`). Skips cleanly
+  without `DATABASE_URL`, exactly like its siblings, so `check-go-skips.mjs`
+  stays green.
+
+### 3. Fixture immutability check (dedicated workflow)
+
+New `scripts/check-wire-fixtures.mjs`, mirroring `scripts/check-action-pins.mjs`
+style (`node:` builtins only, collect `problems[]`, `process.exit(1)` on
+failure, success `console.log`).
+
+- Run `git diff --name-status $BASE_SHA...HEAD`, keep lines under
+  `test-fixtures/wire/`, **fail on `M` (modified), `D` (deleted), or `R`
+  (renamed)**. Added (`A`) is allowed.
+- Fail message names the offending files and points at the `contract-change`
+  label + `docs/contracts/events.md`.
+
+New `.github/workflows/wire-fixtures.yml`:
+
+```yaml
+name: Wire fixtures
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+permissions:
+  contents: read
+jobs:
+  wire-fixtures:
+    name: Wire-fixture immutability (append-only)
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'contract-change') }}
+    steps:
+      - uses: actions/checkout@<sha>   # SHA-pinned per check-action-pins
+        with:
+          persist-credentials: false
+          fetch-depth: 0               # so $BASE_SHA is in history
+      - name: Wire-fixture immutability
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/check-wire-fixtures.mjs
+```
+
+Made a **required status check** on `main` via branch protection (see
+Prerequisites). Because the label is one of the trigger activity types, adding
+`contract-change` re-runs this workflow, the `if:` guard is skipped, and the
+required check turns green — a conscious human act, in seconds, without touching
+the rest of the pipeline.
+
+### 4. SDK vitest (`js` job)
+
+New `packages/sdk/src/__tests__/wire-shape.test.ts`, modeled on the existing
+`packages/sdk/src/__tests__/contract.test.ts` harness (captures the real `fetch`
+body).
+
+- The SDK at HEAD emits only the **current** shape, so it compares against the
+  **current release's fixture pair only**, selected by package-version
+  convention: read `version` from `packages/sdk/package.json`, load
+  `v{version}-minimal.json` and `v{version}-full.json`. Historical fixtures are
+  the ingestion side's job, not the SDK's.
+- Construct two scenarios that reproduce the documented minimal and full setups,
+  capture each wire body, then assert **normalized deep equality**: sentinel-
+  replace `timestamp`, `error.stack`, `sdk_version`, `session_id` in both emitted
+  and fixture JSON, then `expect(emitted).toEqual(fixture)` on the full object.
+- Runs under `pnpm --filter @opslane/sdk test`.
+
+The contract is now pinned from both ends: the SDK cannot stop emitting the
+shape, the server cannot stop accepting any historical shape, neither drifts
+silently.
+
+### 5. Written rule
+
+- New `docs/contracts/events.md`, matching the `docs/contracts/reliability.md`
+  format: the event API is append-only / backward-compatible — add optional
+  fields, never remove or require. Changing a frozen fixture requires the
+  `contract-change` label and is a conscious human act.
+- One line in `AGENTS.md` (Guardrails section) pointing to it, so agents do not
+  break the contract.
+
+## Acceptance criteria (from issue #75)
+
+- [ ] Frozen fixtures exist for the current SDK payload (minimal + full),
+      captured from the real wire body, documented as append-only with their
+      exact SDK setup.
+- [ ] Go test in the `go` job replays **every** fixture against ingestion and
+      asserts `202` + full field round-trip + correct grouping (double-POST same
+      `group_id`).
+- [ ] Unknown-field-tolerance test asserts a payload with extra fields is
+      accepted (locks in forward-compat).
+- [ ] Immutability check fails a PR that edits/deletes an existing wire fixture,
+      unless the `contract-change` label is present; adding the label re-runs the
+      check and passes.
+- [ ] SDK vitest asserts the SDK emits wire JSON matching the current-release
+      fixture pair via normalized deep equality.
+- [ ] `docs/contracts/events.md` + `AGENTS.md` state the append-only rule.
+- [ ] `contract-change` label exists; `main` branch protection requires the
+      `wire-fixtures` check and applies to administrators.
+- [ ] Adding a new SDK field is done by adding a *new* fixture and keeping the
+      field optional server-side; old fixtures still pass.
+
+## Verification
+
+- `cd packages/ingestion && go test ./handler` (with `DATABASE_URL` set) — new
+  backward-compat + unknown-field tests pass; double-POST returns identical
+  `group_id`.
+- `pnpm --filter @opslane/sdk test` — wire-shape test passes against the current
+  fixture pair.
+- `node scripts/check-wire-fixtures.mjs` against a scratch edit of an existing
+  fixture — proves it fails; adding a new fixture passes.
+- On a real PR: edit a fixture → `wire-fixtures` check red; add `contract-change`
+  → check re-runs and goes green.
+
+## Out of scope
+
+- No `DisallowUnknownFields` is added anywhere (that would break forward-compat).
+- No changes to the event decoder or SDK payload shape — this issue only adds
+  guards around the existing contract.
+- No push-side immutability verification — closed via branch protection instead.

--- a/docs/plans/2026-07-16-wire-fixtures-backward-compat.md
+++ b/docs/plans/2026-07-16-wire-fixtures-backward-compat.md
@@ -1,0 +1,911 @@
+# SDK↔Event-API Backward-Compatibility Gate — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Pin the `POST /api/v1/events` wire contract from both ends so old SDKs keep working against new servers forever, enforced in CI.
+
+**Architecture:** Freeze the exact JSON the SDK emits as immutable, per-SDK-version fixtures under `test-fixtures/wire/events/`. Replay every fixture against ingestion in a Go test (asserting `202` + full field round-trip + stable grouping), assert the SDK still emits the current fixture pair through its *real transport path* in a vitest test, and guard the fixtures with a trusted-base `pull_request_target` workflow so a frozen fixture can only change as a deliberate, labeled human act — and the guard itself can't be weakened in the same PR.
+
+**Tech Stack:** Go 1.24 (chi, pgx, `httptest`), TypeScript SDK (vitest, `node --test`), Node ESM check script (`node:` builtins), GitHub Actions.
+
+**Design doc:** `docs/plans/2026-07-16-wire-fixtures-backward-compat-design.md`
+
+## Verified facts this plan relies on
+
+- Ingestion decoder `packages/ingestion/handler/error_event.go:56-74` uses plain `json.Unmarshal` (no `DisallowUnknownFields`) → unknown fields already tolerated. Response is `202` with `{event_id, group_id, error_group_id}` (`:177-184`). `sdk_version` is decoded (`:65`) but **never persisted** — assert acceptance only, not DB round-trip.
+- `error_events` columns (`db/migrations/001_baseline.sql`): `id, project_id, environment_id, error_group_id, "timestamp", error_type, error_message, stack_trace_raw, breadcrumbs (jsonb), context (jsonb), session_id, release, end_user_id (uuid fk → end_users)`. Client timestamp is persisted verbatim (`TestIngestEvent_PersistsClientTimestamp`). Benign values survive server redaction unchanged (`TestIngest_RedactsBreadcrumbsAndContextBeforePersist` preserves end-user email).
+- `end_users` columns: `external_user_id, external_account_id, account_name, email, display_name` (unique on `project_id, external_user_id`). Handler maps `EndUserID→external_user_id, EndUserEmail→email, EndUserAccountID→external_account_id, EndUserAccountName→account_name`.
+- Go test helpers in `packages/ingestion/handler/error_event_test.go`: `testDeps(t)` (`:25`, skips without `DATABASE_URL`), `seedTenant(t,q)` (`:46`), in-process drive via `httptest.NewRecorder` + `handler.NewRouter(deps).ServeHTTP` (`:143-144`).
+- SDK real wire path: `enqueueEvent` (`transport.ts:48`) samples, throttles, `scrubEvent`s, runs `beforeSend`, queues; `flushEvents` (`:91`) late-binds `getCurrentUser()` into `context.user`, then `JSON.stringify`s and POSTs (`:110-126`). Testing `buildPayload` alone skips scrub/beforeSend/late-bind — capture the mocked `fetch` body instead.
+- SDK internals: `buildPayload` (`core.ts:62-94`) always `addBreadcrumb`s the passed crumb; `maxBreadcrumbs: 0` evicts it so `breadcrumbs: []` is reachable (`breadcrumbs.ts:33-44`); `release`/`session_id` are returned as `undefined` keys and dropped by `JSON.stringify`. `getSessionId()` returns `''` when state is null but `clearUser()` *creates* a session — so the minimal (no-`session_id`) shape requires `resetSessionId()` after `clearUser()` (`session.ts:106-108,146-157`). `shouldThrottle` returns `false` when `windowMs <= 0` (`throttle.ts:13`), so `errorThrottleMs: 0` disables throttling. `scrubEvent` is a no-op on benign values (no query strings, no secret patterns; `context.user` untouched) (`scrub.ts:62-81`).
+- Exports available: `buildPayload, setUser, clearUser` (`core.ts`), `loadConfig` (`config.ts`), `clearBreadcrumbs` (`breadcrumbs.ts`), `resetSessionId, ensureSessionID` (`session.ts`), `enqueueEvent, flushEvents, _resetQueue` (`transport.ts`), `_resetThrottle` (`throttle.ts`), `SDK_VERSION` (`version.ts`).
+- Existing check-script pattern: `scripts/check-action-pins.mjs`. The `checkout` SHA pin used across CI is `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0` (`ci.yml:58`).
+- A GitHub job's *required-status-check context* is the job's `name` (falls back to job id when unset). Set `name: wire-fixtures` so the context is stable.
+
+**Working directory:** repo root unless a step says otherwise. Branch is already `abhishekray07/ci-enforce-sdk-event-api-backward-compatibility`.
+
+**Database note:** run the Go tests against a *disposable* Postgres (repo memory: port 5434 is shared across worktree sessions — do not assume a clean DB). Apply migrations first: from `packages/ingestion`, `MIGRATION_DIR=db/migrations ../../scripts/run-migrations.sh` with `DATABASE_URL` pointed at the disposable DB.
+
+---
+
+## Task 1: Frozen wire fixtures + README
+
+The shared input for Tasks 2 and 5. Values are benign so both SDK-side (`scrubEvent`) and server-side redaction are no-ops and the JSON round-trips cleanly.
+
+**Files:**
+- Create: `test-fixtures/wire/events/v1.0.0-minimal.json`
+- Create: `test-fixtures/wire/events/v1.0.0-full.json`
+- Create: `test-fixtures/wire/events/README.md`
+
+**Step 1: Create the minimal fixture**
+
+`test-fixtures/wire/events/v1.0.0-minimal.json`:
+
+```json
+{
+  "timestamp": "2026-07-16T00:00:00.000Z",
+  "error": {
+    "type": "TypeError",
+    "message": "Cannot read properties of null (reading 'name')",
+    "stack": "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)"
+  },
+  "breadcrumbs": [],
+  "context": {
+    "url": "https://app.example.com/dashboard",
+    "user_agent": "Mozilla/5.0"
+  },
+  "sdk_version": "1.0.0"
+}
+```
+
+**Step 2: Create the full fixture**
+
+`test-fixtures/wire/events/v1.0.0-full.json`:
+
+```json
+{
+  "timestamp": "2026-07-16T00:00:00.000Z",
+  "error": {
+    "type": "TypeError",
+    "message": "Cannot read properties of null (reading 'name')",
+    "stack": "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)"
+  },
+  "breadcrumbs": [
+    {
+      "type": "navigation",
+      "timestamp": "2026-07-16T00:00:00.000Z",
+      "category": "navigation",
+      "message": "https://app.example.com/dashboard"
+    }
+  ],
+  "context": {
+    "url": "https://app.example.com/dashboard",
+    "user_agent": "Mozilla/5.0",
+    "user": {
+      "id": "user-123",
+      "email": "jane@example.com",
+      "account_id": "acct-42",
+      "account_name": "Example Inc"
+    }
+  },
+  "sdk_version": "1.0.0",
+  "release": "web@2026.07.16",
+  "session_id": "sess-abc"
+}
+```
+
+**Step 3: Create the README**
+
+`test-fixtures/wire/events/README.md`:
+
+```markdown
+# Frozen event wire fixtures
+
+Each file is the exact JSON body an `@opslane/shared` `ErrorEventPayload` reaches
+the wire as, for one released SDK payload shape. They lock the
+`POST /api/v1/events` contract in both directions:
+
+- **Ingestion** (`packages/ingestion/handler/wire_compat_test.go`) replays *every*
+  file here and asserts the server still accepts and stores it.
+- **SDK** (`packages/sdk/src/__tests__/wire-shape.test.ts`) asserts the SDK still
+  emits the *current* version's pair through its real transport path.
+
+## Rule: append-only
+
+**Never edit or delete an existing file.** Add optional fields by adding a *new*
+`v<version>-*.json` pair and keeping the field optional server-side; old fixtures
+must still pass. A modify/delete is a contract break and fails the `wire-fixtures`
+CI check unless the PR carries the `contract-change` label (a deliberate,
+reviewed break). See `docs/contracts/events.md`.
+
+## How each file was produced
+
+- `v1.0.0-minimal.json` — SDK configured `maxBreadcrumbs: 0`, no user, no session,
+  no `release`. `release`/`session_id` keys are absent because the SDK drops
+  `undefined` keys at serialize.
+- `v1.0.0-full.json` — user set, `release` set, session established, one
+  navigation breadcrumb.
+
+Values are benign so SDK and server redaction are no-ops. `sdk_version` is on the
+wire and accepted by the server but not persisted.
+```
+
+**Step 4: Verify JSON is valid**
+
+Run: `node -e "for (const f of ['minimal','full']) JSON.parse(require('fs').readFileSync('test-fixtures/wire/events/v1.0.0-'+f+'.json','utf8')); console.log('ok')"`
+Expected: prints `ok`.
+
+**Step 5: Commit**
+
+```bash
+git add test-fixtures/wire/events/
+git commit -m "test: freeze v1.0.0 event wire fixtures (append-only)"
+```
+
+---
+
+## Task 2: Ingestion backward-compat Go test
+
+Replay every fixture; assert `202`, **full** field round-trip (timestamp, error fields, release, session_id, semantic breadcrumbs + context, both group aliases, all user fields), stable grouping, and unknown-field tolerance.
+
+**Files:**
+- Create: `packages/ingestion/handler/wire_compat_test.go`
+
+**Step 1: Write the test file**
+
+`packages/ingestion/handler/wire_compat_test.go`:
+
+```go
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opslane/opslane/packages/ingestion/handler"
+)
+
+// wireFixtureDir is the frozen-fixture dir relative to this package
+// (packages/ingestion/handler -> repo root is ../../..).
+const wireFixtureDir = "../../../test-fixtures/wire/events"
+
+type wireFixture struct {
+	Timestamp string `json:"timestamp"`
+	Error     struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+		Stack   string `json:"stack"`
+	} `json:"error"`
+	Breadcrumbs json.RawMessage `json:"breadcrumbs"`
+	Context     json.RawMessage `json:"context"`
+	SDKVersion  string          `json:"sdk_version"`
+	Release     string          `json:"release"`
+	SessionID   string          `json:"session_id"`
+	ContextUser *struct {
+		ID          string `json:"id"`
+		Email       string `json:"email"`
+		AccountID   string `json:"account_id"`
+		AccountName string `json:"account_name"`
+	} `json:"-"`
+}
+
+func fixturePaths(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(wireFixtureDir)
+	if err != nil {
+		t.Fatalf("read fixture dir: %v", err)
+	}
+	var paths []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".json") {
+			paths = append(paths, filepath.Join(wireFixtureDir, e.Name()))
+		}
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no wire fixtures found in %s", wireFixtureDir)
+	}
+	return paths
+}
+
+func readFixture(t *testing.T, path string) ([]byte, wireFixture) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var fx wireFixture
+	if err := json.Unmarshal(raw, &fx); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	// Pull context.user separately (it lives under context).
+	var ctxObj struct {
+		User *struct {
+			ID          string `json:"id"`
+			Email       string `json:"email"`
+			AccountID   string `json:"account_id"`
+			AccountName string `json:"account_name"`
+		} `json:"user"`
+	}
+	_ = json.Unmarshal(fx.Context, &ctxObj)
+	if ctxObj.User != nil {
+		fx.ContextUser = ctxObj.User
+	}
+	return raw, fx
+}
+
+func postFixture(t *testing.T, deps *handler.Dependencies, rawKey string, body []byte) map[string]string {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/v1/events", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", rawKey)
+	w := httptest.NewRecorder()
+	handler.NewRouter(deps).ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d (%s)", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp
+}
+
+// semanticJSONEqual compares stored JSONB text against expected raw JSON,
+// ignoring key order and whitespace (Postgres reserializes JSONB).
+func semanticJSONEqual(t *testing.T, label, gotText string, want json.RawMessage) {
+	t.Helper()
+	if len(want) == 0 {
+		return
+	}
+	var got, exp any
+	if err := json.Unmarshal([]byte(gotText), &got); err != nil {
+		t.Fatalf("%s: unmarshal stored: %v", label, err)
+	}
+	if err := json.Unmarshal(want, &exp); err != nil {
+		t.Fatalf("%s: unmarshal fixture: %v", label, err)
+	}
+	if !reflect.DeepEqual(got, exp) {
+		t.Errorf("%s mismatch:\n stored=%s\n fixture=%s", label, gotText, string(want))
+	}
+}
+
+// TestWireFixtures_AcceptedAndStored replays every frozen fixture and asserts the
+// full contract round-trips. sdk_version is accepted (implicit in the 202) but is
+// not persisted by ingestion, so it is intentionally not asserted against the DB.
+func TestWireFixtures_AcceptedAndStored(t *testing.T) {
+	deps, pool := testDeps(t)
+
+	for _, path := range fixturePaths(t) {
+		path := path
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			_, _, _, rawKey := seedTenant(t, deps.Queries)
+			raw, fx := readFixture(t, path)
+
+			resp := postFixture(t, deps, rawKey, raw)
+			eventID := resp["event_id"]
+			if eventID == "" || resp["group_id"] == "" {
+				t.Fatalf("missing ids in response: %v", resp)
+			}
+			// Both response aliases must be present and equal.
+			if resp["error_group_id"] != resp["group_id"] {
+				t.Errorf("error_group_id %q != group_id %q", resp["error_group_id"], resp["group_id"])
+			}
+
+			var (
+				ts                                          time.Time
+				errType, errMsg, stack, release, sessionID  string
+				bcText, ctxText, groupID                    string
+				endUserID                                   *string
+			)
+			if err := pool.QueryRow(context.Background(), `
+				SELECT "timestamp", error_type, error_message, stack_trace_raw,
+				       COALESCE(release,''), COALESCE(session_id,''),
+				       breadcrumbs::text, context::text,
+				       error_group_id::text, end_user_id::text
+				FROM error_events WHERE id = $1`, eventID).
+				Scan(&ts, &errType, &errMsg, &stack, &release, &sessionID, &bcText, &ctxText, &groupID, &endUserID); err != nil {
+				t.Fatalf("query stored event: %v", err)
+			}
+
+			// Timestamp round-trip (client-supplied, persisted verbatim).
+			wantTS, err := time.Parse(time.RFC3339, fx.Timestamp)
+			if err != nil {
+				t.Fatalf("parse fixture timestamp: %v", err)
+			}
+			if !ts.Equal(wantTS) {
+				t.Errorf("timestamp = %v, want %v", ts, wantTS)
+			}
+			// Scalar error fields (empty type defaults to "Error").
+			wantType := fx.Error.Type
+			if wantType == "" {
+				wantType = "Error"
+			}
+			if errType != wantType {
+				t.Errorf("error_type = %q, want %q", errType, wantType)
+			}
+			if errMsg != fx.Error.Message {
+				t.Errorf("error_message = %q, want %q", errMsg, fx.Error.Message)
+			}
+			if stack != fx.Error.Stack {
+				t.Errorf("stack_trace_raw = %q, want %q", stack, fx.Error.Stack)
+			}
+			if release != fx.Release {
+				t.Errorf("release = %q, want %q", release, fx.Release)
+			}
+			if sessionID != fx.SessionID {
+				t.Errorf("session_id = %q, want %q", sessionID, fx.SessionID)
+			}
+			if groupID != resp["group_id"] {
+				t.Errorf("stored error_group_id %q != response group_id %q", groupID, resp["group_id"])
+			}
+			// Semantic JSON round-trip (benign values survive redaction).
+			semanticJSONEqual(t, "breadcrumbs", bcText, fx.Breadcrumbs)
+			semanticJSONEqual(t, "context", ctxText, fx.Context)
+
+			// User extraction: all end_user fields for a fixture with context.user.
+			if fx.ContextUser != nil {
+				if endUserID == nil {
+					t.Fatalf("expected end_user_id set for fixture with context.user")
+				}
+				var extID, extAcct, acctName, email string
+				if err := pool.QueryRow(context.Background(), `
+					SELECT external_user_id, COALESCE(external_account_id,''),
+					       COALESCE(account_name,''), COALESCE(email,'')
+					FROM end_users WHERE id = $1`, *endUserID).
+					Scan(&extID, &extAcct, &acctName, &email); err != nil {
+					t.Fatalf("query end_user: %v", err)
+				}
+				if extID != fx.ContextUser.ID {
+					t.Errorf("external_user_id = %q, want %q", extID, fx.ContextUser.ID)
+				}
+				if email != fx.ContextUser.Email {
+					t.Errorf("end_user email = %q, want %q", email, fx.ContextUser.Email)
+				}
+				if extAcct != fx.ContextUser.AccountID {
+					t.Errorf("external_account_id = %q, want %q", extAcct, fx.ContextUser.AccountID)
+				}
+				if acctName != fx.ContextUser.AccountName {
+					t.Errorf("account_name = %q, want %q", acctName, fx.ContextUser.AccountName)
+				}
+			}
+		})
+	}
+}
+
+// TestWireFixtures_StableGrouping posts the same fixture twice and asserts the
+// same group is reused — proves grouping, not just storage.
+func TestWireFixtures_StableGrouping(t *testing.T) {
+	deps, _ := testDeps(t)
+	_, _, _, rawKey := seedTenant(t, deps.Queries)
+
+	raw, _ := readFixture(t, filepath.Join(wireFixtureDir, "v1.0.0-full.json"))
+	first := postFixture(t, deps, rawKey, raw)
+	second := postFixture(t, deps, rawKey, raw)
+	if first["group_id"] != second["group_id"] {
+		t.Errorf("group_id drifted across identical posts: %q vs %q", first["group_id"], second["group_id"])
+	}
+}
+
+// TestWireFixtures_UnknownFieldsTolerated injects unknown fields and asserts 202.
+// Locks in forward-compat: nobody may add DisallowUnknownFields to /api/v1/events.
+func TestWireFixtures_UnknownFieldsTolerated(t *testing.T) {
+	deps, _ := testDeps(t)
+	_, _, _, rawKey := seedTenant(t, deps.Queries)
+
+	raw, _ := readFixture(t, filepath.Join(wireFixtureDir, "v1.0.0-minimal.json"))
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	obj["future_field"] = "from a newer SDK"
+	obj["error"].(map[string]any)["future_error_field"] = 123
+	augmented, _ := json.Marshal(obj)
+
+	resp := postFixture(t, deps, rawKey, augmented)
+	if resp["event_id"] == "" {
+		t.Errorf("unknown-field payload not stored: %v", resp)
+	}
+}
+```
+
+**Step 2: Run the tests (green against current server)**
+
+Run: `cd packages/ingestion && go test ./handler -run TestWireFixtures -v`
+Expected: PASS (with `DATABASE_URL` set + migrations applied). Guard tests pass against today's correct server.
+
+**Step 3: Prove the guard bites (non-destructive sabotage)**
+
+Back up, then make the decoder strict:
+
+```bash
+cp packages/ingestion/handler/error_event.go /tmp/error_event.go.bak
+```
+
+In `packages/ingestion/handler/error_event.go`, replace `json.Unmarshal(body, &payload)` (`:70`) with:
+
+```go
+dec := json.NewDecoder(strings.NewReader(string(body)))
+dec.DisallowUnknownFields()
+if err := dec.Decode(&payload); err != nil {
+```
+
+Run: `cd packages/ingestion && go test ./handler -run TestWireFixtures_UnknownFieldsTolerated -v`
+Expected: FAIL (server now 400s the unknown field).
+
+**Step 4: Restore from backup (no git ops)**
+
+```bash
+cp /tmp/error_event.go.bak packages/ingestion/handler/error_event.go && rm /tmp/error_event.go.bak
+cd packages/ingestion && go test ./handler -run TestWireFixtures -v
+```
+Expected: PASS again.
+
+**Step 5: Commit**
+
+```bash
+git add packages/ingestion/handler/wire_compat_test.go
+git commit -m "test(ingestion): replay frozen wire fixtures (full round-trip + unknown-field tolerance)"
+```
+
+---
+
+## Task 3: Fixture immutability check script + unit test
+
+A `node:`-only script whose diff-parsing core is a pure, unit-tested function — so we verify it without any destructive git operations.
+
+**Files:**
+- Create: `scripts/check-wire-fixtures.mjs`
+- Create: `scripts/check-wire-fixtures.test.mjs`
+
+**Step 1: Write the script (pure parser + thin runner)**
+
+`scripts/check-wire-fixtures.mjs`:
+
+```js
+#!/usr/bin/env node
+/**
+ * Enforce that frozen wire fixtures under test-fixtures/wire/ are append-only.
+ * Fails if a diff modifies (M), deletes (D), or renames (R) an existing fixture.
+ * Additions (A) are allowed. A `contract-change` PR label bypasses this at the
+ * workflow level (.github/workflows/wire-fixtures.yml).
+ *
+ * Diffs BASE_SHA...HEAD_SHA (three-dot = merge base). Defaults suit local runs.
+ *
+ * Usage: node scripts/check-wire-fixtures.mjs
+ */
+import { execFileSync } from 'node:child_process';
+
+export const GUARDED_PREFIX = 'test-fixtures/wire/';
+
+/**
+ * Pure: given `git diff --name-status` output, return human-readable violations.
+ * Renaming a guarded file is a delete of the frozen path, so it fails.
+ */
+export function findViolations(diffOutput, guarded = GUARDED_PREFIX) {
+  const problems = [];
+  for (const line of diffOutput.split('\n')) {
+    if (!line.trim()) continue;
+    const parts = line.split('\t');
+    const status = parts[0][0]; // A, M, D, R, C
+    const affected = parts.slice(1).filter((p) => p.startsWith(guarded));
+    if (affected.length === 0) continue;
+    if (status === 'M' || status === 'D' || status === 'R') {
+      const verb = { M: 'modified', D: 'deleted', R: 'renamed' }[status];
+      for (const p of affected) problems.push(`${p} was ${verb} (fixtures are append-only)`);
+    }
+  }
+  return problems;
+}
+
+function main() {
+  const base = process.env.BASE_SHA || 'origin/main';
+  const head = process.env.HEAD_SHA || 'HEAD';
+  let out;
+  try {
+    out = execFileSync('git', ['diff', '--name-status', `${base}...${head}`], { encoding: 'utf8' });
+  } catch (err) {
+    console.error(`Wire-fixture check could not run git diff (${base}...${head}): ${err.message}`);
+    console.error('In CI ensure fetch-depth: 0 and that BASE_SHA/HEAD_SHA are set.');
+    process.exit(1);
+  }
+  const problems = findViolations(out);
+  if (problems.length > 0) {
+    console.error('Wire-fixture immutability check FAILED:');
+    for (const p of problems) console.error(`  - ${p}`);
+    console.error('');
+    console.error('Frozen fixtures under test-fixtures/wire/ may only be ADDED, never');
+    console.error('changed. If this edit is a deliberate, reviewed contract change, add');
+    console.error('the `contract-change` label to the PR. See docs/contracts/events.md.');
+    process.exit(1);
+  }
+  console.log(`Wire-fixture check OK: no modified/deleted fixtures under ${GUARDED_PREFIX}.`);
+}
+
+// Run only when invoked directly, not when imported by the test.
+if (import.meta.url === `file://${process.argv[1]}`) main();
+```
+
+**Step 2: Write the unit test (no git mutation)**
+
+`scripts/check-wire-fixtures.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { findViolations } from './check-wire-fixtures.mjs';
+
+test('additions are allowed', () => {
+  const diff = 'A\ttest-fixtures/wire/events/v1.1.0-minimal.json';
+  assert.deepEqual(findViolations(diff), []);
+});
+
+test('modifying an existing fixture fails', () => {
+  const diff = 'M\ttest-fixtures/wire/events/v1.0.0-minimal.json';
+  assert.equal(findViolations(diff).length, 1);
+  assert.match(findViolations(diff)[0], /was modified/);
+});
+
+test('deleting an existing fixture fails', () => {
+  const diff = 'D\ttest-fixtures/wire/events/v1.0.0-full.json';
+  assert.match(findViolations(diff)[0], /was deleted/);
+});
+
+test('renaming an existing fixture fails', () => {
+  const diff = 'R100\ttest-fixtures/wire/events/v1.0.0-full.json\ttest-fixtures/wire/events/renamed.json';
+  assert.match(findViolations(diff)[0], /was renamed/);
+});
+
+test('changes outside the guarded prefix are ignored', () => {
+  const diff = 'M\tpackages/sdk/src/core.ts\nA\ttest-fixtures/wire/events/v1.2.0-full.json';
+  assert.deepEqual(findViolations(diff), []);
+});
+```
+
+**Step 3: Run the unit test**
+
+Run: `node --test scripts/check-wire-fixtures.test.mjs`
+Expected: `# pass 5`.
+
+**Step 4: Make the script executable and smoke-run it**
+
+Run: `chmod +x scripts/check-wire-fixtures.mjs && node scripts/check-wire-fixtures.mjs`
+Expected: prints `Wire-fixture check OK: ...` (no fixture edits vs origin/main on a clean tree).
+
+**Step 5: Commit**
+
+```bash
+git add scripts/check-wire-fixtures.mjs scripts/check-wire-fixtures.test.mjs
+git commit -m "ci: add append-only wire-fixture check with unit-tested diff parser"
+```
+
+---
+
+## Task 4: Trusted-base wire-fixtures workflow
+
+Run the check from the **base branch** via `pull_request_target`, reading only the PR's file-change list — never checking out or executing PR code. This closes the self-bypass hole: a PR cannot weaken the workflow or the script in the same PR, because both come from the trusted base.
+
+**Files:**
+- Create: `.github/workflows/wire-fixtures.yml`
+
+**Step 1: Write the workflow**
+
+`.github/workflows/wire-fixtures.yml`:
+
+```yaml
+name: Wire fixtures
+
+# SECURITY: pull_request_target runs the workflow AND scripts from the BASE
+# branch (trusted). A PR therefore cannot weaken this gate by editing the
+# workflow or the checker in the same PR. We only READ the PR's changed-file
+# list via git metadata (diff --name-status). NEVER add a step that checks out
+# or executes the PR head's working tree here — that would run untrusted code in
+# this trigger's elevated context.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  wire-fixtures:
+    name: wire-fixtures # required-status-check context = this name
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Skip (green) only when a human has consciously labeled a contract change.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'contract-change') }}
+    steps:
+      - name: Check out base branch (trusted workflow + script)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Fetch PR head commit (metadata only; never checked out)
+        run: git fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/head"
+      - name: Wire-fixture immutability
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/check-wire-fixtures.mjs
+```
+
+**Step 2: Lint the workflow locally**
+
+Run: `node scripts/check-action-pins.mjs`
+Expected: `Action-pin check OK` (the new `checkout` is SHA-pinned).
+
+Run: `node -e "const y=require('fs').readFileSync('.github/workflows/wire-fixtures.yml','utf8'); for (const s of ['pull_request_target','labeled','contract-change','name: wire-fixtures']) if(!y.includes(s)) throw new Error('missing '+s); if(/checkout.*head|pull.*\/merge/.test(y)) throw new Error('must not check out PR code'); console.log('workflow wiring ok')"`
+Expected: `workflow wiring ok`.
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/wire-fixtures.yml
+git commit -m "ci: add trusted-base wire-fixtures gate (pull_request_target, label-bypass)"
+```
+
+**Note:** this becomes a *gate* only once it is a required status check on `main` and the `contract-change` label exists (Task 7).
+
+---
+
+## Task 5: SDK wire-shape vitest (real transport path)
+
+Capture the SDK's true wire body (through `enqueueEvent` → scrub → `beforeSend` → late-bind → `flushEvents` serialize via a mocked `fetch`), then assert normalized deep equality against the current-release fixture pair.
+
+**Files:**
+- Create: `packages/sdk/src/__tests__/wire-shape.test.ts`
+
+**Step 1: Write the test**
+
+`packages/sdk/src/__tests__/wire-shape.test.ts`:
+
+```ts
+// @vitest-environment node
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type { Breadcrumb } from '@opslane/shared';
+import { buildPayload, setUser, clearUser } from '../core';
+import { loadConfig } from '../config';
+import { clearBreadcrumbs } from '../breadcrumbs';
+import { resetSessionId } from '../session';
+import { enqueueEvent, flushEvents, _resetQueue } from '../transport';
+import { _resetThrottle } from '../throttle';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(here, '../../package.json'), 'utf8')) as { version: string };
+const version = pkg.version;
+const fixtureDir = join(here, '../../../../test-fixtures/wire/events');
+
+function loadFixture(kind: 'minimal' | 'full'): unknown {
+  return JSON.parse(readFileSync(join(fixtureDir, `v${version}-${kind}.json`), 'utf8'));
+}
+
+const FIXTURE_MESSAGE = "Cannot read properties of null (reading 'name')";
+const FIXTURE_STACK =
+  "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)";
+
+// Replace values that legitimately vary between the fixture's authored
+// environment and this node test run. Structure (every key, nesting, array
+// shape) is still compared exactly by toEqual.
+const SENTINEL = '<volatile>';
+function normalize(input: unknown): unknown {
+  const v = structuredClone(input) as Record<string, unknown>;
+  const err = v.error as Record<string, unknown> | undefined;
+  const ctx = v.context as Record<string, unknown> | undefined;
+  if (typeof v.timestamp === 'string') v.timestamp = SENTINEL;
+  if (typeof v.sdk_version === 'string') v.sdk_version = SENTINEL;
+  if (typeof v.session_id === 'string') v.session_id = SENTINEL;
+  if (err && typeof err.stack === 'string') err.stack = SENTINEL;
+  if (ctx && typeof ctx.url === 'string') ctx.url = SENTINEL;
+  if (ctx && typeof ctx.user_agent === 'string') ctx.user_agent = SENTINEL;
+  if (Array.isArray(v.breadcrumbs)) {
+    for (const b of v.breadcrumbs as Array<Record<string, unknown>>) {
+      if (b && typeof b.timestamp === 'string') b.timestamp = SENTINEL;
+    }
+  }
+  return v;
+}
+
+// Enqueue the SDK-built event, then flush with fetch mocked, and return the
+// parsed wire body. This exercises the real transport path, not just buildPayload.
+async function captureWire(event: ReturnType<typeof buildPayload>): Promise<unknown> {
+  let body = '';
+  const fetchMock = vi.fn(async (_url: string, init: { body: string }) => {
+    body = init.body;
+    return { ok: true } as unknown as Response;
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  try {
+    enqueueEvent(event);
+    await flushEvents();
+  } finally {
+    vi.unstubAllGlobals();
+  }
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  return JSON.parse(body);
+}
+
+describe('SDK emits the frozen wire shape', () => {
+  beforeEach(() => {
+    _resetQueue();
+    _resetThrottle();
+    clearBreadcrumbs();
+    clearUser();
+  });
+
+  it('minimal payload matches the frozen fixture', async () => {
+    resetSessionId(); // after clearUser: drop session so session_id is omitted
+    loadConfig({
+      apiKey: 'sk-test', endpoint: 'https://api.test',
+      maxBreadcrumbs: 0, maxBatchSize: 100, errorThrottleMs: 0, release: '',
+    });
+    const crumb: Breadcrumb = { type: 'error', timestamp: new Date().toISOString(), category: 'error', message: 'boot' };
+    const event = buildPayload('TypeError', FIXTURE_MESSAGE, FIXTURE_STACK, crumb);
+
+    const wire = await captureWire(event);
+    expect(normalize(wire)).toEqual(normalize(loadFixture('minimal')));
+  });
+
+  it('full payload matches the frozen fixture', async () => {
+    loadConfig({
+      apiKey: 'sk-test', endpoint: 'https://api.test',
+      maxBatchSize: 100, errorThrottleMs: 0, release: 'web@2026.07.16',
+    });
+    setUser({ id: 'user-123', email: 'jane@example.com', account: { id: 'acct-42', name: 'Example Inc' } });
+    const crumb: Breadcrumb = {
+      type: 'navigation', timestamp: new Date().toISOString(),
+      category: 'navigation', message: 'https://app.example.com/dashboard',
+    };
+    const event = buildPayload('TypeError', FIXTURE_MESSAGE, FIXTURE_STACK, crumb);
+
+    const wire = await captureWire(event);
+    expect(normalize(wire)).toEqual(normalize(loadFixture('full')));
+  });
+});
+```
+
+**Step 2: Run the test**
+
+Run: `pnpm --filter @opslane/sdk test -- wire-shape`
+Expected: PASS (2 tests). A failure here means the SDK's real wire shape drifted from the frozen fixture — investigate before touching the fixture.
+
+**Step 3: Prove it bites (non-destructive)**
+
+```bash
+cp packages/sdk/src/core.ts /tmp/core.ts.bak
+```
+In `packages/sdk/src/core.ts`, add a stray key to the object returned by `buildPayload` (e.g. `extra_field: 'x',` near `sdk_version: SDK_VERSION,` at `:90`).
+Run: `pnpm --filter @opslane/sdk test -- wire-shape`
+Expected: FAIL (emitted has a key the fixture lacks — deep equality catches it).
+Restore: `cp /tmp/core.ts.bak packages/sdk/src/core.ts && rm /tmp/core.ts.bak` and re-run → PASS.
+
+**Step 4: Commit**
+
+```bash
+git add packages/sdk/src/__tests__/wire-shape.test.ts
+git commit -m "test(sdk): assert real wire output matches the frozen v1.0.0 shape"
+```
+
+---
+
+## Task 6: Written contract rule
+
+**Files:**
+- Create: `docs/contracts/events.md`
+- Modify: `AGENTS.md` (Guardrails section)
+
+**Step 1: Write the contract doc**
+
+`docs/contracts/events.md`:
+
+```markdown
+# Event API contract
+
+`POST /api/v1/events` is **append-only and backward-compatible, forever.**
+
+The SDK ships to npm and runs in customers' apps on their upgrade schedule; the
+ingestion API deploys on ours. Old SDK versions POST to our newest server
+indefinitely and we cannot force-upgrade them. A break is a silent customer
+outage we cannot hotfix.
+
+## Rules
+
+- **Add only optional fields.** Never remove a field the SDK may send, never make
+  an existing field required, never stop reading a field an old SDK sends.
+- **Never tighten decoding.** The events decoder must keep tolerating unknown
+  fields (no `DisallowUnknownFields`) so a *newer* SDK's extra fields are ignored,
+  not rejected.
+- **Fixtures are frozen.** `test-fixtures/wire/events/` holds the exact wire JSON
+  per released SDK shape. Add a new `v<version>-*.json` pair for a new shape;
+  never edit or delete an existing file.
+
+## Enforcement
+
+- `packages/ingestion/handler/wire_compat_test.go` (`go` CI job) replays every
+  fixture and asserts `202` + full field round-trip + stable grouping + unknown-
+  field tolerance.
+- `packages/sdk/src/__tests__/wire-shape.test.ts` (`js` CI job) asserts the SDK's
+  real transport output still matches the current version's pair.
+- `.github/workflows/wire-fixtures.yml` (trusted-base `pull_request_target`) fails
+  any PR that modifies or deletes a frozen fixture, unless the PR carries the
+  `contract-change` label — the one deliberate, reviewed way to change the
+  contract.
+
+## Making a deliberate change
+
+Adding a field: add a new fixture pair, keep the field optional server-side, and
+the old fixtures still pass. Editing/removing an existing fixture: apply the
+`contract-change` label, a conscious acknowledgement that live clients may break.
+```
+
+**Step 2: Add the AGENTS.md guardrail line**
+
+In `AGENTS.md`, under `## Guardrails`, add:
+
+```markdown
+- The `POST /api/v1/events` wire contract is append-only and backward-compatible. Add optional fields only; never edit or delete a frozen fixture under `test-fixtures/wire/`. See `docs/contracts/events.md`.
+```
+
+**Step 3: Verify**
+
+Run: `node -e "require('fs').readFileSync('docs/contracts/events.md'); const a=require('fs').readFileSync('AGENTS.md','utf8'); if(!a.includes('docs/contracts/events.md')) throw new Error('AGENTS.md not updated'); console.log('docs ok')"`
+Expected: `docs ok`.
+
+**Step 4: Commit**
+
+```bash
+git add docs/contracts/events.md AGENTS.md
+git commit -m "docs: document the append-only event API contract"
+```
+
+---
+
+## Task 7: Ops prerequisites (make the gate real)
+
+Not code — without these the workflow is advisory.
+
+**Step 1: Create the `contract-change` label**
+
+Run: `gh label create contract-change --description "Deliberate, reviewed change to a frozen API contract (bypasses wire-fixture immutability)" --color B60205`
+Expected: created (or "already exists").
+
+**Step 2: Require the `wire-fixtures` check on `main`, including admins**
+
+In `main` branch protection: add the status check named **`wire-fixtures`** (the job `name`, per the verified fact above — not the workflow filename), and enable "Include administrators". The gate only runs on PRs, so admins must not be exempt or a direct push could edit a frozen fixture.
+
+Verify (admin token): `gh api repos/opslane/opslane-oss/branches/main/protection --jq '.required_status_checks.contexts, .enforce_admins.enabled'`
+Expected: contexts contains `wire-fixtures`; `enforce_admins` is `true`.
+
+**Step 3: Record completion** in the PR description (cannot be proven by the diff).
+
+---
+
+## Final verification (whole feature)
+
+From repo root:
+
+```bash
+# SDK real-wire test
+pnpm --filter @opslane/sdk test -- wire-shape
+# Script parser unit test
+node --test scripts/check-wire-fixtures.test.mjs
+# Ingestion (disposable DB with migrations applied)
+(cd packages/ingestion && go build ./... && go vet ./... && go test ./handler -run TestWireFixtures -v)
+# Guards on a clean tree
+node scripts/check-wire-fixtures.mjs
+node scripts/check-action-pins.mjs
+```
+
+Expected: SDK 2 tests pass; parser 5 tests pass; Go fixture tests pass; both check scripts print OK.
+
+On the PR: confirm the `wire-fixtures` check runs green; in a scratch commit edit a fixture and confirm it goes red; add `contract-change` and confirm the check re-runs green; drop the scratch commit before merge.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "db:migrate": "docker compose run --rm migrate",
     "services:restart": "./scripts/restart-services.sh",
     "services:restart:wipe-db": "./scripts/restart-services.sh --wipe-db",
-    "test": "node scripts/check-docs-drift.mjs && pnpm -r --filter '!@opslane/test-e2e' test",
+    "test": "node scripts/check-docs-drift.mjs && node --test scripts/check-wire-fixtures.test.mjs && pnpm -r --filter '!@opslane/test-e2e' test",
     "test:unit": "pnpm -r --filter '!@opslane/test-e2e' test",
     "test:e2e": "pnpm --filter @opslane/test-e2e test",
     "test:reliability:system": "./scripts/run-reliability-system.sh"

--- a/packages/ingestion/handler/wire_compat_test.go
+++ b/packages/ingestion/handler/wire_compat_test.go
@@ -1,0 +1,266 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opslane/opslane/packages/ingestion/handler"
+)
+
+// wireFixtureDir is the frozen-fixture dir relative to this package
+// (packages/ingestion/handler -> repo root is ../../..).
+const wireFixtureDir = "../../../test-fixtures/wire/events"
+
+type wireFixture struct {
+	Timestamp string `json:"timestamp"`
+	Error     struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+		Stack   string `json:"stack"`
+	} `json:"error"`
+	Breadcrumbs json.RawMessage `json:"breadcrumbs"`
+	Context     json.RawMessage `json:"context"`
+	SDKVersion  string          `json:"sdk_version"`
+	Release     string          `json:"release"`
+	SessionID   string          `json:"session_id"`
+	ContextUser *struct {
+		ID          string `json:"id"`
+		Email       string `json:"email"`
+		AccountID   string `json:"account_id"`
+		AccountName string `json:"account_name"`
+	} `json:"-"`
+}
+
+func fixturePaths(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(wireFixtureDir)
+	if err != nil {
+		t.Fatalf("read fixture dir: %v", err)
+	}
+	var paths []string
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".json") {
+			paths = append(paths, filepath.Join(wireFixtureDir, entry.Name()))
+		}
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no wire fixtures found in %s", wireFixtureDir)
+	}
+	return paths
+}
+
+func readFixture(t *testing.T, path string) ([]byte, wireFixture) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var fixture wireFixture
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+
+	var contextObject struct {
+		User *struct {
+			ID          string `json:"id"`
+			Email       string `json:"email"`
+			AccountID   string `json:"account_id"`
+			AccountName string `json:"account_name"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal(fixture.Context, &contextObject); err != nil {
+		t.Fatalf("parse fixture context: %v", err)
+	}
+	fixture.ContextUser = contextObject.User
+	return raw, fixture
+}
+
+func postFixture(t *testing.T, deps *handler.Dependencies, rawKey string, body []byte) map[string]string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", rawKey)
+	recorder := httptest.NewRecorder()
+	handler.NewRouter(deps).ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d (%s)", recorder.Code, recorder.Body.String())
+	}
+	var response map[string]string
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return response
+}
+
+// semanticJSONEqual compares stored JSONB text against expected raw JSON,
+// ignoring key order and whitespace (Postgres reserializes JSONB).
+func semanticJSONEqual(t *testing.T, label, gotText string, want json.RawMessage) {
+	t.Helper()
+	if len(want) == 0 {
+		return
+	}
+	var got, expected any
+	if err := json.Unmarshal([]byte(gotText), &got); err != nil {
+		t.Fatalf("%s: unmarshal stored: %v", label, err)
+	}
+	if err := json.Unmarshal(want, &expected); err != nil {
+		t.Fatalf("%s: unmarshal fixture: %v", label, err)
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("%s mismatch:\n stored=%s\n fixture=%s", label, gotText, string(want))
+	}
+}
+
+// TestWireFixtures_AcceptedAndStored replays every frozen fixture and asserts the
+// full contract round-trips. sdk_version is accepted (implicit in the 202) but is
+// not persisted by ingestion, so it is intentionally not asserted against the DB.
+func TestWireFixtures_AcceptedAndStored(t *testing.T) {
+	deps, pool := testDeps(t)
+
+	for _, path := range fixturePaths(t) {
+		path := path
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			_, _, _, rawKey := seedTenant(t, deps.Queries)
+			raw, fixture := readFixture(t, path)
+
+			response := postFixture(t, deps, rawKey, raw)
+			eventID := response["event_id"]
+			if eventID == "" || response["group_id"] == "" {
+				t.Fatalf("missing ids in response: %v", response)
+			}
+			if response["error_group_id"] != response["group_id"] {
+				t.Errorf("error_group_id %q != group_id %q", response["error_group_id"], response["group_id"])
+			}
+
+			var (
+				timestamp                                          time.Time
+				errorType, errorMessage, stack, release, sessionID string
+				breadcrumbsText, contextText, groupID              string
+				endUserID                                          *string
+			)
+			if err := pool.QueryRow(context.Background(), `
+				SELECT "timestamp", error_type, error_message, stack_trace_raw,
+				       COALESCE(release,''), COALESCE(session_id,''),
+				       breadcrumbs::text, context::text,
+				       error_group_id::text, end_user_id::text
+				FROM error_events WHERE id = $1`, eventID).
+				Scan(&timestamp, &errorType, &errorMessage, &stack, &release, &sessionID,
+					&breadcrumbsText, &contextText, &groupID, &endUserID); err != nil {
+				t.Fatalf("query stored event: %v", err)
+			}
+
+			wantTimestamp, err := time.Parse(time.RFC3339, fixture.Timestamp)
+			if err != nil {
+				t.Fatalf("parse fixture timestamp: %v", err)
+			}
+			if !timestamp.Equal(wantTimestamp) {
+				t.Errorf("timestamp = %v, want %v", timestamp, wantTimestamp)
+			}
+			wantType := fixture.Error.Type
+			if wantType == "" {
+				wantType = "Error"
+			}
+			if errorType != wantType {
+				t.Errorf("error_type = %q, want %q", errorType, wantType)
+			}
+			if errorMessage != fixture.Error.Message {
+				t.Errorf("error_message = %q, want %q", errorMessage, fixture.Error.Message)
+			}
+			if stack != fixture.Error.Stack {
+				t.Errorf("stack_trace_raw = %q, want %q", stack, fixture.Error.Stack)
+			}
+			if release != fixture.Release {
+				t.Errorf("release = %q, want %q", release, fixture.Release)
+			}
+			if sessionID != fixture.SessionID {
+				t.Errorf("session_id = %q, want %q", sessionID, fixture.SessionID)
+			}
+			if groupID != response["group_id"] {
+				t.Errorf("stored error_group_id %q != response group_id %q", groupID, response["group_id"])
+			}
+			semanticJSONEqual(t, "breadcrumbs", breadcrumbsText, fixture.Breadcrumbs)
+			semanticJSONEqual(t, "context", contextText, fixture.Context)
+
+			if fixture.ContextUser == nil {
+				if endUserID != nil {
+					t.Errorf("unexpected end_user_id %q for fixture without context.user", *endUserID)
+				}
+				return
+			}
+			if endUserID == nil {
+				t.Fatalf("expected end_user_id set for fixture with context.user")
+			}
+			var externalID, externalAccountID, accountName, email string
+			if err := pool.QueryRow(context.Background(), `
+				SELECT external_user_id, COALESCE(external_account_id,''),
+				       COALESCE(account_name,''), COALESCE(email,'')
+				FROM end_users WHERE id = $1`, *endUserID).
+				Scan(&externalID, &externalAccountID, &accountName, &email); err != nil {
+				t.Fatalf("query end_user: %v", err)
+			}
+			if externalID != fixture.ContextUser.ID {
+				t.Errorf("external_user_id = %q, want %q", externalID, fixture.ContextUser.ID)
+			}
+			if email != fixture.ContextUser.Email {
+				t.Errorf("end_user email = %q, want %q", email, fixture.ContextUser.Email)
+			}
+			if externalAccountID != fixture.ContextUser.AccountID {
+				t.Errorf("external_account_id = %q, want %q", externalAccountID, fixture.ContextUser.AccountID)
+			}
+			if accountName != fixture.ContextUser.AccountName {
+				t.Errorf("account_name = %q, want %q", accountName, fixture.ContextUser.AccountName)
+			}
+		})
+	}
+}
+
+// TestWireFixtures_StableGrouping posts the same fixture twice and asserts the
+// same group is reused, proving grouping as well as storage.
+func TestWireFixtures_StableGrouping(t *testing.T) {
+	deps, _ := testDeps(t)
+	_, _, _, rawKey := seedTenant(t, deps.Queries)
+
+	for _, path := range fixturePaths(t) {
+		path := path
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			raw, _ := readFixture(t, path)
+			first := postFixture(t, deps, rawKey, raw)
+			second := postFixture(t, deps, rawKey, raw)
+			if first["group_id"] != second["group_id"] {
+				t.Errorf("group_id drifted across identical posts: %q vs %q", first["group_id"], second["group_id"])
+			}
+		})
+	}
+}
+
+// TestWireFixtures_UnknownFieldsTolerated locks in forward compatibility: the
+// events decoder must keep ignoring fields introduced by newer SDKs.
+func TestWireFixtures_UnknownFieldsTolerated(t *testing.T) {
+	deps, _ := testDeps(t)
+	_, _, _, rawKey := seedTenant(t, deps.Queries)
+
+	raw, _ := readFixture(t, filepath.Join(wireFixtureDir, "v1.0.0-minimal.json"))
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	object["future_field"] = "from a newer SDK"
+	object["error"].(map[string]any)["future_error_field"] = 123
+	augmented, err := json.Marshal(object)
+	if err != nil {
+		t.Fatalf("encode augmented fixture: %v", err)
+	}
+
+	response := postFixture(t, deps, rawKey, augmented)
+	if response["event_id"] == "" {
+		t.Errorf("unknown-field payload not stored: %v", response)
+	}
+}

--- a/packages/sdk/src/__tests__/wire-shape.test.ts
+++ b/packages/sdk/src/__tests__/wire-shape.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Breadcrumb } from '@opslane/shared';
+import { clearBreadcrumbs } from '../breadcrumbs';
+import { loadConfig } from '../config';
+import { buildPayload, clearUser, setUser } from '../core';
+import { resetSessionId } from '../session';
+import { _resetThrottle } from '../throttle';
+import { _resetQueue, enqueueEvent, flushEvents } from '../transport';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageMetadata = JSON.parse(readFileSync(join(here, '../../package.json'), 'utf8')) as { version: string };
+const fixtureDir = join(here, '../../../../test-fixtures/wire/events');
+
+function loadFixture(kind: 'minimal' | 'full'): unknown {
+  return JSON.parse(
+    readFileSync(join(fixtureDir, `v${packageMetadata.version}-${kind}.json`), 'utf8'),
+  );
+}
+
+const FIXTURE_MESSAGE = "Cannot read properties of null (reading 'name')";
+const FIXTURE_STACK =
+  "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)";
+const SENTINEL = '<volatile>';
+
+// Replace values that legitimately vary between the authored fixture and this
+// node test. Deep equality still locks every key, nesting level, and array shape.
+function normalize(input: unknown): unknown {
+  const value = structuredClone(input) as Record<string, unknown>;
+  const context = value.context as Record<string, unknown> | undefined;
+  if (typeof value.timestamp === 'string') value.timestamp = SENTINEL;
+  if (typeof value.session_id === 'string') value.session_id = SENTINEL;
+  if (context && typeof context.url === 'string') context.url = SENTINEL;
+  if (context && typeof context.user_agent === 'string') context.user_agent = SENTINEL;
+  if (Array.isArray(value.breadcrumbs)) {
+    for (const breadcrumb of value.breadcrumbs as Array<Record<string, unknown>>) {
+      if (breadcrumb && typeof breadcrumb.timestamp === 'string') breadcrumb.timestamp = SENTINEL;
+    }
+  }
+  return value;
+}
+
+async function captureWire(event: ReturnType<typeof buildPayload>): Promise<unknown> {
+  let body = '';
+  const fetchMock = vi.fn(async (_url: string, init: { body: string }) => {
+    body = init.body;
+    return { ok: true } as Response;
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  try {
+    enqueueEvent(event);
+    await flushEvents();
+  } finally {
+    vi.unstubAllGlobals();
+  }
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  return JSON.parse(body);
+}
+
+describe('SDK emits the frozen wire shape', () => {
+  beforeEach(() => {
+    _resetQueue();
+    _resetThrottle();
+    clearBreadcrumbs();
+    clearUser();
+  });
+
+  it('minimal payload matches the frozen fixture', async () => {
+    resetSessionId();
+    loadConfig({
+      apiKey: 'sk-test',
+      endpoint: 'https://api.test',
+      maxBreadcrumbs: 0,
+      maxBatchSize: 100,
+      errorThrottleMs: 0,
+      release: '',
+    });
+    const breadcrumb: Breadcrumb = {
+      type: 'error',
+      timestamp: new Date().toISOString(),
+      category: 'error',
+      message: 'boot',
+    };
+
+    const wire = await captureWire(buildPayload('TypeError', FIXTURE_MESSAGE, FIXTURE_STACK, breadcrumb));
+    expect(normalize(wire)).toEqual(normalize(loadFixture('minimal')));
+  });
+
+  it('full payload matches the frozen fixture', async () => {
+    loadConfig({
+      apiKey: 'sk-test',
+      endpoint: 'https://api.test',
+      maxBatchSize: 100,
+      errorThrottleMs: 0,
+      release: 'web@2026.07.16',
+    });
+    setUser({
+      id: 'user-123',
+      email: 'jane@example.com',
+      account: { id: 'acct-42', name: 'Example Inc' },
+    });
+    const breadcrumb: Breadcrumb = {
+      type: 'navigation',
+      timestamp: new Date().toISOString(),
+      category: 'navigation',
+      message: 'https://app.example.com/dashboard',
+    };
+
+    const wire = await captureWire(buildPayload('TypeError', FIXTURE_MESSAGE, FIXTURE_STACK, breadcrumb));
+    expect(normalize(wire)).toEqual(normalize(loadFixture('full')));
+  });
+});

--- a/scripts/check-wire-fixtures.mjs
+++ b/scripts/check-wire-fixtures.mjs
@@ -1,10 +1,17 @@
 #!/usr/bin/env node
 /**
  * Enforce that frozen wire fixtures under test-fixtures/wire/ are append-only.
- * Fails if a diff changes or removes an existing fixture. Additions are allowed.
- * A `contract-change` PR label bypasses this at the workflow level.
+ * Fails if a change modifies, deletes, renames, or type-changes an existing
+ * fixture. Additions (and copies that preserve the source) are allowed. A
+ * `contract-change` PR label bypasses this at the workflow level.
  *
- * Diffs BASE_SHA...HEAD_SHA (three-dot = merge base). Defaults suit local runs.
+ * Two input sources, one rule:
+ *   - CI (PR_NUMBER set): read the PR's changed-file list from the GitHub API
+ *     (`gh api repos/<repo>/pulls/<n>/files`). This is strictly metadata — the
+ *     PR head is never fetched, checked out, or executed, so the check stays
+ *     safe to run from the trusted base under pull_request_target.
+ *   - Local (no PR_NUMBER): diff BASE_SHA...HEAD_SHA (defaults origin/main...HEAD)
+ *     plus uncommitted changes under the guarded prefix.
  *
  * Usage: node scripts/check-wire-fixtures.mjs
  */
@@ -12,6 +19,10 @@ import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 export const GUARDED_PREFIX = 'test-fixtures/wire/';
+
+// GitHub file statuses that never touch an existing frozen path: a new file, a
+// copy (source preserved), or an unchanged entry. Anything else is inspected.
+const SAFE_API_STATUSES = new Set(['added', 'copied', 'unchanged']);
 
 /**
  * Pure: given `git diff --name-status` output, return human-readable violations.
@@ -34,22 +45,72 @@ export function findViolations(diffOutput, guarded = GUARDED_PREFIX) {
   return problems;
 }
 
-function main() {
+/**
+ * Pure: given the GitHub PR-files API shape (`[{status, filename,
+ * previous_filename}]`), return the same human-readable violations. A rename is
+ * a violation only when the *old* path was frozen (a frozen file disappearing);
+ * a rename that lands a new file inside the prefix from outside is an addition.
+ * Unknown statuses on a guarded path fail closed.
+ */
+export function findViolationsFromFiles(files, guarded = GUARDED_PREFIX) {
+  const problems = [];
+  for (const file of files) {
+    const status = file.status;
+    if (SAFE_API_STATUSES.has(status)) continue;
+
+    if (status === 'renamed') {
+      const from = file.previous_filename || '';
+      if (from.startsWith(guarded)) problems.push(`${from} was renamed (fixtures are append-only)`);
+      continue;
+    }
+
+    const path = file.filename || '';
+    if (!path.startsWith(guarded)) continue;
+    const verb = { modified: 'modified', removed: 'deleted', changed: 'type-changed' }[status] ?? `changed (${status})`;
+    problems.push(`${path} was ${verb} (fixtures are append-only)`);
+  }
+  return problems;
+}
+
+function problemsFromApi(repo, prNumber) {
+  // `--jq '.[]'` streams one compact JSON object per line across paginated
+  // pages, avoiding any assumption about how gh concatenates array pages.
+  const raw = execFileSync(
+    'gh',
+    ['api', '--paginate', `repos/${repo}/pulls/${prNumber}/files`, '--jq', '.[]'],
+    { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+  );
+  const files = raw.split('\n').filter((line) => line.trim()).map((line) => JSON.parse(line));
+  return findViolationsFromFiles(files);
+}
+
+function problemsFromGit() {
   const base = process.env.BASE_SHA || 'origin/main';
   const head = process.env.HEAD_SHA || 'HEAD';
-  let output;
+  let output = execFileSync('git', ['diff', '--name-status', `${base}...${head}`], { encoding: 'utf8' });
+  if (!process.env.BASE_SHA && !process.env.HEAD_SHA) {
+    output += execFileSync('git', ['diff', '--name-status', 'HEAD', '--', GUARDED_PREFIX], { encoding: 'utf8' });
+  }
+  return findViolations(output);
+}
+
+function main() {
+  const prNumber = process.env.PR_NUMBER;
+  const repo = process.env.GITHUB_REPOSITORY;
+  let problems;
   try {
-    output = execFileSync('git', ['diff', '--name-status', `${base}...${head}`], { encoding: 'utf8' });
-    if (!process.env.BASE_SHA && !process.env.HEAD_SHA) {
-      output += execFileSync('git', ['diff', '--name-status', 'HEAD', '--', GUARDED_PREFIX], { encoding: 'utf8' });
-    }
+    problems = prNumber && repo ? problemsFromApi(repo, prNumber) : problemsFromGit();
   } catch (error) {
-    console.error(`Wire-fixture check could not run git diff (${base}...${head}): ${error.message}`);
-    console.error('In CI ensure fetch-depth: 0 and that BASE_SHA/HEAD_SHA are set.');
+    if (prNumber && repo) {
+      console.error(`Wire-fixture check could not read PR files (${repo}#${prNumber}): ${error.message}`);
+      console.error('Ensure the workflow grants pull-requests: read and sets GH_TOKEN.');
+    } else {
+      console.error(`Wire-fixture check could not run git diff: ${error.message}`);
+      console.error('In CI ensure PR_NUMBER and GITHUB_REPOSITORY are set for the API path.');
+    }
     process.exit(1);
   }
 
-  const problems = findViolations(output);
   if (problems.length > 0) {
     console.error('Wire-fixture immutability check FAILED:');
     for (const problem of problems) console.error(`  - ${problem}`);

--- a/scripts/check-wire-fixtures.mjs
+++ b/scripts/check-wire-fixtures.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Enforce that frozen wire fixtures under test-fixtures/wire/ are append-only.
+ * Fails if a diff changes or removes an existing fixture. Additions are allowed.
+ * A `contract-change` PR label bypasses this at the workflow level.
+ *
+ * Diffs BASE_SHA...HEAD_SHA (three-dot = merge base). Defaults suit local runs.
+ *
+ * Usage: node scripts/check-wire-fixtures.mjs
+ */
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+export const GUARDED_PREFIX = 'test-fixtures/wire/';
+
+/**
+ * Pure: given `git diff --name-status` output, return human-readable violations.
+ * Any status other than an addition changes or removes at least one frozen path.
+ */
+export function findViolations(diffOutput, guarded = GUARDED_PREFIX) {
+  const problems = [];
+  for (const line of diffOutput.split('\n')) {
+    if (!line.trim()) continue;
+    const parts = line.split('\t');
+    const status = parts[0][0];
+    const affected = parts.slice(1).filter((path) => path.startsWith(guarded));
+    if (affected.length === 0 || status === 'A') continue;
+
+    const verb = { M: 'modified', D: 'deleted', R: 'renamed', T: 'type-changed' }[status] ?? `changed (${parts[0]})`;
+    for (const path of affected) {
+      problems.push(`${path} was ${verb} (fixtures are append-only)`);
+    }
+  }
+  return problems;
+}
+
+function main() {
+  const base = process.env.BASE_SHA || 'origin/main';
+  const head = process.env.HEAD_SHA || 'HEAD';
+  let output;
+  try {
+    output = execFileSync('git', ['diff', '--name-status', `${base}...${head}`], { encoding: 'utf8' });
+    if (!process.env.BASE_SHA && !process.env.HEAD_SHA) {
+      output += execFileSync('git', ['diff', '--name-status', 'HEAD', '--', GUARDED_PREFIX], { encoding: 'utf8' });
+    }
+  } catch (error) {
+    console.error(`Wire-fixture check could not run git diff (${base}...${head}): ${error.message}`);
+    console.error('In CI ensure fetch-depth: 0 and that BASE_SHA/HEAD_SHA are set.');
+    process.exit(1);
+  }
+
+  const problems = findViolations(output);
+  if (problems.length > 0) {
+    console.error('Wire-fixture immutability check FAILED:');
+    for (const problem of problems) console.error(`  - ${problem}`);
+    console.error('');
+    console.error('Frozen fixtures under test-fixtures/wire/ may only be ADDED, never');
+    console.error('changed. If this edit is a deliberate, reviewed contract change, add');
+    console.error('the `contract-change` label to the PR. See docs/contracts/events.md.');
+    process.exit(1);
+  }
+
+  console.log(`Wire-fixture check OK: no changed fixtures under ${GUARDED_PREFIX}.`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/check-wire-fixtures.test.mjs
+++ b/scripts/check-wire-fixtures.test.mjs
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { findViolations } from './check-wire-fixtures.mjs';
+
+test('additions are allowed', () => {
+  const diff = 'A\ttest-fixtures/wire/events/v1.1.0-minimal.json';
+  assert.deepEqual(findViolations(diff), []);
+});
+
+test('modifying an existing fixture fails', () => {
+  const diff = 'M\ttest-fixtures/wire/events/v1.0.0-minimal.json';
+  assert.equal(findViolations(diff).length, 1);
+  assert.match(findViolations(diff)[0], /was modified/);
+});
+
+test('deleting an existing fixture fails', () => {
+  const diff = 'D\ttest-fixtures/wire/events/v1.0.0-full.json';
+  assert.match(findViolations(diff)[0], /was deleted/);
+});
+
+test('renaming an existing fixture fails', () => {
+  const diff = 'R100\ttest-fixtures/wire/events/v1.0.0-full.json\ttest-fixtures/wire/events/renamed.json';
+  assert.match(findViolations(diff)[0], /was renamed/);
+});
+
+test('type-changing an existing fixture fails', () => {
+  const diff = 'T\ttest-fixtures/wire/events/v1.0.0-full.json';
+  assert.match(findViolations(diff)[0], /was type-changed/);
+});
+
+test('changes outside the guarded prefix are ignored', () => {
+  const diff = 'M\tpackages/sdk/src/core.ts\nA\ttest-fixtures/wire/events/v1.2.0-full.json';
+  assert.deepEqual(findViolations(diff), []);
+});

--- a/scripts/check-wire-fixtures.test.mjs
+++ b/scripts/check-wire-fixtures.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { findViolations } from './check-wire-fixtures.mjs';
+import { findViolations, findViolationsFromFiles } from './check-wire-fixtures.mjs';
 
 test('additions are allowed', () => {
   const diff = 'A\ttest-fixtures/wire/events/v1.1.0-minimal.json';
@@ -31,4 +31,52 @@ test('type-changing an existing fixture fails', () => {
 test('changes outside the guarded prefix are ignored', () => {
   const diff = 'M\tpackages/sdk/src/core.ts\nA\ttest-fixtures/wire/events/v1.2.0-full.json';
   assert.deepEqual(findViolations(diff), []);
+});
+
+// --- API path (GitHub PR-files shape) ---
+
+const F = (status, filename, previous_filename) => ({ status, filename, previous_filename });
+
+test('API: added / copied / unchanged fixtures are allowed', () => {
+  const files = [
+    F('added', 'test-fixtures/wire/events/v1.1.0-minimal.json'),
+    F('copied', 'test-fixtures/wire/events/v1.1.0-full.json', 'test-fixtures/wire/events/v1.0.0-full.json'),
+    F('unchanged', 'test-fixtures/wire/events/v1.0.0-minimal.json'),
+  ];
+  assert.deepEqual(findViolationsFromFiles(files), []);
+});
+
+test('API: modifying an existing fixture fails', () => {
+  const problems = findViolationsFromFiles([F('modified', 'test-fixtures/wire/events/v1.0.0-minimal.json')]);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /was modified/);
+});
+
+test('API: removing an existing fixture fails', () => {
+  assert.match(findViolationsFromFiles([F('removed', 'test-fixtures/wire/events/v1.0.0-full.json')])[0], /was deleted/);
+});
+
+test('API: renaming a frozen file away fails (old path was frozen)', () => {
+  const files = [F('renamed', 'test-fixtures/wire/events/renamed.json', 'test-fixtures/wire/events/v1.0.0-full.json')];
+  assert.match(findViolationsFromFiles(files)[0], /v1\.0\.0-full\.json was renamed/);
+});
+
+test('API: renaming an outside file INTO the prefix is an addition, allowed', () => {
+  const files = [F('renamed', 'test-fixtures/wire/events/v2.0.0-full.json', 'drafts/candidate.json')];
+  assert.deepEqual(findViolationsFromFiles(files), []);
+});
+
+test('API: type-changed frozen fixture fails', () => {
+  assert.match(findViolationsFromFiles([F('changed', 'test-fixtures/wire/events/v1.0.0-full.json')])[0], /was type-changed/);
+});
+
+test('API: changes outside the guarded prefix are ignored', () => {
+  const files = [F('modified', 'packages/sdk/src/core.ts'), F('added', 'test-fixtures/wire/events/v1.2.0-full.json')];
+  assert.deepEqual(findViolationsFromFiles(files), []);
+});
+
+test('API: unknown status on a guarded path fails closed', () => {
+  const problems = findViolationsFromFiles([F('mangled', 'test-fixtures/wire/events/v1.0.0-full.json')]);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /changed \(mangled\)/);
 });

--- a/test-fixtures/wire/events/README.md
+++ b/test-fixtures/wire/events/README.md
@@ -1,0 +1,29 @@
+# Frozen event wire fixtures
+
+Each file is the exact JSON body an `@opslane/shared` `ErrorEventPayload` reaches
+the wire as, for one released SDK payload shape. They lock the
+`POST /api/v1/events` contract in both directions:
+
+- **Ingestion** (`packages/ingestion/handler/wire_compat_test.go`) replays *every*
+  file here and asserts the server still accepts and stores it.
+- **SDK** (`packages/sdk/src/__tests__/wire-shape.test.ts`) asserts the SDK still
+  emits the *current* version's pair through its real transport path.
+
+## Rule: append-only
+
+**Never edit or delete an existing file.** Add a *new* `v<version>-*.json` pair
+for every SDK release, keeping any new fields optional server-side; old fixtures
+must still pass. A modify/delete is a contract break and fails the
+`wire-fixtures` CI check unless the PR carries the `contract-change` label (a
+deliberate, reviewed break). See `docs/contracts/events.md`.
+
+## How each file was produced
+
+- `v1.0.0-minimal.json` — SDK configured `maxBreadcrumbs: 0`, no user, no session,
+  no `release`. `release`/`session_id` keys are absent because the SDK drops
+  `undefined` keys at serialize.
+- `v1.0.0-full.json` — user set, `release` set, session established, one
+  navigation breadcrumb.
+
+Values are benign so SDK and server redaction are no-ops. `sdk_version` is on the
+wire and accepted by the server but not persisted.

--- a/test-fixtures/wire/events/v1.0.0-full.json
+++ b/test-fixtures/wire/events/v1.0.0-full.json
@@ -1,0 +1,29 @@
+{
+  "timestamp": "2026-07-16T00:00:00.000Z",
+  "error": {
+    "type": "TypeError",
+    "message": "Cannot read properties of null (reading 'name')",
+    "stack": "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)"
+  },
+  "breadcrumbs": [
+    {
+      "type": "navigation",
+      "timestamp": "2026-07-16T00:00:00.000Z",
+      "category": "navigation",
+      "message": "https://app.example.com/dashboard"
+    }
+  ],
+  "context": {
+    "url": "https://app.example.com/dashboard",
+    "user_agent": "Mozilla/5.0",
+    "user": {
+      "id": "user-123",
+      "email": "jane@example.com",
+      "account_id": "acct-42",
+      "account_name": "Example Inc"
+    }
+  },
+  "sdk_version": "1.0.0",
+  "release": "web@2026.07.16",
+  "session_id": "sess-abc"
+}

--- a/test-fixtures/wire/events/v1.0.0-minimal.json
+++ b/test-fixtures/wire/events/v1.0.0-minimal.json
@@ -1,0 +1,14 @@
+{
+  "timestamp": "2026-07-16T00:00:00.000Z",
+  "error": {
+    "type": "TypeError",
+    "message": "Cannot read properties of null (reading 'name')",
+    "stack": "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)"
+  },
+  "breadcrumbs": [],
+  "context": {
+    "url": "https://app.example.com/dashboard",
+    "user_agent": "Mozilla/5.0"
+  },
+  "sdk_version": "1.0.0"
+}


### PR DESCRIPTION
## Why

The SDK ships to npm and runs in customers' apps on their own upgrade schedule, while ingestion deploys on ours. Old SDKs POST to the newest server forever, so a wire break to `POST /api/v1/events` is a silent customer outage we cannot hotfix. Nothing guarded this contract; this PR adds enforcement.

## What

- **Frozen fixtures** — the exact wire JSON per SDK release under `test-fixtures/wire/events/` (v1.0.0 minimal + full pair).
- **Go replay** (`wire_compat_test.go`) — replays every fixture and asserts `202`, full field round-trip, stable grouping, and unknown-field tolerance (forward-compat).
- **SDK shape** (`wire-shape.test.ts`) — asserts the SDK's real transport output still matches the current version's pair.
- **Immutability checker** (`check-wire-fixtures.mjs` + unit tests) — fixtures are append-only; modify/delete/rename fails. Wired into the root `test` script.
- **CI gate** (`.github/workflows/wire-fixtures.yml`) — trusted-base `pull_request_target` publishes the required `wire-fixtures` status on the PR head and honors a `contract-change` label as the one deliberate, reviewed way to change the contract.
- **Docs** — `docs/contracts/events.md` documents the contract; `AGENTS.md` gains the guardrail.

## Verification

- `vitest run wire-shape.test.ts` — pass (2/2)
- `node --test check-wire-fixtures.test.mjs` — pass (6/6)
- `check-wire-fixtures.mjs` against the tree — OK
- `go vet ./handler` — compiles
- `check-docs-drift.mjs` — no drift
- Not run locally: `go test ./handler` (the fixture replay) — needs a Postgres test DB.

## Follow-up (after merge)

The `wire-fixtures` check is advisory until `main` branch protection *requires* it. It uses `pull_request_target`, so the workflow must be on `main` before the required check is added — otherwise PRs deadlock on a status that never posts. Add `wire-fixtures` to `main`'s required status checks (alongside `ci-ok`) once this merges.