### PR TITLE
feat: release-aware issue lifecycle (auto-resolve, regression gating, hash-stable grouping)

### DIFF
--- a/docs/plans/2026-07-16-issue-lifecycle-and-grouping.md
+++ b/docs/plans/2026-07-16-issue-lifecycle-and-grouping.md
@@ -1,0 +1,581 @@
+# Issue Lifecycle & Grouping Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make Opslane issues group correctly and close on their own — fix over-splitting from cache-busting hashes, auto-resolve issues that stop happening, and reopen them only on a genuinely newer release (release-aware regression).
+
+**Architecture:** Three independent workstreams, shippable as separate commits/PRs.
+- **A — Grouping (Go/ingestion):** extend fingerprint normalization to collapse deploy-varying tokens (host, content-hashes, and the coordinates of hashed bundle frames) in the message *and* stack frames. New-events-only; existing groups age out via B.
+- **B — Auto-resolve (Node/worker):** a periodic sweep that resolves stuck-open issues (`needs_human` / `investigated`) after `RESOLVE_AGE_DAYS` (default 14) of no new events, independent of any fix.
+- **C — Release-aware regression (Go/ingestion + migration):** record the release an issue was resolved in (`resolved_in_release`); on recurrence, reopen only if the incoming `release` is that release *or newer* (ordered by first-seen time) **and both releases are known**. Reasons that are permanently unfixable never reopen.
+
+**Tech Stack:** Go 1.24 (chi, pgx) for ingestion; Node 22 / TypeScript (Vitest) for worker; Postgres (append-only SQL migrations, next number `009`).
+
+**Terminology (industry-aligned — see research):** `regression`/`regressed` (not "reopen/requeue/reactivate"), `resolved_in_release` (Rollbar/Sentry), `resolve_age` / auto-resolve (Sentry/Rollbar), `resolved_reason ∈ {auto_resolved, merged, manual}` (Sentry `SET_RESOLVED_BY_AGE`). Reopen-if-`>=`-resolved-version matches Rollbar/Raygun exactly.
+
+**Out of scope (deliberately deferred):** merging existing split groups (new-events-only); `occurrence_count → times_seen` rename; a lifecycle/activity audit table; the mute-until-escalating substatus model.
+
+---
+
+## Decisions locked (revised after review 2026-07-16)
+
+| # | Decision |
+|---|---|
+| A1 | New-events-only. No re-fingerprint/merge of existing groups. |
+| A2 | Collapse deploy-varying tokens, but only in recognized URL/asset contexts: strip scheme+host; collapse a filename hash token **only when it looks like a hash** (length ≥ 8 **and** contains a digit), keeping the logical name (`index-<HASH>.js`); when a hashed asset carries a query string or `:line:col`, drop those too. **No global query-string strip.** Apply to message **and** top frames. |
+| A3 | Frame coordinates (`:line:col`) are stripped **only for hashed bundle frames** (build-specific noise). Non-hashed source frames keep their coordinates — avoids over-merging distinct bugs in un-minified stacks. |
+| B1 | Window = `RESOLVE_AGE_DAYS`, default **14**, measured against `last_seen`. |
+| B2 | Eligible statuses: **`needs_human`, `investigated`** only. Excluded: active pipeline (`new`, `queued`, `analyzing`, `fixing`); terminal (`resolved`, `merged`, `archived`); **and `pr_created`** — see B3. |
+| B3 | **`pr_created` is NOT eligible** (reversed after review). `ProcessPRWebhook` matches on `status='pr_created'` (`queries.go:1165`); auto-resolving it would orphan a later close/merge webhook (no `pr_outcomes` receipt; `recoverReopenedMerge` can't recover). |
+| C1 | Rank releases by **first-seen time** = `min(error_events.created_at)` per `(project_id, release)`. Uses server-recorded `created_at`, NOT the client-supplied `timestamp` (issue #27): `timestamp` is attacker/clock-controllable, and one back-dated event would pin a release's `min()` to a bogus-old value and silently suppress a real regression. **One canonical ranking query used everywhere** (gate + stamp). No `releases` table, no backfill. |
+| C2 | Store `resolved_in_release` = the **newest release by first-seen** in the project at resolve time (NOT the most-recent event's release). Reopen unless incoming release is **strictly older** than `resolved_in_release`. |
+| C2a | **Release-absent policy:** gating applies **only when both the incoming release and `resolved_in_release` are non-empty**. If either is missing, fall back to current behaviour (reopen on any recurrence). Prod is 100% release-populated; release-less projects are no worse than today. |
+| C3 | Permanence is defined **per reason code, not by prefix**. Add to the never-reopen set: `unfixable_infra`, `unfixable_third_party`, `unfixable_test_error`. **Do NOT** add `unfixable_no_sourcemap` (remediation says "upload source maps then retry" → must stay reopenable). Keep the existing set unchanged. |
+| C4 | No new `regressed` enum state; reuse the existing requeue→`queued` path, now gated. Requeue must also clear `resolved_reason` and `resolved_in_release`. |
+| Idx | Index `error_events(project_id, release, created_at)` for the ranking `min()`; partial index `error_groups(last_seen) WHERE status IN ('needs_human','investigated')` for the sweep. |
+| Audit | Minimal: two new columns (`resolved_in_release`, `resolved_reason`). No history table. |
+
+### Canonical release-ranking (single source of truth)
+
+Every path that needs "newest release" or "is X older than Y" uses these two, both
+served by `idx_error_events_project_release_created`. First-seen is `min(created_at)`
+(server arrival), never the client-supplied `timestamp`:
+
+```sql
+-- Newest release in a project = the release whose FIRST event arrived most recently.
+SELECT release FROM error_events
+WHERE project_id = $1 AND release IS NOT NULL AND release <> ''
+GROUP BY release ORDER BY min(created_at) DESC LIMIT 1;
+
+-- First-seen of a specific release (for older/newer comparison).
+SELECT min(created_at) FROM error_events
+WHERE project_id = $1 AND release = $2;
+```
+
+---
+
+## Workstream A — Grouping normalization (Go / ingestion)
+
+Isolated to `packages/ingestion/grouping/`. No schema, no worker changes. Verify with `cd packages/ingestion && go test ./grouping`.
+
+### Task A1: Failing tests — collapse hashes, but do NOT over-merge
+
+**Files:**
+- Test: `packages/ingestion/grouping/fingerprint_test.go` (create or extend)
+
+**Step 1: Write failing tests (positive AND negative cases)**
+
+```go
+package grouping
+
+import "testing"
+
+// POSITIVE: same error, different per-deploy chunk hash -> one fingerprint.
+func TestFingerprint_CollapsesContentHash(t *testing.T) {
+	a := Fingerprint("TypeError", "Failed to fetch dynamically imported module: https://app.example.com/assets/index-DbQ2xY9p.js", "")
+	b := Fingerprint("TypeError", "Failed to fetch dynamically imported module: https://app.example.com/assets/index-Zz88Aa10.js", "")
+	if a != b {
+		t.Fatalf("expected same fingerprint across deploy hashes, got %s vs %s", a, b)
+	}
+}
+
+// POSITIVE: absolute vs relative URL of the same chunk -> one fingerprint.
+func TestFingerprint_StripsHost(t *testing.T) {
+	a := Fingerprint("Error", "Unable to preload CSS for https://app.example.com/assets/main-AbC12345.css", "")
+	b := Fingerprint("Error", "Unable to preload CSS for /assets/main-Zx9Yq077.css", "")
+	if a != b {
+		t.Fatalf("expected host-independent fingerprint, got %s vs %s", a, b)
+	}
+}
+
+// NEGATIVE: different logical modules stay distinct (no over-merge).
+func TestFingerprint_KeepsLogicalName(t *testing.T) {
+	idx := Fingerprint("TypeError", "Failed to fetch dynamically imported module: /assets/index-AbC12345.js", "")
+	vnd := Fingerprint("TypeError", "Failed to fetch dynamically imported module: /assets/vendor-AbC12345.js", "")
+	if idx == vnd {
+		t.Fatalf("expected index and vendor to stay distinct")
+	}
+}
+
+// NEGATIVE: ordinary hyphenated filenames are NOT hashes -> must stay distinct.
+// "widget"/"button" are 6 letters, no digit: must not be collapsed.
+func TestFingerprint_DoesNotCollapseOrdinaryNames(t *testing.T) {
+	a := Fingerprint("TypeError", "Failed to import /assets/checkout-widget.js", "")
+	b := Fingerprint("TypeError", "Failed to import /assets/checkout-button.js", "")
+	if a == b {
+		t.Fatalf("expected checkout-widget and checkout-button to stay distinct")
+	}
+}
+
+// NEGATIVE: a '?' in ordinary prose must not be treated as a URL query.
+func TestFingerprint_DoesNotManglePlainText(t *testing.T) {
+	a := Fingerprint("Error", "Is the value correct? yes it was 5", "")
+	b := Fingerprint("Error", "Is the value correct? no it was 9", "")
+	// Differs only by the numbers, which reNum already collapses -> equal is fine.
+	// The point: normalization must not throw an error or delete the words after '?'.
+	if a != b {
+		t.Fatalf("plain-text prose should normalize by numbers only; got %s vs %s", a, b)
+	}
+}
+
+// POSITIVE: hashed bundle FRAMES with differing hash AND coordinates -> one fingerprint.
+func TestFingerprint_NormalizesHashedFrameCoords(t *testing.T) {
+	s1 := "at load (https://app.example.com/assets/index-DbQ2xY9p.js:1:100)\nat run (/assets/app-Abc12345.js:2:5)"
+	s2 := "at load (https://app.example.com/assets/index-Zz88Aa10.js:9:842)\nat run (/assets/app-Zzz99999.js:7:311)"
+	if Fingerprint("TypeError", "boom", s1) != Fingerprint("TypeError", "boom", s2) {
+		t.Fatalf("expected hashed frame hash+coords to be normalized")
+	}
+}
+
+// NEGATIVE: non-hashed source frames KEEP their coordinates (distinct bugs, same file).
+func TestFingerprint_KeepsNonHashedFrameCoords(t *testing.T) {
+	s1 := "at a (/src/app.js:42:1)"
+	s2 := "at a (/src/app.js:99:1)"
+	if Fingerprint("TypeError", "boom", s1) == Fingerprint("TypeError", "boom", s2) {
+		t.Fatalf("expected non-hashed frames to keep line/col granularity")
+	}
+}
+```
+
+**Step 2: Run to verify they fail**
+
+Run: `cd packages/ingestion && go test ./grouping -run TestFingerprint -v`
+Expected: FAIL.
+
+**Step 3: Commit failing tests**
+
+```bash
+git add packages/ingestion/grouping/fingerprint_test.go
+git commit -m "test(grouping): hash-collapse with over-merge negatives (RED)"
+```
+
+### Task A2: Implement context-scoped, hash-aware normalization
+
+**Files:**
+- Modify: `packages/ingestion/grouping/fingerprint.go`
+
+**Step 1: Add regexps + helpers**
+
+```go
+var (
+	// scheme + host, e.g. https://app.example.com -> "" (keeps the path)
+	reURL = regexp.MustCompile(`https?://[^/\s]+`)
+
+	// A hashed asset token: name-HASH.ext with optional ?query and :line:col.
+	//   group 1 = logical name, 2 = hash token, 3 = ext, 4 = query, 5 = coords
+	// The hash-likeness of group 2 is checked in code (looksLikeHash), not the regex,
+	// so ordinary names like "checkout-widget" are left alone.
+	reAssetToken = regexp.MustCompile(
+		`([A-Za-z0-9_.]+)-([A-Za-z0-9_]+)\.(js|mjs|cjs|css|map)(\?[^\s:'")]*)?(:\d+:\d+)?`)
+)
+
+// looksLikeHash: content hashes are long and mix letters with digits.
+// "widget"/"button" (letters only) and short tokens are rejected.
+func looksLikeHash(s string) bool {
+	if len(s) < 8 {
+		return false
+	}
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			return true
+		}
+	}
+	return false
+}
+```
+
+**Step 2: Add the shared normalizer (message + frames)**
+
+```go
+// normalizeVolatile removes deploy-varying tokens that would fragment one error
+// into many groups: URL host, and — only for hash-named bundle assets — the hash,
+// any query string, and the :line:col coordinates. Ordinary text is untouched.
+func normalizeVolatile(s string) string {
+	s = reURL.ReplaceAllString(s, "") // drop scheme+host, keep path
+	s = reAssetToken.ReplaceAllStringFunc(s, func(m string) string {
+		sub := reAssetToken.FindStringSubmatch(m)
+		if looksLikeHash(sub[2]) {
+			return sub[1] + "-<HASH>." + sub[3] // drop hash(2), query(4), coords(5)
+		}
+		return m // ordinary filename: leave as-is
+	})
+	return s
+}
+```
+
+**Step 3: Wire into `normalizeMessage` and `topFrames`**
+
+`normalizeMessage` — run `normalizeVolatile` first, then the existing rules (`reAssetToken` protects `<HASH>` from `reNum`):
+
+```go
+func normalizeMessage(msg string) string {
+	result := normalizeVolatile(msg)
+	result = reHex.ReplaceAllString(result, "0xN")
+	result = reUUID.ReplaceAllString(result, "<UUID>")
+	result = rePathNum.ReplaceAllString(result, "/N")
+	result = reNum.ReplaceAllString(result, "N")
+	result = reQuoted.ReplaceAllString(result, `"..."`)
+	result = reSpaces.ReplaceAllString(result, " ")
+	return strings.ToLower(strings.TrimSpace(result))
+}
+```
+
+`topFrames` — normalize each retained frame line:
+
+```go
+func topFrames(stack string, n int) []string {
+	lines := strings.Split(stack, "\n")
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	for i, l := range lines {
+		lines[i] = normalizeVolatile(l)
+	}
+	return lines
+}
+```
+
+**Step 4: Run tests, then build**
+
+Run: `cd packages/ingestion && go test ./grouping -run TestFingerprint -v && go build ./...`
+Expected: PASS (all cases, positive and negative).
+
+**Step 5: Commit**
+
+```bash
+git add packages/ingestion/grouping/fingerprint.go
+git commit -m "feat(grouping): context-scoped hash-aware fingerprint normalization (GREEN)"
+```
+
+---
+
+## Workstream C — Schema + release-aware regression (Go / ingestion)
+
+Do C before B: B writes the new columns the migration adds.
+
+### Task C1: Migration 009 — columns + both indexes
+
+**Files:**
+- Create: `packages/ingestion/db/migrations/009_regression_lifecycle.sql`
+
+**Step 1: Write the migration (idempotent, guarded)**
+
+```sql
+-- 009_regression_lifecycle.sql
+-- Release-aware regression + resolution provenance. Append-only; safe to reapply.
+
+ALTER TABLE error_groups ADD COLUMN IF NOT EXISTS resolved_in_release TEXT;
+-- Why an issue is in resolved: 'auto_resolved' (inactivity), 'merged' (fix), 'manual'.
+ALTER TABLE error_groups ADD COLUMN IF NOT EXISTS resolved_reason TEXT;
+
+-- Serves the canonical release-ranking min(created_at) grouped by release.
+CREATE INDEX IF NOT EXISTS idx_error_events_project_release_created
+  ON error_events(project_id, release, created_at);
+
+-- Serves the 15-minute inactivity sweep without a full-table scan.
+CREATE INDEX IF NOT EXISTS idx_error_groups_inactivity
+  ON error_groups(last_seen)
+  WHERE status IN ('needs_human', 'investigated');
+```
+
+**Step 2: Apply to a disposable clean DB and reapply for idempotency**
+
+> Use a throwaway DB — never the shared 5434 (see repo hazard notes).
+```bash
+cd packages/ingestion
+psql "$DISPOSABLE_DB_URL" -f db/migrations/009_regression_lifecycle.sql
+psql "$DISPOSABLE_DB_URL" -f db/migrations/009_regression_lifecycle.sql   # must be a no-op
+```
+Expected: both runs succeed.
+
+**Step 3: Commit**
+
+```bash
+git add packages/ingestion/db/migrations/009_regression_lifecycle.sql
+git commit -m "feat(db): resolved_in_release, resolved_reason, ranking + sweep indexes (009)"
+```
+
+### Task C2: Release-order gate + per-code permanence + provenance clear
+
+**Files:**
+- Modify: `packages/ingestion/db/queries.go` (`nonRetriableReasonCodes` ~185; `isRequeueEligible` ~216; requeue block ~467–509)
+- Test: `packages/ingestion/db/regression_test.go` (create; model on `client_timestamp_test.go`)
+
+**Step 1: Write failing tests — cover every branch**
+
+Assert, with a seeded release history:
+- resolved group + recurrence from a **strictly older** release → `Requeued == false`, status stays `resolved`.
+- resolved group + recurrence from the **same** release → `Requeued == true` (same build re-erroring is real).
+- resolved group + recurrence from a **newer** release → `Requeued == true`, status `queued`.
+- **release absent** on the incoming event (empty) → `Requeued == true` (fallback), per C2a.
+- **`resolved_in_release` empty** → `Requeued == true` (fallback), per C2a.
+- resolved group whose `reason_code == 'unfixable_infra'` + newer release → `Requeued == false`.
+- resolved group whose `reason_code == 'unfixable_no_sourcemap'` + newer release → `Requeued == true` (remediable).
+- after a requeue, `resolved_reason IS NULL` and `resolved_in_release IS NULL`.
+- **Table-driven test over the full reason-code catalog** asserting each code's permanence matches the map (guards against drift when a code is added).
+
+Run: `cd packages/ingestion && go test ./db -run TestRegression -v`
+Expected: FAIL. Commit RED.
+
+**Step 2: Per-code permanence (NOT prefix-based)**
+
+Add only the truly-permanent unfixables; leave `unfixable_no_sourcemap` reopenable:
+
+```go
+var nonRetriableReasonCodes = map[string]struct{}{
+	// existing
+	"policy_blocked":          {},
+	"auth_invalid":            {},
+	"unfixable_no_app_frames": {},
+	"triage_unfixable":        {},
+	"low_confidence_fix":      {},
+	"tests_failed":            {},
+	// added: permanently not app-fixable (per reason-codes.ts semantics)
+	"unfixable_infra":       {}, // infra/network, not application code
+	"unfixable_third_party": {}, // originates entirely in third-party code
+	"unfixable_test_error":  {}, // deliberate test error; no fix needed
+	// NOTE: unfixable_no_sourcemap is intentionally NOT here — remediable by
+	// uploading source maps and retrying, so a newer release should reopen it.
+}
+```
+
+`isRequeueEligible` — block known-unfixable regardless of status (so inactivity-resolved unfixables don't reopen):
+
+```go
+func isRequeueEligible(groupStatus string, reasonCode *string) bool {
+	if _, ok := requeueStatuses[groupStatus]; !ok {
+		return false
+	}
+	if reasonCode != nil {
+		if _, nonRetriable := nonRetriableReasonCodes[*reasonCode]; nonRetriable {
+			return false
+		}
+	}
+	return true
+}
+```
+
+**Step 3: Release-order helper (canonical ranking, both-known-only)**
+
+```go
+// releaseNotOlder reports whether candidate is the resolved release or newer,
+// ranked by first-seen time. Per C2a, gating only applies when BOTH releases are
+// known; an empty side returns true (fall back to reopen-on-recurrence).
+func (q *Queries) releaseNotOlder(ctx context.Context, tx pgx.Tx, projectID, candidate, resolvedRelease string) (bool, error) {
+	if candidate == "" || resolvedRelease == "" || candidate == resolvedRelease {
+		return true, nil
+	}
+	const sql = `
+		SELECT
+			(SELECT min(created_at) FROM error_events WHERE project_id = $1 AND release = $2) AS cand,
+			(SELECT min(created_at) FROM error_events WHERE project_id = $1 AND release = $3) AS resolved`
+	var cand, resolved *time.Time
+	if err := tx.QueryRow(ctx, sql, projectID, candidate, resolvedRelease).Scan(&cand, &resolved); err != nil {
+		return true, err // conservative fallback
+	}
+	if cand == nil || resolved == nil {
+		return true, nil // unknown first-seen -> reopen
+	}
+	return !cand.Before(*resolved), nil
+}
+```
+
+**Step 4: Gate the requeue path + clear provenance**
+
+In the requeue block (`queries.go:467`), extend the group read to include `resolved_in_release`, gate the reopen, and clear the new columns on requeue:
+
+```go
+var groupStatus, resolvedInRelease string
+var reasonCode *string
+err = tx.QueryRow(ctx,
+	`SELECT status, reason_code, COALESCE(resolved_in_release, '')
+	   FROM error_groups WHERE id = $1 AND project_id = $2`,
+	groupID, p.ProjectID,
+).Scan(&groupStatus, &reasonCode, &resolvedInRelease)
+// ...
+eligible := isRequeueEligible(groupStatus, reasonCode)
+if eligible && (groupStatus == "resolved" || groupStatus == "merged") {
+	notOlder, err := q.releaseNotOlder(ctx, tx, p.ProjectID, p.Release, resolvedInRelease)
+	if err != nil {
+		return nil, fmt.Errorf("release-order check: %w", err)
+	}
+	eligible = notOlder
+}
+if eligible {
+	// ... existing job insert ...
+	_, err = tx.Exec(ctx,
+		`UPDATE error_groups
+		 SET status = 'queued',
+		     reason_code = NULL, reason_message = NULL, remediation = NULL,
+		     root_cause = NULL, suggested_mitigation = NULL,
+		     merged_at = NULL, resolved_at = NULL, archived_at = NULL,
+		     resolved_in_release = NULL, resolved_reason = NULL,   -- NEW: clear provenance
+		     updated_at = now()
+		 WHERE id = $1`,
+		groupID,
+	)
+	// ...
+	requeued = true
+}
+```
+
+**Step 5: Run tests to pass, then build**
+
+Run: `cd packages/ingestion && go test ./db -run TestRegression -v && go build ./...`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add packages/ingestion/db/queries.go packages/ingestion/db/regression_test.go
+git commit -m "feat(regression): release-order gate, per-code permanence, provenance clear"
+```
+
+### Task C3: Stamp provenance on manual resolve (canonical newest release)
+
+**Files:**
+- Modify: `packages/ingestion/db/queries.go:1312` (`ResolveErrorGroup`)
+
+**Step 1: Use the canonical newest-by-first-seen ranking (NOT most-recent event)**
+
+```sql
+UPDATE error_groups
+SET status = 'resolved',
+    resolved_at = now(),
+    resolved_reason = 'manual',
+    resolved_in_release = (
+      SELECT release FROM error_events
+      WHERE project_id = $1 AND release IS NOT NULL AND release <> ''
+      GROUP BY release ORDER BY min(created_at) DESC LIMIT 1
+    ),
+    updated_at = now()
+WHERE id = $2 AND project_id = $1 AND status <> 'archived'
+```
+
+**Step 2: Build + existing resolve tests, then commit**
+
+Run: `cd packages/ingestion && go test ./db && go build ./...`
+```bash
+git add packages/ingestion/db/queries.go
+git commit -m "feat(resolve): stamp resolved_reason=manual + newest resolved_in_release"
+```
+
+---
+
+## Workstream B — Auto-resolve on inactivity (Node / worker)
+
+Depends on migration 009. Verify with `pnpm --filter @opslane/worker build && pnpm --filter @opslane/worker test`.
+
+### Task B1: Failing test for the inactivity sweep
+
+**Files:**
+- Test: `packages/worker/src/__tests__/resolveInactiveGroups.test.ts` (create)
+
+**Step 1: Write failing tests**
+
+Assert `resolveInactiveGroups(14)`:
+- Resolves a `needs_human` group with `last_seen` 20 days ago → `resolved`, `resolved_reason='auto_resolved'`, `resolved_in_release` set to the newest release.
+- Resolves an `investigated` group the same way.
+- **Does NOT touch `pr_created`** (excluded — B3).
+- Does not touch a group last seen 3 days ago.
+- Does not touch `analyzing`/`queued`/`fixing`/`archived`/already-`resolved`.
+
+Run: `pnpm --filter @opslane/worker test -- resolveInactiveGroups`
+Expected: FAIL. Commit RED.
+
+### Task B2: Implement the sweep
+
+**Files:**
+- Modify: `packages/worker/src/db.ts` (beside `resolveSilentMergedGroups` ~516)
+
+```ts
+/**
+ * System-level background query: auto-resolves stuck-open issues not seen in
+ * `ageDays` days, independent of any fix (Sentry/Rollbar inactivity auto-resolve).
+ * pr_created is intentionally excluded — ProcessPRWebhook matches status='pr_created',
+ * so auto-resolving it would orphan a later PR close/merge. Not tenant-scoped.
+ */
+export async function resolveInactiveGroups(ageDays: number): Promise<string[]> {
+  const pool = getPool();
+  const result = await pool.query<{ id: string }>(
+    `UPDATE error_groups g
+     SET status = 'resolved',
+         resolved_at = now(),
+         resolved_reason = 'auto_resolved',
+         resolved_in_release = (
+           SELECT release FROM error_events
+           WHERE project_id = g.project_id AND release IS NOT NULL AND release <> ''
+           GROUP BY release ORDER BY min(created_at) DESC LIMIT 1
+         ),
+         updated_at = now()
+     WHERE g.status IN ('needs_human', 'investigated')
+       AND g.last_seen < now() - ($1 || ' days')::interval
+     RETURNING g.id`,
+    [String(ageDays)]
+  );
+  return result.rows.map(r => r.id);
+}
+```
+
+Run: `pnpm --filter @opslane/worker test -- resolveInactiveGroups` → PASS. Commit GREEN.
+
+### Task B3: Schedule the sweep + config
+
+**Files:**
+- Modify: `packages/worker/src/index.ts` (config ~80; timers ~938–965)
+
+```ts
+const RESOLVE_AGE_DAYS = Number(process.env.RESOLVE_AGE_DAYS ?? 14);
+const INACTIVITY_CHECK_INTERVAL_MS = Number(process.env.INACTIVITY_CHECK_INTERVAL_MS ?? 15 * 60 * 1000);
+
+const inactivityTimer = setInterval(async () => {
+  try {
+    const ids = await resolveInactiveGroups(RESOLVE_AGE_DAYS);
+    if (ids.length) log.info({ count: ids.length, ageDays: RESOLVE_AGE_DAYS }, 'auto-resolved inactive groups');
+  } catch (err) {
+    log.error({ err }, 'inactivity auto-resolve sweep failed');
+  }
+}, INACTIVITY_CHECK_INTERVAL_MS);
+```
+
+Add `clearInterval(inactivityTimer);` beside `clearInterval(silenceTimer);` in shutdown (~965).
+
+Run: `pnpm --filter @opslane/worker build && pnpm --filter @opslane/worker test` → PASS. Commit.
+
+### Task B4: Stamp provenance on the merged-silence path
+
+**Files:**
+- Modify: `packages/worker/src/db.ts:516` (`resolveSilentMergedGroups`)
+
+Add to its existing UPDATE: `resolved_reason = 'merged'` and `resolved_in_release =` (the same canonical newest-release subquery as B2), so all three resolve paths populate the new columns consistently.
+
+Run: `pnpm --filter @opslane/worker test` → PASS. Commit.
+
+---
+
+## Final verification (whole change)
+
+```bash
+pnpm install --frozen-lockfile
+pnpm -r build
+pnpm test
+(cd packages/ingestion && go build ./... && go test ./...)
+docker compose config --quiet
+```
+
+**Live smoke (pipeline touched):** apply migrations incl. 009 to a disposable DB, seed `scripts/seed-e2e.sql`, rebuild ingestion + worker, then:
+1. Send an event → new group.
+2. Send the same error with a different chunk hash **and different `:line:col`** in a bundle-frame URL → **same group** (A: `occurrence_count` increments).
+3. Send `checkout-widget.js` and `checkout-button.js` errors → **two groups** (A: no over-merge).
+4. Manually resolve a group; send a recurrence with an **older** `release` → stays resolved; with a **newer** `release` → `queued` (C). Send one with **no** `release` → `queued` (C2a fallback).
+5. Set a group's `last_seen` back 15 days → after the sweep it becomes `resolved`, `resolved_reason='auto_resolved'` (B). Confirm a `pr_created` group is untouched.
+
+---
+
+## Rollout notes
+
+- **A** takes effect for new events immediately; existing split groups are cleaned up by **B** as they age past 14 days.
+- **B** on first run resolves a large backlog (~800 stale groups in current prod). Intended one-time cleanup; `resolved_reason='auto_resolved'` makes it auditable and reversible via C on genuine (newer-release) recurrence.
+- **C3 changes existing `needs_human` recurrence behaviour** for `unfixable_infra` / `unfixable_third_party` / `unfixable_test_error` (they stop re-investigating). `unfixable_no_sourcemap` intentionally still reopens. Confirm before shipping.
+- **C2a:** projects that don't send `release` get no regression gating (same as today). Only affects release-less projects; prod sends release on 100% of events.
+```

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -42,6 +42,8 @@ Ingestion reads **only** the `REPLAY_STORE_*` names; `MINIO_*` names appear in i
 | `DASHBOARD_URL` / `DASHBOARD_ORIGIN` | no | Links in PR bodies and notifications |
 | `WORKER_ID` | no (generated) | Stable worker identity for lease ownership |
 | `POLL_INTERVAL_MS` / `LEASE_DURATION_MS` / `REAPER_INTERVAL_MS` / `SILENCE_CHECK_INTERVAL_MS` | no | Queue tuning |
+| `RESOLVE_AGE_DAYS` | no (14) | Days without a new occurrence before `needs_human` and `investigated` issues are auto-resolved |
+| `INACTIVITY_CHECK_INTERVAL_MS` | no (900000) | How often the worker sweeps for inactive issues (15 minutes by default) |
 | `SESSION_ANALYSIS_MAX_CONCURRENT` | no (2) | Fleet-wide cap on concurrently claimed `session_analysis` jobs; `0` disables analysis claiming entirely |
 | `HEALTH_PORT` | no (8081) | Health endpoint port |
 | `REPLAY_STORE_ENDPOINT` / `REPLAY_STORE_ACCESS_KEY` / `REPLAY_STORE_SECRET_KEY` / `REPLAY_STORE_BUCKET` | for replay analysis | Reading stored replays |

--- a/packages/ingestion/db/migrations/009_regression_lifecycle.sql
+++ b/packages/ingestion/db/migrations/009_regression_lifecycle.sql
@@ -1,0 +1,17 @@
+-- 009_regression_lifecycle.sql
+-- Release-aware regression + resolution provenance. Append-only; safe to reapply.
+
+ALTER TABLE error_groups ADD COLUMN IF NOT EXISTS resolved_in_release TEXT;
+-- Why an issue is in resolved: 'auto_resolved' (inactivity), 'merged' (fix), 'manual'.
+ALTER TABLE error_groups ADD COLUMN IF NOT EXISTS resolved_reason TEXT;
+
+-- Serves the canonical release-ranking min(created_at) grouped by release.
+-- created_at (server arrival), not the client-supplied timestamp, so a back-dated
+-- event cannot poison release ordering.
+CREATE INDEX IF NOT EXISTS idx_error_events_project_release_created
+  ON error_events(project_id, release, created_at);
+
+-- Serves the inactivity sweep without a full-table scan.
+CREATE INDEX IF NOT EXISTS idx_error_groups_inactivity
+  ON error_groups(last_seen)
+  WHERE status IN ('needs_human', 'investigated');

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -200,6 +200,13 @@ var nonRetriableReasonCodes = map[string]struct{}{
 	// writeup terminal on recurrence rather than wiping it and re-investigating.
 	"low_confidence_fix": {},
 	"tests_failed":       {},
+	// These errors cannot be fixed in application code. They remain terminal even
+	// if inactivity resolution changes the group's status from needs_human.
+	"unfixable_infra":       {},
+	"unfixable_third_party": {},
+	"unfixable_test_error":  {},
+	// unfixable_no_sourcemap is intentionally absent: uploading source maps can
+	// make a later investigation actionable.
 }
 
 // requeueStatuses defines error group statuses eligible for re-queuing when a new
@@ -214,16 +221,42 @@ var requeueStatuses = map[string]struct{}{
 }
 
 // isRequeueEligible returns true if a group should be re-queued on recurrence.
-// Non-retriable needs_human reason codes (e.g. policy_blocked) are excluded.
+// Non-retriable reason codes (e.g. policy_blocked) are excluded regardless of
+// status so an auto-resolved permanent failure remains terminal.
 func isRequeueEligible(groupStatus string, reasonCode *string) bool {
 	if _, ok := requeueStatuses[groupStatus]; !ok {
 		return false
 	}
-	if groupStatus == "needs_human" && reasonCode != nil {
-		_, nonRetriable := nonRetriableReasonCodes[*reasonCode]
-		return !nonRetriable
+	if reasonCode != nil {
+		if _, nonRetriable := nonRetriableReasonCodes[*reasonCode]; nonRetriable {
+			return false
+		}
 	}
 	return true
+}
+
+// releaseNotOlder reports whether candidate is the resolved release or newer,
+// ranked by first-seen time. First-seen uses server-recorded created_at (not the
+// client-supplied timestamp) so a back-dated event cannot poison release ordering
+// and silently suppress a genuine regression. Gating applies only when both
+// releases are known; an empty or unranked side falls back to reopening.
+func (q *Queries) releaseNotOlder(ctx context.Context, tx pgx.Tx, projectID, candidate, resolvedRelease string) (bool, error) {
+	if candidate == "" || resolvedRelease == "" || candidate == resolvedRelease {
+		return true, nil
+	}
+
+	const query = `
+		SELECT
+			(SELECT min(created_at) FROM error_events WHERE project_id = $1 AND release = $2),
+			(SELECT min(created_at) FROM error_events WHERE project_id = $1 AND release = $3)`
+	var candidateFirstSeen, resolvedFirstSeen *time.Time
+	if err := tx.QueryRow(ctx, query, projectID, candidate, resolvedRelease).Scan(&candidateFirstSeen, &resolvedFirstSeen); err != nil {
+		return true, err
+	}
+	if candidateFirstSeen == nil || resolvedFirstSeen == nil {
+		return true, nil
+	}
+	return !candidateFirstSeen.Before(*resolvedFirstSeen), nil
 }
 
 // === Error groups ===
@@ -465,17 +498,27 @@ func (q *Queries) InsertErrorEventAndGroup(ctx context.Context, p IngestParams) 
 			return nil, fmt.Errorf("update group status to queued: %w", err)
 		}
 	} else {
-		var groupStatus string
+		var groupStatus, resolvedInRelease string
 		var reasonCode *string
 		err = tx.QueryRow(ctx,
-			`SELECT status, reason_code FROM error_groups WHERE id = $1 AND project_id = $2`,
+			`SELECT status, reason_code, COALESCE(resolved_in_release, '')
+			 FROM error_groups WHERE id = $1 AND project_id = $2`,
 			groupID, p.ProjectID,
-		).Scan(&groupStatus, &reasonCode)
+		).Scan(&groupStatus, &reasonCode, &resolvedInRelease)
 		if err != nil {
 			return nil, fmt.Errorf("query group status for requeue check: %w", err)
 		}
 
-		if isRequeueEligible(groupStatus, reasonCode) {
+		eligible := isRequeueEligible(groupStatus, reasonCode)
+		if eligible && (groupStatus == "resolved" || groupStatus == "merged") {
+			notOlder, err := q.releaseNotOlder(ctx, tx, p.ProjectID, p.Release, resolvedInRelease)
+			if err != nil {
+				return nil, fmt.Errorf("release-order check: %w", err)
+			}
+			eligible = notOlder
+		}
+
+		if eligible {
 			err = tx.QueryRow(ctx,
 				`INSERT INTO error_group_jobs (error_group_id, project_id)
 				 VALUES ($1, $2)
