### PR TITLE
[DO NOT MERGE] docs-sync e2e verification

### DIFF
--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -44,7 +44,7 @@ This example uses Vite. In Next.js, read `process.env.NEXT_PUBLIC_OPSLANE_API_KE
 
 - **Render errors** (thrown during render, in lifecycle, or in hooks' render phase) are caught by `OpslaneErrorBoundary`, reported, and replaced with your `fallback` UI.
 - **Everything else** — event handlers, `setTimeout`, promise rejections — bypasses React error boundaries by design; the SDK's global handlers (installed by `init`) catch those.
-- To report an error you caught yourself inside a boundary of your own, use `captureReactError(error)` from `@opslane/sdk/react` (or the framework-agnostic `captureException`).
+- To report an error you caught yourself inside a boundary of your own, use `captureReactError(error, componentStack?)` from `@opslane/sdk/react` (pass `componentStack` from `ErrorInfo` to include React's component trace; or use the framework-agnostic `captureException`).
 
 Place boundaries as granularly as you like — a boundary per route keeps one broken page from blanking the whole app, and every boundary still reports.
 

--- a/packages/sdk/src/react.tsx
+++ b/packages/sdk/src/react.tsx
@@ -38,9 +38,16 @@ export class OpslaneErrorBoundary extends Component<Props, State> {
   }
 }
 
-/** For Next.js app/global-error.tsx and error.tsx, which receive the error as a prop. */
-export function captureReactError(error: Error): void {
+/**
+ * For Next.js app/global-error.tsx and error.tsx, which receive the error as a prop.
+ * Pass the optional `componentStack` (from an error boundary's `ErrorInfo`) to
+ * append React's component trace to the reported stack for easier triage.
+ */
+export function captureReactError(error: Error, componentStack?: string): void {
   try {
+    if (componentStack) {
+      error.stack = `${error.stack ?? ''}\n${componentStack}`;
+    }
     captureException(error);
   } catch {
     /* SDK must never throw */


### PR DESCRIPTION
Throwaway PR to verify the docs-sync validate/publish pipeline (landed in #85) actually runs end-to-end.

The one commit adds an optional `componentStack` param to `captureReactError` (`packages/sdk/src/react.tsx`), which maps to `docs/guides/react.md` via `covers:`. Expected: `plan` maps it, `validate` builds the SDK + runs the react-app runnable snippet + site overlay, and `publish` pushes a `docs: sync for #N` commit updating react.md.

**Do not merge — close after verifying.**