### PR TITLE
ci: pin npm to 11.18.0 in release workflow

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -63,8 +63,10 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
+      # Pinned, not @latest: npm 12 requires Node ^22.22.2 and would fail
+      # EBADENGINE against the Node in .nvmrc. Bump alongside .nvmrc.
       - name: Update npm (trusted publishing requires >= 11.5.1)
-        run: npm install -g npm@latest && npm --version
+        run: npm install -g npm@11.18.0 && npm --version
       - name: Install (lifecycle scripts blocked)
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Build publishable packages


### PR DESCRIPTION
## Problem

The `npm release` workflow has failed on every push to `main` for a while, turning main red. `CI` and `CodeQL` were unaffected — only this workflow.

The failing step, `.github/workflows/release-npm.yml:67`:

```yaml
run: npm install -g npm@latest && npm --version
```

`npm@latest` is now **12.0.1**, whose engines are `^22.22.2 || ^24.15.0 || >=26.0.0`. The job runs on the Node in `.nvmrc` (**22.12**), so the install aborts:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.0","node":"v22.12.0"}
```

Nothing in our code broke — npm 12 shipped and the unpinned `@latest` picked it up.

## Fix

Pin to `npm@11.18.0` (engines `^20.17.0 || >=22.9.0`), which satisfies Node 22.12 and is well above the `>= 11.5.1` floor that trusted publishing needs.

Pinning rather than bumping `.nvmrc` because:

- `.nvmrc` also feeds three jobs in `ci.yml` that are currently **green**; this keeps the change scoped to the broken job.
- The real defect is the unpinned `@latest`, not the Node version. Bumping `.nvmrc` fixes it until npm 13 raises the floor and main goes red the same way.

A comment on the step ties the pin to `.nvmrc` so the two get bumped together.

## Verification

Reproduced and confirmed in the exact job environment (`docker run node:22.12`):

- `npm install -g npm@11.18.0` → succeeds, reports `11.18.0`
- `npm install -g npm@latest` → reproduces `EBADENGINE`

Registry engine ranges checked directly; workflow file still parses as valid YAML.

Not verified locally: the publish steps downstream of this one. They have not run green recently, so if something further down is also broken, this change surfaces it rather than hiding it. Watching the `npm release` check on this PR.

## Follow-up

`.nvmrc` at 22.12 is behind current 22.x. Not urgent now that npm is pinned — worth a separate PR with a full CI run behind it.