@@ -497,6 +540,8 @@ func (q *Queries) InsertErrorEventAndGroup(ctx context.Context, p IngestParams) 
 				     merged_at = NULL,
 				     resolved_at = NULL,
 				     archived_at = NULL,
+				     resolved_in_release = NULL,
+				     resolved_reason = NULL,
 				     updated_at = now()
 				 WHERE id = $1`,
 				groupID,
@@ -1312,9 +1357,17 @@ func recoverReopenedMerge(ctx context.Context, tx pgx.Tx, githubRepo string, prN
 func (q *Queries) ResolveErrorGroup(ctx context.Context, projectID, groupID string) error {
 	ct, err := q.pool.Exec(ctx,
 		`UPDATE error_groups
-		 SET status = 'resolved', resolved_at = now(), updated_at = now()
-		 WHERE id = $1 AND project_id = $2 AND status != 'archived'`,
-		groupID, projectID,
+		 SET status = 'resolved',
+		     resolved_at = now(),
+		     resolved_reason = 'manual',
+		     resolved_in_release = (
+		       SELECT release FROM error_events
+		       WHERE project_id = $1 AND release IS NOT NULL AND release <> ''
+		       GROUP BY release ORDER BY min(created_at) DESC LIMIT 1
+		     ),
+		     updated_at = now()
+		 WHERE id = $2 AND project_id = $1 AND status != 'archived'`,
+		projectID, groupID,
 	)
 	if err != nil {
 		return fmt.Errorf("resolve error group: %w", err)

--- a/packages/ingestion/db/regression_test.go
+++ b/packages/ingestion/db/regression_test.go
@@ -1,0 +1,211 @@
+package db_test
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/opslane/opslane/packages/ingestion/db"
+)
+
+type regressionFixture struct {
+	q         *db.Queries
+	projectID string
+	envID     string
+}
+
+func newRegressionFixture(t *testing.T, name string) regressionFixture {
+	t.Helper()
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+
+	org, err := q.CreateOrg(ctx, name)
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	t.Cleanup(func() { cleanupTenant(t, pool, org.ID) })
+
+	project, err := q.CreateProject(ctx, org.ID, name+"-project", ptrStr("org/repo"))
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	environment, err := q.CreateEnvironment(ctx, project.ID, "production")
+	if err != nil {
+		t.Fatalf("CreateEnvironment: %v", err)
+	}
+
+	return regressionFixture{q: q, projectID: project.ID, envID: environment.ID}
+}
+
+func (f regressionFixture) ingest(t *testing.T, fingerprint, release string, eventTime time.Time) *db.IngestResult {
+	t.Helper()
+	result, err := f.q.InsertErrorEventAndGroup(context.Background(), db.IngestParams{
+		ProjectID:     f.projectID,
+		EnvironmentID: f.envID,
+		ErrorType:     "TypeError",
+		ErrorMessage:  "regression test error",
+		StackTraceRaw: "at regression.js:1:1",
+		Fingerprint:   fingerprint,
+		Title:         "TypeError: regression test error",
+		Release:       release,
+		EventTime:     eventTime,
+	})
+	if err != nil {
+		t.Fatalf("InsertErrorEventAndGroup(%q, %q): %v", fingerprint, release, err)
+	}
+	return result
+}
+
+func (f regressionFixture) markResolved(t *testing.T, groupID string, resolvedRelease *string, reasonCode *string) {
+	t.Helper()
+	if _, err := f.q.Pool().Exec(context.Background(),
+		`UPDATE error_groups
+		 SET status = 'resolved', resolved_at = now(), resolved_reason = 'manual',
+		     resolved_in_release = $2, reason_code = $3,
+		     reason_message = CASE WHEN $3::text IS NULL THEN NULL ELSE 'reason' END,
+		     remediation = CASE WHEN $3::text IS NULL THEN NULL ELSE 'remediation' END
+		 WHERE id = $1 AND project_id = $4`,
+		groupID, resolvedRelease, reasonCode, f.projectID,
+	); err != nil {
+		t.Fatalf("mark group resolved: %v", err)
+	}
+}
+
+func TestRegressionReleaseOrderingAndFallbacks(t *testing.T) {
+	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	resolvedRelease := "release-resolved"
+
+	tests := []struct {
+		name            string
+		candidate       string
+		storedRelease   *string
+		seedOlder       bool
+		wantRequeued    bool
+		wantFinalStatus string
+	}{
+		{name: "strictly older release stays resolved", candidate: "release-older", storedRelease: &resolvedRelease, seedOlder: true, wantFinalStatus: "resolved"},
+		{name: "same release regresses", candidate: resolvedRelease, storedRelease: &resolvedRelease, wantRequeued: true, wantFinalStatus: "queued"},
+		{name: "newer release regresses", candidate: "release-newer", storedRelease: &resolvedRelease, wantRequeued: true, wantFinalStatus: "queued"},
+		{name: "missing incoming release falls back", candidate: "", storedRelease: &resolvedRelease, wantRequeued: true, wantFinalStatus: "queued"},
+		{name: "missing resolved release falls back", candidate: "release-newer", storedRelease: nil, wantRequeued: true, wantFinalStatus: "queued"},
+		{name: "unranked resolved release falls back", candidate: "release-newer", storedRelease: ptrStr("release-never-seen"), wantRequeued: true, wantFinalStatus: "queued"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newRegressionFixture(t, "regression-order-"+tc.name)
+			if tc.seedOlder {
+				fixture.ingest(t, "older-release-seed", tc.candidate, base)
+			}
+			initial := fixture.ingest(t, "target", resolvedRelease, base.Add(time.Hour))
+			fixture.markResolved(t, initial.GroupID, tc.storedRelease, nil)
+
+			result := fixture.ingest(t, "target", tc.candidate, base.Add(2*time.Hour))
+			if result.Requeued != tc.wantRequeued {
+				t.Fatalf("Requeued = %v, want %v", result.Requeued, tc.wantRequeued)
+			}
+
+			var status string
+			var resolvedInRelease, resolvedReason *string
+			if err := fixture.q.Pool().QueryRow(context.Background(),
+				`SELECT status, resolved_in_release, resolved_reason FROM error_groups WHERE id = $1`,
+				initial.GroupID,
+			).Scan(&status, &resolvedInRelease, &resolvedReason); err != nil {
+				t.Fatalf("read group provenance: %v", err)
+			}
+			if status != tc.wantFinalStatus {
+				t.Errorf("status = %q, want %q", status, tc.wantFinalStatus)
+			}
+			if tc.wantRequeued && (resolvedInRelease != nil || resolvedReason != nil) {
+				t.Errorf("requeue left provenance: resolved_in_release=%v resolved_reason=%v", resolvedInRelease, resolvedReason)
+			}
+		})
+	}
+}
+
+func reasonCodeCatalog(t *testing.T) []string {
+	t.Helper()
+	source, err := os.ReadFile("../../../shared/src/types.ts")
+	if err != nil {
+		t.Fatalf("read ReasonCode catalog: %v", err)
+	}
+	block := regexp.MustCompile(`(?s)export type ReasonCode =(.+?);`).FindSubmatch(source)
+	if block == nil {
+		t.Fatal("ReasonCode catalog not found in shared/src/types.ts")
+	}
+	matches := regexp.MustCompile(`'([^']+)'`).FindAllSubmatch(block[1], -1)
+	codes := make([]string, 0, len(matches))
+	for _, match := range matches {
+		codes = append(codes, string(match[1]))
+	}
+	if len(codes) == 0 {
+		t.Fatal("ReasonCode catalog is empty")
+	}
+	sort.Strings(codes)
+	return codes
+}
+
+func TestRegressionReasonCodePermanenceMatchesCatalog(t *testing.T) {
+	permanent := map[string]bool{
+		"auth_invalid":            true,
+		"low_confidence_fix":      true,
+		"policy_blocked":          true,
+		"tests_failed":            true,
+		"triage_unfixable":        true,
+		"unfixable_infra":         true,
+		"unfixable_no_app_frames": true,
+		"unfixable_test_error":    true,
+		"unfixable_third_party":   true,
+	}
+	fixture := newRegressionFixture(t, "regression-reason-catalog")
+	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	resolvedRelease := "release-resolved"
+
+	for i, code := range reasonCodeCatalog(t) {
+		t.Run(code, func(t *testing.T) {
+			fingerprint := "reason-" + code
+			initial := fixture.ingest(t, fingerprint, resolvedRelease, base.Add(time.Duration(i)*time.Minute))
+			fixture.markResolved(t, initial.GroupID, &resolvedRelease, &code)
+
+			result := fixture.ingest(t, fingerprint, "release-newer", base.Add(24*time.Hour+time.Duration(i)*time.Minute))
+			wantRequeued := !permanent[code]
+			if result.Requeued != wantRequeued {
+				t.Errorf("reason %q: Requeued = %v, want %v", code, result.Requeued, wantRequeued)
+			}
+		})
+	}
+}
+
+func TestRegressionManualResolveStampsNewestReleaseByFirstSeen(t *testing.T) {
+	fixture := newRegressionFixture(t, "regression-manual-provenance")
+	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+
+	// Ranking is by first-seen created_at (server arrival, ingest order), not the
+	// client timestamp. release-b is ingested after release-a's first event, so it
+	// is the newest release even though release-a keeps receiving later events.
+	target := fixture.ingest(t, "manual-target", "release-a", base)
+	fixture.ingest(t, "release-b-seed", "release-b", base.Add(2*time.Hour))
+	fixture.ingest(t, "manual-target", "release-a", base.Add(4*time.Hour))
+
+	if err := fixture.q.ResolveErrorGroup(context.Background(), fixture.projectID, target.GroupID); err != nil {
+		t.Fatalf("ResolveErrorGroup: %v", err)
+	}
+	var status, resolvedReason string
+	var resolvedInRelease *string
+	if err := fixture.q.Pool().QueryRow(context.Background(),
+		`SELECT status, resolved_reason, resolved_in_release FROM error_groups WHERE id = $1`,
+		target.GroupID,
+	).Scan(&status, &resolvedReason, &resolvedInRelease); err != nil {
+		t.Fatalf("read resolved provenance: %v", err)
+	}
+	if status != "resolved" || resolvedReason != "manual" {
+		t.Errorf("resolved state = (%q, %q), want (resolved, manual)", status, resolvedReason)
+	}
+	if resolvedInRelease == nil || *resolvedInRelease != "release-b" {
+		t.Errorf("resolved_in_release = %v, want release-b", resolvedInRelease)
+	}
+}

