### PR TITLE
fix(ingestion): exempt server-side SDKs from the origin allowlist on /events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
         env:
           # The with-secrets PR pipeline suite is the only allowed skip here.
           E2E_ALLOWED_SKIP_PATTERN: '^pr_created pipeline \(full flow\)'
-          E2E_MIN_TESTS: "46"
+          E2E_MIN_TESTS: "53"
           # The browser smoke suites must be collected AND pass by name, so a
           # future edit cannot drop them while keeping the total count intact.
           # The environments/projects suites below are pinned for the same
@@ -269,6 +269,10 @@ jobs:
           # would silently drop them while the total count still passed.
           # The python smoke's live leg is pinned for the same reason: it
           # self-skips without flask, and a skip here is a coverage hole.
+          # The origin-allowlist cases are pinned individually rather than by
+          # suite prefix: they carry the #104 security contract, and a suite
+          # prefix would let the rejection cases be deleted while the accepted
+          # case alone keeps the pattern matching.
           E2E_REQUIRED_PATTERNS: |
             ^browser smoke: Vue error to needs_human >
             ^browser smoke: React error to needs_human >
@@ -282,6 +286,13 @@ jobs:
             ^dashboard environment filtering > gates readiness and filters incidents, detail chips, and sessions in real Chromium
             ^first-class projects dashboard > switches safely from a deep link and provisions a usable project key
             ^SDK environment browser contract > sends the configured name through real Chromium
+            ^origin allowlist with a server-side SDK > accepts a backend event that carries no Origin or Referer$
+            ^origin allowlist with a server-side SDK > accepts a browser event from an allowlisted origin$
+            ^origin allowlist with a server-side SDK > rejects a browser event from an origin not on the list$
+            ^origin allowlist with a server-side SDK > rejects a referer-only event from an origin not on the list$
+            ^origin allowlist with a server-side SDK > keeps browser-only routes strict for header-less callers$
+            ^real Chromium always sends Origin to /events > rejects a page whose origin is not on the allowlist$
+            ^real Chromium always sends Origin to /events > accepts the same page once its origin is allowlisted$
         run: node scripts/check-e2e-results.mjs "${{ runner.temp }}/e2e-results.json"
       - name: Token-leak scan over logs and public HTTP surfaces
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,13 @@ jobs:
         env:
           # The with-secrets PR pipeline suite is the only allowed skip here.
           E2E_ALLOWED_SKIP_PATTERN: '^pr_created pipeline \(full flow\)'
-          E2E_MIN_TESTS: "53"
+          # The exact collected total, not a slack floor, so any silently
+          # dropped test trips it. Re-derive from an actual run's
+          # numTotalTests — NOT from `vitest list`, which does not expand
+          # it.each and undercounts (60 vs 75, the 24 REASON_CODES cases):
+          #   vitest run --reporter=json --outputFile=/tmp/e2e.json
+          #   node -e 'console.log(require("/tmp/e2e.json").numTotalTests)'
+          E2E_MIN_TESTS: "75"
           # The browser smoke suites must be collected AND pass by name, so a
           # future edit cannot drop them while keeping the total count intact.
           # The environments/projects suites below are pinned for the same

--- a/docs/architecture/life-of-an-error.md
+++ b/docs/architecture/life-of-an-error.md
@@ -14,7 +14,7 @@ The SDK catches the error via global handlers (or a framework hook), attaches br
 
 ## 2. Ingest and group (ingestion API)
 
-The event is authenticated by API key, origin-checked, rate-limited, and masked again server-side (sensitive headers, API-key prefixes, URL credentials). It is fingerprinted on platform + error type + message + stack; matching events join an existing **error group**, new fingerprints create one. New groups enqueue an `investigate` job — a Postgres row, not a message queue — and enqueue `issue.created` events for enabled notification destinations.
+The event is authenticated by API key, origin-checked for browser traffic, rate-limited, and masked again server-side (sensitive headers, API-key prefixes, URL credentials). It is fingerprinted on platform + error type + message + stack; matching events join an existing **error group**, new fingerprints create one. New groups enqueue an `investigate` job — a Postgres row, not a message queue — and enqueue `issue.created` events for enabled notification destinations.
 
 ## 3. Claim (worker)
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -51,7 +51,7 @@ flowchart LR
 
 ## Trust boundaries
 
