### PR TITLE
Skip docs-sync on jumbo PRs

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -65,6 +65,16 @@ jobs:
             echo "publish=0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Jumbo-PR guard: per-doc planning assumes a reviewable diff. Beyond
+          # 50 changed code files the agent blows the 15-minute job budget, so
+          # skip the sync and leave documentation to the PR author (reference
+          # docs are still enforced by the drift check in pnpm test).
+          code_changed=$(grep -cvE '^(docs/|[^/]+\.md$)' "$RUNNER_TEMP/changed.txt" || true)
+          if [ "$code_changed" -gt 50 ]; then
+            echo "::notice::docs-sync skipped: $code_changed changed code files exceeds the 50-file planning budget. Sync docs in this PR by hand or run docs-sync on a smaller follow-up."
+            echo "publish=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           node scripts/docs-map.mjs < "$RUNNER_TEMP/changed.txt" > "$RUNNER_TEMP/map.json"
           node --input-type=module - "$RUNNER_TEMP/map.json" <<'NODE'
           import { readFileSync } from 'node:fs';


### PR DESCRIPTION
## What

The docs-sync `plan` job's per-doc reasoning agent was canceled at its 15-minute ceiling on PR #92 (102 changed files). Rather than raising the budget, the map step now skips the sync when a PR changes more than 50 code files: it emits `publish=0` with a workflow notice telling the author to sync docs by hand. The timeout stays at 15 minutes as a bound on a hung agent.

Reference docs stay safe either way — the drift check in `pnpm test` fails any PR whose code and reference docs disagree; this guard only affects the LLM-proposed prose edits.

## Why skip instead of a bigger budget

A 100-file diff isn't just slow to plan against — per-doc reasoning quality degrades with diff size, and a jumbo PR author is already writing docs by hand (as #92 did: all six matched prose docs were updated in the PR itself; verified post-merge by running the mapping manually — zero missed edits).

## Verification

- YAML validated; the guard logic reuses the step's existing changed-file list and early-exit pattern.
- PR #92's post-merge manual mapping run doubles as the guard's justification: 6 matched docs already updated in-PR, 2 manual-review contracts verified untouched, both docs checks green on main.
- This PR itself is small, so the guard must NOT fire here — the plan job should run normally.

https://claude.ai/code/session_0142FjJSmbR9RjAvTzA2LSmt