--- a/packages/ingestion/grouping/fingerprint.go
+++ b/packages/ingestion/grouping/fingerprint.go
@@ -9,12 +9,14 @@ import (
 
 // Pre-compiled regexps for message normalization.
 var (
-	reHex     = regexp.MustCompile(`0x[0-9a-fA-F]+`)
-	reUUID    = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
-	rePathNum = regexp.MustCompile(`/\d+`)
-	reNum     = regexp.MustCompile(`\b\d+\b`)
-	reQuoted  = regexp.MustCompile(`"[^"]*"`)
-	reSpaces  = regexp.MustCompile(`\s+`)
+	reHex        = regexp.MustCompile(`0x[0-9a-fA-F]+`)
+	reUUID       = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+	rePathNum    = regexp.MustCompile(`/\d+`)
+	reNum        = regexp.MustCompile(`\b\d+\b`)
+	reQuoted     = regexp.MustCompile(`"[^"]*"`)
+	reSpaces     = regexp.MustCompile(`\s+`)
+	reURL        = regexp.MustCompile(`https?://[^/\s]+`)
+	reAssetToken = regexp.MustCompile(`([A-Za-z0-9_.]+)-([A-Za-z0-9_]+)\.(js|mjs|cjs|css|map)(\?[^\s:'")]*)?(:\d+:\d+)?`)
 )
 
 // Fingerprint generates a stable fingerprint for error grouping.
@@ -27,10 +29,11 @@ func Fingerprint(errorType, errorMessage, stackTrace string) string {
 	return fmt.Sprintf("%x", hash[:16])
 }
 
-// normalizeMessage strips variable content (hex addresses, UUIDs, path numbers,
-// quoted strings) from error messages to produce stable grouping templates.
+// normalizeMessage strips deploy-varying URLs and asset hashes along with the
+// existing variable values to produce stable grouping templates.
 func normalizeMessage(msg string) string {
-	result := reHex.ReplaceAllString(msg, "0xN")
+	result := normalizeVolatile(msg)
+	result = reHex.ReplaceAllString(result, "0xN")
 	result = reUUID.ReplaceAllString(result, "<UUID>")
 	result = rePathNum.ReplaceAllString(result, "/N")
 	result = reNum.ReplaceAllString(result, "N")
@@ -39,10 +42,39 @@ func normalizeMessage(msg string) string {
 	return strings.ToLower(strings.TrimSpace(result))
 }
 
+// normalizeVolatile removes deploy-varying URL and hashed-asset content while
+// leaving ordinary filenames and prose untouched.
+func normalizeVolatile(s string) string {
+	s = reURL.ReplaceAllString(s, "")
+	return reAssetToken.ReplaceAllStringFunc(s, func(match string) string {
+		parts := reAssetToken.FindStringSubmatch(match)
+		if !looksLikeHash(parts[2]) {
+			return match
+		}
+		return parts[1] + "-<HASH>." + parts[3]
+	})
+}
+
+// looksLikeHash rejects short or letter-only suffixes used in ordinary names.
+func looksLikeHash(s string) bool {
+	if len(s) < 8 {
+		return false
+	}
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
 func topFrames(stack string, n int) []string {
 	lines := strings.Split(stack, "\n")
 	if len(lines) > n {
 		lines = lines[:n]
+	}
+	for i, line := range lines {
+		lines[i] = normalizeVolatile(line)
 	}
 	return lines
 }

--- a/packages/ingestion/grouping/fingerprint_test.go
+++ b/packages/ingestion/grouping/fingerprint_test.go
@@ -40,3 +40,83 @@ func TestFingerprint_DifferentErrorTypesDiffer(t *testing.T) {
 		t.Errorf("different error types should produce different fingerprints")
 	}
 }
+
+func TestFingerprint_CollapsesContentHash(t *testing.T) {
+	a := Fingerprint("TypeError", "Failed to fetch dynamically imported module: https://app.example.com/assets/index-DbQ2xY9p.js", "")
+	b := Fingerprint("TypeError", "Failed to fetch dynamically imported module: https://app.example.com/assets/index-Zz88Aa10.js", "")
+	if a != b {
+		t.Fatalf("expected same fingerprint across deploy hashes, got %s vs %s", a, b)
+	}
+}
+
+func TestFingerprint_StripsHost(t *testing.T) {
+	a := Fingerprint("Error", "Unable to preload CSS for https://app.example.com/assets/main-AbC12345.css", "")
+	b := Fingerprint("Error", "Unable to preload CSS for /assets/main-Zx9Yq077.css", "")
+	if a != b {
+		t.Fatalf("expected host-independent fingerprint, got %s vs %s", a, b)
+	}
+}
+
+func TestFingerprint_KeepsLogicalName(t *testing.T) {
+	idx := Fingerprint("TypeError", "Failed to fetch dynamically imported module: /assets/index-AbC12345.js", "")
+	vnd := Fingerprint("TypeError", "Failed to fetch dynamically imported module: /assets/vendor-AbC12345.js", "")
+	if idx == vnd {
+		t.Fatalf("expected index and vendor to stay distinct")
+	}
+}
+
+func TestFingerprint_DoesNotCollapseOrdinaryNames(t *testing.T) {
+	a := Fingerprint("TypeError", "Failed to import /assets/checkout-widget.js", "")
+	b := Fingerprint("TypeError", "Failed to import /assets/checkout-button.js", "")
+	if a == b {
+		t.Fatalf("expected checkout-widget and checkout-button to stay distinct")
+	}
+}
+
+func TestFingerprint_DoesNotCollapseLongLetterOnlyNames(t *testing.T) {
+	a := Fingerprint("TypeError", "Failed to import /assets/checkout-widgetname.js", "")
+	b := Fingerprint("TypeError", "Failed to import /assets/checkout-buttonname.js", "")
+	if a == b {
+		t.Fatalf("expected long suffixes without digits to stay distinct")
+	}
+}
+
+func TestFingerprint_DropsHashedAssetQuery(t *testing.T) {
+	a := Fingerprint("Error", "Unable to load /assets/main-AbC12345.js?cache=one", "")
+	b := Fingerprint("Error", "Unable to load /assets/main-AbC12345.js?cache=two", "")
+	if a != b {
+		t.Fatalf("expected hashed asset queries to be ignored, got %s vs %s", a, b)
+	}
+}
+
+func TestFingerprint_KeepsNonHashedAssetQuery(t *testing.T) {
+	a := Fingerprint("Error", "Unable to load /assets/main.js?variant=one", "")
+	b := Fingerprint("Error", "Unable to load /assets/main.js?variant=two", "")
+	if a == b {
+		t.Fatalf("expected non-hashed asset queries to stay distinct")
+	}
+}
+
+func TestFingerprint_DoesNotManglePlainText(t *testing.T) {
+	a := Fingerprint("Error", "Is the value correct? yes it was 5", "")
+	b := Fingerprint("Error", "Is the value correct? no it was 9", "")
+	if a == b {
+		t.Fatalf("plain-text prose after '?' must remain part of the fingerprint")
+	}
+}
+
+func TestFingerprint_NormalizesHashedFrameCoords(t *testing.T) {
+	s1 := "at load (https://app.example.com/assets/index-DbQ2xY9p.js:1:100)\nat run (/assets/app-Abc12345.js:2:5)"
+	s2 := "at load (https://app.example.com/assets/index-Zz88Aa10.js:9:842)\nat run (/assets/app-Zzz99999.js:7:311)"
+	if Fingerprint("TypeError", "boom", s1) != Fingerprint("TypeError", "boom", s2) {
+		t.Fatalf("expected hashed frame hash+coords to be normalized")
+	}
+}
+
+func TestFingerprint_KeepsNonHashedFrameCoords(t *testing.T) {
+	s1 := "at a (/src/app.js:42:1)"
+	s2 := "at a (/src/app.js:99:1)"
+	if Fingerprint("TypeError", "boom", s1) == Fingerprint("TypeError", "boom", s2) {
+		t.Fatalf("expected non-hashed frames to keep line/col granularity")
+	}
+}

--- a/packages/worker/src/__tests__/db.test.ts
+++ b/packages/worker/src/__tests__/db.test.ts
@@ -6,6 +6,7 @@ import {
   completeJob,
   failJob,
   requeueStaleJobs,
+  resolveInactiveGroups,
   resolveSilentMergedGroups,
   updateGroupStatus,
   updateGroupInvestigation,
@@ -781,6 +782,21 @@ describeDb('db.ts integration tests', () => {
       const groupId = await seedMergedGroup();
       const resolved = await resolveSilentMergedGroups();
       expect(resolved).toContain(groupId);
+
+      const group = await testPool.query<{
+        status: string;
+        resolved_reason: string | null;
+        resolved_in_release: string | null;
+      }>(
+        `SELECT status, resolved_reason, resolved_in_release
+         FROM error_groups WHERE id = $1`,
+        [groupId],
+      );
+      expect(group.rows[0]).toEqual({
+        status: 'resolved',
+        resolved_reason: 'merged',
+        resolved_in_release: null,
+      });
     });
 
     it('does not resolve when active accepted linked friction occurred after merged_at', async () => {
@@ -803,6 +819,95 @@ describeDb('db.ts integration tests', () => {
       await seedLinkedSignal(groupId, { status: 'accepted', occurredAt: afterMerge(), retracted: true });
       const resolved = await resolveSilentMergedGroups();
       expect(resolved).toContain(groupId);
+    });
+  });
+
+  describe('resolveInactiveGroups', () => {
+    it('resolves only stale eligible groups and stamps the newest release', async () => {
+      const env = await testPool.query<{ id: string }>(
+        `INSERT INTO environments (project_id, name)
+         VALUES ($1, $2) RETURNING id`,
+        [testProjectId, `env-${crypto.randomUUID()}`],
+      );
+      const environmentId = env.rows[0]!.id;
+
+      await testPool.query(
+        // created_at (server arrival), not the client timestamp, drives release
+        // ranking — set it explicitly so the two rows don't tie on now().
+        `INSERT INTO error_events
+           (project_id, environment_id, timestamp, error_type, error_message,
+            stack_trace_raw, release, created_at)
+         VALUES
+           ($1, $2, now() - interval '10 days', 'Error', 'old', 'stack', 'release-old', now() - interval '10 days'),
+           ($1, $2, now() - interval '2 days', 'Error', 'new', 'stack', 'release-new', now() - interval '2 days')`,
+        [testProjectId, environmentId],
+      );
+
+      const statuses = [
+        'needs_human',
+        'investigated',
+        'new',
+        'pr_created',
+        'analyzing',
+        'queued',
+        'fixing',
+        'merged',
+        'archived',
+        'resolved',
+      ] as const;
+      const groupIds = new Map<string, string>();
+      for (const status of statuses) {
+        const group = await testPool.query<{ id: string }>(
+          `INSERT INTO error_groups
+             (project_id, fingerprint, title, first_seen, last_seen, status)
+           VALUES ($1, $2, 'Inactive Error', now() - interval '30 days',
+                   now() - interval '20 days', $3::error_group_status)
+           RETURNING id`,
+          [testProjectId, `fp-${status}-${crypto.randomUUID()}`, status],
+        );
+        groupIds.set(status, group.rows[0]!.id);
+      }
+      const recent = await testPool.query<{ id: string }>(
+        `INSERT INTO error_groups
+           (project_id, fingerprint, title, first_seen, last_seen, status)
+         VALUES ($1, $2, 'Recent Error', now() - interval '5 days',
+                 now() - interval '3 days', 'needs_human')
+         RETURNING id`,
+        [testProjectId, `fp-recent-${crypto.randomUUID()}`],
+      );
+
+      const resolved = await resolveInactiveGroups(14);
+      expect(new Set(resolved)).toEqual(new Set([
+        groupIds.get('needs_human')!,
+        groupIds.get('investigated')!,
+      ]));
+
+      const groups = await testPool.query<{
+        id: string;
+        status: string;
+        resolved_at: Date | null;
+        resolved_reason: string | null;
+        resolved_in_release: string | null;
+      }>(
+        `SELECT id, status, resolved_at, resolved_reason, resolved_in_release
+         FROM error_groups
+         WHERE id = ANY($1::uuid[])`,
+        [[...groupIds.values(), recent.rows[0]!.id]],
+      );
+      const byId = new Map(groups.rows.map((row) => [row.id, row]));
+
+      for (const status of ['needs_human', 'investigated'] as const) {
+        expect(byId.get(groupIds.get(status)!)).toMatchObject({
+          status: 'resolved',
+          resolved_at: expect.any(Date),
+          resolved_reason: 'auto_resolved',
+          resolved_in_release: 'release-new',
+        });
+      }
+      for (const status of statuses.slice(2)) {
+        expect(byId.get(groupIds.get(status)!)?.status).toBe(status);
+      }
+      expect(byId.get(recent.rows[0]!.id)?.status).toBe('needs_human');
     });
   });
 

--- a/packages/worker/src/__tests__/index.test.ts
+++ b/packages/worker/src/__tests__/index.test.ts
@@ -22,6 +22,7 @@ vi.mock('../db.js', () => ({
   getReplayArtifacts: vi.fn(),
   getSourceMaps: vi.fn(),
   requeueStaleJobs: vi.fn(),
+  resolveInactiveGroups: vi.fn(),
   resolveSilentMergedGroups: vi.fn(),
   updateJobTraceUrl: vi.fn(),
   closePool: vi.fn(),

--- a/packages/worker/src/__tests__/resolveInactiveGroups.test.ts
+++ b/packages/worker/src/__tests__/resolveInactiveGroups.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockQuery = vi.fn();
+
+vi.mock('pg', () => ({
+  default: {
+    Pool: vi.fn(() => ({ query: mockQuery, end: vi.fn() })),
+  },
+}));
+
+import { resolveInactiveGroups, resolveSilentMergedGroups } from '../db.js';
+
+describe('resolveInactiveGroups', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('only resolves inactive eligible statuses and stamps resolution provenance', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'needs-human' }, { id: 'investigated' }] });
+
+    await expect(resolveInactiveGroups(14)).resolves.toEqual(['needs-human', 'investigated']);
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, string[]];
+    expect(sql).toContain("g.status IN ('needs_human', 'investigated')");
+    expect(sql).not.toContain("'pr_created'");
+    expect(sql).toContain("resolved_reason = 'auto_resolved'");
+    expect(sql).toContain('resolved_at = now()');
+    expect(sql).toContain('resolved_in_release = (');
+    expect(sql).toContain('WHERE project_id = g.project_id');
+    expect(sql).toContain("release IS NOT NULL AND release <> ''");
+    expect(sql).toContain('GROUP BY release ORDER BY min(created_at) DESC LIMIT 1');
+    expect(sql).toContain("g.last_seen < now() - ($1 || ' days')::interval");
+    expect(params).toEqual(['14']);
+  });
+
+  it('stamps merged provenance using the same newest-release ranking', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'merged-group' }] });
+
+    await expect(resolveSilentMergedGroups()).resolves.toEqual(['merged-group']);
+
+    const sql = String(mockQuery.mock.calls[0]?.[0]);
+    expect(sql).toContain("resolved_reason = 'merged'");
+    expect(sql).toContain('resolved_in_release = (');
+    expect(sql).toContain('WHERE project_id = g.project_id');
+    expect(sql).toContain('GROUP BY release ORDER BY min(created_at) DESC LIMIT 1');
+  });
+});