-1. **Browser → ingestion.** Authenticated by per-environment API keys (stored hashed), origin-gated for browser endpoints, and rate-limited per project. Scrubbing starts in the browser (SDK) and continues server-side ([masking](trust.md#browser-data-and-masking)).
+1. **Browser → ingestion.** Authenticated by per-environment API keys (stored hashed), origin-gated for browser calls (events endpoint also accepts server-side SDKs), and rate-limited per project. Scrubbing starts in the browser (SDK) and continues server-side ([masking](trust.md#browser-data-and-masking)).
 2. **Host → external services.** Two services cross this boundary, each only when credentialed. The **worker** reaches Anthropic (investigation), E2B (fix verification sandbox), and GitHub (clone, fix-branch push, PR). The **ingestion API** also reaches GitHub (installation/repository listing during GitHub App setup), Slack (notification delivery when destinations are configured), and, for authentication, whichever identity provider is configured (GitHub OAuth by default, or WorkOS for cloud multi-org deployments; WorkOS supports social providers including Google and GitHub) — so egress rules must allow GitHub (and WorkOS, if configured) from both services, not just the worker, and Slack webhooks (hooks.slack.com) from ingestion when notifications are enabled. With no credentials configured, nothing leaves your host and investigations end in explicit `needs_human` states.
 3. **Worker → sandbox.** Candidate fixes execute in an isolated E2B sandbox, not on your Opslane host. Repository code is cloned into the sandbox; secrets in the worker's environment are scrubbed from what the agent can read (`repo-clone.ts`).
 

--- a/docs/plans/2026-07-20-origin-allowlist-server-side-exemption.md
+++ b/docs/plans/2026-07-20-origin-allowlist-server-side-exemption.md
@@ -38,7 +38,7 @@ State this accurately; the current doc comment does not.
 
 - The allowlist is **a browser-origin control only.** `Origin` is trustworthy because browsers set it and page JavaScript cannot forge it. Any non-browser caller can send whatever `Origin` it likes, so the allowlist never constrained scripts and does not become weaker by admitting header-less ones.
 - **Do not claim rate limits bound a stolen key's blast radius.** `eventsLimiter` is an in-memory, per-process fixed-window counter (`newRateLimiter`, `auth_handlers.go:35`): every replica gets its own allowance and a restart resets it. It sheds sustained floods per pod; it is not a distributed quota and does not bound storage or worker-job cost.
-- **Assumption worth naming:** a proxy in front of ingestion that strips `Origin` would make browser traffic look header-less on `/events` and silently skip the check. Task 1 logs the exemption so that is greppable rather than invisible.
+- **Assumption worth naming:** a proxy in front of ingestion that strips `Origin` would make browser traffic look header-less on `/events` and silently skip the check. Task 1 logs each exemption at `Debug`, but `main.go:24` builds the logger at the default `Info` level and there is no `LOG_LEVEL` knob, so that line is a hook for investigation, not live detection. Closing this properly needs a counter, which is out of scope here.
 - **Why scoping to `/events` matters:** browsers always send `Origin` on POST (Fetch spec: `Origin` is included for every request whose method is not GET/HEAD, same-origin included), so a real browser hitting `/events` is never exempted. Task 4 verifies that in real Chromium instead of trusting the spec.
 
 ---

--- a/docs/plans/2026-07-20-origin-allowlist-server-side-exemption.md
+++ b/docs/plans/2026-07-20-origin-allowlist-server-side-exemption.md
@@ -1,0 +1,667 @@
+# Origin Allowlist: Server-Side SDK Exemption — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop the browser origin allowlist from silently dropping every backend SDK event, so one project can hold both browser and server-side errors — which is what our one-project-many-platforms model requires.
+
+**Architecture:** `EnforceOrigin` treats "no `Origin`" as "not on the allowlist" and returns 403. Server-side SDKs send neither `Origin` nor `Referer`, so an allowlisted project rejects every Python event. Rather than relax the middleware everywhere, add a second entry point used by **`POST /api/v1/events` only** — the one route a server-side SDK touches (`packages/sdk-python/opslane/transport.py:84` builds exactly that URL and no other). The other seven routes it guards are browser-only (replay init/complete/fail, session init, chunk upload-url/commit/inline) and keep today's strict behavior. Within the relaxed path, the exemption keys on header **presence**, not emptiness.
+
+**Tech Stack:** Go 1.24 (chi) in `packages/ingestion`; Vitest + `pg` + Playwright in `test-e2e`.
+
+**Tracker:** issue #104. Rationale and the Sentry citation live in the issue comment.
+
+---
+
+## Ground rules for the executor
+
+- **Branch:** `abhishekray07/origin-allowlist-server-exemption` off up-to-date `origin/main`:
+  ```bash
+  git fetch origin && git checkout -b abhishekray07/origin-allowlist-server-exemption origin/main
+  ```
+- **DB-backed Go tests** skip without `DATABASE_URL`. Use a disposable Postgres, never the shared 5434 instance (another worktree uses it):
+  ```bash
+  docker run -d --rm --name origin-pg -e POSTGRES_USER=opslane -e POSTGRES_PASSWORD=opslane \
+    -e POSTGRES_DB=opslane -p 5497:5432 postgres:16-alpine
+  # pg_isready can report OK mid-init; gate on a real query instead
+  for i in $(seq 1 60); do docker exec origin-pg psql -U opslane -d opslane -tAc "select 1" >/dev/null 2>&1 && break; sleep 1; done
+  for f in packages/ingestion/db/migrations/*.sql; do
+    docker exec -i origin-pg psql -q -U opslane -d opslane -v ON_ERROR_STOP=1 < "$f"; done
+  export DATABASE_URL="postgres://opslane:opslane@localhost:5497/opslane"
+  ```
+  Tear down with `docker stop origin-pg`.
+- **This is a deliberate contract change.** An existing test asserts the old behavior (Task 1). Per AGENTS.md, documented contracts may change — explicitly. The commit message must say so.
+- Commit after every task with the message given. No Claude attribution, no co-author lines.
+
+## Threat model (read before writing the comment in Task 1)
+
+State this accurately; the current doc comment does not.
+
+- The allowlist is **a browser-origin control only.** `Origin` is trustworthy because browsers set it and page JavaScript cannot forge it. Any non-browser caller can send whatever `Origin` it likes, so the allowlist never constrained scripts and does not become weaker by admitting header-less ones.
+- **Do not claim rate limits bound a stolen key's blast radius.** `eventsLimiter` is an in-memory, per-process fixed-window counter (`newRateLimiter`, `auth_handlers.go:35`): every replica gets its own allowance and a restart resets it. It sheds sustained floods per pod; it is not a distributed quota and does not bound storage or worker-job cost.
+- **Assumption worth naming:** a proxy in front of ingestion that strips `Origin` would make browser traffic look header-less on `/events` and silently skip the check. Task 1 logs the exemption so that is greppable rather than invisible.
+- **Why scoping to `/events` matters:** browsers always send `Origin` on POST (Fetch spec: `Origin` is included for every request whose method is not GET/HEAD, same-origin included), so a real browser hitting `/events` is never exempted. Task 4 verifies that in real Chromium instead of trusting the spec.
+
+---
+
+### Task 1: Presence-based exemption behind a separate entry point
+
+**Files:**
+- Modify: `packages/ingestion/handler/ingest_limits.go:51-90`
+- Test: `packages/ingestion/handler/ingest_limits_test.go`
+
+**Step 1: Change the existing assertion that encodes the old behavior**
+
+In `TestEnforceOrigin_RejectsNonAllowlistedOrigin` (`ingest_limits_test.go:69`), the final block asserts an Origin-less request is rejected. That behavior is **retained** for `EnforceOrigin` (browser-only routes), so this test stays as-is. Confirm it still passes unchanged at the end of this task — if it fails, the exemption leaked into the strict path.
+
+**Step 2: Write the failing tests for the new entry point**
+
+```go
+func TestEnforceOriginAllowingServerSDK_HeaderlessRequestPasses(t *testing.T) {
+	deps := &handler.Dependencies{}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	h := deps.EnforceOriginAllowingServerSDK(next)
+
+	// Exactly what packages/sdk-python sends: no Origin, no Referer.
+	req := httptest.NewRequest("POST", "/api/v1/events", nil)
+	req = req.WithContext(handler.WithAllowedOriginsForTest(
+		context.Background(), []string{"https://app.example.com"}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("server-side SDK must reach an allowlisted project, got %d", rec.Code)
+	}
+}
+
+// http.Header.Get returns "" for BOTH an absent header and a present-but-empty
+// one, so an emptiness check would let `Origin:` bypass the allowlist. The
+// exemption must key on presence.
+func TestEnforceOriginAllowingServerSDK_EmptyValuedHeadersAreNotHeaderless(t *testing.T) {
+	deps := &handler.Dependencies{}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	h := deps.EnforceOriginAllowingServerSDK(next)
+	allowed := []string{"https://app.example.com"}
+
+	for _, header := range []string{"Origin", "Referer"} {
+		req := httptest.NewRequest("POST", "/api/v1/events", nil)
+		req.Header.Set(header, "") // present, empty
+		req = req.WithContext(handler.WithAllowedOriginsForTest(context.Background(), allowed))
+
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("empty-valued %s must not be treated as header-less, got %d", header, rec.Code)
+		}
+	}
+}
+
+func TestEnforceOriginAllowingServerSDK_BrowserRequestsStillEnforced(t *testing.T) {
+	deps := &handler.Dependencies{}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	h := deps.EnforceOriginAllowingServerSDK(next)
+	allowed := []string{"https://app.example.com"}
+
+	mk := func(key, value string) *http.Request {
+		req := httptest.NewRequest("POST", "/api/v1/events", nil)
+		req.Header.Set(key, value)
+		return req.WithContext(handler.WithAllowedOriginsForTest(context.Background(), allowed))
+	}
+
+	cases := []struct {
+		name string
+		req  *http.Request
+		want int
+	}{
+		{"allowlisted origin", mk("Origin", "https://app.example.com"), http.StatusOK},
+		{"foreign origin", mk("Origin", "https://evil.com"), http.StatusForbidden},
+		{"allowlisted referer", mk("Referer", "https://app.example.com/checkout"), http.StatusOK},
+		{"foreign referer", mk("Referer", "https://evil.com/x"), http.StatusForbidden},
+		// A present-but-unparseable Referer is still browser context: fail closed.
+		{"malformed referer", mk("Referer", "::not a url::"), http.StatusForbidden},
+	}
+	for _, tc := range cases {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, tc.req)
+		if rec.Code != tc.want {
+			t.Errorf("%s: got %d, want %d", tc.name, rec.Code, tc.want)
+		}
+	}
+}
+
+// The strict middleware must NOT gain the exemption: replay and session routes
+// are browser-only, so a header-less caller has no business there.
+func TestEnforceOrigin_HeaderlessStillRejected(t *testing.T) {
+	deps := &handler.Dependencies{}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	h := deps.EnforceOrigin(next)
+
+	req := httptest.NewRequest("POST", "/api/v1/sessions/init", nil)
+	req = req.WithContext(handler.WithAllowedOriginsForTest(
+		context.Background(), []string{"https://app.example.com"}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("browser-only routes must still reject header-less callers, got %d", rec.Code)
+	}
+}
+```
+
+**Step 3: Run to verify they fail**
+
+Run: `cd packages/ingestion && go test ./handler -run TestEnforceOrigin -count=1`
+Expected: the three `AllowingServerSDK` tests FAIL to compile (`undefined: EnforceOriginAllowingServerSDK`). `TestEnforceOrigin_HeaderlessStillRejected` should PASS once it compiles — it describes today's behavior, which we are keeping. Comment the new tests out one at a time if you want to see that independently.
+
+**Step 4: Implement**
+
+Replace `EnforceOrigin` (`ingest_limits.go:51-77`) with the split below. Keep `originAllowed` and `originFromReferer` unchanged.
+
+```go
+// EnforceOrigin rejects SDK ingest from origins not on the project's allowlist.
+//
+// Scope: this is a BROWSER-ORIGIN control, and only that. `Origin` is
+// meaningful because browsers set it and page JavaScript cannot forge it; any
+// non-browser caller can send whatever it likes. It stops another site from
+// reusing a public SDK key, not a script. Opt-in: an empty allowlist allows
+// all origins.
+//
+// Used by the browser-only routes (replays, sessions, chunks). A caller with
+// no browser context has no legitimate business on those, so header-less
+// requests stay rejected here. See EnforceOriginAllowingServerSDK for /events.
+func (d *Dependencies) EnforceOrigin(next http.Handler) http.Handler {
+	return d.enforceOrigin(next, false)
+}
+
+// EnforceOriginAllowingServerSDK is EnforceOrigin for POST /api/v1/events, the
+// only route a server-side SDK touches (packages/sdk-python/opslane/transport.py
+// builds that URL and no other).
+//
+// A request carrying neither Origin nor Referer has no browser context, so the
+// browser-origin allowlist does not apply to it (#104). Denying it bought
+// nothing — the same caller can forge an Origin — while breaking every
+// legitimate backend SDK and forcing customers into a second project.
+//
+// Browsers always send Origin on POST (Fetch spec: included for any method
+// other than GET/HEAD, same-origin included), so real browser traffic is never
+// exempted here. If a proxy in front of ingestion strips Origin, browser
+// traffic would look header-less; the debug log below makes that greppable.
+func (d *Dependencies) EnforceOriginAllowingServerSDK(next http.Handler) http.Handler {
+	return d.enforceOrigin(next, true)
+}
+
+func (d *Dependencies) enforceOrigin(next http.Handler, allowServerSDK bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		allowed := AllowedOriginsFromCtx(r.Context())
+		if len(allowed) == 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Presence, not emptiness: Header.Get returns "" for an absent header
+		// AND for a present-but-empty one, so `Origin:` would otherwise slip
+		// through as "no browser context".
+		hasBrowserContext := len(r.Header.Values("Origin")) > 0 ||
+			len(r.Header.Values("Referer")) > 0
+		if allowServerSDK && !hasBrowserContext {
+			slog.Debug("ingest allowed: no browser context (server-side SDK)",
+				"project_id", ProjectIDFromCtx(r.Context()), "path", r.URL.Path)
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			origin = originFromReferer(r.Header.Get("Referer"))
+		}
+		if !originAllowed(origin, allowed) {
+			slog.Warn("ingest rejected: origin not allowlisted",
+				"project_id", ProjectIDFromCtx(r.Context()), "origin", origin)
+			writeJSONError(w, http.StatusForbidden, "origin not allowed")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+```
+
+Note on the log level: `Debug`, not `Info` — `/events` runs at up to 600 req/min/project, and a per-request `Info` line would be noise. A counter would be better than a log for detecting proxy stripping, but this file has no metrics surface and inventing one belongs with the metrics work, not here.
+
+**Step 5: Run to verify they pass**
+
+Run: `cd packages/ingestion && go test ./handler -run TestEnforceOrigin -count=1 -v`
+Expected: all `TestEnforceOrigin*` tests PASS, including the untouched `TestEnforceOrigin_EmptyAllowlistAllowsAll`, `TestEnforceOrigin_RejectsNonAllowlistedOrigin`, and `TestEnforceOrigin_MatchIsCaseInsensitive`.
+
+Then: `go build ./... && go vet ./...`
+
+**Step 6: Commit**
+
+```bash
+git add packages/ingestion/handler/ingest_limits.go packages/ingestion/handler/ingest_limits_test.go
+git commit -m "fix(ingestion): exempt server-side SDKs from the origin allowlist on /events
+
+EnforceOrigin treated a missing Origin as 'not allowlisted' and returned
+403. Server-side SDKs send neither Origin nor Referer, so a project with an
+allowlist configured dropped every backend event and the Python SDK README
+had to tell people to use a second project.
+
+The allowlist is a browser-origin control and only that: Origin is
+meaningful because browsers set it and page script cannot forge it, while
+any non-browser caller can send whatever it likes. Denying the header-less
+case bought nothing against an attacker and broke legitimate SDKs.
+
+Scoped deliberately. EnforceOriginAllowingServerSDK is used by /events
+alone, the only route a server-side SDK touches; the seven browser-only
+routes keep the strict middleware unchanged. The exemption keys on header
+presence rather than Header.Get emptiness, so a present-but-empty Origin
+cannot slip through as 'no browser context'.
+
+This intentionally changes behavior on /events; the strict path's existing
+assertions are unchanged and still pass."
+```
+
+---
+
+### Task 2: Point `/events` at the new middleware
+
+**Files:**
+- Modify: `packages/ingestion/handler/routes.go:81-91`
+- Test: `packages/ingestion/handler/ingest_limits_test.go` (router-level)
+
+**Step 1: Write the failing router test**
+
+A middleware unit test cannot catch the routes table being wired to the wrong entry point. This one goes through `handler.NewRouter`, so it needs `DATABASE_URL` and the existing `testDeps`/`seedTenant` helpers in `error_event_test.go`.
+
+```go
+func TestRouter_OriginExemptionIsScopedToEvents(t *testing.T) {
+	deps, pool := testDeps(t)
+	_, projectID, _, rawKey := seedTenant(t, deps.Queries)
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE projects SET allowed_origins = $2 WHERE id = $1`,
+		projectID, []string{"https://app.example.com"}); err != nil {
+		t.Fatalf("set allowlist: %v", err)
+	}
+	router := handler.NewRouter(deps)
+
+	post := func(path, body string) int {
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-API-Key", rawKey)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	// /events: header-less server SDK is admitted (not 403).
+	if code := post("/api/v1/events", `{"timestamp":"2026-07-20T00:00:00Z","platform":"python","error":{"type":"ValueError","message":"scoped","stack":"Traceback (most recent call last):\nValueError: scoped"},"breadcrumbs":[],"context":{}}`); code == http.StatusForbidden {
+		t.Fatalf("/events must not 403 a header-less server SDK, got %d", code)
+	}
+
+	// A browser-only route must still reject the same header-less caller.
+	if code := post("/api/v1/sessions/init", `{}`); code != http.StatusForbidden {
+		t.Fatalf("/sessions/init must still 403 a header-less caller, got %d", code)
+	}
+}
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `cd packages/ingestion && go test ./handler -run TestRouter_OriginExemptionIsScopedToEvents -count=1` (needs `DATABASE_URL`)
+Expected: FAIL — `/events` returns 403, because the route still uses the strict middleware.
+
+**Step 3: Implement**
+
+In `routes.go`, change only the `/events` line and update the comment above the block:
+
+```go
+		// SDK endpoints (authenticated by API key, rate-limited per project).
+		// Browser endpoints (replays, sessions, chunks) are origin-gated
+		// strictly. /events also accepts server-side SDKs, which send no
+		// Origin or Referer (#104). Sourcemaps are uploaded at build time from
+		// Node (no Origin header), so EnforceOrigin is not applied there.
+		r.With(deps.AuthenticateSDK, deps.EnforceOriginAllowingServerSDK, rateLimitByProject(eventsLimiter)).Post("/events", deps.IngestEvent)
+```
+
+Leave the seven other `deps.EnforceOrigin` lines untouched.
+
+**Step 4: Run to verify it passes**
+
+Run: `go test ./handler -count=1` (needs `DATABASE_URL`). All pass.
+
+**Step 5: Commit**
+
+```bash
+git add packages/ingestion/handler/routes.go packages/ingestion/handler/ingest_limits_test.go
+git commit -m "fix(ingestion): route /events through the server-SDK origin middleware
+
+Router-level test pins the scope: /events admits a header-less server SDK
+while /sessions/init still rejects one, so the exemption cannot silently
+spread to the browser-only routes."
+```
+
+---
+
+### Task 3: End-to-end proof against a real allowlisted project
+
+**Files:**
+- Test: `test-e2e/origin-allowlist.test.ts` (create)
+
+**Step 1: Write the test**
+
+```ts
+/**
+ * E2E: a project with a browser origin allowlist must still accept
+ * server-side SDK events, which carry neither Origin nor Referer (#104),
+ * while browser-shaped requests stay gated and browser-only routes stay
+ * strict.
+ *
+ * Required:
+ *   DATABASE_URL   — Postgres connection string
+ *   INGESTION_URL  — Base URL for ingestion API (default: http://localhost:8082)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  seedTenant, cleanupTenant, closePool, getPool, getConfig, postEvent,
+  type TestTenant,
+} from './helpers.js';
+
+const ALLOWED_ORIGIN = 'https://app.allowlisted.example';
+
+function errorPayload(message: string): Record<string, unknown> {
+  return {
+    timestamp: new Date().toISOString(),
+    platform: 'python',
+    error: {
+      type: 'ValueError',
+      message,
+      stack: `Traceback (most recent call last):\nValueError: ${message}`,
+    },
+    breadcrumbs: [],
+    context: {},
+  };
+}
+
+async function post(
+  path: string,
+  apiKey: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const { ingestionUrl } = getConfig();
+  return fetch(`${ingestionUrl}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey, ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('origin allowlist with a server-side SDK', () => {
+  let tenant: TestTenant;
+
+  beforeAll(async () => {
+    tenant = await seedTenant('e2e/origin-allowlist');
+    await getPool().query(
+      `UPDATE projects SET allowed_origins = $2 WHERE id = $1`,
+      [tenant.projectId, [ALLOWED_ORIGIN]],
+    );
+  }, 30_000);
+
+  afterAll(async () => {
+    if (tenant) await cleanupTenant(tenant.orgId);
+    await closePool();
+  });
+
+  it('accepts a backend event that carries no Origin or Referer', async () => {
+    const res = await postEvent(tenant.apiKey, errorPayload('backend accepted'));
+    expect(res.status).toBe(202);
+  });
+
+  it('accepts a browser event from an allowlisted origin', async () => {
+    const res = await post('/api/v1/events', tenant.apiKey, errorPayload('browser ok'),
+      { Origin: ALLOWED_ORIGIN });
+    expect(res.status).toBe(202);
+  });
+
+  it('rejects a browser event from an origin not on the list', async () => {
+    const res = await post('/api/v1/events', tenant.apiKey, errorPayload('browser blocked'),
+      { Origin: 'https://evil.example' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects a referer-only event from an origin not on the list', async () => {
+    const res = await post('/api/v1/events', tenant.apiKey, errorPayload('referer blocked'),
+      { Referer: 'https://evil.example/checkout' });
+    expect(res.status).toBe(403);
+  });
+
+  it('keeps browser-only routes strict for header-less callers', async () => {
+    const res = await post('/api/v1/sessions/init', tenant.apiKey, {});
+    expect(res.status).toBe(403);
+  });
+});
+```
+
+**Step 2: Get a genuine red**
+
+Task 1 and 2 are already committed, so a build of `HEAD` contains the fix. To see the test actually fail, build the ingestion image from `origin/main` in a scratch worktree — do not revert the branch in place:
+
+```bash
+git worktree add /tmp/origin-base origin/main
+docker compose -f /tmp/origin-base/docker-compose.yml config \
+  | sed -e 's/published: "5434"/published: "5461"/' -e 's/published: "9012"/published: "9061"/' \
+        -e 's/published: "8082"/published: "8093"/' > /tmp/origin-compose.yml
+docker compose -p origin-smoke -f /tmp/origin-compose.yml up -d postgres minio minio-setup
+docker compose -p origin-smoke -f /tmp/origin-compose.yml run --rm migrate
+docker compose -p origin-smoke -f /tmp/origin-compose.yml up -d --build --wait ingestion
+cd test-e2e && DATABASE_URL="postgres://opslane:opslane_dev@localhost:5461/opslane" \
+  INGESTION_URL="http://localhost:8093" npx vitest run origin-allowlist.test.ts
+```
+Expected: the first case FAILS with 403; the other four PASS.
+
+**Step 3: Rebuild from the branch and re-run**
+
+```bash
+docker compose -p origin-smoke -f /tmp/origin-compose.yml down -v
+git worktree remove /tmp/origin-base
+# rebuild from this branch's tree
+docker compose config | sed -e 's/published: "5434"/published: "5461"/' \
+  -e 's/published: "9012"/published: "9061"/' -e 's/published: "8082"/published: "8093"/' > /tmp/origin-compose.yml
+docker compose -p origin-smoke -f /tmp/origin-compose.yml up -d postgres minio minio-setup
+docker compose -p origin-smoke -f /tmp/origin-compose.yml run --rm migrate
+docker compose -p origin-smoke -f /tmp/origin-compose.yml up -d --build --wait ingestion
+cd test-e2e && DATABASE_URL="postgres://opslane:opslane_dev@localhost:5461/opslane" \
+  INGESTION_URL="http://localhost:8093" npx vitest run origin-allowlist.test.ts
+```
+Expected: 5 passed. Keep the stack up for Task 4.
+
+**Step 4: Commit**
+
+```bash
+git add test-e2e/origin-allowlist.test.ts
+git commit -m "test(e2e): server-side SDK reaches an allowlisted project
+
+Real key, real allowed_origins row: header-less backend events are
+accepted, allowlisted browser origins pass, foreign origins and foreign
+referers are rejected, and /sessions/init stays strict."
+```
+
+---
+
+### Task 4: Prove a real browser is never exempted
+
+The exemption is only safe because browsers always send `Origin` on POST. That is a claim about browser behavior, and every other test here uses Node `fetch`, which is not a browser. Verify it in real Chromium using the existing Playwright setup in `test-e2e/browser-smoke.test.ts` (read it first for the launch and skip-guard pattern).
+
+**Files:**
+- Test: `test-e2e/origin-allowlist-browser.test.ts` (create)
+
+**Step 1: Write the test**
+
+Serve a trivial page from a local origin, have the page `fetch` the events endpoint, and assert the server rejects it — proving Chromium attached an `Origin` the allowlist did not contain, rather than being waved through as header-less.
+
+```ts
+// Mirror browser-smoke.test.ts: skip when Playwright is unavailable rather
+// than failing the suite on a machine without browsers installed.
+```
+
+Assertions:
+1. From a page origin **not** on the allowlist, the POST is rejected (403). If Chromium sent no `Origin`, this would be 202 — that is the regression this test exists to catch.
+2. With that same page origin added to `allowed_origins`, the POST is accepted (202).
+
+**Step 2: Run**
+
+```bash
+cd test-e2e && DATABASE_URL="postgres://opslane:opslane_dev@localhost:5461/opslane" \
+  INGESTION_URL="http://localhost:8093" npx vitest run origin-allowlist-browser.test.ts
+```
+Expected: 2 passed. If Chromium is not installed: `pnpm --filter @opslane/test-e2e exec playwright install --with-deps chromium`.
+
+Tear down: `docker compose -p origin-smoke -f /tmp/origin-compose.yml down -v`
+
+**Step 3: Commit**
+
+```bash
+git add test-e2e/origin-allowlist-browser.test.ts
+git commit -m "test(e2e): real Chromium always sends Origin to /events
+
+The exemption is only safe because browsers attach Origin to POST. Every
+other test uses Node fetch, which proves nothing about that. This drives a
+real page and asserts a non-allowlisted page origin is still rejected."
+```
+
+---
+
+### Task 5: Remove the documented workaround
+
+**Files:**
+- Modify: `packages/sdk-python/README.md:36-38`
+
+**Step 1: Delete the limitation paragraph**
+
+Remove:
+
+```
+If your Opslane project has a browser origin allowlist configured, backend
+events are rejected: server-side requests carry no `Origin` header. Send
+backend errors to a project with an empty allowlist (or a separate project).
+```
+
+Add nothing in its place.
+
+**Step 2: Confirm nothing else documents it**
+
+```bash
+grep -rn "origin allowlist" docs/ packages/sdk-python/ cli/ --include="*.md"
+```
+Note the CLI lives at `cli/`, not `packages/cli/`. Expected: no hits outside `docs/plans/`.
+
+**Step 3: Verify the docs gate**
+
+Run: `node scripts/check-docs-drift.mjs`
+Expected: no drift.
+
+**Step 4: Commit**
+
+```bash
+git add packages/sdk-python/README.md
+git commit -m "docs(sdk-python): drop the origin-allowlist workaround
+
+Backend events now reach allowlisted projects, so the advice to use a
+separate project no longer applies."
+```
+
+---
+
+### Task 6: CI gates
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `Enforce zero unexpected skips` step)
+
+**Step 1: Get the authoritative test count**
+
+`scripts/check-e2e-results.mjs` reads `numTotalTests` from the JSON report, so derive the floor from the same artifact CI consumes — not from `vitest list`:
+
+```bash
+cd test-e2e && DATABASE_URL=... INGESTION_URL=... \
+  npx vitest run --reporter=json --outputFile=/tmp/e2e.json
+node -e "console.log(require('/tmp/e2e.json').numTotalTests)"
+```
+Set `E2E_MIN_TESTS` from that number, keeping the existing slack margin.
+
+**Step 2: Pin each security case by full name**
+
+A suite-prefix pattern lets three of five cases be deleted while the count is propped up by unrelated tests. Pin the ones that carry the security contract:
+
+```
+            ^origin allowlist with a server-side SDK > accepts a backend event that carries no Origin or Referer
+            ^origin allowlist with a server-side SDK > rejects a browser event from an origin not on the list
+            ^origin allowlist with a server-side SDK > rejects a referer-only event from an origin not on the list
+            ^origin allowlist with a server-side SDK > keeps browser-only routes strict for header-less callers
+```
+
+Add the browser suite's names from Task 4 the same way.
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: pin the origin-allowlist security cases by name
+
+Raise the collected-test floor from the JSON report CI actually reads, and
+pin each accepted/rejected case so none can be dropped while the total
+count stays propped up by unrelated tests."
+```
+
+---
+
+### Task 7: Full gate
+
+**Step 1: Repo gate**
+
+```bash
+pnpm install --frozen-lockfile && pnpm -r build && pnpm test
+(cd packages/ingestion && go build ./... && go vet ./... && DATABASE_URL=... go test ./... -count=1)
+docker compose config --quiet
+```
+All green, using the disposable-DB `DATABASE_URL` from the ground rules.
+
+**Step 2: Open the PR**
+
+Reference #104. State plainly that this changes behavior on `/events` only, that the seven browser-only routes are untouched, and that the threat model is "browser-origin control, not a script control".
+
+---
+
+## Acceptance criteria
+
+- [ ] A project with a non-empty `allowed_origins` accepts `/events` requests carrying neither `Origin` nor `Referer` (Task 1, Task 3)
+- [ ] The seven browser-only routes still reject header-less callers (Task 1 unit, Task 2 router, Task 3 e2e)
+- [ ] A present-but-empty `Origin` or `Referer` is NOT treated as header-less (Task 1)
+- [ ] Foreign `Origin` and foreign `Referer` are still 403 on `/events`; a malformed `Referer` still fails closed (Task 1, Task 3)
+- [ ] Real Chromium is still gated on `/events`, proving browsers attach `Origin` (Task 4)
+- [ ] The empty-allowlist path is unchanged (existing tests still pass untouched)
+- [ ] The Python SDK README no longer tells people to use a second project (Task 5)
+- [ ] `E2E_MIN_TESTS` derived from `numTotalTests`, and each security case pinned by full name (Task 6)
+
+## Explicitly out of scope
+
+- **Applying origin enforcement to `/sourcemaps`.** Unrelated route, unchanged behavior.
+- **Per-key browser/server marking.** Considered on #104 and rejected as more machinery for the same outcome. Revisit only if a customer needs to *forbid* server-side keys.
+- **A distributed or cost-aware rate limit.** Codex is right that `eventsLimiter` is per-process and does not bound storage or worker cost, but that is a pre-existing property of every SDK route and its own piece of work. This plan stops claiming otherwise; it does not fix it.
+- **A metrics counter for the exemption path.** A debug log is the proportionate move here; a real counter belongs with the metrics work.
+- **#102 (idempotency key).** Same neighborhood, unrelated problem.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | not run | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 1 | FAIL → addressed | 12 findings (5 P1, 7 P2), 12/12 addressed |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 0 | not run | — |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | n/a (no UI) | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | not run | — |
+
+**CODEX:** Gate failed on 5 P1s, every one verified against the source before acceptance. The load-bearing catch: `EnforceOrigin` guards **8 routes**, not just `/events` (`grep -c` confirms), so the original plan would have relaxed replay and session-chunk endpoints with no rationale or tests. The plan now splits the middleware and scopes the exemption to `/events`, the only route `packages/sdk-python` posts to. Also fixed: `Header.Get` cannot distinguish an absent header from a present-but-empty one (verified with a Go probe: `Values()` length 0 vs 1), so the exemption now keys on presence; the "rate limits bound a stolen key's blast radius" claim was false and is retracted (`newRateLimiter` at `auth_handlers.go:35` is an in-memory per-process counter); the red/green sequence in the e2e task was unachievable as written and now builds the base image from a scratch worktree; `E2E_MIN_TESTS` is derived from `numTotalTests` rather than `vitest list | wc -l`; required-pattern pins moved from suite prefix to per-case; and a `packages/cli/` path that does not exist became `cli/`. One finding was accepted in part: a metrics counter for the bypass path is out of scope, replaced with a debug log and an explicit note.
+
+**VERDICT:** Codex review CLEAR after revision. Eng review not run — not required by the user for this scope, and the plan's own risk (a security-control relaxation) was the specific thing Codex was pointed at.
+
+NO UNRESOLVED DECISIONS

--- a/docs/reference/http-routes.md
+++ b/docs/reference/http-routes.md
@@ -1,6 +1,6 @@
 # HTTP routes
 
-All routes registered by the ingestion API (`packages/ingestion/handler/routes.go`). Auth column legend: **none** (public), **poll token** (`X-Opslane-Poll-Token` for one agent session), **SDK** (`X-API-Key` per-environment key; browser endpoints also origin-gated and rate-limited per project), **session** (dashboard JWT cookie or CLI token), **either** (session or SDK).
+All routes registered by the ingestion API (`packages/ingestion/handler/routes.go`). Auth column legend: **none** (public), **poll token** (`X-Opslane-Poll-Token` for one agent session), **SDK** (`X-API-Key` per-environment key; rate-limited per project, and origin-gated — unconditionally on the browser-only endpoints, and on `/api/v1/events` only when the request presents `Origin` or `Referer`), **session** (dashboard JWT cookie or CLI token), **either** (session or SDK).
 
 These are curated tables, not a stability contract — the API is early-stage and may change. The [drift check](../../scripts/check-docs-drift.mjs) fails the repository test gate (`pnpm test`, which CI runs) if this page and `routes.go` disagree.
 
@@ -35,7 +35,7 @@ The agent callback requires `code`, `installation_id`, and UUID `state`; definit
 
 | Method | Path | Origin-gated | Purpose |
 | --- | --- | --- | --- |
-| POST | `/api/v1/events` | yes | Ingest an error event; optional payload `environment` is project-gated and falls back to the key environment |
+| POST | `/api/v1/events` | browser callers only | Ingest an error event; optional payload `environment` is project-gated and falls back to the key environment |
 | POST | `/api/v1/replays/init` | yes | Begin a replay upload |
 | POST | `/api/v1/replays/{replayID}/complete` | yes | Finish a replay upload |
 | POST | `/api/v1/replays/{replayID}/fail` | yes | Record a replay upload failure |

--- a/packages/ingestion/handler/ingest_limits.go
+++ b/packages/ingestion/handler/ingest_limits.go
@@ -74,8 +74,11 @@ func (d *Dependencies) EnforceOrigin(next http.Handler) http.Handler {
 //
 // Browsers always send Origin on POST (Fetch spec: included for any method
 // other than GET/HEAD, same-origin included), so real browser traffic is never
-// exempted here. If a proxy in front of ingestion strips Origin, browser
-// traffic would look header-less; the debug log below makes that greppable.
+// exempted here. Residual risk: a proxy in front of ingestion that strips
+// Origin would make browser traffic look header-less and skip the check. The
+// Debug line below records each exemption, but main.go builds the logger at
+// the default Info level with no LOG_LEVEL knob, so observing it takes a code
+// change today — it is a hook for investigation, not live detection.
 func (d *Dependencies) EnforceOriginAllowingServerSDK(next http.Handler) http.Handler {
 	return d.enforceOrigin(next, true)
 }

--- a/packages/ingestion/handler/ingest_limits.go
+++ b/packages/ingestion/handler/ingest_limits.go
@@ -50,13 +50,52 @@ func rateLimitByProject(limiter *rateLimiter) func(http.Handler) http.Handler {
 
 // EnforceOrigin rejects SDK ingest from origins not on the project's allowlist.
 //
-// This is the server-side control against stolen public SDK keys. CORS only
-// constrains browsers, so the Origin header is validated after the key resolves
-// to a project. Opt-in: an empty allowlist allows all origins for compatibility.
+// Scope: this is a BROWSER-ORIGIN control, and only that. `Origin` is
+// meaningful because browsers set it and page JavaScript cannot forge it; any
+// non-browser caller can send whatever it likes. It stops another site from
+// reusing a public SDK key, not a script. Opt-in: an empty allowlist allows
+// all origins.
+//
+// Used by the browser-only routes (replays, sessions, chunks). A caller with
+// no browser context has no legitimate business on those, so header-less
+// requests stay rejected here. See EnforceOriginAllowingServerSDK for /events.
 func (d *Dependencies) EnforceOrigin(next http.Handler) http.Handler {
+	return d.enforceOrigin(next, false)
+}
+
+// EnforceOriginAllowingServerSDK is EnforceOrigin for POST /api/v1/events, the
+// only route a server-side SDK touches (packages/sdk-python/opslane/transport.py
+// builds that URL and no other).
+//
+// A request carrying neither Origin nor Referer has no browser context, so the
+// browser-origin allowlist does not apply to it (#104). Denying it bought
+// nothing — the same caller can forge an Origin — while breaking every
+// legitimate backend SDK and forcing customers into a second project.
+//
+// Browsers always send Origin on POST (Fetch spec: included for any method
+// other than GET/HEAD, same-origin included), so real browser traffic is never
+// exempted here. If a proxy in front of ingestion strips Origin, browser
+// traffic would look header-less; the debug log below makes that greppable.
+func (d *Dependencies) EnforceOriginAllowingServerSDK(next http.Handler) http.Handler {
+	return d.enforceOrigin(next, true)
+}
+
+func (d *Dependencies) enforceOrigin(next http.Handler, allowServerSDK bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		allowed := AllowedOriginsFromCtx(r.Context())
 		if len(allowed) == 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Presence, not emptiness: Header.Get returns "" for an absent header
+		// AND for a present-but-empty one, so `Origin:` would otherwise slip
+		// through as "no browser context".
+		hasBrowserContext := len(r.Header.Values("Origin")) > 0 ||
+			len(r.Header.Values("Referer")) > 0
+		if allowServerSDK && !hasBrowserContext {
+			slog.Debug("ingest allowed: no browser context (server-side SDK)",
+				"project_id", ProjectIDFromCtx(r.Context()), "path", r.URL.Path)
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/packages/ingestion/handler/ingest_limits_test.go
+++ b/packages/ingestion/handler/ingest_limits_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/opslane/opslane/packages/ingestion/handler"
@@ -160,7 +161,9 @@ func TestEnforceOriginAllowingServerSDK_BrowserRequestsStillEnforced(t *testing.
 		{"foreign origin", mk("Origin", "https://evil.com"), http.StatusForbidden},
 		{"allowlisted referer", mk("Referer", "https://app.example.com/checkout"), http.StatusOK},
 		{"foreign referer", mk("Referer", "https://evil.com/x"), http.StatusForbidden},
-		// A present-but-unparseable Referer is still browser context: fail closed.
+		// A junk Referer must not be mistaken for a header-less server SDK:
+		// the header is present, so the exemption does not apply and the
+		// unusable origin falls through to the allowlist check.
 		{"malformed referer", mk("Referer", "::not a url::"), http.StatusForbidden},
 	}
 	for _, tc := range cases {
@@ -205,5 +208,37 @@ func TestEnforceOrigin_MatchIsCaseInsensitive(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("case-insensitive origin must pass, got %d", rec.Code)
+	}
+}
+
+// Router-level: a middleware unit test cannot catch the routes table wiring
+// the wrong entry point, so drive the real router. Needs DATABASE_URL.
+func TestRouter_OriginExemptionIsScopedToEvents(t *testing.T) {
+	deps, pool := testDeps(t)
+	_, projectID, _, rawKey := seedTenant(t, deps.Queries)
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE projects SET allowed_origins = $2 WHERE id = $1`,
+		projectID, []string{"https://app.example.com"}); err != nil {
+		t.Fatalf("set allowlist: %v", err)
+	}
+	router := handler.NewRouter(deps)
+
+	post := func(path, body string) int {
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-API-Key", rawKey)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	// /events: header-less server SDK is admitted (not 403).
+	if code := post("/api/v1/events", `{"timestamp":"2026-07-20T00:00:00Z","platform":"python","error":{"type":"ValueError","message":"scoped","stack":"Traceback (most recent call last):\nValueError: scoped"},"breadcrumbs":[],"context":{}}`); code == http.StatusForbidden {
+		t.Fatalf("/events must not 403 a header-less server SDK, got %d", code)
+	}
+
+	// A browser-only route must still reject the same header-less caller.
+	if code := post("/api/v1/sessions/init", `{}`); code != http.StatusForbidden {
+		t.Fatalf("/sessions/init must still 403 a header-less caller, got %d", code)
 	}
 }

--- a/packages/ingestion/handler/ingest_limits_test.go
+++ b/packages/ingestion/handler/ingest_limits_test.go
@@ -232,13 +232,28 @@ func TestRouter_OriginExemptionIsScopedToEvents(t *testing.T) {
 		return rec.Code
 	}
 
-	// /events: header-less server SDK is admitted (not 403).
-	if code := post("/api/v1/events", `{"timestamp":"2026-07-20T00:00:00Z","platform":"python","error":{"type":"ValueError","message":"scoped","stack":"Traceback (most recent call last):\nValueError: scoped"},"breadcrumbs":[],"context":{}}`); code == http.StatusForbidden {
-		t.Fatalf("/events must not 403 a header-less server SDK, got %d", code)
+	// /events: header-less server SDK is fully accepted, not merely un-403ed.
+	// Asserting the exact 202 keeps an unrelated 400/401/500 from passing as a
+	// working exemption.
+	if code := post("/api/v1/events", `{"timestamp":"2026-07-20T00:00:00Z","platform":"python","error":{"type":"ValueError","message":"scoped","stack":"Traceback (most recent call last):\nValueError: scoped"},"breadcrumbs":[],"context":{}}`); code != http.StatusAccepted {
+		t.Fatalf("/events must accept a header-less server SDK with 202, got %d", code)
 	}
 
-	// A browser-only route must still reject the same header-less caller.
-	if code := post("/api/v1/sessions/init", `{}`); code != http.StatusForbidden {
-		t.Fatalf("/sessions/init must still 403 a header-less caller, got %d", code)
+	// Every browser-only route must still reject the same header-less caller.
+	// These 403 from the middleware before the handler runs, so `{}` is a fine
+	// body for all of them.
+	browserOnly := []string{
+		"/api/v1/replays/init",
+		"/api/v1/replays/r1/complete",
+		"/api/v1/replays/r1/fail",
+		"/api/v1/sessions/init",
+		"/api/v1/sessions/s1/chunks/upload-url",
+		"/api/v1/sessions/s1/chunks/0/commit",
+		"/api/v1/sessions/s1/chunks/0/inline",
+	}
+	for _, path := range browserOnly {
+		if code := post(path, `{}`); code != http.StatusForbidden {
+			t.Errorf("%s must still 403 a header-less caller, got %d", path, code)
+		}
 	}
 }

--- a/packages/ingestion/handler/ingest_limits_test.go
+++ b/packages/ingestion/handler/ingest_limits_test.go
@@ -239,6 +239,19 @@ func TestRouter_OriginExemptionIsScopedToEvents(t *testing.T) {
 		t.Fatalf("/events must accept a header-less server SDK with 202, got %d", code)
 	}
 
+	// ...and the exemption is an exemption, not a removal: a browser-shaped
+	// request to the same route still meets the allowlist. Without this, a
+	// route wired with no origin middleware at all would pass this test.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", rawKey)
+	req.Header.Set("Origin", "https://evil.example")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("/events must still 403 a foreign browser origin, got %d", rec.Code)
+	}
+
 	// Every browser-only route must still reject the same header-less caller.
 	// These 403 from the middleware before the handler runs, so `{}` is a fine
 	// body for all of them.

--- a/packages/ingestion/handler/ingest_limits_test.go
+++ b/packages/ingestion/handler/ingest_limits_test.go
@@ -100,6 +100,96 @@ func TestEnforceOrigin_RejectsNonAllowlistedOrigin(t *testing.T) {
 	}
 }
 
+func TestEnforceOriginAllowingServerSDK_HeaderlessRequestPasses(t *testing.T) {
+	deps := &handler.Dependencies{}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	h := deps.EnforceOriginAllowingServerSDK(next)
+
+	// Exactly what packages/sdk-python sends: no Origin, no Referer.
+	req := httptest.NewRequest("POST", "/api/v1/events", nil)
+	req = req.WithContext(handler.WithAllowedOriginsForTest(
+		context.Background(), []string{"https://app.example.com"}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("server-side SDK must reach an allowlisted project, got %d", rec.Code)
+	}
+}
+
+// http.Header.Get returns "" for BOTH an absent header and a present-but-empty
+// one, so an emptiness check would let `Origin:` bypass the allowlist. The
+// exemption must key on presence.
+func TestEnforceOriginAllowingServerSDK_EmptyValuedHeadersAreNotHeaderless(t *testing.T) {
+	deps := &handler.Dependencies{}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	h := deps.EnforceOriginAllowingServerSDK(next)
+	allowed := []string{"https://app.example.com"}
+
+	for _, header := range []string{"Origin", "Referer"} {
+		req := httptest.NewRequest("POST", "/api/v1/events", nil)
+		req.Header.Set(header, "") // present, empty
+		req = req.WithContext(handler.WithAllowedOriginsForTest(context.Background(), allowed))
+
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("empty-valued %s must not be treated as header-less, got %d", header, rec.Code)
+		}
+	}
+}
+
+func TestEnforceOriginAllowingServerSDK_BrowserRequestsStillEnforced(t *testing.T) {
+	deps := &handler.Dependencies{}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	h := deps.EnforceOriginAllowingServerSDK(next)
+	allowed := []string{"https://app.example.com"}
+
+	mk := func(key, value string) *http.Request {
+		req := httptest.NewRequest("POST", "/api/v1/events", nil)
+		req.Header.Set(key, value)
+		return req.WithContext(handler.WithAllowedOriginsForTest(context.Background(), allowed))
+	}
+
+	cases := []struct {
+		name string
+		req  *http.Request
+		want int
+	}{
+		{"allowlisted origin", mk("Origin", "https://app.example.com"), http.StatusOK},
+		{"foreign origin", mk("Origin", "https://evil.com"), http.StatusForbidden},
+		{"allowlisted referer", mk("Referer", "https://app.example.com/checkout"), http.StatusOK},
+		{"foreign referer", mk("Referer", "https://evil.com/x"), http.StatusForbidden},
+		// A present-but-unparseable Referer is still browser context: fail closed.
+		{"malformed referer", mk("Referer", "::not a url::"), http.StatusForbidden},
+	}
+	for _, tc := range cases {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, tc.req)
+		if rec.Code != tc.want {
+			t.Errorf("%s: got %d, want %d", tc.name, rec.Code, tc.want)
+		}
+	}
+}
+
+// The strict middleware must NOT gain the exemption: replay and session routes
+// are browser-only, so a header-less caller has no business there.
+func TestEnforceOrigin_HeaderlessStillRejected(t *testing.T) {
+	deps := &handler.Dependencies{}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	h := deps.EnforceOrigin(next)
+
+	req := httptest.NewRequest("POST", "/api/v1/sessions/init", nil)
+	req = req.WithContext(handler.WithAllowedOriginsForTest(
+		context.Background(), []string{"https://app.example.com"}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("browser-only routes must still reject header-less callers, got %d", rec.Code)
+	}
+}
+
 func TestEnforceOrigin_MatchIsCaseInsensitive(t *testing.T) {
 	deps := &handler.Dependencies{}
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })

--- a/packages/ingestion/handler/routes.go
+++ b/packages/ingestion/handler/routes.go
@@ -212,7 +212,8 @@ func simpleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 // corsMiddleware applies a split CORS policy:
-//   - SDK endpoints reflect Origin; server-side EnforceOrigin is the real gate.
+//   - SDK endpoints reflect Origin; the server-side origin middleware is the
+//     real gate (EnforceOrigin, or EnforceOriginAllowingServerSDK on /events).
 //   - Dashboard endpoints are restricted to DASHBOARD_ORIGIN env var.
 func corsMiddleware() func(http.Handler) http.Handler {
 	dashboardOrigin := os.Getenv("DASHBOARD_ORIGIN")

--- a/packages/ingestion/handler/routes.go
+++ b/packages/ingestion/handler/routes.go
@@ -81,7 +81,7 @@ func NewRouterWithPool(deps *Dependencies, pool *pgxpool.Pool) *chi.Mux {
 		// Browser endpoints (replays, sessions, chunks) are origin-gated
 		// strictly. /events also accepts server-side SDKs, which send no
 		// Origin or Referer (#104). Sourcemaps are uploaded at build time from
-		// Node (no Origin header), so EnforceOrigin is not applied there.
+		// Node (no Origin header), so no origin middleware is applied there.
 		r.With(deps.AuthenticateSDK, deps.EnforceOriginAllowingServerSDK, rateLimitByProject(eventsLimiter)).Post("/events", deps.IngestEvent)
 		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(replaysLimiter)).Post("/replays/init", deps.ReplayInit)
 		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(replaysLimiter)).Post("/replays/{replayID}/complete", deps.ReplayComplete)

--- a/packages/ingestion/handler/routes.go
+++ b/packages/ingestion/handler/routes.go
@@ -78,10 +78,11 @@ func NewRouterWithPool(deps *Dependencies, pool *pgxpool.Pool) *chi.Mux {
 
 	r.Route("/api/v1", func(r chi.Router) {
 		// SDK endpoints (authenticated by API key, rate-limited per project).
-		// Browser endpoints (events, replays) are also origin-gated. Sourcemaps are
-		// uploaded at build time from Node (no Origin header), so EnforceOrigin is
-		// not applied there.
-		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(eventsLimiter)).Post("/events", deps.IngestEvent)
+		// Browser endpoints (replays, sessions, chunks) are origin-gated
+		// strictly. /events also accepts server-side SDKs, which send no
+		// Origin or Referer (#104). Sourcemaps are uploaded at build time from
+		// Node (no Origin header), so EnforceOrigin is not applied there.
+		r.With(deps.AuthenticateSDK, deps.EnforceOriginAllowingServerSDK, rateLimitByProject(eventsLimiter)).Post("/events", deps.IngestEvent)
 		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(replaysLimiter)).Post("/replays/init", deps.ReplayInit)
 		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(replaysLimiter)).Post("/replays/{replayID}/complete", deps.ReplayComplete)
 		r.With(deps.AuthenticateSDK, deps.EnforceOrigin, rateLimitByProject(replaysLimiter)).Post("/replays/{replayID}/fail", deps.ReplayFail)

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -33,8 +33,4 @@ hook is cleared.
 Client IP addresses (`remote_addr`) are only sent when you opt in with
 `opslane.init(..., send_pii=True)`.
 
-If your Opslane project has a browser origin allowlist configured, backend
-events are rejected: server-side requests carry no `Origin` header. Send
-backend errors to a project with an empty allowlist (or a separate project).
-
 Licensed under the MIT License.

--- a/test-e2e/origin-allowlist-browser.test.ts
+++ b/test-e2e/origin-allowlist-browser.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment node
+/**
+ * The /events exemption for header-less callers is only safe because a real
+ * browser always attaches Origin to a POST. Every other test in this repo
+ * uses Node fetch, which proves nothing about that. This drives real Chromium
+ * from a local page origin and asserts the allowlist still gates it.
+ *
+ * Required:
+ *   DATABASE_URL   — Postgres connection string
+ *   INGESTION_URL  — Base URL for ingestion API (default: http://localhost:8082)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer as createHttpServer, type Server } from 'node:http';
+import {
+  seedTenant, cleanupTenant, closePool, getPool, getConfig,
+  type TestTenant,
+} from './helpers.js';
+import { isPlaywrightAvailable } from './browser-helpers.js';
+
+const playwrightAvailable = await isPlaywrightAvailable();
+
+const PAGE_BODY = '<!doctype html><meta charset="utf-8"><title>origin probe</title>';
+
+/** Serves a blank page so Chromium has a real HTTP origin to fetch from. */
+async function startPageServer(): Promise<{ url: string; close(): Promise<void> }> {
+  const server: Server = createHttpServer((_request, response) => {
+    response.setHeader('Content-Type', 'text/html; charset=utf-8');
+    response.end(PAGE_BODY);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing page server address');
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    }),
+  };
+}
+
+describe.skipIf(!playwrightAvailable)('real Chromium always sends Origin to /events', () => {
+  let tenant: TestTenant;
+  let page: { url: string; close(): Promise<void> };
+  let browser: import('@playwright/test').Browser;
+
+  beforeAll(async () => {
+    tenant = await seedTenant('e2e/origin-allowlist-browser');
+    // An allowlist that deliberately excludes the page origin. A browser that
+    // sent no Origin would be treated as a server SDK and admitted.
+    await getPool().query(
+      `UPDATE projects SET allowed_origins = $2 WHERE id = $1`,
+      [tenant.projectId, ['https://app.allowlisted.example']],
+    );
+    page = await startPageServer();
+    const { chromium } = await import('@playwright/test');
+    browser = await chromium.launch();
+  }, 60_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    await page?.close();
+    if (tenant) await cleanupTenant(tenant.orgId);
+    await closePool();
+  });
+
+  /** Posts an /events payload from inside the page and returns the HTTP status. */
+  async function postFromPage(message: string): Promise<number> {
+    const tab = await browser.newPage();
+    try {
+      await tab.goto(page.url);
+      return await tab.evaluate(
+        async ([ingestionUrl, apiKey, text]) => {
+          const response = await fetch(`${ingestionUrl}/api/v1/events`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
+            body: JSON.stringify({
+              timestamp: new Date().toISOString(),
+              platform: 'browser',
+              error: {
+                type: 'TypeError',
+                message: text,
+                stack: `TypeError: ${text}\n    at probe (http://127.0.0.1/probe.js:1:1)`,
+              },
+              breadcrumbs: [],
+              context: {},
+            }),
+          });
+          return response.status;
+        },
+        [getConfig().ingestionUrl, tenant.apiKey, message] as const,
+      );
+    } finally {
+      await tab.close();
+    }
+  }
+
+  it('rejects a page whose origin is not on the allowlist', async () => {
+    // A 202 here would mean Chromium omitted Origin and took the exempt path.
+    expect(await postFromPage('browser origin blocked')).toBe(403);
+  }, 60_000);
+
+  it('accepts the same page once its origin is allowlisted', async () => {
+    await getPool().query(
+      `UPDATE projects SET allowed_origins = $2 WHERE id = $1`,
+      [tenant.projectId, ['https://app.allowlisted.example', page.url]],
+    );
+    expect(await postFromPage('browser origin allowed')).toBe(202);
+  }, 60_000);
+});

