### PR TITLE
Python errors in the dashboard: platform read-through, sample-event endpoint, traceback rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,15 @@ jobs:
       - run: pnpm --filter @opslane/shared --filter @opslane/worker --filter @opslane/dashboard build
       - name: Install Playwright chromium (browser smoke)
         run: pnpm --filter @opslane/test-e2e exec playwright install --with-deps chromium
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+      # The python smoke serves test-fixtures/flask-app with the real SDK.
+      # Without flask its live leg skips, and the skip gate below fails the
+      # job rather than letting Python coverage silently disappear. Flask is
+      # pinned to the fixture's requirements.txt.
+      - name: Install Flask for the python SDK smoke
+        run: python -m pip install 'flask==3.0.3'
       - name: Assert the LLM key is absent
         run: |
           if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
@@ -237,6 +246,9 @@ jobs:
           MINIO_ACCESS_KEY: minio
           MINIO_SECRET_KEY: minio12345
           MINIO_BUCKET: opslane-replays
+          # Interpreter the python smoke serves the Flask fixture with; the
+          # setup-python step above put flask in it.
+          OPSLANE_PYTHON: python
         run: >
           pnpm --filter @opslane/test-e2e exec vitest run
           --reporter=default --reporter=json
@@ -245,14 +257,18 @@ jobs:
         env:
           # The with-secrets PR pipeline suite is the only allowed skip here.
           E2E_ALLOWED_SKIP_PATTERN: '^pr_created pipeline \(full flow\)'
-          E2E_MIN_TESTS: "31"
+          E2E_MIN_TESTS: "40"
           # The browser smoke suites must be collected AND pass by name, so a
           # future edit cannot drop them while keeping the total count intact.
+          # The python smoke's live leg is listed for the same reason: it
+          # self-skips without flask, and a skip here is a coverage hole.
           E2E_REQUIRED_PATTERNS: |
             ^browser smoke: Vue error to needs_human >
             ^browser smoke: React error to needs_human >
             ^browser smoke: rage click to friction signal >
             ^notifications contract
+            ^python SDK live smoke \(Flask fixture → ingestion\) >
+            ^python wire adversarial \(hostile non-SDK client\) >
         run: node scripts/check-e2e-results.mjs "${{ runner.temp }}/e2e-results.json"
       - name: Token-leak scan over logs and public HTTP surfaces
         run: |

--- a/docs/architecture/trust.md
+++ b/docs/architecture/trust.md
@@ -63,8 +63,7 @@ object at completion, so an upload interrupted before completion leaves the raw
 recording in storage. That path is retired once error replays resolve to chunk
 pointers.
 
-For error events, ingestion also replaces sensitive headers, well-known API-key
-prefixes, and URL-embedded credentials with `[REDACTED]` before persistence.
+For error events, ingestion redacts breadcrumbs and context (sensitive headers, API-key prefixes, URL-embedded credentials) before persistence. Error messages and stack traces are stored verbatim to preserve grouping fingerprints, then redacted when served.
 
 See [replay privacy and masking](../guides/replay-privacy.md) for what replay data may contain.
 