--- a/packages/worker/src/db.ts
+++ b/packages/worker/src/db.ts
@@ -516,15 +516,23 @@ export async function updateGroupStatus(
 export async function resolveSilentMergedGroups(): Promise<string[]> {
   const pool = getPool();
   const result = await pool.query<{ id: string }>(
-    `UPDATE error_groups
-     SET status = 'resolved', resolved_at = now(), updated_at = now()
-     WHERE status = 'merged'
-       AND merged_at < now() - interval '24 hours'
+    `UPDATE error_groups g
+     SET status = 'resolved',
+         resolved_at = now(),
+         resolved_reason = 'merged',
+         resolved_in_release = (
+           SELECT release FROM error_events
+           WHERE project_id = g.project_id AND release IS NOT NULL AND release <> ''
+           GROUP BY release ORDER BY min(created_at) DESC LIMIT 1
+         ),
+         updated_at = now()
+     WHERE g.status = 'merged'
+       AND g.merged_at < now() - interval '24 hours'
        AND NOT EXISTS (
          SELECT 1
          FROM error_events
-         WHERE error_group_id = error_groups.id
-           AND created_at > error_groups.merged_at
+         WHERE error_group_id = g.id
+           AND created_at > g.merged_at
        )
        -- Ongoing linked friction blocks silence resolution (issue #56):
        -- an incident with active accepted friction after the merge is not
@@ -532,13 +540,40 @@ export async function resolveSilentMergedGroups(): Promise<string[]> {
        AND NOT EXISTS (
          SELECT 1
          FROM friction_signals fs
-         WHERE fs.incident_id = error_groups.id
+         WHERE fs.incident_id = g.id
            AND fs.adjudication_status = 'accepted'
            AND fs.retracted_at IS NULL
            AND fs.superseded_by IS NULL
-           AND fs.occurred_at > error_groups.merged_at
+           AND fs.occurred_at > g.merged_at
        )
-     RETURNING id`
+     RETURNING g.id`
+  );
+  return result.rows.map(r => r.id);
+}
+
+/**
+ * System-level background query: auto-resolves stuck-open issues not seen in
+ * `ageDays` days, independent of any fix. pr_created is intentionally excluded
+ * because the PR webhook only processes groups that remain in that status.
+ * Intentionally not tenant-scoped.
+ */
+export async function resolveInactiveGroups(ageDays: number): Promise<string[]> {
+  const pool = getPool();
+  const result = await pool.query<{ id: string }>(
+    `UPDATE error_groups g
+     SET status = 'resolved',
+         resolved_at = now(),
+         resolved_reason = 'auto_resolved',
+         resolved_in_release = (
+           SELECT release FROM error_events
+           WHERE project_id = g.project_id AND release IS NOT NULL AND release <> ''
+           GROUP BY release ORDER BY min(created_at) DESC LIMIT 1
+         ),
+         updated_at = now()
+     WHERE g.status IN ('needs_human', 'investigated')
+       AND g.last_seen < now() - ($1 || ' days')::interval
+     RETURNING g.id`,
+    [String(ageDays)]
   );
   return result.rows.map(r => r.id);
 }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 import http from 'node:http';
 import type { ClaimedJob } from './db.js';
 import * as db from './db.js';
-import { requeueStaleJobs, updateGroupStatus, closePool, updateGroupInvestigation, updateGroupAndCreateFixJob, getGroupInvestigation, resolveSilentMergedGroups, updateJobTraceUrl } from './db.js';
+import { requeueStaleJobs, updateGroupStatus, closePool, updateGroupInvestigation, updateGroupAndCreateFixJob, getGroupInvestigation, resolveInactiveGroups, resolveSilentMergedGroups, updateJobTraceUrl } from './db.js';
 import { buildReason } from './reason-codes.js';
 import { logger, setWorkerId } from './logger.js';
 import { fetchObject, getMinIOConfig } from './minio-client.js';
@@ -79,6 +79,21 @@ const REAPER_INTERVAL_MS = parseInt(
 );
 const SILENCE_CHECK_INTERVAL_MS = parseInt(
   process.env['SILENCE_CHECK_INTERVAL_MS'] ?? '300000', // 5 minutes default
+  10
+);
+const RESOLVE_AGE_DAYS_DEFAULT = 14;
+const RESOLVE_AGE_DAYS_RAW = parseInt(
+  process.env['RESOLVE_AGE_DAYS'] ?? String(RESOLVE_AGE_DAYS_DEFAULT),
+  10
+);
+// Guard against NaN/negative misconfiguration: a negative value would flip the
+// `now() - N days` window into the future and auto-resolve recent/active issues.
+const RESOLVE_AGE_DAYS =
+  Number.isInteger(RESOLVE_AGE_DAYS_RAW) && RESOLVE_AGE_DAYS_RAW > 0
+    ? RESOLVE_AGE_DAYS_RAW
+    : RESOLVE_AGE_DAYS_DEFAULT;
+const INACTIVITY_CHECK_INTERVAL_MS = parseInt(
+  process.env['INACTIVITY_CHECK_INTERVAL_MS'] ?? '900000', // 15 minutes default
   10
 );
 const WORKER_ID =
@@ -950,12 +965,36 @@ async function main(): Promise<void> {
       });
   }, SILENCE_CHECK_INTERVAL_MS);
 
