### PR TITLE
test: docs-sync e2e — add onError to React error boundary

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -58,3 +58,5 @@ flowchart LR
 - [Life of an error](life-of-an-error.md) — the pipeline stage by stage
 - [Precision](precision.md) — what "verified" guarantees and what it does not
 - [Trust](trust.md) — permissions, data flow, token handling, retention
+</content>
+<changed>false</changed>

--- a/docs/architecture/trust.md
+++ b/docs/architecture/trust.md
@@ -83,3 +83,4 @@ These are known, tracked, and stated here so you can make an informed deployment
 ## Why the prompts are public
 
 The investigation and fix prompts live in this repository (`packages/worker/src`), not behind an API. That is intentional: you can read exactly what instructions the agent operates under, what it is told never to do, and how untrusted error text is fenced (`<untrusted_user_data>` delimiters in the fix loop) before you let it near your code.
+</content>

--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -45,6 +45,7 @@ This example uses Vite. In Next.js, read `process.env.NEXT_PUBLIC_OPSLANE_API_KE
 - **Render errors** (thrown during render, in lifecycle, or in hooks' render phase) are caught by `OpslaneErrorBoundary`, reported, and replaced with your `fallback` UI.
 - **Everything else** — event handlers, `setTimeout`, promise rejections — bypasses React error boundaries by design; the SDK's global handlers (installed by `init`) catch those.
 - To report an error you caught yourself inside a boundary of your own, use `captureReactError(error)` from `@opslane/sdk/react` (or the framework-agnostic `captureException`).
+- Pass an `onError(error)` prop to `OpslaneErrorBoundary` to run your own logging or UI side effects after the error has been reported.
 
 Place boundaries as granularly as you like — a boundary per route keeps one broken page from blanking the whole app, and every boundary still reports.
 

--- a/packages/sdk/src/react.tsx
+++ b/packages/sdk/src/react.tsx
@@ -4,6 +4,8 @@ import { captureException } from './core';
 interface Props {
   children: ReactNode;
   fallback?: ReactNode | ((error: Error) => ReactNode);
+  /** Invoked after the error is reported, for your own logging or UI side effects. */
+  onError?: (error: Error) => void;
 }
 interface State {
   error: Error | null;
@@ -23,6 +25,7 @@ export class OpslaneErrorBoundary extends Component<Props, State> {
   componentDidCatch(error: Error, _info: ErrorInfo): void {
     try {
       captureException(error);
+      this.props.onError?.(error);
     } catch {
       /* SDK must never throw */
     }


### PR DESCRIPTION
End-to-end test of the docs-sync workflow (merged in #82).

Touches `packages/sdk/src/react.tsx` (covered by `docs/guides/react.md` and the
`packages/sdk/**` architecture docs), adding an optional `onError` callback to
`OpslaneErrorBoundary`. Additive and green locally (SDK build + 190 tests pass).

Expectation: the **Docs sync** workflow runs, the Claude auth smoke passes, and
the publish job pushes a `docs: sync for #N` commit updating react.md to mention
`onError`. If nothing is stale it no-ops — either way it proves the token + pipeline.

Throwaway test PR; not intended to merge as-is.