### PR TITLE
test(ingestion): cover repo_not_granted classification in the agent callback

### DIFF
--- a/packages/ingestion/handler/agent_callback_integration_test.go
+++ b/packages/ingestion/handler/agent_callback_integration_test.go
@@ -235,6 +235,24 @@ func TestAgentCallbackEndToEndAndFailureSemantics(t *testing.T) {
 		}
 	})
 
+	t.Run("repo missing from the installation is definitive", func(t *testing.T) {
+		installVisible, emailStatus, verifiedEmails = true, http.StatusOK, true
+		userID++
+		// The installation grants one repo; the session asks for a different
+		// one, which is what "only select repositories" looks like on the wire.
+		repoFullName = "CB-Owner/CB-granted-" + uuid.NewString()
+		session, raw := createCallbackSession(t, q, strings.ToLower("CB-Owner/CB-ungranted-"+uuid.NewString()))
+		t.Cleanup(func() { cleanupCallbackTenant(t, pool, session.ID, installationID, "") })
+		w := callback(session.ID)
+		if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), "Repository not granted") {
+			t.Fatalf("code=%d body=%q", w.Code, w.Body.String())
+		}
+		_, body := pollAgentSession(t, deps, session.ID, raw)
+		if body["status"] != "failed" || body["failure_reason"] != "repo_not_granted" {
+			t.Fatalf("poll body=%v", body)
+		}
+	})
+
 	t.Run("successful empty email list is definitive", func(t *testing.T) {
 		installVisible, emailStatus, verifiedEmails = true, http.StatusOK, false
 		userID++


### PR DESCRIPTION
## Summary

Of the five terminal agent failure reasons, `repo_not_granted` was the only one with no test proving the server produces it.

The string appeared in `db/agent_session_v2_test.go` (which stores it) and `db/admin_onboarding_test.go` (which counts it in the funnel), but nothing exercised the handler branch that *classifies* it — `agent_setup.go`, where a repo absent from the installation's repo list becomes a definitive failure.

This drives that branch through the existing fake-GitHub callback harness: the installation grants one repo, the session asks for a different one, which is what "only select repositories" looks like on the wire. The test asserts both halves of the contract — the human gets 403 "Repository not granted", and the agent's next poll gets `status: failed` with `failure_reason: repo_not_granted`.

## Why this branch was worth pinning down

The test passes against current `main`, so I verified it has teeth by making the guard unreachable and re-running. It failed — but the failure mode is the interesting part:

```
INFO agent session completed  org_id=1934…  project_id=b52d…  repo=""
HTTP 200  "Done! Opslane is set up for <strong></strong>."
```

Without the guard the callback does not merely skip a check. It provisions: creates an org, creates a project with `github_repo=""`, seals a key, and shows the human a success page with a blank repo name.

So this guard is what stands between a partially-granted installation and a junk tenant, and it had nothing holding it in place.

## Coverage after this change

| Reason | Server produces it | Agent sees it via poll |
| --- | --- | --- |
| `identity_unverified` | callback test | yes |
| `installation_not_yours` | callback test | yes |
| `repo_not_granted` | **this PR** | **this PR** |
| `org_exists_needs_invite` | `db/agent_provision_test.go` | not through HTTP |
| `repo_already_configured` | `db/agent_provision_test.go` | not through HTTP |

The last two are covered where the logic lives. Walking them through the HTTP layer would add symmetry but little else; not done here.

All of this exercises a stubbed GitHub. It does not prove real GitHub returns these shapes — only a live run does, which is what PR 6 covered for the happy path.

## Verification

- `go build ./... && go test ./... -count=1` in `packages/ingestion` — all packages pass
- Mutation check: guard made unreachable, subtest fails; guard restored, all five callback subtests pass

## Scope

Test only. No production code changes.