--- a/test-e2e/origin-allowlist-browser.test.ts
+++ b/test-e2e/origin-allowlist-browser.test.ts
@@ -22,10 +22,20 @@ const playwrightAvailable = await isPlaywrightAvailable();
 
 const PAGE_BODY = '<!doctype html><meta charset="utf-8"><title>origin probe</title>';
 
-/** Serves a blank page so Chromium has a real HTTP origin to fetch from. */
+/**
+ * Serves a blank page so Chromium has a real HTTP origin to fetch from.
+ *
+ * `Referrer-Policy: no-referrer` is what makes these tests mean anything. The
+ * middleware treats Referer as browser context too, and an http->http
+ * cross-origin fetch sends BOTH headers by default — so without this, the
+ * assertions below would pass on Referer alone and would keep passing even if
+ * Chromium stopped sending Origin, which is the one assumption the /events
+ * exemption rests on. Suppressing Referer leaves Origin as the only signal.
+ */
 async function startPageServer(): Promise<{ url: string; close(): Promise<void> }> {
   const server: Server = createHttpServer((_request, response) => {
     response.setHeader('Content-Type', 'text/html; charset=utf-8');
+    response.setHeader('Referrer-Policy', 'no-referrer');
     response.end(PAGE_BODY);
   });
   await new Promise<void>((resolve, reject) => {
@@ -47,14 +57,16 @@ describe.skipIf(!playwrightAvailable)('real Chromium always sends Origin to /eve
   let page: { url: string; close(): Promise<void> };
   let browser: import('@playwright/test').Browser;
 
-  beforeAll(async () => {
-    tenant = await seedTenant('e2e/origin-allowlist-browser');
-    // An allowlist that deliberately excludes the page origin. A browser that
-    // sent no Origin would be treated as a server SDK and admitted.
+  /** Each test sets the allowlist it needs, so neither depends on run order. */
+  async function setAllowlist(origins: string[]): Promise<void> {
     await getPool().query(
       `UPDATE projects SET allowed_origins = $2 WHERE id = $1`,
-      [tenant.projectId, ['https://app.allowlisted.example']],
+      [tenant.projectId, origins],
     );
+  }
+
+  beforeAll(async () => {
+    tenant = await seedTenant('e2e/origin-allowlist-browser');
     page = await startPageServer();
     const { chromium } = await import('@playwright/test');
     browser = await chromium.launch();
@@ -99,15 +111,15 @@ describe.skipIf(!playwrightAvailable)('real Chromium always sends Origin to /eve
   }
 
   it('rejects a page whose origin is not on the allowlist', async () => {
-    // A 202 here would mean Chromium omitted Origin and took the exempt path.
+    // An allowlist that deliberately excludes the page origin. A browser that
+    // sent no Origin would be treated as a server SDK and admitted, so a 202
+    // here would mean Chromium omitted Origin and took the exempt path.
+    await setAllowlist(['https://app.allowlisted.example']);
     expect(await postFromPage('browser origin blocked')).toBe(403);
   }, 60_000);
 
   it('accepts the same page once its origin is allowlisted', async () => {
-    await getPool().query(
-      `UPDATE projects SET allowed_origins = $2 WHERE id = $1`,
-      [tenant.projectId, ['https://app.allowlisted.example', page.url]],
-    );
+    await setAllowlist(['https://app.allowlisted.example', page.url]);
     expect(await postFromPage('browser origin allowed')).toBe(202);
   }, 60_000);
 });

--- a/test-e2e/origin-allowlist.test.ts
+++ b/test-e2e/origin-allowlist.test.ts
@@ -1,0 +1,91 @@
+/**
+ * E2E: a project with a browser origin allowlist must still accept
+ * server-side SDK events, which carry neither Origin nor Referer (#104),
+ * while browser-shaped requests stay gated and browser-only routes stay
+ * strict.
+ *
+ * Required:
+ *   DATABASE_URL   — Postgres connection string
+ *   INGESTION_URL  — Base URL for ingestion API (default: http://localhost:8082)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  seedTenant, cleanupTenant, closePool, getPool, getConfig, postEvent,
+  type TestTenant,
+} from './helpers.js';
+
+const ALLOWED_ORIGIN = 'https://app.allowlisted.example';
+
+function errorPayload(message: string): Record<string, unknown> {
+  return {
+    timestamp: new Date().toISOString(),
+    platform: 'python',
+    error: {
+      type: 'ValueError',
+      message,
+      stack: `Traceback (most recent call last):\nValueError: ${message}`,
+    },
+    breadcrumbs: [],
+    context: {},
+  };
+}
+
+async function post(
+  path: string,
+  apiKey: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const { ingestionUrl } = getConfig();
+  return fetch(`${ingestionUrl}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey, ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('origin allowlist with a server-side SDK', () => {
+  let tenant: TestTenant;
+
+  beforeAll(async () => {
+    tenant = await seedTenant('e2e/origin-allowlist');
+    await getPool().query(
+      `UPDATE projects SET allowed_origins = $2 WHERE id = $1`,
+      [tenant.projectId, [ALLOWED_ORIGIN]],
+    );
+  }, 30_000);
+
+  afterAll(async () => {
+    if (tenant) await cleanupTenant(tenant.orgId);
+    await closePool();
+  });
+
+  it('accepts a backend event that carries no Origin or Referer', async () => {
+    const res = await postEvent(tenant.apiKey, errorPayload('backend accepted'));
+    expect(res.status).toBe(202);
+  });
+
+  it('accepts a browser event from an allowlisted origin', async () => {
+    const res = await post('/api/v1/events', tenant.apiKey, errorPayload('browser ok'),
+      { Origin: ALLOWED_ORIGIN });
+    expect(res.status).toBe(202);
+  });
+
+  it('rejects a browser event from an origin not on the list', async () => {
+    const res = await post('/api/v1/events', tenant.apiKey, errorPayload('browser blocked'),
+      { Origin: 'https://evil.example' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects a referer-only event from an origin not on the list', async () => {
+    const res = await post('/api/v1/events', tenant.apiKey, errorPayload('referer blocked'),
+      { Referer: 'https://evil.example/checkout' });
+    expect(res.status).toBe(403);
+  });
+
+  it('keeps browser-only routes strict for header-less callers', async () => {
+    const res = await post('/api/v1/sessions/init', tenant.apiKey, {});
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
Closes #104.

A project with a browser origin allowlist rejected every backend SDK event, because server-side requests carry no `Origin`. Denying them bought nothing — the same caller can forge an `Origin` — while forcing customers into a second project just to receive backend errors.

## What changed

`POST /api/v1/events` now exempts requests carrying neither `Origin` nor `Referer` from the allowlist. The browser-only routes (replays, sessions, chunks) keep the strict check via the unchanged `EnforceOrigin`, since a caller with no browser context has no business on them.

The exemption keys on header **presence**, not emptiness: `Header.Get` returns `""` for both an absent header and a present-but-empty one, so a bare `Origin:` would otherwise slip through as "no browser context".

## Scope of the control

This was always a browser-origin control and only that. `Origin` is meaningful because browsers set it and page JavaScript cannot forge it. It stops another site reusing a public SDK key; it never stopped a script. The exemption grants nothing an attacker could not already get by sending an arbitrary `Origin`.

Residual risk, documented in the code: a proxy in front of ingestion that strips `Origin` would make browser traffic look header-less and skip the check.

## Verification

- `go build ./... && go vet ./...` clean; 8 origin tests pass, including `TestRouter_OriginExemptionIsScopedToEvents` driving the real router against Postgres
- All 7 e2e cases pass against a freshly built ingestion binary
- **Control:** the exemption case fails (`expected 403 to be 202`) against a pre-change build, so the test detects the change rather than passing by accident
- The browser suite drives real Chromium and serves `Referrer-Policy: no-referrer`, so it tests `Origin` alone — without that, a cross-origin fetch sends `Referer` too and the assertions would hold on `Referer` even if Chromium stopped sending `Origin`
- `E2E_MIN_TESTS` re-derived from a real run's `numTotalTests` (75); verified by feeding a real report to `check-e2e-results.mjs`

## Worth a look in review

Neither is addressed here.

- `eventsLimiter` is 600/min shared per project. This change puts backend and browser events in the same project, so a backend error storm can evict browser errors — asymmetrically, since the Python transport retries 429 with backoff while browsers drop theirs.
- The exemption's only detection hook is a `slog.Debug` line, and `main.go` builds the logger at Info with no `LOG_LEVEL` knob, so it never emits in production. Deliberate for now; the code comment says so plainly.