+  // Inactivity checker — auto-resolve unresolved groups after the configured age
+  const inactivityTimer = setInterval(() => {
+    resolveInactiveGroups(RESOLVE_AGE_DAYS)
+      .then((ids) => {
+        if (ids.length > 0) {
+          logger.info('Inactivity checker: auto-resolved inactive groups', {
+            count: ids.length,
+            // Cap the sample: the first post-deploy sweep can resolve a large
+            // historical backlog and a full UUID array would blow up the log line.
+            group_ids: ids.slice(0, 50),
+            group_ids_truncated: ids.length > 50,
+            resolve_age_days: RESOLVE_AGE_DAYS,
+          });
+        }
+      })
+      .catch((err: unknown) => {
+        logger.error('Inactivity checker error', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+  }, INACTIVITY_CHECK_INTERVAL_MS);
+
   logger.info('Worker ready', {
     worker_id: WORKER_ID,
     poll_interval_ms: POLL_INTERVAL_MS,
     lease_duration_ms: LEASE_DURATION_MS,
     reaper_interval_ms: REAPER_INTERVAL_MS,
     silence_check_interval_ms: SILENCE_CHECK_INTERVAL_MS,
+    resolve_age_days: RESOLVE_AGE_DAYS,
+    inactivity_check_interval_ms: INACTIVITY_CHECK_INTERVAL_MS,
     health_port: HEALTH_PORT,
   });
 
@@ -963,6 +1002,7 @@ async function main(): Promise<void> {
     logger.info('Worker shutting down');
     clearInterval(reaperTimer);
     clearInterval(silenceTimer);
+    clearInterval(inactivityTimer);
     await poller.stop();
     healthServer.close();
     await shutdownTracing();


### PR DESCRIPTION
## Summary
Make Opslane issues group correctly and close on their own. Three workstreams from `docs/plans/2026-07-16-issue-lifecycle-and-grouping.md`, each independently reviewable.

**A · Grouping (ingestion).** Fingerprint normalization collapses deploy-varying URLs and content-hashed asset tokens (`index-<HASH>.js`) in the message *and* top stack frames, so cache-busting hashes stop splitting one bug into many groups. A token is treated as a hash only when it is >=8 chars and contains a digit; ordinary filenames are left untouched.

**B · Auto-resolve (worker).** A periodic sweep resolves stuck-open `needs_human` / `investigated` issues after `RESOLVE_AGE_DAYS` (default 14) of no new events, independent of any fix. `pr_created` is excluded so a later close/merge webhook is not orphaned. `RESOLVE_AGE_DAYS` is validated (positive integer, else default) and the sweep log caps the group-id sample.

**C · Release-aware regression (ingestion + migration `009`).** Records `resolved_in_release` and `resolved_reason`; on recurrence, reopen only if the incoming release is not strictly older than the resolved release. Releases are ranked by first-seen `min(created_at)` — server arrival, not the client-supplied `timestamp`, so a back-dated event cannot poison ordering and silently suppress a real regression. Permanently-unfixable reason codes never reopen.

## Migration
`009_regression_lifecycle.sql` — append-only, safe to reapply: adds `resolved_in_release` / `resolved_reason` columns, an index on `error_events(project_id, release, created_at)` for the ranking, and a partial index on `error_groups(last_seen)` for the sweep.

## New env vars (documented in `docs/reference/environment-variables.md`)
- `RESOLVE_AGE_DAYS` (default 14) — inactivity window before auto-resolve.
- `INACTIVITY_CHECK_INTERVAL_MS` (default 900000) — sweep cadence.

## Verification
- **Live docker compose smoke:** event -> group -> queued job; grouping collapsed differing hashes/hosts into one group; the auto-resolve sweep resolved inactive groups on a real worker timer (correct `auto_resolved` provenance, left recent + `pr_created` groups untouched); the regression gate reopened on a newer release and stayed resolved on an older one, through the real HTTP ingestion path.
- **Go suite** (`packages/ingestion`, incl. release-ordering + reason-code-permanence-vs-catalog + manual-resolve stamp) and **worker integration suite** (all 42, incl. `resolveInactiveGroups`) run green on a disposable Postgres with the `created_at` ranking.