--- a/docs/plans/2026-07-19-python-sdk-batch2-implementation.md
+++ b/docs/plans/2026-07-19-python-sdk-batch2-implementation.md
@@ -1,0 +1,670 @@
+# Python SDK Batch 2: Dashboard Platform Support — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make Python errors visible and readable in the dashboard — platform read-through, a sample-event read path (stack trace, breadcrumbs, context), platform filter + badge, and Python traceback rendering.
+
+**Architecture:** Server first, UI second. `platform` is stored (migration 016) but never read back, and **no endpoint returns a group's stack/breadcrumbs/context today — for JS or Python; the dashboard renders no stack trace at all**. So this batch plumbs platform through the read path (struct → 2 SELECTs → `incidentJSON` → shared type), adds one new tenant-scoped endpoint (`GET /api/v1/projects/{projectID}/incidents/{incidentID}/sample-event`), then builds the dashboard rendering from scratch on top. Read-API changes are additive only.
+
+**Tech Stack:** Go 1.24 (chi, pgx) in `packages/ingestion`; Vue 3 + Vite + Tailwind in `packages/dashboard`; shared TS contracts in `shared/src/types.ts`. Tests: `go test` (handler/db integration tests need `DATABASE_URL`), Vitest for dashboard.
+
+**Tracker:** issue #88. Design: `docs/plans/2026-07-17-python-sdk-design.md` §7–8. Blocked-by #87 is merged (PR #98).
+
+---
+
+## Ground rules for the executor
+
+- **Branch:** `abhishekray07/python-sdk-batch2` off up-to-date `origin/main`. Create it before Task 1:
+  ```bash
+  git fetch origin && git checkout -b abhishekray07/python-sdk-batch2 origin/main
+  ```
+- **DB-backed Go tests** skip without `DATABASE_URL`. Run them against a disposable migrated Postgres, never the shared 5434 instance:
+  ```bash
+  docker run -d --rm --name b2-pg -e POSTGRES_USER=opslane -e POSTGRES_PASSWORD=opslane \
+    -e POSTGRES_DB=opslane -p 5499:5432 postgres:16-alpine
+  until docker exec b2-pg pg_isready -U opslane -d opslane >/dev/null 2>&1; do sleep 0.5; done
+  for f in packages/ingestion/db/migrations/*.sql; do
+    docker exec -i b2-pg psql -q -U opslane -d opslane -v ON_ERROR_STOP=1 < "$f"; done
+  export DATABASE_URL="postgres://opslane:opslane@localhost:5499/opslane"
+  ```
+  Tear down with `docker stop b2-pg` when done.
+- Existing test helpers: `testDeps(t)` + `seedTenant(t, ...)` in `packages/ingestion/handler/error_event_test.go:27`; `postErrorPayload` helper posts a raw event body. Reuse them — do not write new seeding machinery.
+- The `POST /api/v1/events` wire contract is frozen; this batch does not touch it. The read API (`/projects/...`) is not the frozen contract, but stay additive anyway.
+- Commit after every task with the message given. No Claude attribution, no co-author lines.
+
+---
+
+### Task 1: Shared + dashboard types — `platform` on Incident, new `SampleEvent`
+
+**Files:**
+- Modify: `shared/src/types.ts` (Incident interface, ~line 221–252)
+- Modify: `packages/dashboard/src/types/api.ts` (`IncidentFilters` at line ~238; local `Incident` mirror if present — grep `interface Incident` in that file)
+
+**Step 1: Add to `shared/src/types.ts`** — inside `export interface Incident`, after `kind`:
+
+```ts
+  /** Platform wire token ('javascript', 'python', future tokens) for error
+   *  incidents; null/absent for friction. Response fields stay `string` —
+   *  ingestion accepts any valid token, and the UI must render unknown
+   *  tokens rather than lie about them. Only the FILTER input is
+   *  restricted to the two supported choices. */
+  platform?: string | null;
+```
+
+And a new exported interface next to `Incident`:
+
+```ts
+/** Sample event for an error group, served by
+ *  GET /projects/{projectId}/incidents/{incidentId}/sample-event.
+ *  Mirrors sampleEventJSON in packages/ingestion/handler/read_api.go. */
+export interface SampleEvent {
+  timestamp: string; // ISO 8601
+  platform: string;
+  error: {
+    type: string;
+    message: string;
+    stack: string;
+  };
+  /** ALWAYS an array: the endpoint normalizes non-array stored values
+   *  (ingestion accepts any JSON for breadcrumbs — null/object/scalar can
+   *  be stored) to [] before serving. Still narrow per-item with unknown. */
+  breadcrumbs: unknown[];
+  context: Record<string, unknown>;
+}
+```
+
+**Step 2: Mirror in `packages/dashboard/src/types/api.ts`:** add `platform?: string | null;` to its `Incident`, add the same `SampleEvent` interface (or re-export), and extend `IncidentFilters` (filter input IS restricted — it drives the two UI choices):
+
+```ts
+  platform?: 'javascript' | 'python';
+```
+
+**Step 3: Verify**
+
+Run: `pnpm --filter @opslane/shared build && pnpm --filter @opslane/dashboard build`
+Expected: both pass (types are additive; nothing consumes them yet).
+
+**Step 4: Commit** — `feat(shared): platform on Incident, SampleEvent contract for the dashboard read path`
+
+---
+
+### Task 2: DB read-through — `ErrorGroup.Platform` in both group SELECTs
+
+**Files:**
+- Modify: `packages/ingestion/db/queries.go` — `ErrorGroup` struct (line ~287), `ListErrorGroups` SELECT (line ~613), `GetErrorGroup` SELECT (line ~806), and both row-`Scan` calls
+- Test: `packages/ingestion/handler/error_event_test.go` (append)
+
+**Step 1: Write the failing test** (DB-backed; goes next to the other ingest tests):
+
+```go
+func TestIngest_PlatformReadBackThroughGroupQueries(t *testing.T) {
+	deps, _ := testDeps(t)
+	_, projectID, _, rawKey := seedTenant(t, deps.Queries)
+	body := `{"timestamp":"2026-07-19T00:00:00Z","platform":"python","error":{"type":"ValueError","message":"boom","stack":"Traceback (most recent call last):\ngarbage"},"breadcrumbs":[],"context":{},"sdk_version":"0.1.0a2"}`
+	response := postErrorPayload(t, deps, rawKey, body)
+
+	groups, err := deps.Queries.ListErrorGroups(context.Background(), projectID, nil)
+	if err != nil {
+		t.Fatalf("list groups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Platform == nil || *groups[0].Platform != "python" {
+		t.Fatalf("ListErrorGroups platform = %+v, want python", groups)
+	}
+	group, err := deps.Queries.GetErrorGroup(context.Background(), projectID, response["group_id"])
+	if err != nil {
+		t.Fatalf("get group: %v", err)
+	}
+	if group.Platform == nil || *group.Platform != "python" {
+		t.Fatalf("GetErrorGroup platform = %v, want python", group.Platform)
+	}
+}
+```
+
+(`GetErrorGroup`'s signature is `(ctx, projectID, groupID)` — verified at `queries.go:806`.)
+
+**Step 2: Run to verify it fails**
+
+Run: `cd packages/ingestion && go test ./handler -run TestIngest_PlatformReadBackThroughGroupQueries -count=1`
+Expected: compile error — `groups[0].Platform undefined`.
+
+**Step 3: Implement**
+
+- Add `Platform *string` to the `ErrorGroup` struct (nullable: friction incidents have no platform).
+- Add `eg.platform` to **both** SELECT column lists (`ListErrorGroups` line 607 block and `GetErrorGroup` line ~802 block) and `&g.Platform` to the matching `Scan` calls, keeping column/scan order aligned.
+
+**Step 4: Run to verify it passes** (same command). Also run `go build ./... && go vet ./db ./handler`.
+
+**Step 5: Commit** — `feat(ingestion): read platform back through ListErrorGroups and GetErrorGroup`
+
+---
+
+### Task 3: `incidentJSON.platform` + unit test
+
+**Files:**
+- Modify: `packages/ingestion/handler/read_api.go` — `incidentJSON` struct (line 19), `toIncidentJSON` (line 67)
+- Test: `packages/ingestion/handler/read_api_test.go` (append; these are pure unit tests, no DB)
+
+**Step 1: Write the failing test**
+
+```go
+func TestToIncidentJSON_Platform(t *testing.T) {
+	platform := "python"
+	inc := toIncidentJSON(db.ErrorGroup{Platform: &platform})
+	if inc.Platform == nil || *inc.Platform != "python" {
+		t.Fatalf("platform = %v, want python", inc.Platform)
+	}
+	if got := toIncidentJSON(db.ErrorGroup{}); got.Platform != nil {
+		t.Fatalf("friction incident platform should marshal as absent, got %v", got.Platform)
+	}
+}
+```
+
+**Step 2: Run to verify it fails** — `go test ./handler -run TestToIncidentJSON_Platform -count=1` → compile error.
+
+**Step 3: Implement** — in `incidentJSON` add `Platform *string \`json:"platform,omitempty"\`` (place after `Kind`), and in `toIncidentJSON` add `Platform: g.Platform,`.
+
+**Step 4: Run to verify it passes.**
+
+**Step 5: Commit** — `feat(ingestion): expose platform in incident JSON`
+
+---
+
+### Task 4: Platform filter in `ListErrorGroups` (DB layer)
+
+**Files:**
+- Modify: `packages/ingestion/db/queries.go` — `ErrorGroupFilters` (line ~606), `ListErrorGroups` WHERE building (just below it)
+- Test: `packages/ingestion/handler/error_event_test.go` (append)
+
+**Step 1: Write the failing test.** Seed one python group (post an event as in Task 2), one javascript group (post a JS-stack event), and one friction incident (insert directly: look at how friction rows are created — grep `kind = 'friction'` or `friction` INSERTs in `queries.go`/test helpers and reuse; if there is no helper, insert a minimal `error_groups` row with `kind='friction'`, `platform IS NULL` via `pool.Exec`). Then:
+
+```go
+func TestListErrorGroups_PlatformFilter(t *testing.T) {
+	// ...seeding as above...
+	python := "python"
+	got, err := deps.Queries.ListErrorGroups(ctx, projectID, &db.ErrorGroupFilters{Platform: python})
+	// expect: exactly the python group
+	all, err := deps.Queries.ListErrorGroups(ctx, projectID, nil)
+	// expect: all three rows, friction included
+}
+```
+
+Assert: platform filter returns ONLY the python error group (friction excluded even though its platform is NULL — the filter implies `kind = 'error'`); unfiltered list includes the friction row.
+
+**Step 2: Run to verify it fails** — compile error on `Platform` field.
+
+**Step 3: Implement** — add `Platform string` to `ErrorGroupFilters` with the comment `// filter by platform; implies kind='error' (friction incidents have no platform)`. In the WHERE-builder, following the existing `filters.Status` pattern:
+
+```go
+if filters.Platform != "" {
+	wheres = append(wheres, fmt.Sprintf("eg.platform = $%d AND eg.kind = 'error'", argIdx))
+	args = append(args, filters.Platform)
+	argIdx++
+}
+```
+
+**Step 4: Run to verify it passes** (needs `DATABASE_URL`).
+
+**Step 5: Commit** — `feat(ingestion): platform filter on ListErrorGroups, scoped to error incidents`
+
+---
+
+### Task 5: Handler parses `?platform=` (with token validation)
+
+**Files:**
+- Modify: `packages/ingestion/handler/read_api.go` — `ListIncidents` (line 185), where it builds `db.ErrorGroupFilters` from query params
+- Test: `packages/ingestion/handler/error_event_test.go` or `read_api_test.go` (DB-backed end-to-end through the router)
+
+**Step 1: Write the failing test.** Reuse Task 4's seeding; hit the HTTP route:
+
+```go
+// GET /api/v1/projects/{projectID}/incidents?platform=python  → only python group
+// GET ...?platform=Not%20A%20Token                            → 400 (or ignored — see Step 3)
+```
+
+**Step 3: Implement.** Read `r.URL.Query().Get("platform")`. Validate with the same token rule ingestion uses (`rePlatformToken` in `error_event.go:15` — it's package-level, reuse it). Invalid non-empty value → `writeJSONError(w, http.StatusBadRequest, "invalid platform")` (read side should be strict, unlike the lenient write side — a typo'd filter silently returning everything would mislead).
+
+**Allocation gotcha (`read_api.go:193`):** the handler currently allocates `filters` ONLY when `accountID != "" || endUserID != "" || status != ""` — a platform-only request would leave `filters` nil and the value silently dropped. Add `platform != ""` to that condition AND `Platform: platform,` to the struct literal:
+
+```go
+if accountID != "" || endUserID != "" || status != "" || platform != "" {
+	filters = &db.ErrorGroupFilters{
+		AccountID: accountID,
+		EndUserID: endUserID,
+		Status:    status,
+		Platform:  platform,
+	}
+}
+```
+
+The Step-1 test must include a platform-ONLY request (no other params) so a regression to the old condition fails it.
+
+**Step 4: Run all handler tests** — `go test ./handler -count=1`.
+
+**Step 5: Commit** — `feat(ingestion): platform query param on incident list`
+
+---
+
+### Task 6: `GetSampleEvent` query (DB layer)
+
+**Files:**
+- Modify: `packages/ingestion/db/queries.go` (append near the other read queries)
+- Test: `packages/ingestion/handler/error_event_test.go` (append)
+
+**Step 1: Write the failing test**
+
+```go
+func TestGetSampleEvent_TenantScopedRoundTrip(t *testing.T) {
+	deps, pool := testDeps(t)
+	_, projectID, _, rawKey := seedTenant(t, deps.Queries)
+	body := `{"timestamp":"2026-07-19T00:00:00Z","platform":"python","runtime":{"name":"cpython","version":"3.12.1"},"error":{"type":"ValueError","message":"No row was found","stack":"Traceback (most recent call last):\n  File \"/app/api/x.py\", line 1, in f\n    raise ValueError()\nValueError: No row was found"},"breadcrumbs":[{"type":"log","timestamp":"t","category":"app","level":"warning","message":"near expiry"}],"context":{},"sdk_version":"0.1.0a2"}`
+	response := postErrorPayload(t, deps, rawKey, body)
+
+	ev, err := deps.Queries.GetSampleEvent(context.Background(), projectID, response["group_id"])
+	if err != nil {
+		t.Fatalf("get sample event: %v", err)
+	}
+	if ev.ErrorType != "ValueError" || ev.Platform != "python" ||
+		!strings.HasPrefix(ev.StackTraceRaw, "Traceback") {
+		t.Fatalf("unexpected sample event: %+v", ev)
+	}
+	// Tenant scoping: a different project must not see it. Assert the
+	// SPECIFIC no-rows error — `err != nil` would also pass on broken SQL
+	// or connection failures and prove nothing about invisibility.
+	_, otherProject, _, _ := seedTenant(t, deps.Queries)
+	if _, err := deps.Queries.GetSampleEvent(context.Background(), otherProject, response["group_id"]); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("cross-project sample event read must be pgx.ErrNoRows, got %v", err)
+	}
+}
+```
+
+(Check `seedTenant`'s return values — if calling it twice collides on fixed IDs, look at how other multi-tenant tests isolate; there is prior art in the auth/session tests.)
+
+**Step 3: Implement** in `queries.go`:
+
+```go
+// SampleEvent is the representative event for an error group, used by the
+// dashboard detail view. Tenant-scoped through the owning group's project_id.
+type SampleEvent struct {
+	Timestamp     time.Time
+	Platform      string
+	ErrorType     string
+	ErrorMessage  string
+	StackTraceRaw string
+	Breadcrumbs   []byte // JSONB passthrough
+	Context       []byte // JSONB passthrough
+}
+
+// GetSampleEvent returns the sample event for a group, scoped to the project.
+// The candidate predicate matches GetErrorGroup (queries.go:806): ordinary
+// candidate rows are hidden workflow records (issue #56) and must stay
+// invisible through this read path too. The join REQUIRES the event to be in
+// the same project as the group: sample_event_id has no FK or same-project
+// constraint, so without `e.project_id = g.project_id` a corrupt pointer
+// could disclose another tenant's event.
+func (q *Queries) GetSampleEvent(ctx context.Context, projectID, groupID string) (*SampleEvent, error) {
+	var ev SampleEvent
+	err := q.pool.QueryRow(ctx,
+		`SELECT e."timestamp", e.platform, e.error_type, e.error_message,
+		        e.stack_trace_raw, e.breadcrumbs, e.context
+		 FROM error_groups g
+		 JOIN error_events e ON e.id = g.sample_event_id AND e.project_id = g.project_id
+		 WHERE g.id = $1 AND g.project_id = $2
+		   AND (g.status <> 'candidate' OR g.adjudication_status = 'unchecked')`,
+		groupID, projectID,
+	).Scan(&ev.Timestamp, &ev.Platform, &ev.ErrorType, &ev.ErrorMessage,
+		&ev.StackTraceRaw, &ev.Breadcrumbs, &ev.Context)
+	if err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}
+```
+
+Note the JOIN handles the friction case for free: friction incidents have no `sample_event_id`, so the join is empty → `pgx.ErrNoRows`.
+
+**Additional Step-1 test case — hidden candidates stay hidden:** after the round-trip assertions, flip the group to an ordinary candidate and assert the read disappears:
+
+```go
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE error_groups SET status = 'candidate', adjudication_status = NULL WHERE id = $1`,
+		response["group_id"]); err != nil {
+		t.Fatalf("hide group as ordinary candidate: %v", err)
+	}
+	if _, err := deps.Queries.GetSampleEvent(context.Background(), projectID, response["group_id"]); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("hidden candidate's sample event must be pgx.ErrNoRows, got %v", err)
+	}
+```
+
+(`adjudication_status` — per `007_friction_adjudication.sql:66`, the CHECK allows only `'unchecked'` or NULL. An ordinary hidden candidate is `status='candidate', adjudication_status=NULL`; there is no `'confirmed'` value.)
+
+**Step 4: Run to verify it passes.**
+
+**Step 5: Commit** — `feat(ingestion): GetSampleEvent query, tenant-scoped through the owning group`
+
+---
+
+### Task 7: Sample-event endpoint + server-side header deny-list
+
+**Files:**
+- Modify: `packages/ingestion/masking/masking.go` (expand + export the sensitive-header policy) and `packages/ingestion/masking/masking_test.go`
+- Modify: `packages/ingestion/handler/read_api.go` (new handler + JSON type + header filter)
+- Modify: `packages/ingestion/handler/routes.go` (route registration — session-only, see below)
+- Modify: `docs/reference/http-routes.md` — document the new route. NOT optional: `scripts/check-docs-drift.mjs:93` fails the root `pnpm test` gate for any registered-but-undocumented route.
+- Test: `packages/ingestion/handler/read_api_test.go` (unit: header filter) and `error_event_test.go` (integration: endpoint)
+
+**Step 1: Write the failing unit test for the filter** (no DB). Cover EVERY deny-listed key and mixed-case variants — the stored JSON keys come from clients, not from Go's canonicalized `http.Header`:
+
+```go
+func TestFilterSensitiveHeaders(t *testing.T) {
+	in := map[string]json.RawMessage{"content-type": json.RawMessage(`"application/json"`)}
+	for _, k := range []string{
+		"Authorization", "PROXY-AUTHORIZATION", "authentication",
+		"Cookie", "set-cookie", "x-api-key", "X-CSRF-Token",
+		"x-auth-token", "X-Access-Token", "x-amz-security-token",
+	} {
+		in[k] = json.RawMessage(`"secret"`)
+	}
+	out := filterSensitiveHeaders(in)
+	if len(out) != 1 {
+		t.Fatalf("expected only content-type to survive, got %v", out)
+	}
+	if _, ok := out["content-type"]; !ok {
+		t.Fatal("benign header must survive")
+	}
+}
+```
+
+**Step 2: Write the failing integration test** — POST an event whose `context` includes `request.headers` with `Authorization` (note: the SDK strips it client-side, so build the body by hand — this test is exactly the defense-in-depth case of a non-SDK client), then:
+
+```go
+// GET /api/v1/projects/{projectID}/incidents/{groupID}/sample-event
+// via handler.NewRouter(deps), authenticated with a USER SESSION —
+// see how auth_middleware_test.go / session-authenticated handler tests
+// mint a session cookie, and copy that setup exactly.
+```
+
+Assert: 200; body has `error.type`, `error.stack` starting `Traceback`, breadcrumbs array; `context.request.headers` lacks `authorization` but keeps `content-type`; `context.request.remote_addr` passes through if present; `Cache-Control: no-store` response header set (this endpoint returns stack traces, headers, client IPs, and user identity — it must never be cached; mirror the explicit cache policies on `embedded_auth.go:101` / `session_read.go:262`). Second case: unknown incident ID → 404. Third case: incident from another project → 404 (not 403 — do not leak existence). Careful: `verifyProjectAccess` (`read_api.go:169`) returns 403 for a project outside the caller's org BEFORE the incident lookup — so to test non-disclosure, use a second project in the SAME org (accessible to the caller) with the first project's incident ID. Fourth case: SDK-key auth (`X-API-Key` as in `postErrorPayload`) → 401. Fifth case: POST an event whose `context.request.headers` is a NON-OBJECT (e.g. `[["Authorization","secret"]]`) — the response's `request.headers` must be absent or `{}`, never the raw value.
+
+**Step 3: Implement.**
+
+**Single source of truth: extend `packages/ingestion/masking/masking.go`, don't create a second Go deny-list.** `masking.sensitiveHeaders` (masking.go:11) already owns sensitive-header policy but predates Batch 1's expanded SDK list (it has 5 entries; the SDK's `DEFAULT_SENSITIVE_HEADERS` in `packages/sdk-python/opslane/client.py` has 10). In the masking package:
+
+1. Add the missing entries: `proxy-authorization`, `authentication`, `x-auth-token`, `x-access-token`, `x-amz-security-token`. This is strictly-more redaction at ingest time — safe by direction — and it aligns write-side masking with the SDK. Extend the masking package's own tests (`packages/ingestion/masking/masking_test.go`) for the new names.
+2. Export a predicate for read-side reuse:
+
+```go
+// IsSensitiveHeader reports whether a header name (any case) must never be
+// exposed or persisted in cleartext. Single source of truth for write-side
+// redaction and read-side filtering.
+func IsSensitiveHeader(name string) bool {
+	_, ok := sensitiveHeaders[strings.ToLower(name)]
+	return ok
+}
+```
+
+Then in `read_api.go`, `filterSensitiveHeaders(map[string]json.RawMessage) map[string]json.RawMessage` — copy minus keys where `masking.IsSensitiveHeader(key)`. (Read-side filtering still matters even though write-side masking now redacts these: rows ingested before the expansion carry unredacted values.)
+
+**Read-side redaction must cover the WHOLE payload, not just `request.headers`.** Sensitive values can sit anywhere in historical `context` and `breadcrumbs` (the pre-expansion write-side list missed 5 header names, and breadcrumb messages/URLs were never key-filtered). The masking package already has recursive redaction: `masking.RedactContext` and `masking.RedactBreadcrumbs` (masking.go:95/159, both walking `redactValue` at masking.go:126). Run the stored `context` and `breadcrumbs` bytes through those on the way out, THEN apply `filterSensitiveHeaders` to `request.headers` (key-drop is stronger than value-redaction for headers). Verify what `redactValue` actually catches before relying on it — extend it only if a gap shows up in the tests.
+
+**Malformed sub-objects are dropped, not passed through.** If `context.request` or `context.request.headers` fails to unmarshal into a JSON object, REMOVE that node (replace `headers` with `{}` / omit `request`), and never 500. Pass-through would defeat the filter: ingestion accepts arbitrary JSON, so `headers: [["Authorization","secret"]]` is storable, bypasses a map-shaped filter, and would be served verbatim to the browser.
+
+`sampleEventJSON`:
+
+```go
+type sampleEventJSON struct {
+	Timestamp   string          `json:"timestamp"`
+	Platform    string          `json:"platform"`
+	Error       sampleErrorJSON `json:"error"`
+	Breadcrumbs json.RawMessage `json:"breadcrumbs"`
+	Context     json.RawMessage `json:"context"`
+}
+type sampleErrorJSON struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	Stack   string `json:"stack"`
+}
+```
+
+Handler `GetSampleEvent` (mirror `ListAffectedUsers`'s shape: chi URL params, `verifyProjectAccess`, then):
+- `deps.Queries.GetSampleEvent(ctx, projectID, incidentID)`; `pgx.ErrNoRows` → 404 `"no sample event"`.
+- Redact `Breadcrumbs`/`Context` bytes via `masking.RedactBreadcrumbs`/`masking.RedactContext`; then unmarshal `Context` into `map[string]json.RawMessage`; if it has `request`, unmarshal that into `map[string]json.RawMessage`, filter its `headers` object through `filterSensitiveHeaders` (drop the node if it isn't an object — see above), re-marshal.
+- Normalize `Breadcrumbs`: if the stored bytes aren't a JSON array, serve `[]` — the `SampleEvent` contract promises an array and the UI iterates it.
+- Set `Cache-Control: no-store` on the response.
+- Marshal `sampleEventJSON` with breadcrumbs/context as `json.RawMessage`.
+
+Route in `routes.go` — **session-only auth, deliberately stricter than the other incident reads**:
+
+```go
+r.With(deps.AuthenticateUserSession).Get("/projects/{projectID}/incidents/{incidentID}/sample-event", deps.GetSampleEvent)
+```
+
+Why: browser SDK keys are necessarily client-visible (`packages/sdk/src/transport.ts`), and this endpoint returns request headers, client IPs, and user identity. A leaked/extracted SDK key must not become a PII read path. `AuthenticateUserSession` (see `routes.go:89-108` for usage) restricts it to logged-in dashboard users; `verifyProjectAccess` still applies for org scoping. If a rate limiter wraps the adjacent incident routes, carry it too.
+
+**Additional integration test case:** the same request authenticated with the SDK API key (the `X-API-Key` header pattern from `postErrorPayload`) must get **401**, not data.
+
+**Step 4: Run** — `go test ./handler -count=1` (with `DATABASE_URL`). All pass.
+
+**Step 5: Commit** — `feat(ingestion): tenant-scoped sample-event endpoint with server-side header deny-list`
+
+---
+
+### Task 8: Dashboard API client
+
+**Files:**
+- Modify: `packages/dashboard/src/api.ts` — `listIncidents` (line ~526), new `getSampleEvent`
+- Test: new colocated api test (fetch-mock pattern — see below)
+
+**Step 1: Implement:**
+
+In `listIncidents`, after the `status` param: `if (filters?.platform) params.set('platform', filters.platform);`
+
+New function, following `fetchJSON` conventions in the same file:
+
+```ts
+export function getSampleEvent(
+  projectId: string,
+  incidentId: string
+): Promise<SampleEvent> {
+  return fetchJSON<SampleEvent>(
+    `/projects/${projectId}/incidents/${incidentId}/sample-event`
+  );
+}
+```
+
+Import `SampleEvent` from the types module the file already uses.
+
+**Step 2: Test.** The dashboard DOES have HTTP-client tests that mock `fetch` — `packages/dashboard/src/api-project-settings.test.ts` and `api-notifications.test.ts`. Copy that pattern into a colocated test asserting: `listIncidents` with `{platform: 'python'}` requests a URL containing `platform=python` (and omits it when unset), and `getSampleEvent('p1','i1')` requests `/projects/p1/incidents/i1/sample-event`. Type-checking alone can't catch a wrong path or dropped query param.
+
+**Step 3: Verify** — `pnpm --filter @opslane/dashboard test && pnpm --filter @opslane/dashboard build`.
+
+**Step 4: Commit** — `feat(dashboard): sample-event fetch and platform filter param`
+
+---
+
+### Task 9: Platform filter UI + badge
+
+**Files:**
+- Modify: `packages/dashboard/src/components/FilterBar.vue` (emits `filter-change` with `IncidentFilters` — line 12/31)
+- Modify: `packages/dashboard/src/views/ActivityFeed.vue` (table row, near the Kind badge at line 153–231)
+- Create: `packages/dashboard/src/components/platform-badge.ts` + colocated test `packages/dashboard/src/components/platform-badge.test.ts` (mirror `incident-kind.ts` and its test at `components/incident-kind.test.ts` — colocated next to the module, NOT under `__tests__/` — read both first and copy their shape)
+
+**Step 1: Write the failing badge-helper test** (pattern-match `incident-kind.test.ts`):
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { platformBadge } from './platform-badge';
+
+describe('platformBadge', () => {
+  it('labels javascript and python', () => {
+    expect(platformBadge('javascript')?.label).toBe('JavaScript');
+    expect(platformBadge('python')?.label).toBe('Python');
+  });
+  it('returns null for absent platform (friction incidents)', () => {
+    expect(platformBadge(null)).toBeNull();
+    expect(platformBadge(undefined)).toBeNull();
+  });
+  it('renders unknown future tokens verbatim rather than hiding them', () => {
+    expect(platformBadge('ruby')?.label).toBe('ruby');
+  });
+});
+```
+
+**Step 2: Run to verify it fails** — `pnpm --filter @opslane/dashboard test` → module not found.
+
+**Step 3: Implement** `platform-badge.ts` (styling: copy the class conventions from `incident-kind.ts` so badges match visually):
+
+```ts
+export interface PlatformBadge {
+  label: string;
+  class: string; // named `class`, matching incident-kind.ts:5 — do not invent `classes`
+}
+
+const KNOWN: Record<string, string> = {
+  javascript: 'JavaScript',
+  python: 'Python',
+};
+
+export function platformBadge(
+  platform: string | null | undefined
+): PlatformBadge | null {
+  if (!platform) return null;
+  return {
+    label: KNOWN[platform] ?? platform,
+    class: '<copy badge class values from incident-kind.ts>',
+  };
+}
+```
+
+**Step 4: FilterBar** — add a platform `<select>` next to the existing status filter (read the current template first and match its markup): options All (empty) / JavaScript / Python. The existing filters have THREE synchronization touchpoints (see `selectedStatus` for the pattern, FilterBar.vue:15-45) and platform needs all three or a reload silently drops it:
+
+1. **Init from the URL — validated, not cast:** a raw cast lets `?platform=ruby` (or any garbage) through the `'javascript' | 'python'` type and would send an invalid token the server now 400s. Accept only known values:
+   ```ts
+   const rawPlatform = route.query['platform'];
+   const selectedPlatform = ref(
+     rawPlatform === 'javascript' || rawPlatform === 'python' ? rawPlatform : ''
+   );
+   ```
+2. **Emit:** in `emitFilters()`, `if (selectedPlatform.value) filters.platform = selectedPlatform.value;` (already narrowed by step 1 — no cast needed).
+3. **URL sync:** in `onFilterChange()`, set `query['platform']` when non-empty, `delete query['platform']` when empty — exactly mirroring the `status` branch.
+
+Note: FilterBar syncs the URL with `router.replace` (FilterBar.vue:37/54), so filter changes create no history entries and browser-Back restore is NOT how the existing filters behave. Match that existing behavior — do not switch to `push` for this batch. The manual check is reload-only: apply the Python filter, reload the page → filter still applied.
+
+**End-user filter passthrough (required for Task 11's acceptance criterion):** the server supports `?end_user_id=` but the dashboard currently DROPS it — FilterBar neither reads nor emits it (FilterBar.vue:18), so on mount it emits filters without `end_user_id` and any user-scoped URL loses its scope. Fix in the same three-touchpoint pattern, minus UI: read `route.query['end_user_id']` (string, no validation set — it's an opaque ID), carry it through `emitFilters()` and the URL sync, but render no visible control for it. This makes `/…?end_user_id=X` a working cross-stack user timeline.
+
+**ActivityFeed** — render the platform badge in the Kind column cell next to the kind badge, `v-if` on `platformBadge(incident.platform)`.
+
+**Step 5: Run** — `pnpm --filter @opslane/dashboard test && pnpm --filter @opslane/dashboard build`.
+
+**Step 6: Commit** — `feat(dashboard): platform filter and badge on the activity feed`
+
+---
+
+### Task 10: IncidentDetail — traceback, breadcrumbs, request context
+
+**Files:**
+- Modify: `packages/dashboard/src/views/IncidentDetail.vue` (Overview tab; lines ~383–396 are the root-cause markup — the metadata/dl region starts around line 529)
+- Reuse: `packages/dashboard/src/components/CodeBlock.vue` (pre/code + copy button)
+
+**Step 1: Implement** (component test after — the fetch logic is the testable seam):
+
+In `<script setup>`: after `getIncident()` resolves and `incident.kind === 'error'`, call `getSampleEvent(projectId, incidentId)`; store in `sampleEvent = ref<SampleEvent | null>(null)`. Error isolation matters: **only the `getIncident` fetch is page-fatal.** A sample-event 404 → `sampleEvent = null`, section simply absent (friction groups and groups whose sample event was pruned have none). A sample-event 500/network error → set a LOCAL `sampleEventError` ref and render a small inline "couldn't load stack trace" note in that section — never blank or error out the otherwise-usable incident page.
+
+In the Overview tab template, above the AI root-cause block:
+
+```html
+<!-- Wrapper renders when EITHER the data or the error exists — a section
+     gated only on sampleEvent has nowhere to show the fetch-error note,
+     because on a 500 sampleEvent is null. -->
+<section v-if="sampleEvent || sampleEventError" class="...">
+  <p v-if="sampleEventError">Couldn't load stack trace.</p>
+  <template v-if="sampleEvent">
+  <h3>Stack trace</h3>
+  <CodeBlock :code="sampleEvent.error.stack" />
+  <div v-if="requestContext" class="...">
+    <h3>Request</h3>
+    <dl>
+      <div><dt>Method</dt><dd>{{ requestContext.method }}</dd></div>
+      <div><dt>Path</dt><dd>{{ requestContext.path }}</dd></div>
+      <div v-if="requestContext.remote_addr"><dt>Client IP</dt><dd>{{ requestContext.remote_addr }}</dd></div>
+    </dl>
+    <details v-if="requestContext.headers">
+      <summary>Headers</summary>
+      <dl><!-- k/v rows from requestContext.headers --></dl>
+    </details>
+  </div>
+  <div v-if="sampleEvent.breadcrumbs.length">
+    <h3>Breadcrumbs</h3>
+    <ol><!-- per crumb: timestamp, type/category chip, level, message —
+         each crumb is `unknown`: narrow per-field before rendering --></ol>
+  </div>
+  </template>
+</section>
+```
+
+with `requestContext` a computed narrowing `sampleEvent.context.request` (use `unknown` + narrowing, never `any` — repo rule). Python tracebacks are already human-readable text; `CodeBlock` renders both platforms — no syntax highlighting, no platform branch in the template (the design explicitly says `<pre>`-class rendering is enough).
+
+Match the surrounding markup/classes of the existing Overview sections — read the neighboring sections and copy their container classes rather than inventing new styling.
+
+**Step 2: Component test** — `packages/dashboard/src/views/__tests__` ALREADY EXISTS; read a test there for the route/API mocking pattern and add a mount test for IncidentDetail covering: sample-event section renders on success; 404 → section absent, page fine; 500 → inline error note, page fine; friction incident → no fetch or no section. A helper-only test is NOT an acceptable substitute — the fetch wiring, 404-vs-500 branching, and page-fatal isolation are exactly the seams that need coverage. Additionally extract the `requestContext` narrowing + breadcrumb formatting into a small `sample-event.ts` helper and unit-test that too if it keeps the mount test simpler.
+
+**Step 3: Run** — `pnpm --filter @opslane/dashboard test && pnpm --filter @opslane/dashboard build`.
+
+**Step 4: Commit** — `feat(dashboard): render sample-event traceback, request context, and breadcrumbs`
+
+---
+
+### Task 11: Cross-stack user timeline — verification test
+
+**Files:**
+- Test: `packages/ingestion/handler/error_event_test.go` (append)
+
+This is **verification, not construction** (design §8.5). The "user timeline" surface is **ActivityFeed filtered by `end_user_id`** — which did NOT work until Task 9's end-user passthrough fix (the server supported `?end_user_id=` but FilterBar dropped it on mount). With that fix plus the badge, the user-scoped URL lists one user's incidents across both platforms. No new dashboard surface is in scope; issue #88's criterion is met by that filtered feed, and this task proves the data layer plus the HTTP path behind it (the smoke in Task 12 proves the dashboard leg).
+
+**Step 1: Write the test.** POST two events through `postErrorPayload`: one JS-shaped (no `platform`, JS stack), one Python-shaped, both with `context.user.id = "cross-stack-user"`. Then assert at BOTH layers:
+- `ListErrorGroups(ctx, projectID, &db.ErrorGroupFilters{EndUserID: "cross-stack-user"})` returns both groups — one platform `javascript`, one `python`.
+- `GET /api/v1/projects/{projectID}/incidents?end_user_id=cross-stack-user` through the router returns both, each carrying its `platform` in the JSON (this is the exact request the dashboard's user-filtered feed makes).
+
+**Step 2: Run** — with `DATABASE_URL`. If this fails, the bug is in end-user upsert reuse; investigate before patching (it may be a test-setup issue — both events must share the seeded tenant).
+
+**Step 3: Commit** — `test(ingestion): one end user spans JS and Python error groups`
+
+---
+
+### Task 12: Full gate + live smoke
+
+**Step 1: Repo gate**
+
+```bash
+pnpm install --frozen-lockfile && pnpm -r build && pnpm test
+(cd packages/ingestion && go build ./... && go vet ./... && DATABASE_URL=... go test ./... -count=1)
+docker compose config --quiet
+```
+
+All green, with the disposable-DB `DATABASE_URL` from the ground rules.
+
+**Step 2: Live smoke (seeded mixed-platform data).** Boot an ISOLATED compose stack (do not clobber 5434/8082 — check `docker ps`; the Batch 1 review used a rendered-config override at ports 5461/9061/8093, same trick works: `docker compose config | sed` the published ports, `-p b2-smoke`). Then:
+1. Apply migrations + `scripts/seed-e2e.sql`.
+2. POST one JS event and two Python events (same Python fingerprint) with `context.user.id` shared across one JS + one Python event — reuse the wire fixtures as bodies.
+3. **Mint a dashboard session first** — the sample-event route and the dashboard are session-auth'd, and the default compose stack gives you NO way to log in: `AUTH_PROVIDER` defaults to the GitHub provider with empty OAuth credentials, and that provider doesn't implement `PasswordAuthenticator` (`github_provider.go:13`), so `seed-e2e.sql`'s password users are unusable. Mint the session directly the way `test-e2e/helpers.ts:304` (`generateTestJWT`) does: insert a user row for the seeded org, sign an HS256 JWT (`sub`, `org_id`, `email`, `iat`, `exp`) with the stack's `JWT_SECRET`, and present it the way `AuthenticateUserSession` expects (cookie or bearer — copy what the e2e helpers do). Then:
+   - `GET /api/v1/projects/{id}/incidents` (SDK key is fine for the list routes) → both groups carry `platform`; `?platform=python` returns only the Python group.
+   - `GET .../incidents/{pythonGroupID}/sample-event` **with the session JWT — an SDK key must get 401 here, per Task 7's auth contract** → traceback + breadcrumbs, headers filtered, `Cache-Control: no-store`.
+   - Dashboard at the mapped port (browser carrying the session cookie): platform badges visible, filter works and survives a page reload (URL sync), Python incident detail shows the traceback, and the activity feed filtered to the shared user (`?end_user_id=...`) shows both the JS and Python incidents with their badges.
+4. Tear down (`docker compose -p b2-smoke down -v`).
+
+**Step 3: Update docs** — `docs/contracts/` untouched (ingest contract unchanged). If `docs/architecture/*` or dashboard docs describe the incident detail view, note the new sample-event section (check `docs/` with grep for "incident detail").
+
+**Step 4: Commit anything outstanding; run `/review changes` before `/ship`.**
+
+---
+
+## Acceptance criteria (from issue #88 — every box must have evidence)
+
+- [ ] Sample-event endpoint returns the traceback, tenant-scoped, header deny-list applied server-side (Tasks 6–7 tests)
+- [ ] Filter + badge work against seeded mixed-platform data; friction incidents appear only under "All" (Tasks 4–5, 9; smoke)
+- [ ] Python traceback renders legibly; JS incidents unchanged-or-improved via the same endpoint (Task 10; smoke)
+- [ ] A user with one JS and one Python error shows both in their timeline (Task 11; smoke)
+- [ ] No `any` types; `pnpm --filter @opslane/dashboard build` passes (every dashboard task)
+
+## Explicitly out of scope
+
+- Worker/agent changes (Batch 3, #89). Real-PyPI release. Runtime display beyond what `context.runtime` already carries. Backlog issues #102–#105 unless one blocks a task.

--- a/docs/reference/http-routes.md
+++ b/docs/reference/http-routes.md
@@ -78,6 +78,7 @@ The agent callback requires `code`, `installation_id`, and UUID `state`; definit
 | GET | `/api/v1/projects/{projectID}/sessions/{sessionID}` | Session detail and scrubbed chunk manifest |
 | GET | `/api/v1/projects/{projectID}/sessions/{sessionID}/chunks/{seq}` | Fetch one decoded, re-redacted scrubbed chunk |
 | GET | `/api/v1/projects/{projectID}/incidents/{incidentID}/affected-users` | Affected users |
+| GET | `/api/v1/projects/{projectID}/incidents/{incidentID}/sample-event` | Fetch the redacted representative error event for traceback, breadcrumbs, and request context |
 | POST | `/api/v1/projects/{projectID}/incidents/{incidentID}/fix` | Trigger an eligible error or approved friction fix |
 | POST | `/api/v1/projects/{projectID}/incidents/{incidentID}/resolve` | Resolve incident |
 | POST | `/api/v1/projects/{projectID}/incidents/{incidentID}/archive` | Archive incident |

--- a/packages/dashboard/src/api-incidents.test.ts
+++ b/packages/dashboard/src/api-incidents.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getSampleEvent, listIncidents } from './api';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function response(body: unknown): object {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  };
+}
+
+describe('incident API', () => {
+  it('includes the platform filter when set', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await listIncidents('p1', { platform: 'python' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/projects/p1/incidents?platform=python',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+
+  it('omits the platform filter when unset', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await listIncidents('p1');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/projects/p1/incidents',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+
+  it('fetches an incident sample event', async () => {
+    const event = {
+      timestamp: '2026-07-19T00:00:00Z',
+      platform: 'python',
+      error: { type: 'ValueError', message: 'boom', stack: 'Traceback' },
+      breadcrumbs: [],
+      context: {},
+    };
+    const fetchMock = vi.fn().mockResolvedValue(response(event));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(getSampleEvent('p1', 'i1')).resolves.toEqual(event);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/projects/p1/incidents/i1/sample-event',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+});

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -1,5 +1,6 @@
 import type {
   Incident, AffectedUser, Account, IncidentFilters,
+  SampleEvent,
   GitHubConfig, GitHubAppStatus, GitHubRepo, SetupPrStatus,
   SessionDetail, SessionFilters, SessionListResponse,
   AdminOverview, AdminJobsResponse, HealthResponse,
@@ -531,6 +532,7 @@ export function listIncidents(
   if (filters?.account_id) params.set('account_id', filters.account_id);
   if (filters?.end_user_id) params.set('end_user_id', filters.end_user_id);
   if (filters?.status) params.set('status', filters.status);
+  if (filters?.platform) params.set('platform', filters.platform);
   const qs = params.toString();
   return fetchJSON<Incident[]>(
     `/projects/${projectId}/incidents${qs ? `?${qs}` : ''}`
@@ -543,6 +545,15 @@ export function getIncident(
 ): Promise<Incident> {
   return fetchJSON<Incident>(
     `/projects/${projectId}/incidents/${incidentId}`
+  );
+}
+
+export function getSampleEvent(
+  projectId: string,
+  incidentId: string
+): Promise<SampleEvent> {
+  return fetchJSON<SampleEvent>(
+    `/projects/${projectId}/incidents/${incidentId}/sample-event`
   );
 }
 

--- a/packages/dashboard/src/components/FilterBar.vue
+++ b/packages/dashboard/src/components/FilterBar.vue
@@ -17,6 +17,12 @@ const router = useRouter();
 const accounts = ref<Account[]>([]);
 const selectedAccountId = ref((route.query['account_id'] as string) || '');
 const selectedStatus = ref((route.query['status'] as string) || '');
+const rawPlatform = route.query['platform'];
+const selectedPlatform = ref<'' | 'javascript' | 'python'>(
+  rawPlatform === 'javascript' || rawPlatform === 'python' ? rawPlatform : '',
+);
+const rawEndUserId = route.query['end_user_id'];
+const selectedEndUserId = ref(typeof rawEndUserId === 'string' ? rawEndUserId : '');
 
 onMounted(async () => {
   try {
@@ -30,7 +36,9 @@ onMounted(async () => {
 function emitFilters() {
   const filters: IncidentFilters = {};
   if (selectedAccountId.value) filters.account_id = selectedAccountId.value;
+  if (selectedEndUserId.value) filters.end_user_id = selectedEndUserId.value;
   if (selectedStatus.value) filters.status = selectedStatus.value;
+  if (selectedPlatform.value) filters.platform = selectedPlatform.value;
   emit('filter-change', filters);
 }
 
@@ -47,11 +55,21 @@ function onFilterChange() {
   } else {
     delete query['status'];
   }
+  if (selectedPlatform.value) {
+    query['platform'] = selectedPlatform.value;
+  } else {
+    delete query['platform'];
+  }
+  if (selectedEndUserId.value) {
+    query['end_user_id'] = selectedEndUserId.value;
+  } else {
+    delete query['end_user_id'];
+  }
   router.replace({ query });
   emitFilters();
 }
 
-watch([selectedAccountId, selectedStatus], onFilterChange);
+watch([selectedAccountId, selectedStatus, selectedPlatform], onFilterChange);
 </script>
 
 <template>
@@ -88,6 +106,18 @@ watch([selectedAccountId, selectedStatus], onFilterChange);
         <option value="needs_human">Needs Human</option>
         <option value="resolved">Resolved</option>
         <option value="archived">Archived</option>
+      </select>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <label class="text-sm text-text-muted whitespace-nowrap">Platform:</label>
+      <select
+        v-model="selectedPlatform"
+        class="text-sm rounded-md px-2 py-1.5"
+      >
+        <option value="">All platforms</option>
+        <option value="javascript">JavaScript</option>
+        <option value="python">Python</option>
       </select>
     </div>
   </div>

--- a/packages/dashboard/src/components/FilterBar.vue
+++ b/packages/dashboard/src/components/FilterBar.vue
@@ -24,14 +24,20 @@ const selectedPlatform = ref<'' | 'javascript' | 'python'>(
 const rawEndUserId = route.query['end_user_id'];
 const selectedEndUserId = ref(typeof rawEndUserId === 'string' ? rawEndUserId : '');
 
-onMounted(async () => {
+onMounted(() => {
+  // Apply URL-derived filters immediately. Account options are auxiliary and
+  // must not delay (or race) the activity feed's initial scoped request.
+  emitFilters();
+  void loadAccounts();
+});
+
+async function loadAccounts() {
   try {
     accounts.value = await listAccounts(props.projectId);
   } catch {
     // Non-fatal: filter bar still works without account list
   }
-  emitFilters();
-});
+}
 
 function emitFilters() {
   const filters: IncidentFilters = {};

--- a/packages/dashboard/src/components/platform-badge.test.ts
+++ b/packages/dashboard/src/components/platform-badge.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { platformBadge } from './platform-badge';
+
+describe('platformBadge', () => {
+  it('labels javascript and python', () => {
+    expect(platformBadge('javascript')?.label).toBe('JavaScript');
+    expect(platformBadge('python')?.label).toBe('Python');
+  });
+
+  it('returns null for absent platform (friction incidents)', () => {
+    expect(platformBadge(null)).toBeNull();
+    expect(platformBadge(undefined)).toBeNull();
+  });
+
+  it('renders unknown future tokens verbatim rather than hiding them', () => {
+    expect(platformBadge('ruby')?.label).toBe('ruby');
+  });
+});

--- a/packages/dashboard/src/components/platform-badge.ts
+++ b/packages/dashboard/src/components/platform-badge.ts
@@ -1,0 +1,19 @@
+export interface PlatformBadge {
+  label: string;
+  class: string;
+}
+
+const KNOWN: Record<string, string> = {
+  javascript: 'JavaScript',
+  python: 'Python',
+};
+
+export function platformBadge(
+  platform: string | null | undefined,
+): PlatformBadge | null {
+  if (!platform) return null;
+  return {
+    label: KNOWN[platform] ?? platform,
+    class: 'bg-surface-2 text-text',
+  };
+}

--- a/packages/dashboard/src/components/platform-badge.ts
+++ b/packages/dashboard/src/components/platform-badge.ts
@@ -12,8 +12,10 @@ export function platformBadge(
   platform: string | null | undefined,
 ): PlatformBadge | null {
   if (!platform) return null;
+  // Outlined, not filled: the Error kind badge is bg-surface-2, so an
+  // identical fill would make the two adjacent pills read as one.
   return {
     label: KNOWN[platform] ?? platform,
-    class: 'bg-surface-2 text-text',
+    class: 'border border-border text-text',
   };
 }

--- a/packages/dashboard/src/components/sample-event.test.ts
+++ b/packages/dashboard/src/components/sample-event.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatBreadcrumb, getRequestContext } from './sample-event';
+
+describe('getRequestContext', () => {
+  it('narrows request fields and string header values', () => {
+    expect(getRequestContext({
+      request: {
+        method: 'GET',
+        path: '/users/42',
+        remote_addr: '203.0.113.8',
+        headers: {
+          Accept: 'application/json',
+          ignored: 42,
+        },
+      },
+    })).toEqual({
+      method: 'GET',
+      path: '/users/42',
+      remote_addr: '203.0.113.8',
+      headers: [{ name: 'Accept', value: 'application/json' }],
+    });
+  });
+
+  it('rejects non-object request context', () => {
+    expect(getRequestContext({ request: 'GET /users/42' })).toBeNull();
+    expect(getRequestContext({ request: null })).toBeNull();
+  });
+});
+
+describe('formatBreadcrumb', () => {
+  it('formats only narrowed string fields', () => {
+    expect(formatBreadcrumb({
+      timestamp: '2026-07-19T00:00:00Z',
+      type: 'log',
+      category: 'app',
+      level: 'warning',
+      message: 'Near expiry',
+      ignored: { nested: true },
+    })).toEqual({
+      timestamp: '2026-07-19T00:00:00Z',
+      label: 'log · app',
+      level: 'warning',
+      message: 'Near expiry',
+    });
+  });
+
+  it('drops scalars and objects without displayable strings', () => {
+    expect(formatBreadcrumb('not an object')).toBeNull();
+    expect(formatBreadcrumb({ message: 42 })).toBeNull();
+  });
+});

--- a/packages/dashboard/src/components/sample-event.ts
+++ b/packages/dashboard/src/components/sample-event.ts
@@ -1,0 +1,70 @@
+export interface RequestHeader {
+  name: string;
+  value: string;
+}
+
+export interface RequestContext {
+  method?: string;
+  path?: string;
+  remote_addr?: string;
+  headers?: RequestHeader[];
+}
+
+export interface BreadcrumbDisplay {
+  timestamp?: string;
+  label?: string;
+  level?: string;
+  message?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringField(
+  value: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const field = value[key];
+  return typeof field === 'string' ? field : undefined;
+}
+
+export function getRequestContext(
+  context: Record<string, unknown>,
+): RequestContext | null {
+  const request = context['request'];
+  if (!isRecord(request)) return null;
+
+  const rawHeaders = request['headers'];
+  const headers = isRecord(rawHeaders)
+    ? Object.entries(rawHeaders).flatMap(([name, value]) => (
+      typeof value === 'string' ? [{ name, value }] : []
+    ))
+    : [];
+
+  return {
+    method: stringField(request, 'method'),
+    path: stringField(request, 'path'),
+    remote_addr: stringField(request, 'remote_addr'),
+    headers: headers.length > 0 ? headers : undefined,
+  };
+}
+
+export function formatBreadcrumb(value: unknown): BreadcrumbDisplay | null {
+  if (!isRecord(value)) return null;
+
+  const type = stringField(value, 'type');
+  const category = stringField(value, 'category');
+  const timestamp = stringField(value, 'timestamp');
+  const level = stringField(value, 'level');
+  const message = stringField(value, 'message');
+
+  if (!type && !category && !timestamp && !level && !message) return null;
+
+  return {
+    timestamp,
+    label: [type, category].filter((part): part is string => Boolean(part)).join(' · ') || undefined,
+    level,
+    message,
+  };
+}

--- a/packages/dashboard/src/types/api.ts
+++ b/packages/dashboard/src/types/api.ts
@@ -129,6 +129,7 @@ export interface Incident {
   id: string;
   project_id: string;
   kind: 'error' | 'friction';
+  platform?: string | null;
   /** Present only on kind='friction': friction identity is environment-scoped. */
   environment_id?: string;
   /** Present only on kind='friction'; 'unchecked' flags an exhausted,
@@ -157,6 +158,18 @@ export interface Incident {
     session_id: string;
     error_at: string;
   };
+}
+
+export interface SampleEvent {
+  timestamp: string;
+  platform: string;
+  error: {
+    type: string;
+    message: string;
+    stack: string;
+  };
+  breadcrumbs: unknown[];
+  context: Record<string, unknown>;
 }
 
 // === Session replay browsing ===
@@ -239,6 +252,7 @@ export interface IncidentFilters {
   account_id?: string;
   end_user_id?: string;
   status?: string;
+  platform?: 'javascript' | 'python';
 }
 
 // === GitHub integration ===

--- a/packages/dashboard/src/views/ActivityFeed.vue
+++ b/packages/dashboard/src/views/ActivityFeed.vue
@@ -48,18 +48,27 @@ const { sorted: sortedIncidents, toggleSort, sortIndicator } = useTableSort<Sort
 
 const newIncidentCount = ref(0);
 let pollTimer: ReturnType<typeof setInterval> | null = null;
+let fetchGeneration = 0;
 
 async function fetchIncidents(filters?: IncidentFilters) {
+  const generation = ++fetchGeneration;
   loading.value = true;
   error.value = null;
   newIncidentCount.value = 0;
   try {
-    incidents.value = await listIncidents(projectId.value, filters);
+    const result = await listIncidents(projectId.value, filters);
+    if (generation === fetchGeneration) {
+      incidents.value = result;
+    }
   } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    error.value = `Failed to load incidents: ${msg}`;
+    if (generation === fetchGeneration) {
+      const msg = e instanceof Error ? e.message : String(e);
+      error.value = `Failed to load incidents: ${msg}`;
+    }
   } finally {
-    loading.value = false;
+    if (generation === fetchGeneration) {
+      loading.value = false;
+    }
   }
 }
 
@@ -103,7 +112,6 @@ onMounted(async () => {
     return;
   }
 
-  await fetchIncidents();
   startPolling();
 });
 

--- a/packages/dashboard/src/views/ActivityFeed.vue
+++ b/packages/dashboard/src/views/ActivityFeed.vue
@@ -4,6 +4,7 @@ import type { Incident, IncidentFilters, ErrorGroupStatus } from '../types/api';
 import { listIncidents } from '../api';
 import { getProjectId, statusBadgeClass, statusLabel, formatDate } from '../utils';
 import { kindBadge } from '../components/incident-kind';
+import { platformBadge } from '../components/platform-badge';
 import { useTableSort } from '../composables/useTableSort';
 import FilterBar from '../components/FilterBar.vue';
 
@@ -201,12 +202,21 @@ onUnmounted(() => stopPolling());
               </router-link>
             </td>
             <td class="py-2.5 px-4">
-              <span
-                class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium whitespace-nowrap"
-                :class="kindBadge(incident.kind, incident.adjudication_status).class"
-                v-text="kindBadge(incident.kind, incident.adjudication_status).label"
-              >
-              </span>
+              <div class="flex flex-wrap items-center gap-1.5">
+                <span
+                  class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium whitespace-nowrap"
+                  :class="kindBadge(incident.kind, incident.adjudication_status).class"
+                  v-text="kindBadge(incident.kind, incident.adjudication_status).label"
+                >
+                </span>
+                <span
+                  v-if="platformBadge(incident.platform)"
+                  class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium whitespace-nowrap"
+                  :class="platformBadge(incident.platform)?.class"
+                  v-text="platformBadge(incident.platform)?.label"
+                >
+                </span>
+              </div>
             </td>
             <td class="py-2.5 px-4">
               <span

--- a/packages/dashboard/src/views/IncidentDetail.vue
+++ b/packages/dashboard/src/views/IncidentDetail.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted, watch } from 'vue';
 import { useRoute } from 'vue-router';
-import type { Incident, AffectedUser } from '../types/api';
-import { getIncident, getReplay, listAffectedUsers, triggerFix, resolveIncident, archiveIncident, unarchiveIncident, type ReplayRecording } from '../api';
+import type { Incident, AffectedUser, SampleEvent } from '../types/api';
+import { APIError, getIncident, getSampleEvent, getReplay, listAffectedUsers, triggerFix, resolveIncident, archiveIncident, unarchiveIncident, type ReplayRecording } from '../api';
 import { getProjectId, statusBadgeClass, statusLabel, safeUrl, formatDate, formatAbsolute } from '../utils';
 import { kindBadge, fixControlsVisible } from '../components/incident-kind';
 import EvidenceCard from '../components/EvidenceCard.vue';
 import PipelineIndicator from '../components/PipelineIndicator.vue';
 import ReplayPlayer from '../components/ReplayPlayer.vue';
+import CodeBlock from '../components/CodeBlock.vue';
+import { formatBreadcrumb, getRequestContext } from '../components/sample-event';
 import type { eventWithTime } from '@rrweb/types';
 import { useSessionPlayback } from '../composables/useSessionPlayback';
 
@@ -20,6 +22,28 @@ const projectId = ref('');
 const replay = ref<ReplayRecording | null>(null);
 const replayLoading = ref(false);
 const replayError = ref<string | null>(null);
+const sampleEvent = ref<SampleEvent | null>(null);
+const sampleEventError = ref<string | null>(null);
+const requestContext = computed(() => (
+  sampleEvent.value ? getRequestContext(sampleEvent.value.context) : null
+));
+const breadcrumbs = computed(() => (
+  sampleEvent.value?.breadcrumbs.flatMap((breadcrumb) => {
+    const formatted = formatBreadcrumb(breadcrumb);
+    return formatted ? [formatted] : [];
+  }) ?? []
+));
+
+async function loadSampleEvent() {
+  sampleEvent.value = null;
+  sampleEventError.value = null;
+  try {
+    sampleEvent.value = await getSampleEvent(projectId.value, incidentId);
+  } catch (e: unknown) {
+    if (e instanceof APIError && e.status === 404) return;
+    sampleEventError.value = e instanceof Error ? e.message : String(e);
+  }
+}
 
 const pointerSessionId = computed(() => incident.value?.session_pointer?.session_id ?? '');
 const pointerErrorAt = computed(() => incident.value?.session_pointer?.error_at);
@@ -177,6 +201,9 @@ onMounted(async () => {
 
   try {
     incident.value = await getIncident(projectId.value, incidentId);
+    if (incident.value.kind === 'error') {
+      void loadSampleEvent();
+    }
     void loadReplay();
     if (incident.value.status === 'fixing') {
       startFixPolling();
@@ -370,6 +397,76 @@ onMounted(async () => {
           >
           </a>
         </div>
+
+        <!-- Representative error payload -->
+        <section
+          v-if="sampleEvent || sampleEventError"
+          data-testid="sample-event"
+          class="p-4 bg-surface border border-border rounded-lg space-y-4"
+        >
+          <p v-if="sampleEventError" class="text-sm text-amber">
+            Couldn't load stack trace.
+          </p>
+          <template v-if="sampleEvent">
+            <div>
+              <h3 class="text-xs font-medium text-text-muted uppercase tracking-wide">Stack trace</h3>
+              <CodeBlock class="mt-2" :code="sampleEvent.error.stack" />
+            </div>
+
+            <div v-if="requestContext" class="space-y-2">
+              <h3 class="text-xs font-medium text-text-muted uppercase tracking-wide">Request</h3>
+              <dl class="grid grid-cols-1 gap-2 text-sm sm:grid-cols-3">
+                <div>
+                  <dt class="text-text-muted">Method</dt>
+                  <dd class="text-text" v-text="requestContext.method || '—'"></dd>
+                </div>
+                <div>
+                  <dt class="text-text-muted">Path</dt>
+                  <dd class="text-text font-mono text-xs" v-text="requestContext.path || '—'"></dd>
+                </div>
+                <div v-if="requestContext.remote_addr">
+                  <dt class="text-text-muted">Client IP</dt>
+                  <dd class="text-text font-mono text-xs" v-text="requestContext.remote_addr"></dd>
+                </div>
+              </dl>
+              <details v-if="requestContext.headers" class="text-sm">
+                <summary class="cursor-pointer text-text-muted">Headers</summary>
+                <dl class="mt-2 space-y-1 rounded bg-surface-2 p-3">
+                  <div
+                    v-for="header in requestContext.headers"
+                    :key="header.name"
+                    class="grid grid-cols-[minmax(0,1fr)_minmax(0,2fr)] gap-3"
+                  >
+                    <dt class="font-mono text-xs text-text-muted" v-text="header.name"></dt>
+                    <dd class="break-all font-mono text-xs text-text" v-text="header.value"></dd>
+                  </div>
+                </dl>
+              </details>
+            </div>
+
+            <div v-if="breadcrumbs.length" class="space-y-2">
+              <h3 class="text-xs font-medium text-text-muted uppercase tracking-wide">Breadcrumbs</h3>
+              <ol class="space-y-2">
+                <li
+                  v-for="(breadcrumb, index) in breadcrumbs"
+                  :key="`${breadcrumb.timestamp || 'breadcrumb'}-${index}`"
+                  class="rounded border border-border p-3 text-sm"
+                >
+                  <div class="flex flex-wrap items-center gap-2 text-xs text-text-muted">
+                    <time v-if="breadcrumb.timestamp" v-text="breadcrumb.timestamp"></time>
+                    <span
+                      v-if="breadcrumb.label"
+                      class="rounded-full bg-surface-2 px-2 py-0.5 text-text"
+                      v-text="breadcrumb.label"
+                    ></span>
+                    <span v-if="breadcrumb.level" v-text="breadcrumb.level"></span>
+                  </div>
+                  <p v-if="breadcrumb.message" class="mt-1 text-text" v-text="breadcrumb.message"></p>
+                </li>
+              </ol>
+            </div>
+          </template>
+        </section>
 
         <!-- Investigation results, including context preserved on drafts and needs_human -->
         <div

--- a/packages/dashboard/src/views/IncidentDetail.vue
+++ b/packages/dashboard/src/views/IncidentDetail.vue
@@ -34,6 +34,12 @@ const breadcrumbs = computed(() => (
   }) ?? []
 ));
 
+// Breadcrumb timestamps are client-supplied and only narrowed to string:
+// format parseable ones like the rest of the view, show the raw value otherwise.
+function formatBreadcrumbTime(timestamp: string): string {
+  return Number.isNaN(Date.parse(timestamp)) ? timestamp : formatAbsolute(timestamp);
+}
+
 async function loadSampleEvent() {
   sampleEvent.value = null;
   sampleEventError.value = null;
@@ -453,7 +459,11 @@ onMounted(async () => {
                   class="rounded border border-border p-3 text-sm"
                 >
                   <div class="flex flex-wrap items-center gap-2 text-xs text-text-muted">
-                    <time v-if="breadcrumb.timestamp" v-text="breadcrumb.timestamp"></time>
+                    <time
+                      v-if="breadcrumb.timestamp"
+                      :datetime="breadcrumb.timestamp"
+                      v-text="formatBreadcrumbTime(breadcrumb.timestamp)"
+                    ></time>
                     <span
                       v-if="breadcrumb.label"
                       class="rounded-full bg-surface-2 px-2 py-0.5 text-text"

--- a/packages/dashboard/src/views/__tests__/activity-feed-filters.test.ts
+++ b/packages/dashboard/src/views/__tests__/activity-feed-filters.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Incident } from '../../types/api';
+
+const mocks = vi.hoisted(() => ({
+  listAccounts: vi.fn(),
+  listIncidents: vi.fn(),
+  replace: vi.fn(),
+  route: { query: {} as Record<string, string> },
+}));
+
+vi.mock('../../api', () => ({
+  listAccounts: mocks.listAccounts,
+  listIncidents: mocks.listIncidents,
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mocks.route,
+  useRouter: () => ({ replace: mocks.replace }),
+}));
+
+import ActivityFeed from '../ActivityFeed.vue';
+
+function incident(
+  id: string,
+  title: string,
+  platform: string | null,
+  kind: 'error' | 'friction' = 'error',
+): Incident {
+  return {
+    id,
+    project_id: 'p1',
+    kind,
+    platform,
+    fingerprint: `fingerprint-${id}`,
+    title,
+    status: kind === 'friction' ? 'insight' : 'new',
+    first_seen: '2026-07-19T00:00:00Z',
+    last_seen: '2026-07-19T00:00:00Z',
+    occurrence_count: 1,
+    affected_users_count: 1,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function mountFeed() {
+  return mount(ActivityFeed, {
+    global: {
+      stubs: {
+        RouterLink: { template: '<a><slot /></a>' },
+      },
+    },
+  });
+}
+
+describe('ActivityFeed URL filters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listAccounts.mockResolvedValue([]);
+    mocks.route.query = {};
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('uses URL-derived platform and end-user filters for the only initial request', async () => {
+    mocks.route.query = {
+      project_id: 'p1',
+      platform: 'python',
+      end_user_id: 'user-123',
+    };
+    window.history.replaceState(
+      {},
+      '',
+      '/?project_id=p1&platform=python&end_user_id=user-123',
+    );
+    mocks.listIncidents.mockResolvedValue([
+      incident('python', 'Python failure', 'python'),
+    ]);
+
+    const wrapper = mountFeed();
+    await flushPromises();
+
+    expect(mocks.listIncidents).toHaveBeenCalledTimes(1);
+    expect(mocks.listIncidents).toHaveBeenCalledWith('p1', {
+      platform: 'python',
+      end_user_id: 'user-123',
+    });
+    expect(wrapper.text()).toContain('Python failure');
+    expect(wrapper.text()).toContain('Python');
+
+    wrapper.unmount();
+  });
+
+  it('ignores a stale response after the platform filter changes', async () => {
+    mocks.route.query = {
+      project_id: 'p1',
+      platform: 'python',
+      end_user_id: 'user-123',
+    };
+    window.history.replaceState(
+      {},
+      '',
+      '/?project_id=p1&platform=python&end_user_id=user-123',
+    );
+    const firstRequest = deferred<Incident[]>();
+    mocks.listIncidents
+      .mockImplementationOnce(() => firstRequest.promise)
+      .mockResolvedValueOnce([incident('javascript', 'JavaScript failure', 'javascript')]);
+
+    const wrapper = mountFeed();
+    await flushPromises();
+    await wrapper.findAll('select')[2]!.setValue('javascript');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('JavaScript failure');
+    expect(mocks.replace).toHaveBeenCalledWith({
+      query: {
+        project_id: 'p1',
+        platform: 'javascript',
+        end_user_id: 'user-123',
+      },
+    });
+
+    firstRequest.resolve([incident('python', 'Stale Python failure', 'python')]);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('JavaScript failure');
+    expect(wrapper.text()).not.toContain('Stale Python failure');
+
+    wrapper.unmount();
+  });
+
+  it('shows friction only in the unfiltered feed and omits a platform badge for it', async () => {
+    mocks.route.query = { project_id: 'p1' };
+    window.history.replaceState({}, '', '/?project_id=p1');
+    mocks.listIncidents.mockResolvedValue([
+      incident('friction', 'Checkout friction', null, 'friction'),
+      incident('python', 'Python failure', 'python'),
+    ]);
+
+    const wrapper = mountFeed();
+    await flushPromises();
+
+    expect(mocks.listIncidents).toHaveBeenCalledWith('p1', {});
+    const rows = wrapper.findAll('tbody tr');
+    const frictionRow = rows.find((row) => row.text().includes('Checkout friction'));
+    const pythonRow = rows.find((row) => row.text().includes('Python failure'));
+    expect(frictionRow?.text()).toContain('Friction');
+    expect(frictionRow?.text()).not.toContain('Python');
+    expect(frictionRow?.text()).not.toContain('JavaScript');
+    expect(pythonRow?.text()).toContain('Python');
+
+    wrapper.unmount();
+  });
+});

--- a/packages/dashboard/src/views/__tests__/incident-detail-sample-event.test.ts
+++ b/packages/dashboard/src/views/__tests__/incident-detail-sample-event.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Incident, SampleEvent } from '../../types/api';
+
+const api = vi.hoisted(() => {
+  class APIError extends Error {
+    constructor(public readonly status: number, message = '') {
+      super(message);
+    }
+  }
+
+  return {
+    APIError,
+    archiveIncident: vi.fn(),
+    getIncident: vi.fn(),
+    getReplay: vi.fn(),
+    getSampleEvent: vi.fn(),
+    getSession: vi.fn(),
+    getSessionChunk: vi.fn(),
+    listAffectedUsers: vi.fn(),
+    resolveIncident: vi.fn(),
+    triggerFix: vi.fn(),
+    unarchiveIncident: vi.fn(),
+  };
+});
+
+vi.mock('../../api', () => api);
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { id: 'i1' } }),
+}));
+
+import IncidentDetail from '../IncidentDetail.vue';
+
+const incident: Incident = {
+  id: 'i1',
+  project_id: 'p1',
+  kind: 'error',
+  platform: 'python',
+  fingerprint: 'valueerror:app.py:8',
+  title: 'ValueError: boom',
+  status: 'new',
+  first_seen: '2026-07-19T00:00:00Z',
+  last_seen: '2026-07-19T00:00:00Z',
+  occurrence_count: 1,
+  affected_users_count: 1,
+};
+
+const sampleEvent: SampleEvent = {
+  timestamp: '2026-07-19T00:00:00Z',
+  platform: 'python',
+  error: {
+    type: 'ValueError',
+    message: 'boom',
+    stack: 'Traceback (most recent call last):\n  File "/app/api.py", line 8',
+  },
+  breadcrumbs: [{
+    timestamp: '2026-07-19T00:00:00Z',
+    type: 'log',
+    category: 'app',
+    level: 'warning',
+    message: 'Near expiry',
+  }],
+  context: {
+    request: {
+      method: 'GET',
+      path: '/users/42',
+      remote_addr: '203.0.113.8',
+      headers: { Accept: 'application/json' },
+    },
+  },
+};
+
+function mountView() {
+  return mount(IncidentDetail, {
+    global: {
+      stubs: {
+        EvidenceCard: true,
+        PipelineIndicator: true,
+        ReplayPlayer: true,
+        RouterLink: { template: '<a><slot /></a>' },
+      },
+    },
+  });
+}
+
+describe('IncidentDetail sample event', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '', '/incidents/i1?project_id=p1');
+    api.getIncident.mockResolvedValue(incident);
+    api.getSampleEvent.mockResolvedValue(sampleEvent);
+  });
+
+  it('renders the traceback, request context, and breadcrumbs', async () => {
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(api.getSampleEvent).toHaveBeenCalledWith('p1', 'i1');
+    const section = wrapper.get('[data-testid="sample-event"]');
+    expect(section.text()).toContain('Stack trace');
+    expect(section.text()).toContain('Traceback (most recent call last)');
+    expect(section.text()).toContain('Request');
+    expect(section.text()).toContain('GET');
+    expect(section.text()).toContain('/users/42');
+    expect(section.text()).toContain('203.0.113.8');
+    expect(section.text()).toContain('Accept');
+    expect(section.text()).toContain('application/json');
+    expect(section.text()).toContain('Breadcrumbs');
+    expect(section.text()).toContain('log · app');
+    expect(section.text()).toContain('Near expiry');
+
+    wrapper.unmount();
+  });
+
+  it('keeps the page usable and omits the section when the sample event is absent', async () => {
+    api.getSampleEvent.mockRejectedValue(new api.APIError(404, 'not found'));
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('ValueError: boom');
+    expect(wrapper.find('[data-testid="sample-event"]').exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it('keeps the page usable and renders a local note on sample-event failure', async () => {
+    api.getSampleEvent.mockRejectedValue(new api.APIError(500, 'server error'));
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('ValueError: boom');
+    expect(wrapper.get('[data-testid="sample-event"]').text()).toContain(
+      "Couldn't load stack trace.",
+    );
+    expect(wrapper.text()).not.toContain('Failed to load incident');
+
+    wrapper.unmount();
+  });
+
+  it('does not request a sample event for friction incidents', async () => {
+    api.getIncident.mockResolvedValue({ ...incident, kind: 'friction', platform: null });
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('ValueError: boom');
+    expect(api.getSampleEvent).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-testid="sample-event"]').exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+});

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -295,6 +295,7 @@ type ErrorGroup struct {
 	AffectedUsersCount   int
 	Status               string
 	Kind                 string
+	Platform             *string
 	EnvironmentID        *string
 	AdjudicationStatus   *string
 	ReasonCode           *string
@@ -612,7 +613,7 @@ type ErrorGroupFilters struct {
 // ListErrorGroups returns error groups for a project with optional filters. Tenant-scoped.
 func (q *Queries) ListErrorGroups(ctx context.Context, projectID string, filters *ErrorGroupFilters) ([]ErrorGroup, error) {
 	query := `SELECT DISTINCT eg.id, eg.project_id, eg.fingerprint, eg.title, eg.first_seen, eg.last_seen,
-		        eg.occurrence_count, eg.affected_users_count, eg.status, eg.kind,
+		        eg.occurrence_count, eg.affected_users_count, eg.status, eg.kind, eg.platform,
 		        eg.environment_id, eg.adjudication_status,
 		        eg.reason_code, eg.reason_message, eg.remediation,
 		        eg.confidence, eg.pr_url, eg.root_cause, eg.suggested_mitigation,
@@ -665,7 +666,7 @@ func (q *Queries) ListErrorGroups(ctx context.Context, projectID string, filters
 		var g ErrorGroup
 		err := rows.Scan(
 			&g.ID, &g.ProjectID, &g.Fingerprint, &g.Title, &g.FirstSeen, &g.LastSeen,
-			&g.OccurrenceCount, &g.AffectedUsersCount, &g.Status, &g.Kind,
+			&g.OccurrenceCount, &g.AffectedUsersCount, &g.Status, &g.Kind, &g.Platform,
 			&g.EnvironmentID, &g.AdjudicationStatus,
 			&g.ReasonCode, &g.ReasonMessage, &g.Remediation,
 			&g.Confidence, &g.PrURL, &g.RootCause, &g.SuggestedMitigation,
@@ -807,7 +808,7 @@ func (q *Queries) GetErrorGroup(ctx context.Context, projectID, groupID string) 
 	var g ErrorGroup
 	err := q.pool.QueryRow(ctx,
 		`SELECT id, project_id, fingerprint, title, first_seen, last_seen,
-		        occurrence_count, affected_users_count, status, kind,
+		        occurrence_count, affected_users_count, status, kind, platform,
 		        environment_id, adjudication_status,
 		        reason_code, reason_message, remediation,
 		        confidence, pr_url, root_cause, suggested_mitigation,
@@ -821,7 +822,7 @@ func (q *Queries) GetErrorGroup(ctx context.Context, projectID, groupID string) 
 		groupID, projectID,
 	).Scan(
 		&g.ID, &g.ProjectID, &g.Fingerprint, &g.Title, &g.FirstSeen, &g.LastSeen,
-		&g.OccurrenceCount, &g.AffectedUsersCount, &g.Status, &g.Kind,
+		&g.OccurrenceCount, &g.AffectedUsersCount, &g.Status, &g.Kind, &g.Platform,
 		&g.EnvironmentID, &g.AdjudicationStatus,
 		&g.ReasonCode, &g.ReasonMessage, &g.Remediation,
 		&g.Confidence, &g.PrURL, &g.RootCause, &g.SuggestedMitigation,

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -608,6 +608,7 @@ type ErrorGroupFilters struct {
 	AccountID string // filter by external_account_id via end_users junction
 	EndUserID string // filter by external_user_id via end_users junction
 	Status    string // filter by error group status
+	Platform  string // filter by platform; implies kind='error' (friction incidents have no platform)
 }
 
 // ListErrorGroups returns error groups for a project with optional filters. Tenant-scoped.
@@ -638,6 +639,11 @@ func (q *Queries) ListErrorGroups(ctx context.Context, projectID string, filters
 		if filters.Status != "" {
 			wheres = append(wheres, fmt.Sprintf("eg.status = $%d", argIdx))
 			args = append(args, filters.Status)
+			argIdx++
+		}
+		if filters.Platform != "" {
+			wheres = append(wheres, fmt.Sprintf("eg.platform = $%d AND eg.kind = 'error'", argIdx))
+			args = append(args, filters.Platform)
 			argIdx++
 		}
 		if filters.AccountID != "" {

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -846,6 +846,39 @@ func (q *Queries) GetErrorGroup(ctx context.Context, projectID, groupID string) 
 	return &g, nil
 }
 
+// SampleEvent is the representative event for an error group, used by the
+// dashboard detail view. Tenant-scoped through the owning group's project_id.
+type SampleEvent struct {
+	Timestamp     time.Time
+	Platform      string
+	ErrorType     string
+	ErrorMessage  string
+	StackTraceRaw string
+	Breadcrumbs   []byte // JSONB passthrough
+	Context       []byte // JSONB passthrough
+}
+
+// GetSampleEvent returns the sample event for a group, scoped to the project.
+// Ordinary candidate rows are hidden workflow records and stay invisible here.
+// The event-project join protects against a corrupt cross-project sample pointer.
+func (q *Queries) GetSampleEvent(ctx context.Context, projectID, groupID string) (*SampleEvent, error) {
+	var ev SampleEvent
+	err := q.pool.QueryRow(ctx,
+		`SELECT e."timestamp", e.platform, e.error_type, e.error_message,
+		        e.stack_trace_raw, e.breadcrumbs, e.context
+		 FROM error_groups g
+		 JOIN error_events e ON e.id = g.sample_event_id AND e.project_id = g.project_id
+		 WHERE g.id = $1 AND g.project_id = $2
+		   AND (g.status <> 'candidate' OR g.adjudication_status = 'unchecked')`,
+		groupID, projectID,
+	).Scan(&ev.Timestamp, &ev.Platform, &ev.ErrorType, &ev.ErrorMessage,
+		&ev.StackTraceRaw, &ev.Breadcrumbs, &ev.Context)
+	if err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}
+
 // GetLatestJobTraceURL returns the trace_url from the most recent job for an error group.
 // Tenant-scoped via error_groups join.
 func (q *Queries) GetLatestJobTraceURL(ctx context.Context, projectID, errorGroupID string) (*string, error) {

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -860,14 +860,17 @@ type SampleEvent struct {
 
 // GetSampleEvent returns the sample event for a group, scoped to the project.
 // Ordinary candidate rows are hidden workflow records and stay invisible here.
-// The event-project join protects against a corrupt cross-project sample pointer.
+// The join requires the event to belong to the same project AND the same group:
+// sample_event_id has no FK, so a corrupt pointer must not serve another
+// tenant's event (cross-project) or another incident's evidence (same-project).
 func (q *Queries) GetSampleEvent(ctx context.Context, projectID, groupID string) (*SampleEvent, error) {
 	var ev SampleEvent
 	err := q.pool.QueryRow(ctx,
 		`SELECT e."timestamp", e.platform, e.error_type, e.error_message,
 		        e.stack_trace_raw, e.breadcrumbs, e.context
 		 FROM error_groups g
-		 JOIN error_events e ON e.id = g.sample_event_id AND e.project_id = g.project_id
+		 JOIN error_events e ON e.id = g.sample_event_id
+		   AND e.project_id = g.project_id AND e.error_group_id = g.id
 		 WHERE g.id = $1 AND g.project_id = $2
 		   AND (g.status <> 'candidate' OR g.adjudication_status = 'unchecked')`,
 		groupID, projectID,

--- a/packages/ingestion/handler/error_event.go
+++ b/packages/ingestion/handler/error_event.go
@@ -170,10 +170,9 @@ func (d *Dependencies) ingestErrorEvent(w http.ResponseWriter, r *http.Request, 
 	}
 
 	// Redact secrets before persistence. End-user identity was already extracted
-	// from raw context above, so B2B tracking remains intact. RedactBreadcrumbs only
-	// scrubs each crumb's "data" field, so layer RedactBody over the whole serialized
-	// array to also catch bare tokens/JWTs in free-text fields (e.g. "message"),
-	// matching the per-value coverage RedactContext already gives the context object.
+	// from raw context above, so B2B tracking remains intact. RedactBreadcrumbs walks
+	// the whole array; retain the serialized body/URL pass as defense in depth for
+	// malformed or future breadcrumb shapes.
 	breadcrumbs = masking.RedactURL(masking.RedactBody(string(masking.RedactBreadcrumbs([]byte(breadcrumbs)))))
 	ctx = string(masking.RedactContext([]byte(ctx)))
 

--- a/packages/ingestion/handler/error_event_test.go
+++ b/packages/ingestion/handler/error_event_test.go
@@ -231,6 +231,28 @@ func TestIngest_NoPlatformDefaultsToJavascript(t *testing.T) {
 	}
 }
 
+func TestIngest_PlatformReadBackThroughGroupQueries(t *testing.T) {
+	deps, _ := testDeps(t)
+	_, projectID, _, rawKey := seedTenant(t, deps.Queries)
+	body := `{"timestamp":"2026-07-19T00:00:00Z","platform":"python","error":{"type":"ValueError","message":"boom","stack":"Traceback (most recent call last):\ngarbage"},"breadcrumbs":[],"context":{},"sdk_version":"0.1.0a2"}`
+	response := postErrorPayload(t, deps, rawKey, body)
+
+	groups, err := deps.Queries.ListErrorGroups(context.Background(), projectID, nil)
+	if err != nil {
+		t.Fatalf("list groups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Platform == nil || *groups[0].Platform != "python" {
+		t.Fatalf("ListErrorGroups platform = %+v, want python", groups)
+	}
+	group, err := deps.Queries.GetErrorGroup(context.Background(), projectID, response["group_id"])
+	if err != nil {
+		t.Fatalf("get group: %v", err)
+	}
+	if group.Platform == nil || *group.Platform != "python" {
+		t.Fatalf("GetErrorGroup platform = %v, want python", group.Platform)
+	}
+}
+
 func TestIngest_SamePythonErrorGroupsTogether(t *testing.T) {
 	deps, pool := testDeps(t)
 	_, projectID, _, rawKey := seedTenant(t, deps.Queries)

--- a/packages/ingestion/handler/error_event_test.go
+++ b/packages/ingestion/handler/error_event_test.go
@@ -347,6 +347,27 @@ func TestGetSampleEvent_TenantScopedRoundTrip(t *testing.T) {
 	if _, err := deps.Queries.GetSampleEvent(context.Background(), projectID, response["group_id"]); !errors.Is(err, pgx.ErrNoRows) {
 		t.Fatalf("hidden candidate's sample event must be pgx.ErrNoRows, got %v", err)
 	}
+
+	// Same-project wrong-group pointer must also be invisible: a stale
+	// sample_event_id must not serve another incident's evidence.
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE error_groups SET status = 'new', adjudication_status = NULL WHERE id = $1`,
+		response["group_id"]); err != nil {
+		t.Fatalf("restore group visibility: %v", err)
+	}
+	other := postErrorPayload(t, deps, rawKey,
+		`{"timestamp":"2026-07-19T00:00:03Z","platform":"python","error":{"type":"KeyError","message":"different group","stack":"Traceback (most recent call last):\nKeyError: different group"},"breadcrumbs":[],"context":{}}`)
+	if other["group_id"] == response["group_id"] {
+		t.Fatal("wrong-group case needs a distinct group")
+	}
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE error_groups SET sample_event_id = $1 WHERE id = $2`,
+		other["event_id"], response["group_id"]); err != nil {
+		t.Fatalf("corrupt same-project sample pointer: %v", err)
+	}
+	if _, err := deps.Queries.GetSampleEvent(context.Background(), projectID, response["group_id"]); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("same-project wrong-group sample pointer must be pgx.ErrNoRows, got %v", err)
+	}
 }
 
 func TestGetSampleEventEndpoint_SessionOnlyAndRedacted(t *testing.T) {
@@ -361,10 +382,13 @@ func TestGetSampleEventEndpoint_SessionOnlyAndRedacted(t *testing.T) {
 	// protection must redact the whole payload and remove sensitive header keys.
 	if _, err := pool.Exec(context.Background(),
 		`UPDATE error_events
-		 SET breadcrumbs = $2::jsonb, context = $3::jsonb
+		 SET breadcrumbs = $2::jsonb, context = $3::jsonb,
+		     error_message = $4, stack_trace_raw = $5
 		 WHERE id = $1`, posted["event_id"],
 		`[{"type":"http","message":"token ghp_historicalmessage","data":{"Proxy-Authorization":"historical-breadcrumb-secret","content-type":"application/json"}}]`,
-		`{"request":{"method":"GET","path":"/users/1","remote_addr":"203.0.113.9","headers":{"Authorization":"Bearer historical-header-secret","content-type":"application/json"}},"nested":{"x-auth-token":"historical-context-secret"}}`); err != nil {
+		`{"request":{"method":"GET","path":"/users/1","remote_addr":"203.0.113.9","headers":{"Authorization":"Bearer historical-header-secret","content-type":"application/json","Private-Token":"historical-gitlab-secret"}},"nested":{"x-auth-token":"historical-context-secret"}}`,
+		`connect to postgres://svc:histdbpassword@db.internal/app failed`,
+		"Traceback (most recent call last):\n  File \"/app/api/x.py\", line 1, in f\n    token ghp_stacksecret123\nValueError: endpoint sample"); err != nil {
 		t.Fatalf("seed historical secrets: %v", err)
 	}
 
@@ -390,7 +414,11 @@ func TestGetSampleEventEndpoint_SessionOnlyAndRedacted(t *testing.T) {
 	if response.Header().Get("Cache-Control") != "no-store" {
 		t.Fatalf("Cache-Control = %q, want no-store", response.Header().Get("Cache-Control"))
 	}
-	for _, leak := range []string{"historical-header-secret", "historical-breadcrumb-secret", "historical-context-secret", "ghp_historicalmessage"} {
+	for _, leak := range []string{
+		"historical-header-secret", "historical-breadcrumb-secret",
+		"historical-context-secret", "ghp_historicalmessage",
+		"historical-gitlab-secret", "histdbpassword", "ghp_stacksecret123",
+	} {
 		if strings.Contains(response.Body.String(), leak) {
 			t.Errorf("sample-event leaked %q: %s", leak, response.Body.String())
 		}

--- a/packages/ingestion/handler/error_event_test.go
+++ b/packages/ingestion/handler/error_event_test.go
@@ -469,6 +469,64 @@ func TestGetSampleEventEndpoint_SessionOnlyAndRedacted(t *testing.T) {
 	}
 }
 
+func TestCrossStackEndUserTimeline(t *testing.T) {
+	deps, _ := testDeps(t)
+	_, projectID, _, rawKey := seedTenant(t, deps.Queries)
+	postErrorPayload(t, deps, rawKey,
+		`{"timestamp":"2026-07-19T00:00:00Z","error":{"type":"TypeError","message":"cross-stack javascript","stack":"at jsFrame (/src/app.js:1:1)"},"breadcrumbs":[],"context":{"user":{"id":"cross-stack-user"}}}`)
+	postErrorPayload(t, deps, rawKey,
+		`{"timestamp":"2026-07-19T00:00:01Z","platform":"python","error":{"type":"ValueError","message":"cross-stack python","stack":"Traceback (most recent call last):\nValueError: cross-stack python"},"breadcrumbs":[],"context":{"user":{"id":"cross-stack-user"}}}`)
+
+	groups, err := deps.Queries.ListErrorGroups(context.Background(), projectID,
+		&db.ErrorGroupFilters{EndUserID: "cross-stack-user"})
+	if err != nil {
+		t.Fatalf("list cross-stack groups: %v", err)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("cross-stack groups = %+v, want two", groups)
+	}
+	wantPlatforms := map[string]bool{"javascript": false, "python": false}
+	for _, group := range groups {
+		if group.Platform == nil {
+			t.Fatalf("group missing platform: %+v", group)
+		}
+		if _, ok := wantPlatforms[*group.Platform]; !ok {
+			t.Fatalf("unexpected platform %q", *group.Platform)
+		}
+		wantPlatforms[*group.Platform] = true
+	}
+	for platform, seen := range wantPlatforms {
+		if !seen {
+			t.Errorf("data-layer timeline missing %s group", platform)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/projects/"+projectID+"/incidents?end_user_id=cross-stack-user", nil)
+	req.Header.Set("X-API-Key", rawKey)
+	response := httptest.NewRecorder()
+	handler.NewRouter(deps).ServeHTTP(response, req)
+	if response.Code != http.StatusOK {
+		t.Fatalf("timeline response = %d (%s), want 200", response.Code, response.Body.String())
+	}
+	var incidents []struct {
+		Platform string `json:"platform"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&incidents); err != nil {
+		t.Fatalf("decode timeline: %v", err)
+	}
+	if len(incidents) != 2 {
+		t.Fatalf("HTTP timeline = %+v, want two incidents", incidents)
+	}
+	httpPlatforms := map[string]bool{}
+	for _, incident := range incidents {
+		httpPlatforms[incident.Platform] = true
+	}
+	if !httpPlatforms["javascript"] || !httpPlatforms["python"] {
+		t.Fatalf("HTTP timeline platforms = %+v, want javascript and python", httpPlatforms)
+	}
+}
+
 func TestIngest_SamePythonErrorGroupsTogether(t *testing.T) {
 	deps, pool := testDeps(t)
 	_, projectID, _, rawKey := seedTenant(t, deps.Queries)

--- a/packages/ingestion/handler/error_event_test.go
+++ b/packages/ingestion/handler/error_event_test.go
@@ -440,6 +440,27 @@ func TestGetSampleEventEndpoint_SessionOnlyAndRedacted(t *testing.T) {
 		t.Fatalf("SDK-key sample event = %d (%s), want 401", sdkResponse.Code, sdkResponse.Body.String())
 	}
 
+	// Lock the event-project join itself: sample_event_id has no same-project
+	// constraint, so a corrupt pointer must not expose another tenant's event.
+	_, _, _, otherRawKey := seedTenant(t, deps.Queries)
+	otherEvent := postErrorPayload(t, deps, otherRawKey,
+		`{"timestamp":"2026-07-19T00:00:02Z","platform":"python","error":{"type":"SecretError","message":"other tenant","stack":"Traceback\nSecretError: other tenant"},"breadcrumbs":[],"context":{"secret":"other-tenant-secret"}}`)
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE error_groups SET sample_event_id = $1 WHERE id = $2`,
+		otherEvent["event_id"], posted["group_id"]); err != nil {
+		t.Fatalf("corrupt cross-project sample pointer: %v", err)
+	}
+	if _, err := deps.Queries.GetSampleEvent(context.Background(), projectID, posted["group_id"]); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("corrupt cross-project sample pointer must be pgx.ErrNoRows, got %v", err)
+	}
+	corruptPointer := get(path, map[string]string{"Authorization": "Bearer " + token})
+	if corruptPointer.Code != http.StatusNotFound {
+		t.Fatalf("corrupt cross-project pointer = %d (%s), want 404", corruptPointer.Code, corruptPointer.Body.String())
+	}
+	if strings.Contains(corruptPointer.Body.String(), "other-tenant-secret") {
+		t.Fatalf("corrupt cross-project pointer leaked another tenant: %s", corruptPointer.Body.String())
+	}
+
 	malformed := postErrorPayload(t, deps, rawKey,
 		`{"timestamp":"2026-07-19T00:00:01Z","platform":"python","error":{"type":"RuntimeError","message":"malformed headers","stack":"Traceback\nRuntimeError: malformed headers"},"breadcrumbs":{},"context":{"request":{"headers":[["Authorization","array-secret"]]}}}`)
 	malformedResponse := get("/api/v1/projects/"+projectID+"/incidents/"+malformed["group_id"]+"/sample-event",

--- a/packages/ingestion/handler/error_event_test.go
+++ b/packages/ingestion/handler/error_event_test.go
@@ -253,6 +253,36 @@ func TestIngest_PlatformReadBackThroughGroupQueries(t *testing.T) {
 	}
 }
 
+func TestListErrorGroups_PlatformFilter(t *testing.T) {
+	deps, pool := testDeps(t)
+	_, projectID, _, rawKey := seedTenant(t, deps.Queries)
+	postErrorPayload(t, deps, rawKey, `{"timestamp":"2026-07-19T00:00:00Z","platform":"python","error":{"type":"ValueError","message":"python-only","stack":"Traceback (most recent call last):\nValueError: python-only"},"breadcrumbs":[],"context":{}}`)
+	postErrorPayload(t, deps, rawKey, `{"timestamp":"2026-07-19T00:00:01Z","platform":"javascript","error":{"type":"TypeError","message":"javascript-only","stack":"at fn (/src/app.js:1:1)"},"breadcrumbs":[],"context":{}}`)
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO error_groups (project_id, fingerprint, title, first_seen, last_seen, kind, status)
+		 VALUES ($1, $2, 'friction-only', now(), now(), 'friction', 'insight')`,
+		projectID, "friction-"+t.Name()); err != nil {
+		t.Fatalf("insert friction incident: %v", err)
+	}
+
+	python := "python"
+	got, err := deps.Queries.ListErrorGroups(context.Background(), projectID, &db.ErrorGroupFilters{Platform: python})
+	if err != nil {
+		t.Fatalf("list python groups: %v", err)
+	}
+	if len(got) != 1 || got[0].Platform == nil || *got[0].Platform != python || got[0].Kind != "error" {
+		t.Fatalf("platform-filtered groups = %+v, want one python error", got)
+	}
+
+	all, err := deps.Queries.ListErrorGroups(context.Background(), projectID, nil)
+	if err != nil {
+		t.Fatalf("list all groups: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("unfiltered groups = %+v, want python, javascript, and friction", all)
+	}
+}
+
 func TestIngest_SamePythonErrorGroupsTogether(t *testing.T) {
 	deps, pool := testDeps(t)
 	_, projectID, _, rawKey := seedTenant(t, deps.Queries)

--- a/packages/ingestion/handler/error_event_test.go
+++ b/packages/ingestion/handler/error_event_test.go
@@ -3,6 +3,7 @@ package handler_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/opslane/opslane/packages/ingestion/db"
 	"github.com/opslane/opslane/packages/ingestion/handler"
@@ -314,6 +316,35 @@ func TestListIncidents_PlatformQueryParam(t *testing.T) {
 	handler.NewRouter(deps).ServeHTTP(badResponse, badReq)
 	if badResponse.Code != http.StatusBadRequest {
 		t.Fatalf("invalid platform = %d (%s), want 400", badResponse.Code, badResponse.Body.String())
+	}
+}
+
+func TestGetSampleEvent_TenantScopedRoundTrip(t *testing.T) {
+	deps, pool := testDeps(t)
+	_, projectID, _, rawKey := seedTenant(t, deps.Queries)
+	body := `{"timestamp":"2026-07-19T00:00:00Z","platform":"python","runtime":{"name":"cpython","version":"3.12.1"},"error":{"type":"ValueError","message":"No row was found","stack":"Traceback (most recent call last):\n  File \"/app/api/x.py\", line 1, in f\n    raise ValueError()\nValueError: No row was found"},"breadcrumbs":[{"type":"log","timestamp":"t","category":"app","level":"warning","message":"near expiry"}],"context":{},"sdk_version":"0.1.0a2"}`
+	response := postErrorPayload(t, deps, rawKey, body)
+
+	ev, err := deps.Queries.GetSampleEvent(context.Background(), projectID, response["group_id"])
+	if err != nil {
+		t.Fatalf("get sample event: %v", err)
+	}
+	if ev.ErrorType != "ValueError" || ev.Platform != "python" ||
+		!strings.HasPrefix(ev.StackTraceRaw, "Traceback") {
+		t.Fatalf("unexpected sample event: %+v", ev)
+	}
+	_, otherProject, _, _ := seedTenant(t, deps.Queries)
+	if _, err := deps.Queries.GetSampleEvent(context.Background(), otherProject, response["group_id"]); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("cross-project sample event read must be pgx.ErrNoRows, got %v", err)
+	}
+
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE error_groups SET status = 'candidate', adjudication_status = NULL WHERE id = $1`,
+		response["group_id"]); err != nil {
+		t.Fatalf("hide group as ordinary candidate: %v", err)
+	}
+	if _, err := deps.Queries.GetSampleEvent(context.Background(), projectID, response["group_id"]); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("hidden candidate's sample event must be pgx.ErrNoRows, got %v", err)
 	}
 }
 

--- a/packages/ingestion/handler/error_event_test.go
+++ b/packages/ingestion/handler/error_event_test.go
@@ -283,6 +283,40 @@ func TestListErrorGroups_PlatformFilter(t *testing.T) {
 	}
 }
 
+func TestListIncidents_PlatformQueryParam(t *testing.T) {
+	deps, _ := testDeps(t)
+	_, projectID, _, rawKey := seedTenant(t, deps.Queries)
+	postErrorPayload(t, deps, rawKey, `{"timestamp":"2026-07-19T00:00:00Z","platform":"python","error":{"type":"ValueError","message":"python-http","stack":"Traceback (most recent call last):\nValueError: python-http"},"breadcrumbs":[],"context":{}}`)
+	postErrorPayload(t, deps, rawKey, `{"timestamp":"2026-07-19T00:00:01Z","platform":"javascript","error":{"type":"TypeError","message":"javascript-http","stack":"at fn (/src/http.js:1:1)"},"breadcrumbs":[],"context":{}}`)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/projects/"+projectID+"/incidents?platform=python", nil)
+	req.Header.Set("X-API-Key", rawKey)
+	response := httptest.NewRecorder()
+	handler.NewRouter(deps).ServeHTTP(response, req)
+	if response.Code != http.StatusOK {
+		t.Fatalf("platform-only request = %d (%s), want 200", response.Code, response.Body.String())
+	}
+	var incidents []struct {
+		Platform *string `json:"platform"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&incidents); err != nil {
+		t.Fatalf("decode incidents: %v", err)
+	}
+	if len(incidents) != 1 || incidents[0].Platform == nil || *incidents[0].Platform != "python" {
+		t.Fatalf("platform-filtered response = %+v, want one python incident", incidents)
+	}
+
+	badReq := httptest.NewRequest(http.MethodGet,
+		"/api/v1/projects/"+projectID+"/incidents?platform=Not%20A%20Token", nil)
+	badReq.Header.Set("X-API-Key", rawKey)
+	badResponse := httptest.NewRecorder()
+	handler.NewRouter(deps).ServeHTTP(badResponse, badReq)
+	if badResponse.Code != http.StatusBadRequest {
+		t.Fatalf("invalid platform = %d (%s), want 400", badResponse.Code, badResponse.Body.String())
+	}
+}
+
 func TestIngest_SamePythonErrorGroupsTogether(t *testing.T) {
 	deps, pool := testDeps(t)
 	_, projectID, _, rawKey := seedTenant(t, deps.Queries)

--- a/packages/ingestion/handler/error_event_test.go
+++ b/packages/ingestion/handler/error_event_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/opslane/opslane/packages/ingestion/auth"
 	"github.com/opslane/opslane/packages/ingestion/db"
 	"github.com/opslane/opslane/packages/ingestion/handler"
 	minioPkg "github.com/opslane/opslane/packages/ingestion/minio"
@@ -345,6 +346,126 @@ func TestGetSampleEvent_TenantScopedRoundTrip(t *testing.T) {
 	}
 	if _, err := deps.Queries.GetSampleEvent(context.Background(), projectID, response["group_id"]); !errors.Is(err, pgx.ErrNoRows) {
 		t.Fatalf("hidden candidate's sample event must be pgx.ErrNoRows, got %v", err)
+	}
+}
+
+func TestGetSampleEventEndpoint_SessionOnlyAndRedacted(t *testing.T) {
+	deps, pool := testDeps(t)
+	orgID, projectID, _, rawKey := seedTenant(t, deps.Queries)
+	deps.JWTSecret = []byte(authTestJWTSecret)
+	router := handler.NewRouter(deps)
+	body := `{"timestamp":"2026-07-19T00:00:00Z","platform":"python","error":{"type":"ValueError","message":"endpoint sample","stack":"Traceback (most recent call last):\n  File \"/app/api/x.py\", line 1, in f\nValueError: endpoint sample"},"breadcrumbs":[{"type":"log","message":"near expiry"}],"context":{"request":{"method":"GET","path":"/users/1","remote_addr":"203.0.113.9","headers":{"Authorization":"Bearer client-secret","content-type":"application/json"}}}}`
+	posted := postErrorPayload(t, deps, rawKey, body)
+
+	// Simulate a historical row written before the expanded deny-list. Read-side
+	// protection must redact the whole payload and remove sensitive header keys.
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE error_events
+		 SET breadcrumbs = $2::jsonb, context = $3::jsonb
+		 WHERE id = $1`, posted["event_id"],
+		`[{"type":"http","message":"token ghp_historicalmessage","data":{"Proxy-Authorization":"historical-breadcrumb-secret","content-type":"application/json"}}]`,
+		`{"request":{"method":"GET","path":"/users/1","remote_addr":"203.0.113.9","headers":{"Authorization":"Bearer historical-header-secret","content-type":"application/json"}},"nested":{"x-auth-token":"historical-context-secret"}}`); err != nil {
+		t.Fatalf("seed historical secrets: %v", err)
+	}
+
+	token, err := auth.SignAccessToken([]byte(authTestJWTSecret), "sample-user", orgID, "sample@example.com")
+	if err != nil {
+		t.Fatalf("sign session token: %v", err)
+	}
+	get := func(path string, headers map[string]string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		for key, value := range headers {
+			req.Header.Set(key, value)
+		}
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, req)
+		return response
+	}
+	path := "/api/v1/projects/" + projectID + "/incidents/" + posted["group_id"] + "/sample-event"
+	response := get(path, map[string]string{"Authorization": "Bearer " + token})
+	if response.Code != http.StatusOK {
+		t.Fatalf("sample-event response = %d (%s), want 200", response.Code, response.Body.String())
+	}
+	if response.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", response.Header().Get("Cache-Control"))
+	}
+	for _, leak := range []string{"historical-header-secret", "historical-breadcrumb-secret", "historical-context-secret", "ghp_historicalmessage"} {
+		if strings.Contains(response.Body.String(), leak) {
+			t.Errorf("sample-event leaked %q: %s", leak, response.Body.String())
+		}
+	}
+	var sample struct {
+		Error struct {
+			Type  string `json:"type"`
+			Stack string `json:"stack"`
+		} `json:"error"`
+		Breadcrumbs []map[string]any `json:"breadcrumbs"`
+		Context     map[string]any   `json:"context"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&sample); err != nil {
+		t.Fatalf("decode sample event: %v", err)
+	}
+	if sample.Error.Type != "ValueError" || !strings.HasPrefix(sample.Error.Stack, "Traceback") || len(sample.Breadcrumbs) != 1 {
+		t.Fatalf("unexpected sample event: %+v", sample)
+	}
+	requestContext, ok := sample.Context["request"].(map[string]any)
+	if !ok || requestContext["remote_addr"] != "203.0.113.9" {
+		t.Fatalf("request context = %#v", sample.Context["request"])
+	}
+	headers, ok := requestContext["headers"].(map[string]any)
+	if !ok || headers["content-type"] != "application/json" {
+		t.Fatalf("filtered headers = %#v", requestContext["headers"])
+	}
+	if _, exists := headers["Authorization"]; exists {
+		t.Fatalf("Authorization header survived: %#v", headers)
+	}
+
+	unknown := get("/api/v1/projects/"+projectID+"/incidents/"+uuid.NewString()+"/sample-event",
+		map[string]string{"Authorization": "Bearer " + token})
+	if unknown.Code != http.StatusNotFound {
+		t.Fatalf("unknown incident = %d (%s), want 404", unknown.Code, unknown.Body.String())
+	}
+	sibling, err := deps.Queries.CreateProject(context.Background(), orgID, "sample-event-sibling", nil)
+	if err != nil {
+		t.Fatalf("create sibling project: %v", err)
+	}
+	crossProject := get("/api/v1/projects/"+sibling.ID+"/incidents/"+posted["group_id"]+"/sample-event",
+		map[string]string{"Authorization": "Bearer " + token})
+	if crossProject.Code != http.StatusNotFound {
+		t.Fatalf("cross-project incident = %d (%s), want 404", crossProject.Code, crossProject.Body.String())
+	}
+	sdkResponse := get(path, map[string]string{"X-API-Key": rawKey})
+	if sdkResponse.Code != http.StatusUnauthorized {
+		t.Fatalf("SDK-key sample event = %d (%s), want 401", sdkResponse.Code, sdkResponse.Body.String())
+	}
+
+	malformed := postErrorPayload(t, deps, rawKey,
+		`{"timestamp":"2026-07-19T00:00:01Z","platform":"python","error":{"type":"RuntimeError","message":"malformed headers","stack":"Traceback\nRuntimeError: malformed headers"},"breadcrumbs":{},"context":{"request":{"headers":[["Authorization","array-secret"]]}}}`)
+	malformedResponse := get("/api/v1/projects/"+projectID+"/incidents/"+malformed["group_id"]+"/sample-event",
+		map[string]string{"Authorization": "Bearer " + token})
+	if malformedResponse.Code != http.StatusOK {
+		t.Fatalf("malformed sample = %d (%s), want 200", malformedResponse.Code, malformedResponse.Body.String())
+	}
+	if strings.Contains(malformedResponse.Body.String(), "array-secret") {
+		t.Fatalf("malformed headers leaked: %s", malformedResponse.Body.String())
+	}
+	var malformedSample struct {
+		Breadcrumbs []any          `json:"breadcrumbs"`
+		Context     map[string]any `json:"context"`
+	}
+	if err := json.NewDecoder(malformedResponse.Body).Decode(&malformedSample); err != nil {
+		t.Fatalf("decode malformed sample: %v", err)
+	}
+	if malformedSample.Breadcrumbs == nil {
+		t.Fatal("non-array breadcrumbs must normalize to []")
+	}
+	if request, ok := malformedSample.Context["request"].(map[string]any); ok {
+		if headers, exists := request["headers"]; exists {
+			if headerMap, isMap := headers.(map[string]any); !isMap || len(headerMap) != 0 {
+				t.Fatalf("malformed headers must be dropped or empty, got %#v", headers)
+			}
+		}
 	}
 }
 

--- a/packages/ingestion/handler/read_api.go
+++ b/packages/ingestion/handler/read_api.go
@@ -10,8 +10,10 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/opslane/opslane/packages/ingestion/db"
+	"github.com/opslane/opslane/packages/ingestion/masking"
 )
 
 // incidentJSON is the JSON representation of an incident, matching the
@@ -54,6 +56,20 @@ type needsHumanReason struct {
 	ReasonCode    string `json:"reason_code"`
 	ReasonMessage string `json:"reason_message"`
 	Remediation   string `json:"remediation"`
+}
+
+type sampleEventJSON struct {
+	Timestamp   string          `json:"timestamp"`
+	Platform    string          `json:"platform"`
+	Error       sampleErrorJSON `json:"error"`
+	Breadcrumbs json.RawMessage `json:"breadcrumbs"`
+	Context     json.RawMessage `json:"context"`
+}
+
+type sampleErrorJSON struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	Stack   string `json:"stack"`
 }
 
 // fmtTimePtr formats a nullable time as an RFC3339 string pointer.
@@ -266,6 +282,97 @@ func (d *Dependencies) GetIncident(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(inc)
+}
+
+func filterSensitiveHeaders(headers map[string]json.RawMessage) map[string]json.RawMessage {
+	filtered := make(map[string]json.RawMessage, len(headers))
+	for name, value := range headers {
+		if !masking.IsSensitiveHeader(name) {
+			filtered[name] = value
+		}
+	}
+	return filtered
+}
+
+func sanitizeSampleContext(raw []byte) json.RawMessage {
+	redacted := masking.RedactContext(raw)
+	var contextObject map[string]json.RawMessage
+	if err := json.Unmarshal(redacted, &contextObject); err != nil || contextObject == nil {
+		return json.RawMessage(`{}`)
+	}
+
+	requestRaw, hasRequest := contextObject["request"]
+	if hasRequest {
+		var requestObject map[string]json.RawMessage
+		if err := json.Unmarshal(requestRaw, &requestObject); err != nil || requestObject == nil {
+			delete(contextObject, "request")
+		} else {
+			if headersRaw, hasHeaders := requestObject["headers"]; hasHeaders {
+				var headersObject map[string]json.RawMessage
+				if err := json.Unmarshal(headersRaw, &headersObject); err != nil || headersObject == nil {
+					delete(requestObject, "headers")
+				} else if filtered, err := json.Marshal(filterSensitiveHeaders(headersObject)); err == nil {
+					requestObject["headers"] = filtered
+				} else {
+					delete(requestObject, "headers")
+				}
+			}
+			if encoded, err := json.Marshal(requestObject); err == nil {
+				contextObject["request"] = encoded
+			} else {
+				delete(contextObject, "request")
+			}
+		}
+	}
+
+	encoded, err := json.Marshal(contextObject)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return encoded
+}
+
+func normalizeSampleBreadcrumbs(raw []byte) json.RawMessage {
+	redacted := masking.RedactBreadcrumbs(raw)
+	var breadcrumbs []json.RawMessage
+	if err := json.Unmarshal(redacted, &breadcrumbs); err != nil || breadcrumbs == nil {
+		return json.RawMessage(`[]`)
+	}
+	return redacted
+}
+
+// GetSampleEvent returns the representative error event for an incident.
+func (d *Dependencies) GetSampleEvent(w http.ResponseWriter, r *http.Request) {
+	projectID := chi.URLParam(r, "projectID")
+	if !d.verifyProjectAccess(w, r, projectID) {
+		return
+	}
+
+	incidentID := chi.URLParam(r, "incidentID")
+	event, err := d.Queries.GetSampleEvent(r.Context(), projectID, incidentID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		writeJSONError(w, http.StatusNotFound, "no sample event")
+		return
+	}
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to get sample event")
+		return
+	}
+
+	response := sampleEventJSON{
+		Timestamp: event.Timestamp.Format(time.RFC3339),
+		Platform:  event.Platform,
+		Error: sampleErrorJSON{
+			Type:    event.ErrorType,
+			Message: event.ErrorMessage,
+			Stack:   event.StackTraceRaw,
+		},
+		Breadcrumbs: normalizeSampleBreadcrumbs(event.Breadcrumbs),
+		Context:     sanitizeSampleContext(event.Context),
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
 }
 
 // === B2B endpoints ===

--- a/packages/ingestion/handler/read_api.go
+++ b/packages/ingestion/handler/read_api.go
@@ -23,6 +23,7 @@ type incidentJSON struct {
 	Title                string              `json:"title"`
 	Status               string              `json:"status"`
 	Kind                 string              `json:"kind"`
+	Platform             *string             `json:"platform,omitempty"`
 	EnvironmentID        *string             `json:"environment_id,omitempty"`
 	AdjudicationStatus   *string             `json:"adjudication_status,omitempty"`
 	FirstSeen            string              `json:"first_seen"`
@@ -72,6 +73,7 @@ func toIncidentJSON(g db.ErrorGroup) incidentJSON {
 		Title:               g.Title,
 		Status:              g.Status,
 		Kind:                g.Kind,
+		Platform:            g.Platform,
 		EnvironmentID:       g.EnvironmentID,
 		AdjudicationStatus:  g.AdjudicationStatus,
 		FirstSeen:           g.FirstSeen.Format(time.RFC3339),

--- a/packages/ingestion/handler/read_api.go
+++ b/packages/ingestion/handler/read_api.go
@@ -196,11 +196,17 @@ func (d *Dependencies) ListIncidents(w http.ResponseWriter, r *http.Request) {
 	accountID := r.URL.Query().Get("account_id")
 	endUserID := r.URL.Query().Get("end_user_id")
 	status := r.URL.Query().Get("status")
-	if accountID != "" || endUserID != "" || status != "" {
+	platform := r.URL.Query().Get("platform")
+	if platform != "" && !rePlatformToken.MatchString(platform) {
+		writeJSONError(w, http.StatusBadRequest, "invalid platform")
+		return
+	}
+	if accountID != "" || endUserID != "" || status != "" || platform != "" {
 		filters = &db.ErrorGroupFilters{
 			AccountID: accountID,
 			EndUserID: endUserID,
 			Status:    status,
+			Platform:  platform,
 		}
 	}
 

--- a/packages/ingestion/handler/read_api.go
+++ b/packages/ingestion/handler/read_api.go
@@ -362,10 +362,13 @@ func (d *Dependencies) GetSampleEvent(w http.ResponseWriter, r *http.Request) {
 	response := sampleEventJSON{
 		Timestamp: event.Timestamp.Format(time.RFC3339),
 		Platform:  event.Platform,
+		// Error text is persisted verbatim (grouping fingerprints the raw
+		// values), so redact on the way out: exception messages and stack
+		// frames are common carriers of leaked tokens, DSNs, and JWTs.
 		Error: sampleErrorJSON{
-			Type:    event.ErrorType,
-			Message: event.ErrorMessage,
-			Stack:   event.StackTraceRaw,
+			Type:    masking.RedactBody(event.ErrorType),
+			Message: masking.RedactURL(masking.RedactBody(event.ErrorMessage)),
+			Stack:   masking.RedactURL(masking.RedactBody(event.StackTraceRaw)),
 		},
 		Breadcrumbs: normalizeSampleBreadcrumbs(event.Breadcrumbs),
 		Context:     sanitizeSampleContext(event.Context),

--- a/packages/ingestion/handler/read_api_test.go
+++ b/packages/ingestion/handler/read_api_test.go
@@ -135,6 +135,8 @@ func TestFilterSensitiveHeaders(t *testing.T) {
 		"Authorization", "PROXY-AUTHORIZATION", "authentication",
 		"Cookie", "set-cookie", "x-api-key", "X-CSRF-Token",
 		"x-auth-token", "X-Access-Token", "x-amz-security-token",
+		"Private-Token", "x-gitlab-token", "X-Vault-Token",
+		"x-goog-api-key", "X-Refresh-Token", "x-session-token", "X-Session-Id",
 	} {
 		in[k] = json.RawMessage(`"secret"`)
 	}
@@ -144,5 +146,19 @@ func TestFilterSensitiveHeaders(t *testing.T) {
 	}
 	if _, ok := out["content-type"]; !ok {
 		t.Fatal("benign header must survive")
+	}
+}
+
+func TestSanitizeSampleContext_NonObjectRequest(t *testing.T) {
+	out := sanitizeSampleContext([]byte(`{"request":"GET /users/42","other":"ok"}`))
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("sanitized context is not an object: %v (%s)", err, out)
+	}
+	if _, exists := decoded["request"]; exists {
+		t.Fatalf("non-object request must be dropped, got %s", out)
+	}
+	if string(decoded["other"]) != `"ok"` {
+		t.Fatalf("benign sibling field clobbered: %s", out)
 	}
 }

--- a/packages/ingestion/handler/read_api_test.go
+++ b/packages/ingestion/handler/read_api_test.go
@@ -128,3 +128,21 @@ func TestIncidentJSON_AdjudicationFieldsOmittedForErrors(t *testing.T) {
 		t.Errorf("error incidents must omit adjudication fields, got %s", data)
 	}
 }
+
+func TestFilterSensitiveHeaders(t *testing.T) {
+	in := map[string]json.RawMessage{"content-type": json.RawMessage(`"application/json"`)}
+	for _, k := range []string{
+		"Authorization", "PROXY-AUTHORIZATION", "authentication",
+		"Cookie", "set-cookie", "x-api-key", "X-CSRF-Token",
+		"x-auth-token", "X-Access-Token", "x-amz-security-token",
+	} {
+		in[k] = json.RawMessage(`"secret"`)
+	}
+	out := filterSensitiveHeaders(in)
+	if len(out) != 1 {
+		t.Fatalf("expected only content-type to survive, got %v", out)
+	}
+	if _, ok := out["content-type"]; !ok {
+		t.Fatal("benign header must survive")
+	}
+}

--- a/packages/ingestion/handler/read_api_test.go
+++ b/packages/ingestion/handler/read_api_test.go
@@ -37,6 +37,17 @@ func TestIncidentJSONIncludesKind(t *testing.T) {
 	}
 }
 
+func TestToIncidentJSON_Platform(t *testing.T) {
+	platform := "python"
+	inc := toIncidentJSON(db.ErrorGroup{Platform: &platform})
+	if inc.Platform == nil || *inc.Platform != "python" {
+		t.Fatalf("platform = %v, want python", inc.Platform)
+	}
+	if got := toIncidentJSON(db.ErrorGroup{}); got.Platform != nil {
+		t.Fatalf("friction incident platform should marshal as absent, got %v", got.Platform)
+	}
+}
+
 func TestIncidentJSON_IncludesVerificationEvidenceAndCandidateDiff(t *testing.T) {
 	diff := "diff --git a/src/a.ts b/src/a.ts"
 	inc := toIncidentJSON(db.ErrorGroup{

--- a/packages/ingestion/handler/routes.go
+++ b/packages/ingestion/handler/routes.go
@@ -132,6 +132,7 @@ func NewRouterWithPool(deps *Dependencies, pool *pgxpool.Pool) *chi.Mux {
 		// Incidents (session or SDK auth — CLI uses API key, dashboard uses JWT)
 		r.With(deps.AuthenticateSessionOrSDK).Get("/projects/{projectID}/incidents", deps.ListIncidents)
 		r.With(deps.AuthenticateSessionOrSDK).Get("/projects/{projectID}/incidents/{incidentID}", deps.GetIncident)
+		r.With(deps.AuthenticateUserSession).Get("/projects/{projectID}/incidents/{incidentID}/sample-event", deps.GetSampleEvent)
 		// === Project D: replay retrieval (project-scoped, dashboard JWT auth) ===
 		r.With(deps.AuthenticateUserSession).Get("/projects/{projectID}/replays/{replayID}", deps.GetReplay)
 		// Always-on session browsing and bounded chunk playback.

--- a/packages/ingestion/masking/masking.go
+++ b/packages/ingestion/masking/masking.go
@@ -1,6 +1,7 @@
 package masking
 
 import (
+	"bytes"
 	"encoding/json"
 	"regexp"
 	"strings"
@@ -21,6 +22,13 @@ var sensitiveHeaders = map[string]struct{}{
 	"x-auth-token":         {},
 	"x-access-token":       {},
 	"x-amz-security-token": {},
+	"private-token":        {},
+	"x-gitlab-token":       {},
+	"x-vault-token":        {},
+	"x-goog-api-key":       {},
+	"x-refresh-token":      {},
+	"x-session-token":      {},
+	"x-session-id":         {},
 }
 
 // IsSensitiveHeader reports whether a header name (any case) must never be
@@ -35,7 +43,10 @@ func IsSensitiveHeader(name string) bool {
 // alphanumeric characters (the key material).
 var apiKeyPrefixRe = regexp.MustCompile(`(?i)(sk_live_|sk_test_|AKIA|ghp_|gho_|def_)[A-Za-z0-9]+`)
 
-var urlCredRe = regexp.MustCompile(`(?i)(https?://)[^/@\s:]+(?::[^/@\s]+)?@`)
+// urlCredRe matches userinfo credentials in any URI scheme, not just HTTP:
+// exception messages routinely embed DSNs (postgres://, redis://, amqp://)
+// with passwords in the authority section.
+var urlCredRe = regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://)[^/@\s:]+(?::[^/@\s]+)?@`)
 
 var urlSecretQueryRe = regexp.MustCompile(
 	`(?i)([?&](?:access_token|refresh_token|token|api_key|apikey|key|secret|password|sig|signature)=)[^&\s"']+`)
@@ -174,9 +185,13 @@ func RedactBreadcrumbs(breadcrumbs []byte) []byte {
 		return breadcrumbs
 	}
 
+	// UseNumber keeps int64-scale values (epoch-nanos timestamps, IDs) exact:
+	// a plain Unmarshal into interface{} would round-trip them through float64.
+	dec := json.NewDecoder(bytes.NewReader(breadcrumbs))
+	dec.UseNumber()
 	var crumbs []interface{}
-	if err := json.Unmarshal(breadcrumbs, &crumbs); err != nil {
-		// Not valid JSON array -- return unchanged.
+	if err := dec.Decode(&crumbs); err != nil {
+		// Not a valid JSON array -- return unchanged.
 		return breadcrumbs
 	}
 

--- a/packages/ingestion/masking/masking.go
+++ b/packages/ingestion/masking/masking.go
@@ -11,11 +11,24 @@ const redacted = "[REDACTED]"
 // sensitiveHeaders is the set of HTTP header names whose values must be
 // redacted before persistence. Comparison is case-insensitive.
 var sensitiveHeaders = map[string]struct{}{
-	"authorization": {},
-	"cookie":        {},
-	"set-cookie":    {},
-	"x-api-key":     {},
-	"x-csrf-token":  {},
+	"authorization":        {},
+	"proxy-authorization":  {},
+	"authentication":       {},
+	"cookie":               {},
+	"set-cookie":           {},
+	"x-api-key":            {},
+	"x-csrf-token":         {},
+	"x-auth-token":         {},
+	"x-access-token":       {},
+	"x-amz-security-token": {},
+}
+
+// IsSensitiveHeader reports whether a header name (any case) must never be
+// exposed or persisted in cleartext. It is the single source of truth for
+// write-side redaction and read-side filtering.
+func IsSensitiveHeader(name string) bool {
+	_, ok := sensitiveHeaders[strings.ToLower(name)]
+	return ok
 }
 
 // apiKeyPrefixRe matches well-known API key prefixes followed by
@@ -44,7 +57,7 @@ var passwordFieldRe = regexp.MustCompile(
 func RedactHeaders(headers map[string]string) map[string]string {
 	out := make(map[string]string, len(headers))
 	for k, v := range headers {
-		if _, ok := sensitiveHeaders[strings.ToLower(k)]; ok {
+		if IsSensitiveHeader(k) {
 			out[k] = redacted
 		} else {
 			out[k] = v
@@ -128,7 +141,7 @@ func redactValue(v interface{}) interface{} {
 	case map[string]interface{}:
 		for k, child := range val {
 			lk := strings.ToLower(k)
-			if _, ok := sensitiveHeaders[lk]; ok {
+			if IsSensitiveHeader(lk) {
 				val[k] = redacted
 				continue
 			}
@@ -151,9 +164,9 @@ func redactValue(v interface{}) interface{} {
 	}
 }
 
-// RedactBreadcrumbs parses a JSON-encoded breadcrumbs array, redacts
-// any sensitive header-like data inside each breadcrumb's "data" field,
-// and returns the re-serialised JSON.
+// RedactBreadcrumbs parses a JSON-encoded breadcrumbs array, recursively
+// redacts sensitive keys and string values throughout every breadcrumb, and
+// returns the re-serialised JSON.
 //
 // If the input is nil, empty, or not valid JSON, it is returned as-is.
 func RedactBreadcrumbs(breadcrumbs []byte) []byte {
@@ -161,42 +174,13 @@ func RedactBreadcrumbs(breadcrumbs []byte) []byte {
 		return breadcrumbs
 	}
 
-	var crumbs []map[string]json.RawMessage
+	var crumbs []interface{}
 	if err := json.Unmarshal(breadcrumbs, &crumbs); err != nil {
 		// Not valid JSON array -- return unchanged.
 		return breadcrumbs
 	}
 
-	for i, crumb := range crumbs {
-		dataRaw, ok := crumb["data"]
-		if !ok {
-			continue
-		}
-
-		// Parse data as map[string]interface{} to handle mixed-type values
-		// (e.g., {"Authorization": "Bearer x", "status_code": 200}).
-		var dataMap map[string]interface{}
-		if err := json.Unmarshal(dataRaw, &dataMap); err != nil {
-			// Data is not an object. Apply body-level redaction on raw JSON.
-			redactedRaw := RedactURL(RedactBody(string(dataRaw)))
-			crumbs[i]["data"] = json.RawMessage(redactedRaw)
-			continue
-		}
-
-		// Recurse so nested header/token values (e.g.
-		// data.request.headers.Authorization) are redacted too, not just
-		// top-level keys. redactValue walks maps/arrays, redacts sensitive
-		// keys at any depth, and scrubs every string value.
-		redactedData := redactValue(dataMap)
-
-		encoded, err := json.Marshal(redactedData)
-		if err != nil {
-			continue
-		}
-		crumbs[i]["data"] = json.RawMessage(encoded)
-	}
-
-	out, err := json.Marshal(crumbs)
+	out, err := json.Marshal(redactValue(crumbs))
 	if err != nil {
 		return breadcrumbs
 	}

--- a/packages/ingestion/masking/masking_test.go
+++ b/packages/ingestion/masking/masking_test.go
@@ -24,6 +24,13 @@ func TestRedactHeaders_SensitiveHeadersRedacted(t *testing.T) {
 		"X-Auth-Token":         "auth-value",
 		"X-Access-Token":       "access-value",
 		"X-Amz-Security-Token": "aws-value",
+		"Private-Token":        "gitlab-value",
+		"X-Gitlab-Token":       "gitlab-hook-value",
+		"X-Vault-Token":        "vault-value",
+		"X-Goog-Api-Key":       "goog-value",
+		"X-Refresh-Token":      "refresh-value",
+		"X-Session-Token":      "session-token-value",
+		"X-Session-Id":         "session-id-value",
 		"Content-Type":         "application/json",
 	}
 
@@ -32,7 +39,9 @@ func TestRedactHeaders_SensitiveHeadersRedacted(t *testing.T) {
 	sensitive := []string{
 		"Authorization", "Proxy-Authorization", "Authentication", "Cookie",
 		"Set-Cookie", "X-Api-Key", "X-CSRF-Token", "X-Auth-Token",
-		"X-Access-Token", "X-Amz-Security-Token",
+		"X-Access-Token", "X-Amz-Security-Token", "Private-Token",
+		"X-Gitlab-Token", "X-Vault-Token", "X-Goog-Api-Key",
+		"X-Refresh-Token", "X-Session-Token", "X-Session-Id",
 	}
 	for _, key := range sensitive {
 		if got[key] != "[REDACTED]" {
@@ -431,5 +440,42 @@ func TestRedactRecording(t *testing.T) {
 	// Non-JSON input falls back to string-level redaction (never returned verbatim).
 	if out := string(masking.RedactRecording([]byte("token ghp_rawleak2 here"))); strings.Contains(out, "ghp_rawleak2") {
 		t.Errorf("non-JSON recording not redacted: %s", out)
+	}
+}
+
+func TestRedactBreadcrumbs_RedactsFieldsOutsideData(t *testing.T) {
+	raw := []byte(`[{"type":"http","message":"token ghp_topLevelSecret123","headers":{"Authorization":"Bearer xoxb-top-secret"}}]`)
+	got := string(masking.RedactBreadcrumbs(raw))
+	for _, leak := range []string{"ghp_topLevelSecret123", "xoxb-top-secret"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("secret %q outside data survived breadcrumb redaction: %s", leak, got)
+		}
+	}
+	if !strings.Contains(got, `"type":"http"`) {
+		t.Errorf("benign field clobbered: %s", got)
+	}
+}
+
+func TestRedactBreadcrumbs_PreservesLargeIntegers(t *testing.T) {
+	raw := []byte(`[{"timestamp_ns":1721430000123456789,"data":{"status_code":200}}]`)
+	got := string(masking.RedactBreadcrumbs(raw))
+	if !strings.Contains(got, "1721430000123456789") {
+		t.Errorf("int64-scale value lost precision through redaction: %s", got)
+	}
+	if !strings.Contains(got, "200") {
+		t.Errorf("numeric data field clobbered: %s", got)
+	}
+}
+
+func TestRedactURL_NonHTTPSchemes(t *testing.T) {
+	for _, tc := range []struct{ in, leak string }{
+		{"connect to postgres://svc:dbpassword1@db.internal/app failed", "dbpassword1"},
+		{"redis://default:cachepw2@cache:6379 timed out", "cachepw2"},
+		{"amqp://guest:queuepw3@mq/vhost unreachable", "queuepw3"},
+	} {
+		got := masking.RedactURL(tc.in)
+		if strings.Contains(got, tc.leak) {
+			t.Errorf("RedactURL leaked DSN credential %q: %s", tc.leak, got)
+		}
 	}
 }

--- a/packages/ingestion/masking/masking_test.go
+++ b/packages/ingestion/masking/masking_test.go
@@ -14,17 +14,26 @@ import (
 
 func TestRedactHeaders_SensitiveHeadersRedacted(t *testing.T) {
 	headers := map[string]string{
-		"Authorization": "Bearer sk_live_abc123",
-		"Cookie":        "session=xyz",
-		"Set-Cookie":    "session=xyz; HttpOnly",
-		"X-Api-Key":     "key-12345",
-		"X-CSRF-Token":  "csrf-value",
-		"Content-Type":  "application/json",
+		"Authorization":        "Bearer sk_live_abc123",
+		"Proxy-Authorization":  "Basic xyz",
+		"Authentication":       "secret",
+		"Cookie":               "session=xyz",
+		"Set-Cookie":           "session=xyz; HttpOnly",
+		"X-Api-Key":            "key-12345",
+		"X-CSRF-Token":         "csrf-value",
+		"X-Auth-Token":         "auth-value",
+		"X-Access-Token":       "access-value",
+		"X-Amz-Security-Token": "aws-value",
+		"Content-Type":         "application/json",
 	}
 
 	got := masking.RedactHeaders(headers)
 
-	sensitive := []string{"Authorization", "Cookie", "Set-Cookie", "X-Api-Key", "X-CSRF-Token"}
+	sensitive := []string{
+		"Authorization", "Proxy-Authorization", "Authentication", "Cookie",
+		"Set-Cookie", "X-Api-Key", "X-CSRF-Token", "X-Auth-Token",
+		"X-Access-Token", "X-Amz-Security-Token",
+	}
 	for _, key := range sensitive {
 		if got[key] != "[REDACTED]" {
 			t.Errorf("RedactHeaders[%q] = %q, want %q", key, got[key], "[REDACTED]")

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -222,6 +222,9 @@ export interface Incident {
   id: string;
   project_id: string;
   kind: IncidentKind;
+  /** Platform wire token ('javascript', 'python', future tokens) for error
+   * incidents; null/absent for friction. */
+  platform?: string | null;
   /** Present only on kind='friction': friction identity is environment-scoped. */
   environment_id?: string;
   /** Present only on kind='friction'; 'unchecked' flags an exhausted
@@ -249,6 +252,21 @@ export interface Incident {
   merged_at?: string;
   resolved_at?: string;
   archived_at?: string;
+}
+
+/** Sample event for an error group, served by
+ * GET /projects/{projectId}/incidents/{incidentId}/sample-event. */
+export interface SampleEvent {
+  timestamp: string;
+  platform: string;
+  error: {
+    type: string;
+    message: string;
+    stack: string;
+  };
+  /** The read API normalizes non-array stored values to an empty array. */
+  breadcrumbs: unknown[];
+  context: Record<string, unknown>;
 }
 
 // === Source map upload ===

--- a/test-e2e/helpers.ts
+++ b/test-e2e/helpers.ts
@@ -476,6 +476,14 @@ export async function cleanupTenant(orgId: string): Promise<void> {
     `DELETE FROM error_events WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
     [orgId]
   );
+  // Events with context.user create affected-user junction rows that block
+  // the error_groups delete (no cascade).
+  await db.query(
+    `DELETE FROM error_group_affected_users WHERE error_group_id IN (
+       SELECT eg.id FROM error_groups eg JOIN projects p ON eg.project_id = p.id WHERE p.org_id = $1
+     )`,
+    [orgId]
+  );
   await db.query(
     `DELETE FROM error_groups WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
     [orgId]

--- a/test-e2e/python-smoke-runner.py
+++ b/test-e2e/python-smoke-runner.py
@@ -1,0 +1,35 @@
+"""Runs the fixture Flask app wired to the real Python SDK.
+
+Spawned by python-smoke.test.ts. Not a test itself: it is the "customer
+application" leg of the e2e — the checked-in test-fixtures/flask-app served
+over real HTTP with the real opslane SDK attached, pointing at whatever
+ingestion stack the e2e suite targets.
+
+Env:
+  OPSLANE_API_KEY   raw SDK key for the seeded tenant (required)
+  OPSLANE_ENDPOINT  ingestion base URL, e.g. http://localhost:8093 (required)
+  PORT              port to serve the Flask app on (required)
+"""
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "packages", "sdk-python"))
+sys.path.insert(0, os.path.join(ROOT, "test-fixtures", "flask-app"))
+
+import opslane
+from opslane.integrations.flask import OpslaneFlask
+
+opslane.init(
+    api_key=os.environ["OPSLANE_API_KEY"],
+    endpoint=os.environ["OPSLANE_ENDPOINT"],
+    release="python-smoke-e2e",
+)
+
+from app import app  # the fixture app: /health, /boom, /boom-secret
+
+app.config["PROPAGATE_EXCEPTIONS"] = False
+OpslaneFlask(app)
+
+if __name__ == "__main__":
+    app.run(port=int(os.environ["PORT"]))

--- a/test-e2e/python-smoke.test.ts
+++ b/test-e2e/python-smoke.test.ts
@@ -1,0 +1,453 @@
+/**
+ * E2E: Python SDK smoke — real Flask fixture app + real SDK → real ingestion.
+ *
+ * Two legs:
+ * 1. Live Flask leg (needs a Python with flask importable): spawns
+ *    python-smoke-runner.py, which serves test-fixtures/flask-app with the
+ *    real opslane SDK attached, then triggers errors over real HTTP and
+ *    verifies grouping, platform read-through/filter, the sample-event read
+ *    path, redaction (client-side, write-side, and read-side), and the
+ *    session-only auth contract. Skipped with a message when flask is absent.
+ * 2. Wire-level adversarial leg (no Python required): hand-built payloads a
+ *    hostile non-SDK client could send, asserting the server's
+ *    defense-in-depth holds without any client cooperation.
+ *
+ * Required:
+ *   DATABASE_URL     — Postgres connection string
+ *   INGESTION_URL    — Base URL for ingestion API (default: http://localhost:8082)
+ * Optional:
+ *   OPSLANE_PYTHON   — Python interpreter with flask installed (default: python3)
+ *   JWT_SECRET       — must match the stack's secret (default: compose dev secret)
+ */
+
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import crypto from 'node:crypto';
+import net from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  seedTenant,
+  seedUserWithJWT,
+  cleanupTenant,
+  closePool,
+  getConfig,
+  getPool,
+  postEvent,
+  type TestTenant,
+} from './helpers.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const RUNNER = path.join(HERE, 'python-smoke-runner.py');
+
+const PYTHON = process.env['OPSLANE_PYTHON'] ?? 'python3';
+const HAS_FLASK = (() => {
+  try {
+    execFileSync(PYTHON, ['-c', 'import flask'], { stdio: 'ignore', timeout: 15_000 });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+if (!HAS_FLASK) {
+  console.warn(
+    `python-smoke: skipping live Flask leg — "${PYTHON}" cannot import flask. ` +
+    'Point OPSLANE_PYTHON at an interpreter with flask installed to run it.'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_JWT_SECRET = 'opslane-dev-jwt-secret-key-minimum-32-bytes-long';
+
+/** Mint an HS256 session JWT with arbitrary claims/secret (for adversarial cases). */
+function mintJWT(
+  claims: Record<string, unknown>,
+  secret = process.env['JWT_SECRET'] ?? DEFAULT_JWT_SECRET,
+): string {
+  const header = Buffer.from('{"alg":"HS256","typ":"JWT"}').toString('base64url');
+  const payload = Buffer.from(JSON.stringify(claims)).toString('base64url');
+  const signingInput = `${header}.${payload}`;
+  const sig = crypto.createHmac('sha256', secret).update(signingInput).digest().toString('base64url');
+  return `${signingInput}.${sig}`;
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const address = srv.address();
+      if (address === null || typeof address === 'string') {
+        srv.close();
+        reject(new Error('could not allocate a port'));
+        return;
+      }
+      const { port } = address;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+async function pollFor<T>(
+  fetchValue: () => Promise<T>,
+  ready: (value: T) => boolean,
+  what: string,
+  timeoutMs = 30_000,
+  intervalMs = 500,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last: T | undefined;
+  while (Date.now() < deadline) {
+    last = await fetchValue();
+    if (ready(last)) return last;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`timed out waiting for ${what}; last value: ${JSON.stringify(last)}`);
+}
+
+interface IncidentRow {
+  id: string;
+  title: string;
+  kind: string;
+  platform?: string;
+  occurrence_count: number;
+}
+
+async function listIncidentsRaw(
+  apiKey: string,
+  projectId: string,
+  query = '',
+): Promise<{ status: number; incidents: IncidentRow[] }> {
+  const { ingestionUrl } = getConfig();
+  const res = await fetch(
+    `${ingestionUrl}/api/v1/projects/${projectId}/incidents${query}`,
+    { headers: { 'X-API-Key': apiKey } },
+  );
+  if (!res.ok) return { status: res.status, incidents: [] };
+  return { status: res.status, incidents: (await res.json()) as IncidentRow[] };
+}
+
+function sampleEventUrl(projectId: string, incidentId: string): string {
+  const { ingestionUrl } = getConfig();
+  return `${ingestionUrl}/api/v1/projects/${projectId}/incidents/${incidentId}/sample-event`;
+}
+
+interface SampleEventBody {
+  timestamp: string;
+  platform: string;
+  error: { type: string; message: string; stack: string };
+  breadcrumbs: unknown[];
+  context: Record<string, unknown>;
+}
+
+function requestHeadersOf(body: SampleEventBody): Record<string, unknown> {
+  const request = body.context['request'];
+  if (typeof request !== 'object' || request === null) return {};
+  const headers = (request as Record<string, unknown>)['headers'];
+  if (typeof headers !== 'object' || headers === null) return {};
+  return headers as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Leg 1: live Flask app + real SDK
+// ---------------------------------------------------------------------------
+
+describe.runIf(HAS_FLASK)('python SDK live smoke (Flask fixture → ingestion)', () => {
+  let tenant: TestTenant;
+  let jwt: string;
+  let flask: ChildProcess | null = null;
+  let boomIncident: IncidentRow;
+  let secretIncident: IncidentRow;
+
+  beforeAll(async () => {
+    tenant = await seedTenant('e2e/python-smoke');
+    ({ jwt } = await seedUserWithJWT(tenant.orgId));
+
+    const port = await getFreePort();
+    const appUrl = `http://127.0.0.1:${port}`;
+    flask = spawn(PYTHON, [RUNNER], {
+      env: {
+        ...process.env,
+        OPSLANE_API_KEY: tenant.apiKey,
+        OPSLANE_ENDPOINT: getConfig().ingestionUrl,
+        PORT: String(port),
+      },
+      stdio: 'ignore',
+    });
+
+    await pollFor(
+      async () => {
+        try {
+          return (await fetch(`${appUrl}/health`)).status;
+        } catch {
+          return 0;
+        }
+      },
+      (status) => status === 200,
+      'flask fixture app to boot',
+      20_000,
+    );
+
+    // First occurrence: benign. Second occurrence: adversarial headers — the
+    // sample event tracks the LAST occurrence, so the served sample must be
+    // the one that carried secrets.
+    expect((await fetch(`${appUrl}/boom`)).status).toBe(500);
+    expect(
+      (
+        await fetch(`${appUrl}/boom`, {
+          headers: {
+            // Stripped client-side by the SDK's own deny-list:
+            Authorization: 'Bearer client-side-should-strip',
+            // NOT in the SDK's client-side list — reaches the server, which
+            // must redact it at write time and drop the key at read time:
+            'X-Vault-Token': 'fake-vault-secret-e2e',
+            // Benign marker — must SURVIVE filtering (prove we filter
+            // selectively, not by dropping everything):
+            'X-E2E-Benign': 'benign-value-visible',
+          },
+        })
+      ).status,
+    ).toBe(500);
+    // Distinct incident whose message and traceback carry planted fake secrets.
+    expect((await fetch(`${appUrl}/boom-secret`)).status).toBe(500);
+
+    // SDK transport is async — wait until both incidents landed and grouped.
+    const incidents = await pollFor(
+      async () => (await listIncidentsRaw(tenant.apiKey, tenant.projectId)).incidents,
+      (rows) =>
+        rows.length === 2 &&
+        rows.some((r) => r.title.includes('seeded failure') && r.occurrence_count >= 2) &&
+        rows.some((r) => r.title.includes('connect to')),
+      'both python incidents to be ingested and grouped',
+    );
+    boomIncident = incidents.find((r) => r.title.includes('seeded failure'))!;
+    secretIncident = incidents.find((r) => r.title.includes('connect to'))!;
+  }, 90_000);
+
+  afterAll(async () => {
+    flask?.kill();
+    if (tenant) await cleanupTenant(tenant.orgId);
+    await closePool();
+  });
+
+  it('groups repeated Flask errors into one python incident', () => {
+    expect(boomIncident.kind).toBe('error');
+    expect(boomIncident.platform).toBe('python');
+    expect(boomIncident.occurrence_count).toBeGreaterThanOrEqual(2);
+    expect(boomIncident.title).toBe('ValueError: seeded failure for SDK testing');
+  });
+
+  it('platform filter matches python, excludes javascript, rejects garbage', async () => {
+    const python = await listIncidentsRaw(tenant.apiKey, tenant.projectId, '?platform=python');
+    expect(python.incidents.map((r) => r.platform)).toEqual(['python', 'python']);
+
+    const js = await listIncidentsRaw(tenant.apiKey, tenant.projectId, '?platform=javascript');
+    expect(js.incidents).toHaveLength(0);
+
+    const garbage = await listIncidentsRaw(
+      tenant.apiKey, tenant.projectId, '?platform=Not%20A%20Token',
+    );
+    expect(garbage.status).toBe(400);
+  });
+
+  it('serves the traceback to a session user, uncacheable', async () => {
+    const res = await fetch(sampleEventUrl(tenant.projectId, boomIncident.id), {
+      headers: { Authorization: `Bearer ${jwt}` },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+
+    const body = (await res.json()) as SampleEventBody;
+    expect(body.platform).toBe('python');
+    expect(body.error.type).toBe('ValueError');
+    expect(body.error.stack.startsWith('Traceback (most recent call last):')).toBe(true);
+    expect(body.error.stack).toContain('in boom');
+    expect(Array.isArray(body.breadcrumbs)).toBe(true);
+    const request = body.context['request'] as Record<string, unknown>;
+    expect(request['method']).toBe('GET');
+    expect(request['path']).toBe('/boom');
+  });
+
+  it('filters denied headers but keeps benign ones', async () => {
+    const res = await fetch(sampleEventUrl(tenant.projectId, boomIncident.id), {
+      headers: { Authorization: `Bearer ${jwt}` },
+    });
+    const raw = JSON.stringify(await res.clone().json());
+    expect(raw).not.toContain('client-side-should-strip'); // SDK stripped it
+    expect(raw).not.toContain('fake-vault-secret-e2e'); // server denied it
+    expect(raw).toContain('benign-value-visible'); // benign survives
+
+    const headers = requestHeadersOf((await res.json()) as SampleEventBody);
+    expect(Object.keys(headers)).not.toContain('authorization');
+    expect(Object.keys(headers)).not.toContain('x-vault-token');
+  });
+
+  it('redacts planted secrets in the error message and stack', async () => {
+    const res = await fetch(sampleEventUrl(tenant.projectId, secretIncident.id), {
+      headers: { Authorization: `Bearer ${jwt}` },
+    });
+    expect(res.status).toBe(200);
+    const raw = JSON.stringify(await res.clone().json());
+    expect(raw).not.toContain('plantedfakepassword'); // DSN credential
+    expect(raw).not.toContain('ghp_plantedfakee2esecret123'); // API token
+
+    const body = (await res.json()) as SampleEventBody;
+    expect(body.error.type).toBe('ValueError'); // still identifiable
+    expect(body.error.message).toContain('[REDACTED]');
+    expect(body.error.stack.startsWith('Traceback (most recent call last):')).toBe(true);
+  });
+
+  it('rejects every non-session credential', async () => {
+    const url = sampleEventUrl(tenant.projectId, boomIncident.id);
+    const attempts: Array<[string, Record<string, string>]> = [
+      ['SDK API key', { 'X-API-Key': tenant.apiKey }],
+      ['no credentials', {}],
+      ['garbage bearer', { Authorization: 'Bearer not-a-jwt' }],
+      [
+        'wrong signing secret',
+        {
+          Authorization: `Bearer ${mintJWT(
+            {
+              sub: crypto.randomUUID(),
+              org_id: tenant.orgId,
+              email: 'attacker@e2e.test',
+              iat: Math.floor(Date.now() / 1000),
+              exp: Math.floor(Date.now() / 1000) + 3600,
+            },
+            'attacker-controlled-secret-thats-long-enough',
+          )}`,
+        },
+      ],
+      [
+        'expired session',
+        {
+          Authorization: `Bearer ${mintJWT({
+            sub: crypto.randomUUID(),
+            org_id: tenant.orgId,
+            email: 'expired@e2e.test',
+            iat: Math.floor(Date.now() / 1000) - 7200,
+            exp: Math.floor(Date.now() / 1000) - 3600,
+          })}`,
+        },
+      ],
+    ];
+    for (const [label, headers] of attempts) {
+      const res = await fetch(url, { headers });
+      expect(res.status, `${label} must be rejected`).toBe(401);
+    }
+  });
+
+  it('does not disclose incidents across projects or invent them', async () => {
+    // Sibling project in the SAME org: accessible to the caller, so a 403
+    // would not fire first — this isolates the incident lookup's 404 path.
+    const sibling = await getPool().query<{ id: string }>(
+      `INSERT INTO projects (org_id, name) VALUES ($1, $2) RETURNING id`,
+      [tenant.orgId, `python-smoke-sibling-${crypto.randomUUID().slice(0, 8)}`],
+    );
+    const crossProject = await fetch(
+      sampleEventUrl(sibling.rows[0]!.id, boomIncident.id),
+      { headers: { Authorization: `Bearer ${jwt}` } },
+    );
+    expect(crossProject.status).toBe(404);
+
+    const unknown = await fetch(
+      sampleEventUrl(tenant.projectId, crypto.randomUUID()),
+      { headers: { Authorization: `Bearer ${jwt}` } },
+    );
+    expect(unknown.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Leg 2: wire-level adversarial payloads (no Python required)
+// ---------------------------------------------------------------------------
+
+describe('python wire adversarial (hostile non-SDK client)', () => {
+  let tenant: TestTenant;
+  let jwt: string;
+
+  beforeAll(async () => {
+    tenant = await seedTenant('e2e/python-wire-adversarial');
+    ({ jwt } = await seedUserWithJWT(tenant.orgId));
+  }, 30_000);
+
+  afterAll(async () => {
+    if (tenant) await cleanupTenant(tenant.orgId);
+    await closePool();
+  });
+
+  it('cannot smuggle secrets past the read API with malformed shapes', async () => {
+    // The SDK strips secrets client-side; a hostile client does not. Headers
+    // as an array-of-pairs bypass any map-shaped filter, and non-array
+    // breadcrumbs break any consumer that trusts the contract blindly.
+    const res = await postEvent(tenant.apiKey, {
+      timestamp: new Date().toISOString(),
+      platform: 'python',
+      error: {
+        type: 'RuntimeError',
+        message: 'malformed shapes',
+        stack: 'Traceback (most recent call last):\nRuntimeError: malformed shapes',
+      },
+      breadcrumbs: { not: 'an array' },
+      context: {
+        request: {
+          method: 'GET',
+          path: '/x',
+          headers: [['Authorization', 'array-smuggled-secret']],
+        },
+      },
+    });
+    expect(res.status).toBe(202);
+    const { group_id } = (await res.json()) as { group_id: string };
+
+    const sample = await fetch(sampleEventUrl(tenant.projectId, group_id), {
+      headers: { Authorization: `Bearer ${jwt}` },
+    });
+    expect(sample.status).toBe(200);
+    const raw = await sample.clone().text();
+    expect(raw).not.toContain('array-smuggled-secret');
+
+    const body = (await sample.json()) as SampleEventBody;
+    expect(body.breadcrumbs).toEqual([]); // normalized, never the raw object
+    const headers = requestHeadersOf(body);
+    expect(Object.keys(headers)).toHaveLength(0); // dropped, never verbatim
+  });
+
+  it('shows one end user across JS and Python incidents with platforms', async () => {
+    const userId = `cross-stack-${crypto.randomUUID().slice(0, 8)}`;
+    const jsRes = await postEvent(tenant.apiKey, {
+      timestamp: new Date().toISOString(),
+      error: {
+        type: 'TypeError',
+        message: 'cross-stack javascript',
+        stack: 'at fn (/src/app.js:1:1)',
+      },
+      breadcrumbs: [],
+      context: { user: { id: userId } },
+    });
+    expect(jsRes.status).toBe(202);
+    const pyRes = await postEvent(tenant.apiKey, {
+      timestamp: new Date().toISOString(),
+      platform: 'python',
+      error: {
+        type: 'ValueError',
+        message: 'cross-stack python',
+        stack: 'Traceback (most recent call last):\nValueError: cross-stack python',
+      },
+      breadcrumbs: [],
+      context: { user: { id: userId } },
+    });
+    expect(pyRes.status).toBe(202);
+
+    const timeline = await listIncidentsRaw(
+      tenant.apiKey, tenant.projectId, `?end_user_id=${userId}`,
+    );
+    expect(timeline.incidents).toHaveLength(2);
+    expect(new Set(timeline.incidents.map((r) => r.platform))).toEqual(
+      new Set(['javascript', 'python']),
+    );
+  });
+});

--- a/test-fixtures/flask-app/.gitignore
+++ b/test-fixtures/flask-app/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.venv/

--- a/test-fixtures/flask-app/app.py
+++ b/test-fixtures/flask-app/app.py
@@ -14,3 +14,14 @@ def health():
 @app.get("/boom")
 def boom():
     raise ValueError("seeded failure for SDK testing")
+
+
+@app.get("/boom-secret")
+def boom_secret():
+    """Raises with planted FAKE credentials (a DSN and a ghp_ token). The
+    python-smoke e2e asserts the read API serves this incident with both
+    values redacted; they must never appear in an API response."""
+    raise ValueError(
+        "connect to postgres://svc:plantedfakepassword@db.internal/app failed"
+        " (token ghp_plantedfakee2esecret123)"
+    )


### PR DESCRIPTION
Closes #88.

Makes Python errors visible and readable in the dashboard. `platform` was stored by migration 016 but never read back, and no endpoint returned a group's stack, breadcrumbs, or context — for JS or Python. So the dashboard rendered no stack trace at all. This plumbs platform through the read path, adds one tenant-scoped sample-event endpoint, and builds the rendering on top.

## What's here

**Server (additive only)**
- `platform` read back through `ListErrorGroups` and `GetErrorGroup`, exposed as `incidentJSON.platform`
- `?platform=` filter on the incident list, validated against the same token regex ingestion uses; an invalid token is a 400 rather than a silently unfiltered list
- `GET /projects/{projectID}/incidents/{incidentID}/sample-event` — tenant-scoped through the owning group, session-auth only, `Cache-Control: no-store`

**Dashboard**
- Platform filter and badge on the activity feed, with URL sync that survives reload
- Stack trace, request context, and breadcrumbs on the incident detail Overview tab
- `end_user_id` passthrough, which FilterBar previously dropped on mount — this is what makes a user-scoped URL a working cross-stack timeline

**Auth choice worth calling out:** the sample-event route uses `AuthenticateUserSession`, deliberately stricter than the sibling incident reads. Browser SDK keys are necessarily client-visible, and this endpoint returns tracebacks, request headers, and client IPs. A leaked SDK key must not become a PII read path. An SDK key gets 401 here, and that is asserted.

## Redaction

The endpoint serves data that historical rows may carry in cleartext, so redaction runs on the way out as well as at ingest:

- Error message and stack are redacted on read. They are persisted raw because grouping fingerprints the original values, and they are the most common carriers of leaked credentials.
- `RedactURL` previously matched only `http(s)://`, so DSN credentials (`postgres://user:pw@host`, `redis://`, `amqp://`) passed through untouched. The scheme is now any URI.
- The sensitive-header deny-list gained `Private-Token`, `X-Gitlab-Token`, `X-Vault-Token`, `X-Goog-Api-Key`, `X-Refresh-Token`, `X-Session-Token`, `X-Session-Id`, strengthening write-side masking and read-side filtering together.
- Malformed sub-objects are dropped rather than passed through. Ingestion accepts arbitrary JSON, so `headers: [["Authorization","secret"]]` is storable and would bypass a map-shaped filter.
- `RedactBreadcrumbs` now decodes with `UseNumber`, so int64-scale values (epoch-nanos timestamps, IDs) survive redaction instead of rounding through float64.

`GetSampleEvent` requires the event to share both the project **and** the group with its pointer. `sample_event_id` has no foreign key, so a corrupt pointer must not serve another tenant's event or another incident's evidence.

## Verification

Full repo gate green: `pnpm -r build`, `pnpm test`, `go build ./... && go vet ./... && go test ./...` against a disposable migrated Postgres, `docker compose config --quiet`, docs-drift check.

Live smoke against an isolated compose stack, with the real SDK driving the real Flask fixture: two `/boom` hits grouped into one `platform: python` incident, `?platform=python` filtered correctly, garbage token 400, sample-event returned the traceback with `no-store`, SDK key 401. Planted secrets did not appear in any response; `X-Vault-Token` was stored `[REDACTED]` and its key dropped on read.

That smoke is now checked in as `test-e2e/python-smoke.test.ts` — the browser SDK had a live e2e through the vue and react fixtures, the Python SDK had none.

- **Live leg**: real Flask app + real SDK. Grouping, platform filter, sample-event, and redaction at all three layers — headers the SDK strips client-side, headers only the server denies, and planted secrets in the message and traceback. A benign header must survive, so the filter is proven selective rather than a blanket drop. Auth is exercised adversarially: SDK key, no credentials, garbage bearer, wrong signing secret, and expired session must all 401. Non-disclosure too: a sibling project in the same org and an unknown incident both 404.
- **Wire leg** (no Python needed): a hostile non-SDK client smuggling array-shaped headers and non-array breadcrumbs, plus the cross-stack timeline where one end user spans a JS and a Python group.

The live leg self-skips without flask, so CI installs it pinned and lists both suites in `E2E_REQUIRED_PATTERNS`. The keyless lane already fails on any unexpected skip, so a missing interpreter breaks the job instead of quietly narrowing coverage. Verified both directions: with flask the gate passes 9/9, without it the gate exits 1 naming every skipped test.

`cleanupTenant` never deleted `error_group_affected_users`; the cross-stack case is the first e2e to create them, and teardown failed on the foreign key until this branch.

## Follow-up

#119 — the candidate-visibility predicate is now inlined in four queries in two divergent forms. Deferred to keep this diff scoped.