### PR TITLE
ci: gate heavy jobs on changed-file classification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,20 +191,6 @@ jobs:
           persist-credentials: false
       - run: docker compose config --quiet
 
-  docker:
-    name: Docker build (${{ matrix.image }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [ingestion, worker]
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - run: docker build -f packages/${{ matrix.image }}/Dockerfile .
-
   e2e-keyless:
     name: Keyless smoke E2E
     runs-on: ubuntu-latest
@@ -366,7 +352,7 @@ jobs:
     name: ci-ok
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [go, js, compose, docker, e2e-keyless, reliability-system, security, sdk-python, repo-checks]
+    needs: [go, js, compose, e2e-keyless, reliability-system, security, sdk-python, repo-checks]
     if: always()
     steps:
       - name: Report job results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,81 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Classifies the PR's changed files into the areas the heavy jobs gate on.
+  #
+  # INVARIANT this design depends on: ci-ok and wire-fixtures are the ONLY
+  # required status checks on main. A job-level `if:` that evaluates false
+  # reports SUCCESS to the status API, not pending -- so if an individual job
+  # below is ever marked required directly, a filtered-out PR would pass with
+  # that check green and nothing behind it. Check before changing:
+  #   gh api repos/opslane/opslane-oss/branches/main/protection \
+  #     --jq '.required_status_checks.contexts'
+  #
+  # Push to main deliberately classifies nothing and turns every area on:
+  # candidate-images is published off a green ci-ok, so it must be backed by a
+  # full run, and a classifier mistake then shows up as a red main rather than
+  # a silent hole.
+  changes:
+    name: Classify changed files
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      go: ${{ steps.classify.outputs.go }}
+      js: ${{ steps.classify.outputs.js }}
+      python: ${{ steps.classify.outputs.python }}
+      e2e: ${{ steps.classify.outputs.e2e }}
+      reliability: ${{ steps.classify.outputs.reliability }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Classify
+        id: classify
+        env:
+          # base.sha is the base ref tip at event time; the three-dot diff
+          # below is what resolves the merge base from it. If main advanced
+          # since, the merge base is the same or older, so the file set is the
+          # same or larger -- wrong in the safe direction.
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "Not a pull request; running every area."
+            for area in go js python e2e reliability; do
+              echo "$area=true" >> "$GITHUB_OUTPUT"
+            done
+            exit 0
+          fi
+          if [ -z "$BASE_SHA" ]; then
+            echo "pull_request.base.sha is empty; cannot classify." >&2
+            exit 1
+          fi
+          # --no-renames: a detected rename reports only the destination, so
+          # moving an active file into docs/ could otherwise suppress the jobs
+          # that covered it. Without rename detection it is a delete plus an
+          # add, and both paths get classified.
+          git diff --no-renames --name-only -z "$BASE_SHA...HEAD" \
+            | node scripts/ci-changed-areas.mjs \
+            | tee -a "$GITHUB_OUTPUT"
+      - name: Summarize
+        run: |
+          {
+            echo "### Changed-file classification"
+            echo '```'
+            echo "go=${{ steps.classify.outputs.go }}"
+            echo "js=${{ steps.classify.outputs.js }}"
+            echo "python=${{ steps.classify.outputs.python }}"
+            echo "e2e=${{ steps.classify.outputs.e2e }}"
+            echo "reliability=${{ steps.classify.outputs.reliability }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   go:
     name: Go build and test
+    needs: [changes]
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
@@ -111,6 +184,8 @@ jobs:
 
   js:
     name: JS build and test
+    needs: [changes]
+    if: needs.changes.outputs.js == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     services:
@@ -150,6 +225,8 @@ jobs:
 
   sdk-python:
     name: Python SDK tests (${{ matrix.python-version }})
+    needs: [changes]
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -193,6 +270,8 @@ jobs:
 
   e2e-keyless:
     name: Keyless smoke E2E
+    needs: [changes]
+    if: needs.changes.outputs.e2e == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -314,6 +393,8 @@ jobs:
 
   reliability-system:
     name: Deterministic event-to-PR reliability
+    needs: [changes]
+    if: needs.changes.outputs.reliability == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -352,16 +433,20 @@ jobs:
     name: ci-ok
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [go, js, compose, e2e-keyless, reliability-system, security, sdk-python, repo-checks]
+    needs: [changes, repo-checks, go, js, sdk-python, compose, e2e-keyless, reliability-system, security]
     if: always()
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Report job results
         env:
           RESULTS: ${{ toJSON(needs) }}
         run: echo "$RESULTS"
-      - name: Fail on any failed, cancelled, or skipped required job
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
-        run: exit 1
+      - name: Verify every job ran or skipped exactly as classified
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: node scripts/check-ci-ok.mjs
 
   # Candidate images: only on push to main, only after ci-ok. The unique tag
   # main-<sha>-<run-id>-<attempt> IS the candidate's identity (no stored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ jobs:
   #   gh api repos/opslane/opslane-oss/branches/main/protection \
   #     --jq '.required_status_checks.contexts'
   #
+  # This workflow runs on `pull_request`, so the classifier, the ci-ok checker,
+  # and their tests all come from the PR head -- weakening the gate takes a
+  # coordinated edit across scripts/ci-changed-areas.mjs, scripts/check-ci-ok.mjs,
+  # and scripts/__tests__/, but it is a code-review control, not a CI one. The
+  # wire-fixtures gate uses pull_request_target precisely to avoid that; this
+  # one cannot, because it must diff the PR's own tree.
+  #
   # Push to main deliberately classifies nothing and turns every area on:
   # candidate-images is published off a green ci-ok, so it must be backed by a
   # full run, and a classifier mistake then shows up as a red main rather than

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,18 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # docs-sync's runnable-snippet tests reach test:repo through
+      # docs:map:test, and they type-check the docs' examples for real: each
+      # runs `pnpm build` inside test-fixtures/react-app or vue-app, which
+      # resolve @opslane/sdk over the workspace link and therefore need
+      # packages/sdk/dist on disk. This job used to be part of js, which ran
+      # `pnpm -r build` first and supplied that implicitly.
+      #
+      # Only the SDK is needed: it has no workspace dependencies of its own,
+      # and those two fixtures depend on nothing else in the repo. Should a
+      # future runnable snippet import another package, this job fails --
+      # it is always-on, so the gap surfaces immediately rather than rotting.
+      - run: pnpm --filter @opslane/sdk build
       - run: pnpm test:repo
 
   js:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,28 @@ jobs:
           go test ./... -v 2>&1 | tee /tmp/go-test.log
           ../../scripts/check-go-skips.mjs /tmp/go-test.log
 
+  # Repo-wide static checks: docs drift/scope, action pinning, wire-fixture
+  # policy tests. Deliberately unconditional, and deliberately NOT inside the
+  # js job -- these are the checks that read docs/, .github/workflows/, and
+  # Go/worker/SDK source, so leaving them in js would make js un-skippable for
+  # almost every change. Keeping them always-on is also what makes it safe to
+  # skip everything else on a docs-only or workflow-only PR.
+  repo-checks:
+    name: Repo-wide checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test:repo
+
   js:
     name: JS build and test
     runs-on: ubuntu-latest
@@ -122,7 +144,7 @@ jobs:
       - name: Install Playwright chromium (SDK browser tests)
         run: pnpm --filter @opslane/sdk exec playwright install --with-deps chromium
       - run: pnpm -r build
-      - run: pnpm test
+      - run: pnpm test:unit
       - name: License-boundary check (MIT-published packages)
         run: node scripts/check-licenses.mjs
 
@@ -328,7 +350,7 @@ jobs:
         run: docker compose down -v
 
   security:
-    name: Secret scan and action pinning
+    name: Secret scan
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -340,14 +362,11 @@ jobs:
           docker run --rm -v "$PWD:/repo:ro"
           ghcr.io/gitleaks/gitleaks@sha256:e1b35e12a8c6fa8901f060459cfb6b2fc4c484d3afbe3b029733a3bbfab07055
           dir /repo --config /repo/.gitleaks.toml --no-banner --redact
-      - name: Enforce SHA-pinned actions
-        run: node scripts/check-action-pins.mjs
-
   ci-ok:
     name: ci-ok
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [go, js, compose, docker, e2e-keyless, reliability-system, security, sdk-python]
+    needs: [go, js, compose, docker, e2e-keyless, reliability-system, security, sdk-python, repo-checks]
     if: always()
     steps:
       - name: Report job results

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "db:migrate": "docker compose run --rm migrate",
     "services:restart": "./scripts/restart-services.sh",
     "services:restart:wipe-db": "./scripts/restart-services.sh --wipe-db",
-    "test": "pnpm docs:map:test && pnpm docs:scope && node scripts/check-docs-drift.mjs && node scripts/check-action-pins.mjs && node --test scripts/check-wire-fixtures.test.mjs && pnpm -r --filter '!@opslane/test-e2e' test",
+    "test:repo": "pnpm docs:map:test && pnpm docs:scope && node scripts/check-docs-drift.mjs && node scripts/check-action-pins.mjs && node --test scripts/check-wire-fixtures.test.mjs",
     "test:unit": "pnpm -r --filter '!@opslane/test-e2e' test",
+    "test": "pnpm test:repo && pnpm test:unit",
     "test:e2e": "pnpm --filter @opslane/test-e2e test",
     "test:reliability:system": "./scripts/run-reliability-system.sh"
   },

--- a/scripts/__tests__/check-ci-ok.test.mjs
+++ b/scripts/__tests__/check-ci-ok.test.mjs
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { verify, GATED, ALWAYS } from '../check-ci-ok.mjs';
 
@@ -162,4 +163,47 @@ test('CLI exits 0 and says so when everything matches', () => {
   const NEEDS = JSON.stringify(needs({ areas: allOn }));
   const out = execFileSync(process.execPath, [CLI], { env: { ...process.env, NEEDS }, encoding: 'utf8' });
   assert.match(out, /ran or skipped exactly as/);
+});
+
+// --- ci.yml and this script must agree about the job list ---
+
+function workflowJobs(yml) {
+  const jobsStart = yml.indexOf('\njobs:\n');
+  assert.notEqual(jobsStart, -1, 'ci.yml must contain a jobs block');
+  const jobsSection = yml.slice(jobsStart + '\njobs:\n'.length);
+  const matches = [...jobsSection.matchAll(/^ {2}([a-z][a-z0-9-]*):$/gm)];
+  return new Map(matches.map((match, index) => {
+    const end = matches[index + 1]?.index ?? jobsSection.length;
+    return [match[1], jobsSection.slice(match.index, end)];
+  }));
+}
+
+test('ci-ok.needs matches exactly the jobs check-ci-ok.mjs knows about', () => {
+  const yml = readFileSync(new URL('../../.github/workflows/ci.yml', import.meta.url), 'utf8');
+  const ciOk = workflowJobs(yml).get('ci-ok');
+  const needsLine = ciOk.match(/^    needs: \[([^\]]+)\]/m);
+  assert.ok(needsLine, 'ci-ok must declare a single-line needs list');
+  const listed = needsLine[1].split(',').map((s) => s.trim()).sort();
+  const known = [...Object.keys(GATED), ...ALWAYS].sort();
+  assert.deepEqual(listed, known);
+});
+
+test('every workflow job is covered by the gate or explicitly downstream', () => {
+  const yml = readFileSync(new URL('../../.github/workflows/ci.yml', import.meta.url), 'utf8');
+  const listed = [...workflowJobs(yml).keys()].sort();
+  const expected = [...Object.keys(GATED), ...ALWAYS, 'ci-ok', 'candidate-images'].sort();
+  assert.deepEqual(listed, expected);
+});
+
+test('every gated job depends on changes and gates on its assigned area', () => {
+  const yml = readFileSync(new URL('../../.github/workflows/ci.yml', import.meta.url), 'utf8');
+  const jobs = workflowJobs(yml);
+  for (const [job, area] of Object.entries(GATED)) {
+    const block = jobs.get(job);
+    assert.ok(block, `${job} is missing from ci.yml`);
+    assert.match(block, /^    needs: \[changes\]$/m, `${job} must depend directly on changes`);
+    const condition = block.match(/^    if: (.+)$/m);
+    assert.ok(condition, `${job} must have a job-level if condition`);
+    assert.equal(condition[1].trim(), `needs.changes.outputs.${area} == 'true'`, `${job} gates on the wrong area`);
+  }
 });

--- a/scripts/__tests__/check-ci-ok.test.mjs
+++ b/scripts/__tests__/check-ci-ok.test.mjs
@@ -171,7 +171,12 @@ function workflowJobs(yml) {
   const jobsStart = yml.indexOf('\njobs:\n');
   assert.notEqual(jobsStart, -1, 'ci.yml must contain a jobs block');
   const jobsSection = yml.slice(jobsStart + '\njobs:\n'.length);
-  const matches = [...jobsSection.matchAll(/^ {2}([a-z][a-z0-9-]*):$/gm)];
+  // Deliberately as permissive as GitHub's own job-id rules (underscores and
+  // uppercase are legal). A narrower pattern would make an unmatched job id
+  // invisible here, and the "every workflow job is covered" assertion below
+  // would pass while that job silently gated nothing.
+  const matches = [...jobsSection.matchAll(/^ {2}([A-Za-z_][A-Za-z0-9_-]*):$/gm)];
+  assert.ok(matches.length > 0, 'ci.yml must define at least one job');
   return new Map(matches.map((match, index) => {
     const end = matches[index + 1]?.index ?? jobsSection.length;
     return [match[1], jobsSection.slice(match.index, end)];

--- a/scripts/__tests__/check-ci-ok.test.mjs
+++ b/scripts/__tests__/check-ci-ok.test.mjs
@@ -1,0 +1,165 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { verify, GATED, ALWAYS } from '../check-ci-ok.mjs';
+
+const CLI = fileURLToPath(new URL('../check-ci-ok.mjs', import.meta.url));
+
+const outputs = (over = {}) => ({
+  go: 'false', js: 'false', python: 'false', e2e: 'false', reliability: 'false', ...over,
+});
+
+/** Builds a `needs` object where gated jobs skip unless their area is on. */
+function needs({ areas = {}, results = {} } = {}) {
+  const o = outputs(areas);
+  const n = { changes: { result: 'success', outputs: o } };
+  for (const [job, area] of Object.entries(GATED)) {
+    n[job] = { result: results[job] ?? (o[area] === 'true' ? 'success' : 'skipped') };
+  }
+  for (const job of ALWAYS) {
+    if (job === 'changes') continue;
+    n[job] = { result: results[job] ?? 'success' };
+  }
+  return n;
+}
+
+const allOn = { go: 'true', js: 'true', python: 'true', e2e: 'true', reliability: 'true' };
+
+// --- happy paths ---
+
+test('all areas off, everything skipped as expected -> pass', () => {
+  assert.deepEqual(verify(needs()), []);
+});
+
+test('all areas on and green -> pass', () => {
+  assert.deepEqual(verify(needs({ areas: allOn })), []);
+});
+
+test('js-only (a docs PR) -> pass', () => {
+  assert.deepEqual(verify(needs({ areas: { js: 'true' } })), []);
+});
+
+// --- both directions of the expectation check ---
+
+test('a job that should have run but skipped -> fail', () => {
+  const problems = verify(needs({ areas: { go: 'true' }, results: { go: 'skipped' } }));
+  assert.equal(problems.length, 1);
+  assert.ok(problems[0].includes('job `go` was expected to run (go=true) but its result was skipped'), problems[0]);
+});
+
+test('a job that should have skipped but ran -> fail (filter drift)', () => {
+  const problems = verify(needs({ results: { go: 'success' } }));
+  assert.equal(problems.length, 1);
+  assert.ok(problems[0].includes('job `go` was expected to skip (go=false) but its result was success'), problems[0]);
+});
+
+test('a failing gated job -> fail', () => {
+  const problems = verify(needs({ areas: { js: 'true' }, results: { js: 'failure' } }));
+  assert.equal(problems.length, 1);
+  assert.ok(problems[0].includes('job `js` was expected to run'), problems[0]);
+});
+
+test('a cancelled gated job -> fail', () => {
+  const problems = verify(needs({ areas: { e2e: 'true' }, results: { 'e2e-keyless': 'cancelled' } }));
+  assert.ok(problems[0].includes('job `e2e-keyless` was expected to run'), problems[0]);
+});
+
+test('multiple problems are all reported, not just the first', () => {
+  assert.equal(verify(needs({ results: { go: 'success', js: 'success' } })).length, 2);
+});
+
+// --- always-on jobs ---
+
+test('an always-on job that skipped -> fail', () => {
+  const problems = verify(needs({ results: { 'repo-checks': 'skipped' } }));
+  assert.ok(problems[0].includes('always-on job `repo-checks` must succeed'), problems[0]);
+});
+
+test('a missing always-on job -> fail', () => {
+  const n = needs();
+  delete n.security;
+  assert.ok(verify(n)[0].includes('always-on job `security` is missing from needs'), verify(n)[0]);
+});
+
+// --- the classifier itself must be trustworthy ---
+
+test('a missing changes job -> fail', () => {
+  const n = needs();
+  delete n.changes;
+  const problems = verify(n);
+  assert.equal(problems.length, 1);
+  assert.ok(problems[0].includes('needs is missing the `changes` job'), problems[0]);
+});
+
+test('a non-object needs value -> fail cleanly', () => {
+  assert.deepEqual(verify(null), ['NEEDS must be a JSON object']);
+  assert.deepEqual(verify([]), ['NEEDS must be a JSON object']);
+});
+
+test('a failed changes job -> fail, and nothing else is interpreted', () => {
+  const n = needs();
+  n.changes.result = 'failure';
+  const problems = verify(n);
+  assert.equal(problems.length, 1);
+  assert.ok(problems[0].includes('`changes` did not succeed'), problems[0]);
+});
+
+for (const [label, value] of [['missing', undefined], ['empty', ''], ['non-literal', 'False']]) {
+  test(`a ${label} area output -> fail`, () => {
+    const n = needs();
+    if (value === undefined) delete n.changes.outputs.go;
+    else n.changes.outputs.go = value;
+    const problems = verify(n);
+    assert.ok(
+      problems[0].includes('the `changes` output for area `go` must be the literal "true" or "false"'),
+      problems[0],
+    );
+  });
+}
+
+// --- drift between ci.yml and this script ---
+
+test('a missing gated job -> fail', () => {
+  const n = needs();
+  delete n.go;
+  assert.ok(verify(n)[0].includes('gated job `go` is missing from needs'), verify(n)[0]);
+});
+
+test('an unknown job in needs -> fail', () => {
+  const n = needs();
+  n['brand-new-job'] = { result: 'success' };
+  assert.ok(
+    verify(n)[0].includes('job `brand-new-job` is in ci-ok.needs but check-ci-ok.mjs does not know it'),
+    verify(n)[0],
+  );
+});
+
+// --- the CLI wrapper ---
+
+test('CLI exits 1 when NEEDS is unset', () => {
+  const run = () => execFileSync(process.execPath, [CLI], { env: { ...process.env, NEEDS: '' }, encoding: 'utf8' });
+  assert.throws(run, (error) => error.status === 1 && error.stderr.includes('NEEDS is not set'));
+});
+
+test('CLI exits 1 on malformed JSON', () => {
+  const run = () => execFileSync(process.execPath, [CLI], { env: { ...process.env, NEEDS: '{oops' }, encoding: 'utf8' });
+  assert.throws(run, (error) => error.status === 1 && error.stderr.includes('NEEDS is not valid JSON'));
+});
+
+test('CLI exits 1 on valid non-object JSON', () => {
+  const run = () => execFileSync(process.execPath, [CLI], { env: { ...process.env, NEEDS: 'null' }, encoding: 'utf8' });
+  assert.throws(run, (error) => error.status === 1 && error.stderr.includes('NEEDS must be a JSON object'));
+});
+
+test('CLI exits 1 and lists problems when verification fails', () => {
+  const NEEDS = JSON.stringify(needs({ results: { go: 'success' } }));
+  const run = () => execFileSync(process.execPath, [CLI], { env: { ...process.env, NEEDS }, encoding: 'utf8' });
+  assert.throws(run, (error) => error.status === 1 && error.stderr.includes('was expected to skip'));
+});
+
+test('CLI exits 0 and says so when everything matches', () => {
+  const NEEDS = JSON.stringify(needs({ areas: allOn }));
+  const out = execFileSync(process.execPath, [CLI], { env: { ...process.env, NEEDS }, encoding: 'utf8' });
+  assert.match(out, /ran or skipped exactly as/);
+});

--- a/scripts/__tests__/ci-changed-areas.test.mjs
+++ b/scripts/__tests__/ci-changed-areas.test.mjs
@@ -1,6 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { AREAS, classify, areasFor, parsePaths } from '../ci-changed-areas.mjs';
+
+const CLI = fileURLToPath(new URL('../ci-changed-areas.mjs', import.meta.url));
 
 const all = () => Object.fromEntries(AREAS.map((a) => [a, true]));
 const none = () => Object.fromEntries(AREAS.map((a) => [a, false]));
@@ -64,7 +68,16 @@ test('executable or unknown .github paths turn every area on', () => {
 test('docs and docs-site turn on js only, because docs-site builds ../docs', () => {
   assert.deepEqual(areasFor(['docs/install.md']), jsOnly());
   assert.deepEqual(areasFor(['docs/contracts/events.md']), jsOnly());
+  assert.deepEqual(areasFor(['docs/images/architecture.png']), jsOnly());
   assert.deepEqual(areasFor(['docs-site/src/pages/index.astro']), jsOnly());
+});
+
+test('an executable file under docs/ is NOT prose and turns every area on', () => {
+  // docs/ holds only .md and .png today. The docs rule matches by extension so
+  // a tool added there later fails closed instead of being silently inert.
+  assert.deepEqual(areasFor(['docs/tools/gen.mjs']), all());
+  assert.deepEqual(areasFor(['docs/deploy.sh']), all());
+  assert.equal(classify('docs/tools/gen.mjs'), 'UNKNOWN');
 });
 
 test('top-level markdown turns on js only', () => {
@@ -105,6 +118,11 @@ test('ci.yml is matched by the global rule before the .github rule', () => {
   assert.notEqual(classify('.github/workflows/ci.yml'), 'meta');
 });
 
+test('the .yaml spelling of the gate file is still global, not inert meta', () => {
+  assert.equal(classify('.github/workflows/ci.yaml'), 'global');
+  assert.deepEqual(areasFor(['.github/workflows/ci.yaml']), all());
+});
+
 // --- input parsing ---
 
 test('parsePaths splits NUL-separated input and drops the trailing empty', () => {
@@ -114,4 +132,34 @@ test('parsePaths splits NUL-separated input and drops the trailing empty', () =>
 
 test('parsePaths keeps paths containing spaces intact', () => {
   assert.deepEqual(parsePaths('docs/a b.md\0'), ['docs/a b.md']);
+});
+
+// --- the CLI wrapper: its stdout IS $GITHUB_OUTPUT ---
+
+const runCli = (stdin) => execFileSync(process.execPath, [CLI], { input: stdin, encoding: 'utf8' });
+
+test('CLI emits exactly one area=value line per area, in AREAS order', () => {
+  assert.equal(runCli('docs/install.md\0'), 'go=false\njs=true\npython=false\ne2e=false\nreliability=false\n');
+});
+
+test('CLI emits every area true for an unrecognised path', () => {
+  assert.equal(runCli('packages/worker/src/index.ts\0'), AREAS.map((a) => `${a}=true`).join('\n') + '\n');
+});
+
+test('CLI emits every area true for empty stdin, not an empty output', () => {
+  // An empty $GITHUB_OUTPUT would leave every `needs.changes.outputs.*` unset,
+  // which check-ci-ok.mjs rejects -- but failing open here would be worse.
+  assert.equal(runCli(''), AREAS.map((a) => `${a}=true`).join('\n') + '\n');
+});
+
+test('CLI cannot inject extra lines into $GITHUB_OUTPUT via a crafted filename', () => {
+  // Per-path classification goes to stderr; only area=value reaches stdout.
+  // The name is also not prose (it does not end in .md), so it fails closed.
+  const hostile = 'docs/x.md\ngo=true\nreliability=true\0';
+  assert.equal(runCli(hostile), AREAS.map((a) => `${a}=true`).join('\n') + '\n');
+});
+
+test('a filename with a trailing newline after .md is not treated as prose', () => {
+  // JS `$` also matches before a trailing newline, so PROSE is lookahead-anchored.
+  assert.deepEqual(areasFor(['docs/x.md\n']), all());
 });

--- a/scripts/__tests__/ci-changed-areas.test.mjs
+++ b/scripts/__tests__/ci-changed-areas.test.mjs
@@ -1,0 +1,117 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AREAS, classify, areasFor, parsePaths } from '../ci-changed-areas.mjs';
+
+const all = () => Object.fromEntries(AREAS.map((a) => [a, true]));
+const none = () => Object.fromEntries(AREAS.map((a) => [a, false]));
+const jsOnly = () => ({ ...none(), js: true });
+
+// --- fail-closed defaults ---
+
+test('an unrecognised path turns every area on', () => {
+  assert.deepEqual(areasFor(['some-new-toplevel-thing/file.txt']), all());
+});
+
+test('an empty file list turns every area on', () => {
+  // No detected changes means the diff computation is wrong, not that there
+  // is nothing to test.
+  assert.deepEqual(areasFor([]), all());
+});
+
+test('source, tests, fixtures, scripts, and lockfiles all turn every area on', () => {
+  for (const path of [
+    'packages/ingestion/handler/routes.go',
+    'packages/worker/src/index.ts',
+    'packages/dashboard/src/App.vue',
+    'packages/sdk/src/core.ts',
+    'packages/sdk-python/src/opslane/__init__.py',
+    'packages/test-reliability/src/system.ts',
+    'shared/src/contracts.ts',
+    'cli/src/init.ts',
+    'eval/src/run.ts',
+    'test-e2e/browser-smoke.test.ts',
+    'test-fixtures/wire/events/v1.2.0-full.json',
+    'scripts/run-migrations.sh',
+    'package.json',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+    '.nvmrc',
+    'docker-compose.yml',
+    'LICENSE',
+  ]) {
+    assert.deepEqual(areasFor([path]), all(), path);
+  }
+});
+
+// --- the two narrow inert cases ---
+
+test('ci.yml itself turns every area on', () => {
+  assert.deepEqual(areasFor(['.github/workflows/ci.yml']), all());
+});
+
+test('other workflow files turn no area on', () => {
+  assert.deepEqual(areasFor(['.github/workflows/release-npm.yml']), none());
+  assert.deepEqual(areasFor(['.github/dependabot.yml']), none());
+  assert.deepEqual(areasFor(['.github/CLA.md']), none());
+});
+
+test('executable or unknown .github paths turn every area on', () => {
+  assert.deepEqual(areasFor(['.github/actions/example/action.yml']), all());
+  assert.deepEqual(areasFor(['.github/workflows/helpers/build.mjs']), all());
+  assert.deepEqual(areasFor(['.github/new-metadata.yml']), all());
+});
+
+test('docs and docs-site turn on js only, because docs-site builds ../docs', () => {
+  assert.deepEqual(areasFor(['docs/install.md']), jsOnly());
+  assert.deepEqual(areasFor(['docs/contracts/events.md']), jsOnly());
+  assert.deepEqual(areasFor(['docs-site/src/pages/index.astro']), jsOnly());
+});
+
+test('top-level markdown turns on js only', () => {
+  assert.deepEqual(areasFor(['README.md']), jsOnly());
+  assert.deepEqual(areasFor(['AGENTS.md']), jsOnly());
+});
+
+test('markdown nested inside a package is NOT treated as prose', () => {
+  // packages/sdk-python/README.md is the wheel's long_description and
+  // `twine check --strict` reads it; a nested README is not safely inert.
+  assert.deepEqual(areasFor(['packages/sdk-python/README.md']), all());
+  assert.deepEqual(areasFor(['packages/ingestion/README.md']), all());
+});
+
+// --- union behaviour ---
+
+test('areas union across files', () => {
+  assert.deepEqual(areasFor(['docs/install.md', '.github/workflows/release-npm.yml']), jsOnly());
+});
+
+test('one unrecognised file poisons an otherwise inert diff', () => {
+  assert.deepEqual(areasFor(['docs/install.md', 'weird-new-file']), all());
+  assert.deepEqual(areasFor(['.github/dependabot.yml', 'packages/worker/src/x.ts']), all());
+});
+
+// --- first-match-wins: every rule is reachable and ordered correctly ---
+
+test('classify returns each tag, proving every rule is reachable', () => {
+  assert.equal(classify('.github/workflows/ci.yml'), 'global');
+  assert.equal(classify('.github/workflows/release-pypi.yml'), 'meta');
+  assert.equal(classify('docs/install.md'), 'docs');
+  assert.equal(classify('docs-site/astro.config.mjs'), 'docs-site');
+  assert.equal(classify('README.md'), 'root-doc');
+  assert.equal(classify('packages/worker/src/index.ts'), 'UNKNOWN');
+});
+
+test('ci.yml is matched by the global rule before the .github rule', () => {
+  assert.notEqual(classify('.github/workflows/ci.yml'), 'meta');
+});
+
+// --- input parsing ---
+
+test('parsePaths splits NUL-separated input and drops the trailing empty', () => {
+  assert.deepEqual(parsePaths('a.txt\0b/c.txt\0'), ['a.txt', 'b/c.txt']);
+  assert.deepEqual(parsePaths(''), []);
+});
+
+test('parsePaths keeps paths containing spaces intact', () => {
+  assert.deepEqual(parsePaths('docs/a b.md\0'), ['docs/a b.md']);
+});

--- a/scripts/check-ci-ok.mjs
+++ b/scripts/check-ci-ok.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * The ci-ok gate.
+ *
+ * Replaces the old blanket `contains(needs.*.result, 'skipped')` condition.
+ * That condition was a real guard -- it stopped a job that silently vanished
+ * from passing -- so introducing path filtering must not simply allow skips.
+ * Instead this checks every job against what the `changes` classifier said
+ * should happen, in BOTH directions:
+ *
+ *   expected to run  -> result must be exactly 'success'
+ *   expected to skip -> result must be exactly 'skipped'
+ *
+ * The second direction catches drift: a job whose `if:` no longer matches the
+ * area it gates on gets flagged instead of quietly passing.
+ *
+ * Consumes toJSON(needs) via $NEEDS. `needs` outputs are strings, so "false"
+ * is truthy in JS -- every check compares exact literals and treats anything
+ * else, including missing and empty, as a hard failure. fromJSON is avoided
+ * deliberately: it throws on an empty output.
+ *
+ * Usage: NEEDS='${{ toJSON(needs) }}' node scripts/check-ci-ok.mjs
+ */
+
+/** job id in ci.yml -> the classifier output that gates it. */
+export const GATED = {
+  go: 'go',
+  js: 'js',
+  'sdk-python': 'python',
+  'e2e-keyless': 'e2e',
+  'reliability-system': 'reliability',
+};
+
+/** Job ids that must always run and always succeed. */
+export const ALWAYS = ['changes', 'repo-checks', 'compose', 'security'];
+
+export function verify(needs) {
+  const problems = [];
+
+  if (needs === null || typeof needs !== 'object' || Array.isArray(needs)) {
+    return ['NEEDS must be a JSON object'];
+  }
+
+  const changes = needs.changes;
+  if (!changes) return ['needs is missing the `changes` job -- add it to ci-ok.needs'];
+  if (changes.result !== 'success') {
+    // Without a trustworthy classification, no skip can be justified.
+    return [`\`changes\` did not succeed (result: ${changes.result}); refusing to interpret any skip`];
+  }
+
+  const known = new Set([...Object.keys(GATED), ...ALWAYS]);
+  for (const job of Object.keys(needs)) {
+    if (!known.has(job)) {
+      problems.push(
+        `job \`${job}\` is in ci-ok.needs but check-ci-ok.mjs does not know it -- add it to GATED or ALWAYS`,
+      );
+    }
+  }
+
+  for (const job of ALWAYS) {
+    if (job === 'changes') continue;
+    const result = needs[job]?.result;
+    if (result === undefined) problems.push(`always-on job \`${job}\` is missing from needs`);
+    else if (result !== 'success') problems.push(`always-on job \`${job}\` must succeed (result: ${result})`);
+  }
+
+  const outputs = changes.outputs ?? {};
+  for (const [job, area] of Object.entries(GATED)) {
+    const raw = outputs[area];
+    if (raw !== 'true' && raw !== 'false') {
+      problems.push(
+        `the \`changes\` output for area \`${area}\` must be the literal "true" or "false" (got: ${JSON.stringify(raw)})`,
+      );
+      continue;
+    }
+    const result = needs[job]?.result;
+    if (result === undefined) {
+      problems.push(`gated job \`${job}\` is missing from needs`);
+      continue;
+    }
+    if (raw === 'true' && result !== 'success') {
+      problems.push(`job \`${job}\` was expected to run (${area}=true) but its result was ${result}`);
+    }
+    if (raw === 'false' && result !== 'skipped') {
+      problems.push(
+        `job \`${job}\` was expected to skip (${area}=false) but its result was ${result} -- the job's if: and the classifier disagree`,
+      );
+    }
+  }
+
+  return problems;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const raw = process.env.NEEDS;
+  if (!raw) {
+    console.error('NEEDS is not set');
+    process.exit(1);
+  }
+  let needs;
+  try {
+    needs = JSON.parse(raw);
+  } catch (error) {
+    console.error(`NEEDS is not valid JSON: ${error.message}`);
+    process.exit(1);
+  }
+  const problems = verify(needs);
+  if (problems.length > 0) {
+    console.error('ci-ok failed:');
+    for (const problem of problems) console.error(`  - ${problem}`);
+    process.exit(1);
+  }
+  console.log('ci-ok: every job ran or skipped exactly as the changed-file classification required.');
+}

--- a/scripts/ci-changed-areas.mjs
+++ b/scripts/ci-changed-areas.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Classifies a pull request's changed files into CI areas.
+ *
+ * Deliberately coarse. There are exactly three outcomes:
+ *
+ *   top-level workflow YAML except ci.yml, plus known repo metadata -> no heavy job
+ *   docs/**, docs-site/**, top-level *.md -> js only
+ *   anything else, including anything unrecognised -> everything
+ *
+ * A finer per-package map was tried and rejected. This monorepo's
+ * cross-directory imports make one unsafe to derive by hand -- an independent
+ * review of the fine-grained version found five real holes:
+ *
+ *   - docs-site/src/__tests__/agent-quickstart-content.test.ts reads
+ *     packages/ingestion/handler/agent_setup.go (ingestion feeds JS)
+ *   - packages/ingestion/handler/wire_compat_test.go replays every fixture
+ *     under test-fixtures/wire/events, and additions are allowed by the
+ *     append-only gate (fixtures feed Go)
+ *   - test-e2e/browser-smoke.test.ts imports ../cli/src/* (CLI feeds E2E)
+ *   - packages/test-reliability is a workspace package with tsc + vitest unit
+ *     tests that run in pnpm test:unit (it feeds JS)
+ *   - packages/sdk-python/tests/test_wire_shape.py reads test-fixtures/wire
+ *     (fixtures feed Python)
+ *
+ * Refine later if the numbers justify it, one rule and one test at a time.
+ * Never add a complement rule ("everything except X") -- that makes paths
+ * which did not exist when the rule was written silently inert, the exact
+ * opposite of what a CI gate should do.
+ *
+ * Usage: git diff --no-renames --name-only -z BASE...HEAD | node scripts/ci-changed-areas.mjs
+ * Writes `area=true|false` lines on stdout for $GITHUB_OUTPUT, and the
+ * per-path classification on stderr for the run log.
+ */
+
+export const AREAS = ['go', 'js', 'python', 'e2e', 'reliability'];
+
+const ALL = AREAS;
+const JS_ONLY = ['js'];
+const NONE = [];
+const INERT_META_PATHS = new Set(['.github/dependabot.yml', '.github/CLA.md']);
+
+// Ordered. First match wins.
+const RULES = [
+  // The gate itself: any change here must run everything.
+  { tag: 'global', areas: ALL, test: (p) => p === '.github/workflows/ci.yml' },
+
+  // Other top-level workflow YAML and explicitly known repo-meta files.
+  // Action pinning is covered by the always-on repo-checks job, secret
+  // scanning by the always-on security job, and workflow security by CodeQL's
+  // `actions` analysis. Deliberately do not match all of .github/: executable
+  // local actions and future unknown metadata must fail closed.
+  {
+    tag: 'meta',
+    areas: NONE,
+    test: (p) => /^\.github\/workflows\/[^/]+\.ya?ml$/.test(p) || INERT_META_PATHS.has(p),
+  },
+
+  // Prose. Feeds js because docs-site/astro.config.mjs processes ../docs and
+  // its build runs check-built-links.mjs, and the js job runs `pnpm -r build`.
+  { tag: 'docs', areas: JS_ONLY, test: (p) => p.startsWith('docs/') },
+  { tag: 'docs-site', areas: JS_ONLY, test: (p) => p.startsWith('docs-site/') },
+
+  // Top level only. Markdown nested inside a package is NOT inert:
+  // packages/sdk-python/README.md is the wheel's long_description and
+  // `twine check --strict` reads it.
+  { tag: 'root-doc', areas: JS_ONLY, test: (p) => !p.includes('/') && p.endsWith('.md') },
+];
+
+/** Returns the tag for a path, or 'UNKNOWN' when no rule matches. */
+export function classify(path) {
+  for (const rule of RULES) {
+    if (rule.test(path)) return rule.tag;
+  }
+  return 'UNKNOWN';
+}
+
+function areasForPath(path) {
+  for (const rule of RULES) {
+    if (rule.test(path)) return rule.areas;
+  }
+  return ALL; // UNKNOWN: fail closed.
+}
+
+/**
+ * Union of the areas every changed path needs. An empty list turns everything
+ * on: no detected changes means the diff computation is wrong.
+ */
+export function areasFor(paths) {
+  if (paths.length === 0) return Object.fromEntries(AREAS.map((a) => [a, true]));
+  const on = Object.fromEntries(AREAS.map((a) => [a, false]));
+  for (const path of paths) {
+    for (const area of areasForPath(path)) on[area] = true;
+  }
+  return on;
+}
+
+/** Splits `git diff -z` output. NUL-separated, trailing separator dropped. */
+export function parsePaths(raw) {
+  return raw.split('\0').filter((p) => p.length > 0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const paths = parsePaths(Buffer.concat(chunks).toString('utf8'));
+  for (const path of paths) console.error(`${classify(path).padEnd(10)} ${path}`);
+  for (const [area, on] of Object.entries(areasFor(paths))) console.log(`${area}=${on}`);
+}

--- a/scripts/ci-changed-areas.mjs
+++ b/scripts/ci-changed-areas.mjs
@@ -39,11 +39,19 @@ const ALL = AREAS;
 const JS_ONLY = ['js'];
 const NONE = [];
 const INERT_META_PATHS = new Set(['.github/dependabot.yml', '.github/CLA.md']);
+/**
+ * File types that are read by humans and rendered, never executed.
+ * Anchored with a negative lookahead rather than `$`: `$` also matches before a
+ * trailing newline, and a filename may legally contain one.
+ */
+const PROSE = /\.(md|png|jpe?g|svg|gif|webp)(?![\s\S])/;
 
 // Ordered. First match wins.
 const RULES = [
   // The gate itself: any change here must run everything.
-  { tag: 'global', areas: ALL, test: (p) => p === '.github/workflows/ci.yml' },
+  // Matched as ya?ml so a rename to ci.yaml cannot fall through to the meta
+  // rule below, which would make the gate file itself inert.
+  { tag: 'global', areas: ALL, test: (p) => /^\.github\/workflows\/ci\.ya?ml$/.test(p) },
 
   // Other top-level workflow YAML and explicitly known repo-meta files.
   // Action pinning is covered by the always-on repo-checks job, secret
@@ -58,7 +66,16 @@ const RULES = [
 
   // Prose. Feeds js because docs-site/astro.config.mjs processes ../docs and
   // its build runs check-built-links.mjs, and the js job runs `pnpm -r build`.
-  { tag: 'docs', areas: JS_ONLY, test: (p) => p.startsWith('docs/') },
+  //
+  // docs/ is matched by extension, not by prefix: it holds only .md and .png
+  // today and nothing there is executed, but a future docs/tools/gen.mjs or
+  // docs/deploy.sh under a prefix rule would be silently inert to go, python,
+  // e2e, and reliability. Anything else under docs/ falls through to UNKNOWN.
+  //
+  // docs-site/ IS matched by prefix, deliberately: it is a pnpm workspace
+  // package, so its code is genuinely covered by `pnpm -r build` and
+  // `pnpm test:unit`, both of which the js area turns on.
+  { tag: 'docs', areas: JS_ONLY, test: (p) => p.startsWith('docs/') && PROSE.test(p) },
   { tag: 'docs-site', areas: JS_ONLY, test: (p) => p.startsWith('docs-site/') },
 
   // Top level only. Markdown nested inside a package is NOT inert:


### PR DESCRIPTION
Most PRs here run the full matrix -- Go + Postgres + MinIO, JS + Playwright, four Python versions, a 30-minute keyless E2E, and a reliability system test -- regardless of what changed. A docs-only PR paid for all of it.

This adds a `changes` job that classifies the PR's changed files into five areas, and gates the heavy jobs on that classification. The design is deliberately coarse and fails closed:

- top-level workflow YAML except `ci.yml`, plus known repo metadata -> no heavy job
- `docs/**` (prose only), `docs-site/**`, top-level `*.md` -> js only
- anything else, **including anything unrecognised** -> everything

A finer per-package map was tried and rejected. An independent review of it found five real holes from cross-directory imports: the ingestion -> docs-site content test, the wire fixtures -> Go replay test, cli -> e2e, test-reliability -> js, and fixtures -> Python. Those are documented in the classifier header so the next person does not rediscover them.

## The skip guard is not weakened

The old blanket `contains(needs.*.result, 'skipped')` was a real guard, so path filtering must not simply allow skips. `scripts/check-ci-ok.mjs` replaces it and checks every job against what the classifier said should happen, in **both** directions:

- expected to run -> result must be exactly `success`
- expected to skip -> result must be exactly `skipped`

The second direction catches drift: a job whose `if:` no longer matches the area it gates on gets flagged instead of quietly passing. Static tests assert that `ci-ok.needs`, the `GATED`/`ALWAYS` tables, and each job's own `if:` condition all agree, so the workflow and the checker cannot drift apart silently.

Job outputs are strings, so `"false"` is truthy in JS. Every check compares exact literals and treats anything else -- including missing and empty -- as a hard failure. `fromJSON` is avoided deliberately: it throws on an empty output.

## Supporting changes

- Repo-wide static checks (docs drift/scope, action pinning, wire-fixture policy) moved into an always-on `repo-checks` job. They read `docs/`, `.github/workflows/`, and Go/worker/SDK source, so leaving them in `js` would have made `js` un-skippable for almost every change. Keeping them always-on is what makes it safe to skip everything else on a docs-only PR.
- `pnpm test` splits into `test:repo` + `test:unit`. Root `pnpm test` still runs both halves, so the gate documented in `AGENTS.md` is unchanged.
- The `docker` build matrix is gone. `e2e-keyless` already builds both images from the same Dockerfiles via compose (`context: .`, no `target:`).

## Verification

- `pnpm test:repo` green: 133 tests, 0 failures.
- Required status checks on `main` are exactly `["ci-ok","wire-fixtures"]` (`gh api .../branches/main/protection`), so deleting the `docker` job leaves no orphaned pending check. That invariant is recorded in the `ci.yml` header with the command to re-check it.
- Classifier run end-to-end against this branch's own diff: correctly turns all five areas on.

## Known trust boundary

This workflow runs on `pull_request`, so the classifier, the checker, and their tests all come from the PR head. Weakening the gate takes a coordinated edit across `scripts/ci-changed-areas.mjs`, `scripts/check-ci-ok.mjs`, and `scripts/__tests__/`, but it is a code-review control, not a CI one. `wire-fixtures.yml` uses `pull_request_target` precisely to avoid this; this workflow cannot, because it must diff the PR's own tree. Noted in the `ci.yml` header. A CODEOWNERS entry over those paths is the cheap hardening if we want one.