### PR TITLE
fix(auth): grant owner membership on GitHub OAuth provisioning

### DIFF
--- a/packages/ingestion/handler/github_oauth.go
+++ b/packages/ingestion/handler/github_oauth.go
@@ -279,6 +279,19 @@ func (d *Dependencies) provisionGitHubIdentity(r *http.Request, identity auth.Id
 			}
 		}
 	}
+	// RequireMembership 403s any session without a memberships row; GitHub
+	// accounts created before membership rows existed have none, so grant the
+	// home-org owner row here without touching an existing (possibly
+	// downgraded) role.
+	role, err := d.Queries.GetMembership(r.Context(), user.ID, user.OrgID)
+	if err != nil {
+		return nil, err
+	}
+	if role == "" {
+		if err := d.Queries.CreateMembership(r.Context(), user.ID, user.OrgID, "owner"); err != nil {
+			return nil, err
+		}
+	}
 	if err := d.Queries.UpdateUserGitHub(r.Context(), user.ID, identity.Username, identity.AvatarURL, identity.Email); err != nil {
 		slog.Warn("refresh GitHub profile failed", "user_id", user.ID, "error", err)
 	}

--- a/packages/ingestion/handler/github_oauth_test.go
+++ b/packages/ingestion/handler/github_oauth_test.go
@@ -462,3 +462,76 @@ func TestGitHubProvisioningResolvesIdentityFirstAndWritesFreshIdentity(t *testin
 		t.Fatalf("fresh identity user=%q err=%v, want %s", gotUserID, err, fresh.ID)
 	}
 }
+
+func TestProvisionGitHubIdentityGrantsOwnerMembership(t *testing.T) {
+	pool := githubOAuthTestPool(t)
+	q := db.New(pool)
+	ctx := context.Background()
+	deps := &Dependencies{Queries: q}
+	request := httptest.NewRequest("GET", "/auth/callback", nil)
+
+	freshID := time.Now().UnixNano()
+	fresh, err := deps.provisionGitHubIdentity(request, auth.Identity{
+		Provider: "github", ProviderSubject: strconv.FormatInt(freshID, 10),
+		Email:         fmt.Sprintf("github-owner-%d@example.com", freshID),
+		EmailVerified: true, Name: "Owner", Username: fmt.Sprintf("owner-%d", freshID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cleanupGitHubOAuthOrg(t, pool, fresh.OrgID) })
+	role, err := q.GetMembership(ctx, fresh.ID, fresh.OrgID)
+	if err != nil || role != "owner" {
+		t.Fatalf("new GitHub user role=%q err=%v, want owner", role, err)
+	}
+}
+
+func TestProvisionGitHubIdentityHealsMissingMembership(t *testing.T) {
+	pool := githubOAuthTestPool(t)
+	q := db.New(pool)
+	ctx := context.Background()
+	org, err := q.CreateOrg(ctx, fmt.Sprintf("github-heal-%d", time.Now().UnixNano()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cleanupGitHubOAuthOrg(t, pool, org.ID) })
+	githubID := time.Now().UnixNano()
+	user, err := q.CreateUserGitHub(ctx, org.ID, fmt.Sprintf("github-heal-%d@example.com", githubID), "Heal", githubID, "heal", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject := strconv.FormatInt(githubID, 10)
+	if err := q.UpsertIdentity(ctx, user.ID, "github", subject); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a legacy account created before membership rows existed.
+	if _, err := pool.Exec(ctx, `DELETE FROM memberships WHERE user_id = $1 AND org_id = $2`, user.ID, org.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := &Dependencies{Queries: q}
+	request := httptest.NewRequest("GET", "/auth/callback", nil)
+	identity := auth.Identity{
+		Provider: "github", ProviderSubject: subject, Email: user.Email,
+		EmailVerified: true, Name: "Heal", Username: "heal",
+	}
+	if _, err := deps.provisionGitHubIdentity(request, identity); err != nil {
+		t.Fatal(err)
+	}
+	role, err := q.GetMembership(ctx, user.ID, org.ID)
+	if err != nil || role != "owner" {
+		t.Fatalf("healed role=%q err=%v, want owner", role, err)
+	}
+
+	// A deliberately downgraded role must survive later logins.
+	if err := q.SetMembershipRole(ctx, user.ID, org.ID, "member"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deps.provisionGitHubIdentity(request, identity); err != nil {
+		t.Fatal(err)
+	}
+	role, err = q.GetMembership(ctx, user.ID, org.ID)
+	if err != nil || role != "member" {
+		t.Fatalf("downgraded role=%q err=%v, want member preserved", role, err)
+	}
+}


### PR DESCRIPTION
## Bug

Accounts created via the GitHub OAuth path get a user row and an org but **no `memberships` row**. `RequireMembership` (`handler/auth.go`) resolves the role from the `memberships` table, so every authenticated request from such an account fails with `403 {"error":"organization membership required"}` — the account is broken from its first login.

The WorkOS path (`ProvisionIdentity`) already inserts the owner membership and self-heals it on later logins; the GitHub path (`provisionGitHubIdentity` → `CreateUserGitHub`) never did.

## Fix

`provisionGitHubIdentity` now ensures the home-org owner membership on every login:

- creates the `owner` row when absent — covers new sign-ups **and** heals legacy accounts that were created broken
- leaves an existing row untouched, so a deliberately downgraded role (e.g. `member`) is never re-promoted

## Tests (TDD)

- `TestProvisionGitHubIdentityGrantsOwnerMembership` — new GitHub user has `owner` role in their org (failed with `role=""` before the fix)
- `TestProvisionGitHubIdentityHealsMissingMembership` — legacy account with no membership row is healed to `owner` on next login, and a downgraded `member` role survives subsequent logins (failed before the fix)

Full ingestion suite green: `go build ./... && go test ./...` passes across all packages.