### PR TITLE
fix(ingestion): agent poll reports expired as soon as the window lapses

### DIFF
--- a/packages/ingestion/handler/agent_callback_integration_test.go
+++ b/packages/ingestion/handler/agent_callback_integration_test.go
@@ -275,6 +275,36 @@ func TestAgentPollExpiredSessionContract(t *testing.T) {
 	}
 }
 
+// A pending session whose expires_at has lapsed must poll as expired even
+// though the hourly ExpireAgentSessions sweep has not run yet. Otherwise the
+// agent is told "pending" (exit 0, keep waiting) for up to an hour while the
+// human opening the same auth link already gets 410.
+func TestAgentPollLapsedPendingSessionIsExpiredBeforeSweep(t *testing.T) {
+	pool := githubOAuthTestPool(t)
+	q := db.New(pool)
+	session, raw := createCallbackSession(t, q, "lapsed-owner/"+uuid.NewString())
+	t.Cleanup(func() { cleanupCallbackTenant(t, pool, session.ID, 0, "") })
+
+	// Lapse the window without running the sweep — status stays 'pending'.
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE agent_sessions SET expires_at = now() - interval '1 minute' WHERE id = $1`, session.ID); err != nil {
+		t.Fatal(err)
+	}
+	var status string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT status FROM agent_sessions WHERE id = $1`, session.ID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "pending" {
+		t.Fatalf("precondition: want status pending (unswept), got %q", status)
+	}
+
+	code, body := pollAgentSession(t, &Dependencies{Queries: q}, session.ID, raw)
+	if code != http.StatusGone || body["status"] != "expired" || body["message"] != "session expired; re-run setup" {
+		t.Fatalf("lapsed pending session: code=%d body=%v", code, body)
+	}
+}
+
 func TestAgentSetupV2ContractAndNoTenantLeakage(t *testing.T) {
 	pool := githubOAuthTestPool(t)
 	q := db.New(pool)

--- a/packages/ingestion/handler/agent_setup.go
+++ b/packages/ingestion/handler/agent_setup.go
@@ -223,6 +223,15 @@ func (d *Dependencies) AgentPoll(w http.ResponseWriter, r *http.Request) {
 		})
 
 	default: // pending
+		// ExpireAgentSessions only flips the status column hourly. Read the
+		// window directly so a lapsed session reports expired immediately,
+		// matching what AgentAuthRedirect already tells the human.
+		if time.Now().After(session.ExpiresAt) {
+			agentJSON(w, http.StatusGone, map[string]any{
+				"status": "expired", "message": "session expired; re-run setup",
+			})
+			return
+		}
 		agentJSON(w, http.StatusOK, map[string]any{"status": "pending"})
 	}
 }


### PR DESCRIPTION
## Summary

An agent polling a lapsed setup session was told `pending` for up to an hour, while the human opening the same authorization link already got `410 session expired`.

`AgentPoll` switched on the `status` column alone. That column only becomes `'expired'` via `ExpireAgentSessions` (`db/queries.go`), driven by a 1-hour ticker in `main.go` whose first tick lands an hour after boot. `expires_at` was consulted only inside the `completed` case, for the key-delivery window.

So between a session's ~15-minute lapse and the next sweep, the two surfaces disagreed. Worse, `docs/quickstart/agent.md` tells the agent that persistent `pending` means "remind the human about the link" — sending them to a link that already returns 410.

The fix reads `expires_at` directly in the pending branch, so the poll and the auth redirect agree immediately.

## Evidence

Reproduced against a live stack (disposable `opslane_smoke` DB, real CLI, real ingestion container), by aging a real session's `expires_at` past now without running the sweep.

**Before:**

| Surface | Result |
| --- | --- |
| Agent polls (raw HTTP) | `{"status":"pending"}` HTTP 200 |
| Agent polls (CLI) | `{"status":"pending","message":"Authorization is still pending. Run setup --poll again."}` exit 0 |
| Human opens `auth_url` | HTTP 410 `{"error":"session expired"}` |

**After (same scenario, rebuilt image, session status still `pending` in the DB):**

| Surface | Result |
| --- | --- |
| Agent polls (raw HTTP) | `{"status":"expired","message":"session expired; re-run setup"}` HTTP 410 |
| Agent polls (CLI) | `{"status":"expired","remediation":"re-run setup"}` exit 1 |
| Human opens `auth_url` | HTTP 410 |

Non-lapsed sessions are unchanged: poll returns `{"status":"pending"}` HTTP 200, auth link returns 302 to GitHub.

## Test

`TestAgentPollLapsedPendingSessionIsExpiredBeforeSweep` asserts the precondition (status still `pending`, sweep not run) before polling, so it fails if a future change makes the sweep synchronous rather than silently passing.

Watched it fail first: `code=200 body=map[status:pending]`.

`TestAgentPollExpiredSessionContract` already covered the post-sweep path (status column set to `'expired'`); nothing covered the lapsed-but-unswept window.

## Verification

- `go build ./... && go test ./... -count=1` in `packages/ingestion` — all packages pass
- `node scripts/check-docs-drift.mjs && node scripts/check-docs-scope.mjs` — pass
- Live before/after reproduction above

## Scope

Server only. Found while verifying the PR 3 agent-quickstart failure-state table, but kept off that branch — the PR 3 plan explicitly excludes CLI and server changes. No doc change is needed: `docs/quickstart/agent.md` already describes the intended behavior this restores.
