### PR TITLE
feat(dashboard): rebuild the session list around friction signals

### DIFF
--- a/docs/design/dashboard-v1/consumer-matrix.md
+++ b/docs/design/dashboard-v1/consumer-matrix.md
@@ -26,6 +26,7 @@ new owned primitive or domain component is added.
 | `IncidentLedgerRow.vue` | `views/ActivityFeed.vue` | incident list row |
 | `IncidentConclusion.vue` | `views/IncidentDetail.vue` | outcome and next action |
 | `IncidentLifecycle.vue` | `views/IncidentDetail.vue` | truthful current-state summary |
+| `SessionLedgerRow.vue` | `views/SessionsList.vue` | session list row |
 | `layout/navigation.ts` | `components/layout/AppNavigation.vue` | navigation model and active-route rule |
 | `session.ts` | `App.vue` | tenant-scoped client state teardown on sign-out |
 

--- a/docs/plans/2026-07-22-session-list-redesign.md
+++ b/docs/plans/2026-07-22-session-list-redesign.md
@@ -1,0 +1,707 @@
+# Session list redesign
+
+Status: reviewed (design)
+Branch: `abhishekray07/session-list-ui`
+Date: 2026-07-22
+
+## Problem
+
+`/sessions` shows how a recording was **stored**, not what happened **inside** it.
+Five of seven columns carry no decision-changing signal:
+
+| Column | Why it fails |
+| --- | --- |
+| Chunks `2/2` | Internal plumbing. Only `0/n` ("still processing") means anything to a user. |
+| Size `2.4 KB` | Storage accounting. Belongs on billing, not on a triage screen. |
+| Status `analyzed` | Identical on every row. Only `analyzing` / `analysis_failed` carry information. |
+| Page `localhost:5174` | Identical on every row, and it is the first URL, not the journey. |
+| User `—` | Empty whenever the SDK never called `identify()`, with no hint that that is why. |
+
+The click target is the relative timestamp ("5 days ago"), which reads as metadata,
+not as a link to a recording.
+
+The filter bar asks for **End-user ID** and **Account ID** as raw UUIDs. Nobody knows
+a UUID by heart, so those two inputs will never be used.
+
+Opslane is an error-resolution engine. The list has to answer one question:
+**which session should I watch?** Storage columns cannot answer it.
+
+## What we already store and never show
+
+- `friction_signals` — `rage_click`, `dead_click`, `form_abandon` per session, with
+  `occurrence_count` (`packages/ingestion/db/migrations/004_friction.sql:35`)
+- `error_events.session_id` — how many errors fired during the session
+- `friction_signals.incident_id` — which session became evidence for an incident
+- `sessions.sdk_release` — which release the user was running
+  (`packages/ingestion/db/migrations/022_session_sdk_identity.sql`)
+
+No migration is needed. `idx_error_events_session` already exists
+(`001_baseline.sql:189`), and `friction_signals`' `UNIQUE (session_id, fingerprint,
+rule_version)` gives a session-prefixed btree.
+
+## Decisions taken
+
+- **Row layout:** three columns, two lines each — Session / Signals / Started.
+  Approved visual direction is variant B (see Approved Mockups). The mockup labels the
+  third column "Activity & Date"; ship it as **Started**, because the cell contains a
+  start timestamp and a duration and "Activity" implies neither.
+- **Scope:** backend and frontend together. Signal counts are the point of the change.
+- **No session summary.** Counts only. The *detection* is a deterministic rule engine
+  (`RULE_VERSION = 1`, `packages/worker/src/friction/analyzer.ts`). An earlier draft of
+  this plan said "no model runs per session" — that was wrong: `worker/src/index.ts:625`
+  runs `processFrictionOutcomes` with an LLM adjudicator inside the session-analysis job
+  whenever `ANTHROPIC_API_KEY` is set. It judges whether a signal is real; it does not
+  summarize the session. So a summary still needs new work, but the reason is scope, not
+  the absence of a model. See "NOT in scope".
+
+## Information architecture
+
+The screen answers one question in this order: **who** → **what went wrong** →
+**when**. Everything else is subordinate or removed.
+
+```
++----------------------------------------------------------------------+
+| SESSION LEDGER                                    (ember eyebrow, xs) |
+| Recorded sessions                                     (h1, 2xl semi)  |
+| Browse scrubbed recordings by user, account, and time.   (sm, muted)  |
+|                                       50 loaded  (mono xs, right) [1] |
++----------------------------------------------------------------------+
+| [ search email or user ID ] [ Last 24 hours v ] [ All envs v ]  Clear |
++======================================================================+
+| SESSION (~45%)          | SIGNALS (~30%)     | STARTED (~25%)         |
++-------------------------+--------------------+------------------------+
+| [>] jane@acme.com       | [3 errors]         | Jul 22, 8:02 PM        |
+|     Acme Corp · v1.4.2  | [2 rage clicks]    | 7m 21s                 |
++-------------------------+--------------------+------------------------+
+| [>] anonymous-8f3a2c1b  |                    | Jul 22, 7:31 PM        |
+|     Acme Corp · v1.4.1  |                    | 2m 48s                 |
++======================================================================+
+|                        [ Load more ]                                  |
++----------------------------------------------------------------------+
+```
+
+**[1] The header count says "loaded", not "records".** `SessionListResponse`
+(`types/api.ts:230`) returns `sessions` and `next_cursor` — there is no total, and keyset
+pagination cannot cheaply produce one. Rendering `sessions.length` as "50 records" when
+the project has 205 is a lie. Either label it `50 loaded` or add an explicit total to the
+contract; do not silently mislabel a page size as a corpus size.
+
+Scan order by design: the eye lands on the h1, drops to the first row's display name,
+then travels right along the row. Signals sits in the middle because a signal is only
+meaningful once you know whose session it is.
+
+**Constraint check — if only three things could be shown:** who (identity), what broke
+(signals), when (time). That is exactly the three columns. Nothing else earns a column.
+
+**One click target per row, plus one deliberate exception.** The play control and the
+identity are a single link. The `<td>` contains one `<router-link>` wrapping the play
+glyph and the display name; the second line is inside the same link. Krug's rule: do not
+make the user choose between two ways to do the same thing.
+
+The exception is the copy-session-id control that exact-match search requires. A `<button>`
+nested inside an `<a>` is invalid HTML and breaks keyboard order, so it **must not** live
+inside the link. Put the copy control outside the `<router-link>` as a sibling in the same
+cell, revealed on row hover and on focus-within, with `aria-label="Copy session ID"`. It
+is a second tab stop by construction — that is the accepted cost of the 4.29 query plan,
+and it is why the control is visually recessive rather than a peer of the primary link.
+
+## Interaction states
+
+| Feature | Loading | Empty | Error | Success | Partial |
+| --- | --- | --- | --- | --- | --- |
+| Session table | 3× `SkeletonBlock` at `h-14` inside a `role="status" aria-busy="true"` wrapper, matching `ActivityFeed.vue` | See two empty variants below | `InlineAlert tone="danger" title="Unable to load sessions"` with the message in the default slot **and a Retry button** — an error with no way out is a dead end | Rows render; record count in the header updates | — |
+| Row playback | — | — | — | Play glyph in ink, whole cell is one link | `playable_chunk_count === 0` → glyph greyed, row not a link. Label depends on status, because zero playable chunks is **not** always "processing": `recording`/`closed`/`analyzing` → `Processing`; `analysis_failed` or `chunk_count > 0` with no playable chunks → `Unavailable`; `chunk_count === 0` → `No recording`. Partial (`1/2`) **is** playable and links normally |
+| Signals cell | — | Renders nothing **only when `status = 'analyzed'`** — that is the one state where silence truthfully means "we looked and found nothing" | — | Chips in severity order: errors first, then rage clicks, dead clicks, form abandons | Every non-`analyzed` status gets an explicit chip: `recording` → `Recording`; `closed` → `Queued`; `analyzing` → `Analyzing`; `analysis_failed` → `Analysis failed` |
+| Identity | — | No `end_user` → `Anonymous` in ink plus the truncated session id in mono on line two | — | Email, else `external_user_id` | Email present but no account → omit the `·` separator entirely, never render a dangling dot |
+| Filters | Submit disabled while a fetch is in flight; table keeps the previous rows rather than flashing to skeletons | `With signals` selected with zero matches → `EmptyState title="No sessions with signals"` and a `Show all sessions` action, distinct from both other empty states | — | Results replace the table | Any filter active → show a `Clear filters` link; clearing refetches |
+| Load more | Button label becomes `Loading...` and disables | Button absent when `next_cursor` is null | Inline retry **below the existing rows** — already-loaded rows must never be discarded by a pagination failure | Appends rows | — |
+
+**Two distinct empty states.** These are different situations and must not share copy:
+
+- **No sessions at all** — `EmptyState title="No sessions recorded yet"
+  description="Recordings appear after the SDK sends its first chunk."` with a
+  `Setup guide` link in the default slot, mirroring `ActivityFeed.vue`.
+- **Filters matched nothing** — `EmptyState title="No sessions match these filters"
+  description="Try widening the date range or clearing the search."` with a
+  `Clear filters` button in the default slot.
+
+Shipping one empty state for both is the failure mode this table exists to prevent:
+a first-run user is told to change filters they never set.
+
+## User journey
+
+| Step | User does | User feels | Plan specifies |
+| --- | --- | --- | --- |
+| 1 | Lands on `/sessions` | "Is there anything here for me?" | Record count in the header answers it in under a second |
+| 2 | Scans down the Signals column | "Which of these is worth 7 minutes of my life?" | Chips appear only on rows with real friction, so problem rows pop |
+| 3 | Searches for a customer who complained | "I have an email, not a UUID" | Single search box matches email or external id |
+| 4 | Clicks a row | "I want the recording, now" | Whole identity cell is the link; no hunting for a play button |
+| 5 | Finds a row still processing | "Is this broken?" | Explicit `Processing` label, not a dead link |
+
+**Five seconds (visceral):** on a fresh install every row is `Anonymous` with an empty
+Signals column. That reads as a broken product, not an idle one. The empty-state copy
+and the `Anonymous` treatment carry the whole trust burden here — they must say *why*
+identity is missing, not just render a dash.
+
+**Five minutes (behavioural):** the user learns that chips mean trouble and blank means
+clean. That convention only holds if blank never also means "not yet analyzed" — which
+is why `analyzing` and `analysis_failed` get explicit chips.
+
+**Five years (reflective):** this is the screen an engineer opens when a customer is
+angry. It should feel like a ledger you can trust, not a storage report.
+
+## Design system alignment
+
+`SessionsList.vue` currently uses none of the shared components. `ActivityFeed.vue` is
+the reference implementation and this screen must match it.
+
+| Need | Use | Exact API |
+| --- | --- | --- |
+| Page header | Copy `ActivityFeed.vue` header block | eyebrow `text-xs font-semibold uppercase tracking-[0.18em] text-accent`, `h1 text-2xl font-semibold tracking-tight`, count in `font-mono text-xs text-muted` |
+| Row | Mirror `components/incidents/IncidentLedgerRow.vue` | Bold link line + `mt-2 text-xs text-muted` metadata line with `·` separators; extract `SessionLedgerRow.vue` |
+| Loading | `ui/SkeletonBlock.vue` | — |
+| Error | `ui/InlineAlert.vue` | prop is **`tone`**, not `variant`; `title` prop; message in default slot |
+| Empty | `ui/EmptyState.vue` | props `title`, `description`; slots are **`icon`** and **default** — there is no `action` slot |
+| Chips | `ui/StatusLabel.vue` + new `frictionSignalRecipe` in `status-recipes.ts` | props `tone` (`StatusTone`), `label` |
+| Filters | Follow `components/FilterBar.vue` shape | inline labelled controls, not a labelled form grid |
+
+Tone mapping for the new `frictionSignalRecipe`: errors → `danger`, rage clicks →
+`warning`, dead clicks → `warning`, form abandons → `neutral`, `Analyzing` → `progress`,
+`Analysis failed` → `warning`.
+
+**Prop and slot names are load-bearing.** Vue silently drops an unknown slot and lets an
+unknown prop fall through to attrs, leaving the real prop at its default — and `vue-tsc`
+catches neither. This repo has already shipped both bugs: `InlineAlert` was passed
+`variant=danger` and rendered as info, and `EmptyState` was passed `#action` so the
+Setup guide link vanished. Check every usage against the child's `defineProps` and slot
+names by hand.
+
+**Contrast is already solved — do not re-derive it.** Measured against each chip's own
+tint, not the page background: danger 5.68:1, warning 5.28:1, success 5.84:1, progress
+5.78:1, insight 5.55:1, muted-on-subtle 5.89:1, accent-on-paper 5.21:1. All pass WCAG AA
+and cluster near an equal ~5.6:1 target. Any new chip colour must be solved to the same
+contrast target, not the same HSL lightness — hue moves luminosity independently.
+
+**No motion is specified anywhere in this screen, deliberately.** Row hover is a
+background change only (`hover:bg-surface-subtle`). A ledger does not animate.
+
+## Responsive
+
+Progressive column hiding, matching `ActivityFeed.vue`. Never "stacked on mobile".
+
+| Viewport | Session | Signals | Started |
+| --- | --- | --- | --- |
+| `< 640px` | Visible. Identity, then a metadata line carrying account, then chips inline below | Hidden (`hidden sm:table-cell`) — chips move **into** the Session cell, never disappear. Signals are the reason this redesign exists; they must survive every breakpoint | Time only; duration drops to the Session metadata line |
+| `≥ 640px` | Visible | Visible as its own column | Visible |
+| `≥ 1024px` | Adds release (`v1.4.2`) and the page path to the metadata line | Visible | Visible |
+
+Long emails, external ids, and session ids truncate with `truncate` on a `min-w-0` cell,
+and carry the full value as accessible text — never truncate without a way to recover it.
+
+Filter row wraps with `flex flex-wrap gap-3`; the search input goes full width below
+`640px` and the date and environment controls sit side by side beneath it.
+
+**Testing caveat.** In `@vue/test-utils` + jsdom, `findAll('td')` counts cells carrying
+`hidden sm:table-cell` as present, because jsdom never applies Tailwind media queries.
+A column-count assertion therefore passes regardless of which breakpoint classes the
+cells carry and cannot detect header/row shear. Assert the visibility class matrix
+element by element — filter classes to `hidden` plus `sm|md|lg|xl:table-cell` and compare
+`th` against `td` — and put real width checks in `test-e2e`.
+
+## Accessibility
+
+- `<table aria-label="Recorded sessions">`; column headers are real `<th scope="col">`.
+- Row link accessible name must not be the bare email. Use
+  `aria-label="Play session for jane@acme.com, 7m 21s, Jul 22 8:02 PM"` so a screen
+  reader user is not handed a naked address with no context.
+- Processing rows are not links. Render a `<span aria-disabled="true">` with the
+  explanatory `title`, never a disabled anchor.
+- Play glyph tap target is at least 44×44px including padding. The approved mockup draws
+  it near 28px, which fails on touch — pad the cell, do not grow the glyph.
+- Focus ring is `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent`,
+  matching `IncidentLedgerRow.vue`. Every row link and every filter control gets one.
+- Chip colour is never the only carrier of meaning — `StatusLabel` already prefixes a
+  mono glyph (`!`, `→`, `◆`) and the chip text states the count in words.
+- Search input keeps a visible `<label>`. Placeholder-as-label disappears the moment the
+  user types.
+- Timestamps render as `<time :datetime="session.started_at">`, so assistive tech and
+  scrapers get the machine value while humans see the formatted one.
+- **`page_url` does not move to a `title` attribute.** A native `title` never appears on
+  touch and is unreliable under keyboard focus, so that would hide information the
+  current screen shows outright. Render the URL's path (not the full URL) as visible text
+  on the Session metadata line at `≥1024px`, still passed through `safeUrl()`. Below that
+  breakpoint it is omitted — omitted is honest, hover-only is not.
+- The dashboard has one URL sanitizer, `safeUrl()` at `packages/dashboard/src/utils.ts:34`.
+  Do not add a second one.
+
+## Backend — `packages/ingestion`
+
+**One query, not three.** An earlier draft fanned out into a page query plus two
+follow-up queries keyed by `session_id = ANY($2)`, on the theory that subqueries in
+`sessionSummarySelect` would be too costly. That reasoning did not hold: the select
+*already* runs a correlated subquery per row for `playable_chunk_count`
+(`sessions_read.go:61`), 51 index-backed lookups is not a cost worth restructuring
+around, and the `has_signals` filter forces friction and error predicates into the
+paginating query anyway — leaving `friction_signals` read twice per request.
+
+Two `LEFT JOIN LATERAL` blocks give the counts and the filter from a single read.
+`count(*) FILTER (WHERE ...)` is already an idiom here (`db/admin.go:115`):
+
+```sql
+LEFT JOIN LATERAL (
+  SELECT COALESCE(sum(occurrence_count) FILTER (WHERE signal_type = 'rage_click'), 0)   AS rage,
+         COALESCE(sum(occurrence_count) FILTER (WHERE signal_type = 'dead_click'), 0)   AS dead,
+         COALESCE(sum(occurrence_count) FILTER (WHERE signal_type = 'form_abandon'), 0) AS abandon
+    FROM friction_signals fs
+   WHERE fs.session_id = s.id
+     AND fs.project_id = $1
+     AND fs.retracted_at IS NULL AND fs.superseded_by IS NULL
+     AND fs.adjudication_status = 'accepted'
+) f ON true
+LEFT JOIN LATERAL (
+  SELECT count(*) AS errors
+    FROM error_events ee
+   WHERE ee.session_id = s.id AND ee.project_id = $1
+) e ON true
+```
+
+Then `has_signals` is `AND ($10 = false OR (f.rage + f.dead + f.abandon + e.errors) > 0)`,
+applied before `LIMIT`.
+
+Four things in that SQL are load-bearing:
+
+- **`sum(occurrence_count)`, not `count(*)`.** `friction_signals` stores repeats within a
+  session in `occurrence_count` (`004_friction.sql:47`, *"Repeat occurrences within one
+  session"*). `count(*)` would count distinct fingerprints and under-report every row —
+  three rage clicks on one button would render as "1 rage click".
+- **`adjudication_status = 'accepted'`.** Signals carry an adjudication verdict
+  (`007_friction_adjudication.sql:9`). Keyless deployments skip adjudication entirely and
+  *"signals stay pending and invisible"* (`worker/src/index.ts:628`). Counting every
+  unretracted signal would surface pending and rejected detector noise that the rest of
+  the product deliberately hides, so the session list would disagree with the incident
+  ledger about the same session.
+
+- **`fs.project_id = $1` and `ee.project_id = $1` are required, not redundant.**
+  `packages/ingestion/AGENTS.md`: *"Scope every database helper to the required project
+  or organization, and enforce that scope in its query."* Joining on `session_id` alone
+  is transitively safe but leans on the outer query instead of enforcing scope.
+- **`retracted_at IS NULL AND superseded_by IS NULL`** is the aggregation rule at
+  `004_friction.sql:57`. Without it a re-analysis at a new `rule_version` double-counts
+  every signal. This needs its own test.
+
+Putting the counts in `sessionSummarySelect` also means `GetSessionSummary`
+(`sessions_read.go:124`) inherits them for free — the fan-out version would have needed
+those follow-up queries written twice.
+
+**Known cost, accepted with a tripwire.** With `has_signals=true`, Postgres walks
+sessions in `started_at DESC` order evaluating the LATERAL per row until it collects 51
+matches. Because most sessions are clean by design, cost scales as `51 / selectivity`:
+at 1M sessions with 1% carrying signals that is roughly 5,100 row visits per page. Fine
+now; not fine forever. **Log query duration for this endpoint, and treat a p95 above
+200ms as the trigger to denormalize `sessions.has_signals` with a partial index.** Do
+not pre-build the column.
+
+Add `HasSignals bool` and `Search string` to `db.SessionFilters`, and `has_signals` /
+`search` to the query contract. The keyset cursor is unaffected: the filter narrows the
+row set, it does not reorder it.
+
+New fields on `db.SessionSummary` (`packages/ingestion/db/sessions_read.go:14`) and on
+the JSON contract: `error_count`, `rage_click_count`, `dead_click_count`,
+`form_abandon_count`, `sdk_release`. Same additions flow to `SessionDetail`.
+
+**Search, with the index behaviour measured rather than assumed.** `end_user_id`
+currently filters on `s.end_user_id::text` (`sessions_read.go:87`), a UUID equality
+match. The single box must match user identifier, email trait, and session id. `EXPLAIN`
+on the live database (Postgres 16, `enable_seqscan=off` to test index usability):
+
+| Predicate | Plan | Cost |
+| --- | --- | --- |
+| `eu.email ILIKE 'jane%'` | `Index Cond: project_id` → `Filter: email ~~* ...` | 8.49 |
+| `eu.email LIKE 'jane%'` | identical — still a Filter | 8.49 |
+| `eu.email = 'jane@acme.com'` | `Index Cond: (project_id AND email)` | 8.40 |
+| `s.id ILIKE 'abc%'` | `Index Only Scan` → `Filter: id ~~* ...` | **367.86** |
+| `s.id = 'abc'` | `Index Cond: (id = 'abc')` | **4.29** |
+
+`ILIKE` never gets an `Index Cond` on a plain btree — anchoring the pattern does not
+change that, and `idx_end_users_email` (`001_baseline.sql:287`) is a plain btree. So:
+
+- **Email and external_user_id: keep `ILIKE`.** The index still bounds the scan to one
+  project's users, which is cheap. No new index, no migration.
+- **Session id: exact match, `s.id = $n`.** `ILIKE` costs 86× more on the table that
+  grows fastest. The row must therefore expose the **full** session id via a copy
+  affordance, so what the user pastes is what matches. A hand-typed partial id will not
+  match, and that is the accepted trade.
+
+## Frontend — `packages/dashboard/src/views/SessionsList.vue`
+
+- Extract `components/sessions/SessionLedgerRow.vue`, mirroring `IncidentLedgerRow.vue`.
+  **Add `sessions` to `ownedRoots` in `test-e2e/dashboard-design-system.test.ts:41` and
+  register the component in `docs/design/dashboard-v1/consumer-matrix.md`**, so it is
+  policed by the orphan and consumer checks exactly like its incident sibling. A new
+  directory under `components/` is otherwise an unpoliced corner.
+- Three columns, two lines per row, per the IA diagram above.
+- The identity cell is one link containing the play glyph, the display name, and the
+  metadata line. Not two targets.
+
+### Identity: identifier vs traits
+
+PostHog and LogRocket draw the same distinction, and this plan follows it. The
+**identifier** is required and stable (PostHog: *distinct ID*; LogRocket: *UID*). The
+**email and account name are traits** — optional, and they change. LogRocket is explicit:
+*"Names and email addresses can be added as user traits as they could change."*
+
+The schema already models this: `setUser` returns early without `id` (`sdk/src/core.ts:38`)
+while `email` is optional on `UserIdentity`. Only the labelling was wrong.
+
+- Column header is **User**, never "Email".
+- Search placeholder is **"Search by user, email, or session ID"**.
+- The filter field is `search`, generic. Never name it `email`.
+- Display name resolves in order: `email` → `external_user_id` → `Anonymous`.
+
+```
+▶  jane@acme.com                    ← email trait present
+   Acme Corp · v1.4.2
+
+▶  user-123                         ← identifier only, no email trait
+   Acme Corp · v1.4.2
+
+▶  Anonymous                        ← no end_user row at all
+   @opslane/sdk 1.2.0 · a8f3c2b1
+```
+
+**The anonymous row is the common case, not the edge case.** Measured on the dev
+database: **205 sessions, 7 identified, 198 anonymous — 3.4%**. Identity exists only
+when the customer calls `setUser()`, which appears nowhere in `docs/install.md` or
+`docs/quickstart/`. So render one dismissible line above the table: *"These sessions have
+no user attached. Call `setUser()` to see who they are."* with a docs link.
+
+**The trigger is project-level, not page-level.** "Every row on this page is anonymous"
+is the wrong condition in both directions: identified sessions may simply be on page two,
+and one identified row would suppress the hint for a project with 198 anonymous sessions.
+The list response carries no identity-coverage figure, so this needs a project-scoped
+`has_identified_sessions` boolean on the response (an `EXISTS` against `sessions` where
+`end_user_id IS NOT NULL`, cheap and index-backed). Show the hint when that is false.
+
+**The hint must state the privacy consequence.** `setUser` sends identifying fields
+unmasked; `docs/guides/replay-privacy.md:44` is the contract. Prompting a customer to
+turn on identity without saying what leaves their browser is not acceptable. The linked
+doc must cover it, and E15 has to write that doc before E8 can link to it.
+- Status badge only for `analyzing` / `analysis_failed`, rendered in the Signals cell.
+- Drop Size and Page as columns. The page path becomes visible text on the metadata line
+  at `≥1024px`, through `safeUrl()`.
+- **Filters: five controls become three**, plus a `Clear filters` link:
+  1. **Search** — matches email, `external_user_id`, **or session id**. Session id is
+     non-negotiable: the row displays a truncated session id, so a user will paste one in.
+     A search box that cannot find what the table just showed them is a broken promise.
+  2. **Date preset** — `Last 24 hours` / `7 days` / `30 days` / `Custom`. Custom range
+     input is interpreted in the browser's local timezone and sent as UTC ISO, matching
+     the existing `isoDate()` behaviour.
+  3. **Environment** — the existing select, unchanged.
+  3b. **Account** — search must also match `eu.account_name` and
+     `eu.external_account_id`. The old Account ID input goes away, but the *capability*
+     must not: the page subtitle promises browsing "by user, account, and time", and a
+     complaint from "Acme" has to be findable. `idx_end_users_account`
+     (`001_baseline.sql:285`) already covers the project-scoped lookup.
+  4. **`All` / `With signals`** — a two-state segmented toggle, defaulting to `All`.
+     This is the control that turns the redesign from "nicer rows" into triage: without
+     it, a session worth watching stays buried on page three beneath clean ones. It is a
+     `WHERE` filter, not an `ORDER BY`, so newest-first ordering and the keyset cursor
+     both survive untouched.
+- Sort stays newest-first. Signals are display-only, not a sort key — sorting by friction
+  would break the `(started_at, id)` keyset cursor.
+
+### Code hygiene carried by this change
+
+- **Wire the new params in `api.ts:613-618`.** `listSessions` serializes filters field by
+  field. Adding `search` and `has_signals` to the `SessionFilters` type compiles clean,
+  passes `vue-tsc`, and yields a UI where the filter silently does nothing. Same silent
+  class as the `InlineAlert variant=` / `EmptyState #action` bugs already shipped here.
+  `session-list-query.ts` needs no change — it spreads `{ ...filters }`.
+- **Delete `formatBytes` (`SessionsList.vue:108`).** Its only caller is the Size column
+  this change removes.
+- **Fix `formatDuration` before consolidating onto it.** `admin-format.ts:19` uses
+  `Math.round` on the remainder, so it carries past the base: 3599.6s renders `59m 60s`
+  and 7199s renders `1h 60m` (verified by execution). Floor the remainder, or normalize
+  the carry. Add boundary tests at 59.5s, 3599.5s, and 7199s. Only then make it canonical.
+- **Consolidate the three duration formatters.** `admin-format.ts:19` is the best base:
+  tested, handles sub-second through hours. `SessionsList.vue:96` reimplements it from
+  milliseconds. `SessionDetail.vue:41` has no hour case and no sub-minute case, so it
+  renders `120m 30s` where the list renders `2h 0m` for the same session. Move
+  `formatDuration` to a shared module, feed it `(last_chunk_at - started_at) / 1000`,
+  delete both local copies. This fixes a shipped bug and stops the row component becoming
+  a fourth implementation.
+- **Build the metadata line by filtering and joining**, not with nested `v-if`s around
+  `·` separators. Account, release, and page path are each independently nullable; three
+  optional segments joined by hand is where dangling-separator bugs live.
+
+## NOT in scope
+
+| Deferred | Why |
+| --- | --- |
+| LLM session summaries | Needs a `sessions.summary` column, a worker step, a prompt, and an eval, plus per-session token cost. Its own epic. |
+| Composed/templated summary line | Rejected in review: keep the table and the basics for this pass. |
+| Sorting by friction severity | Breaks the keyset cursor at `sessions_read.go:92`; would force an offset rewrite. |
+| Severity sorting or a computed friction score | Sorting breaks the keyset cursor at `sessions_read.go:92`. The `With signals` filter delivers the triage benefit without that cost. |
+| Surfacing `adjudication_reason` prose | Per-signal, not per-session, and only exists for adjudicated signals. |
+| Geo and browser columns | Not stored on `sessions`. Would need an ingestion contract change. |
+| Dark mode | Deliberately removed from `tokens.css`; reinstating it needs the `data-theme` switch and the hardcoded select chevron in `base.css` fixed together. |
+
+## What already exists
+
+- **Design tokens:** `packages/dashboard/src/styles/tokens.css` ("Forensic Ledger").
+  There is no `DESIGN.md`; the tokens file plus the shared `ui/` components are the
+  de facto system. Consider `/design-consultation` to write it down — the CI gate that
+  enforced it (`test-e2e/dashboard-design-system.test.ts`) was deleted in `fb3862f`.
+- **Reference page:** `ActivityFeed.vue` — header, filter bar, skeleton, alert, empty state.
+- **Reference row:** `components/incidents/IncidentLedgerRow.vue`.
+- **Shared components:** `EmptyState`, `InlineAlert`, `SkeletonBlock`, `StatusLabel`,
+  `Button`, `TextInput`, `SelectField`.
+- **Status tone mapping:** `status-recipes.ts`, including an existing `sessionStatusRecipe`.
+- **Friction fixture:** `test-fixtures/vue-app/src/components/FrictionLab.vue` — a dead
+  "Complete purchase" button that produces real `rage_click` signals, plus a five-user
+  `setUser()` selector. Use it to populate the Signals column during verification.
+
+## Failure modes
+
+| New codepath | Realistic production failure | Test? | Error handling? | User sees |
+| --- | --- | --- | --- | --- |
+| LATERAL friction counts | Re-analysis at a new `rule_version` leaves both generations unretracted; counts double | **must add** (T2) | none possible — it is a correctness bug, not an error | Wrong numbers, silently. **Critical gap until T2 lands.** |
+| LATERAL error counts | A render-loop error floods one session with 50k `error_events`; the per-row count walks them all | no | none | Slow page, no message. Watch item, confidence 5/10. |
+| `has_signals` filter | Selective filter over a large mostly-clean corpus walks deep before filling a page | no | none | Spinner. Mitigated by the p95 tripwire, not eliminated. |
+| Session id exact search | User pastes the truncated id shown in the row; exact match misses | must add | n/a | Zero results with no explanation. **Mitigated only by the copy-full-id affordance — if that ships late, this is a silent dead end.** |
+| `search` / `has_signals` params | Field not added to `api.ts:613-618`; filter never reaches the server | must add | none | Filter appears to work and silently returns everything. **Critical gap — silent by construction.** |
+| Row link on a processing session | `playable_chunk_count` is 0 but the row still renders as a link | must add | n/a | Navigates to an empty player. |
+| Anonymous hint | Shown when identity exists but is sparse on one page | must add | n/a | Nagging about an already-solved problem. |
+
+Three critical gaps, all in the same shape: **wrong or missing data that produces no
+error**. Each needs a test, because no amount of error handling can surface them.
+
+## Worktree parallelization strategy
+
+| Step | Modules touched | Depends on |
+| --- | --- | --- |
+| A1 — LATERAL counts, search, `has_signals` | `packages/ingestion/db`, `packages/ingestion/handler` | — |
+| B1 — `formatDuration` consolidation | `packages/dashboard/src` (admin-format, SessionsList, SessionDetail) | — |
+| B2 — `ownedRoots` + consumer-matrix | `test-e2e`, `docs/design/dashboard-v1` | — |
+| C1 — Row component, table, states, filters | `packages/dashboard/src/views`, `.../components/sessions` | A1 (contract), B1 (helper) |
+| C2 — e2e identity regex + mock fixture | `test-e2e` | C1 (final copy) |
+
+```
+Lane A: A1                      (ingestion only, independent)
+Lane B: B1 → B2                 (dashboard + test-e2e, independent of A)
+Lane C: C1 → C2                 (waits on A1 and B1)
+```
+
+Launch **A and B in parallel worktrees**. Merge both, then run C sequentially.
+
+**Conflict flag:** B2 and C2 both touch `test-e2e/`. Different files
+(`dashboard-design-system.test.ts` vs `dashboard-screenshots.test.ts` +
+`dashboard-mock-harness.ts`), so no textual conflict, but they are in the same package
+and C2 cannot be written until C1 fixes the final copy. Keep them ordered.
+
+## Outside voice — engineering review (Codex, gpt-5.6-sol)
+
+Ran against this plan after all four review sections. Verdict: found defects the review
+missed, including three the review itself introduced. Every load-bearing finding was
+verified against the code before adoption.
+
+**Adopted after verification:**
+
+| Finding | Verification |
+| --- | --- |
+| `count(*)` counts fingerprints, not occurrences | `004_friction.sql:47` stores repeats in `occurrence_count`. Fixed to `sum(occurrence_count)`. |
+| Counts ignore adjudication status | `worker/src/index.ts:628` — keyless deploys leave signals *"pending and invisible"*. Now filtered to `accepted`. |
+| Blank cannot mean clean | `CloseIdleSessions` (`sessions.go:591`) sets `closed` **and** enqueues the analysis job in one statement, so `closed` means queued. Every non-`analyzed` status now gets a chip. |
+| `formatDuration` is itself buggy | Executed: 3599.6s → `59m 60s`, 7199s → `1h 60m`. Must be fixed before consolidation. |
+| The screenshot suite is not a CI gate | `ci.yml` allowlists it as a permitted skip — *"an opt-in generator, not a test... asserts nothing about product behaviour."* The review claimed twice that it would turn CI red. It would not. |
+| "No model runs per session" was false | `worker/src/index.ts:625` runs the LLM adjudicator inside the session-analysis job. |
+| Account lookup silently dropped | Confirmed against the plan's own subtitle. Search now covers account fields. |
+| Header count has no contract | `types/api.ts:230` returns no total. Now labelled `N loaded`. |
+| Hint heuristic invalid | Page-level anonymity ≠ project-level. Now gated on a project-scoped flag. |
+| Copy control vs one-link-per-row | `<button>` inside `<a>` is invalid. Now an explicit sibling with a stated cost. |
+| Mock proves nothing | One anonymous zero-signal unplayable session. Now expanded to four. |
+
+**Rejected — cross-model tension, user decided:** Codex called the identity-led IA
+P0-premature given 96.6% anonymous sessions, and argued signals should lead. **Kept
+identity-led.** The 3.4% figure comes from a local fixture database, not customer
+traffic, and account-and-user framing is why a B2B buyer wants session replay at all. The
+anonymous hint plus `setUser` documentation closes the gap at its source. Revisit if real
+customer identification rates stay low.
+
+## Outside voice — design review dissent on record
+
+An independent model review (Codex, gpt-5.6-sol, high reasoning) cleared every hard-rejection
+criterion and confirmed the table direction, but disagreed with one decision taken here:
+
+> "Most real sessions are clean, yet the plan only defines positive signal counts. Blank
+> cells make the main new column look unpopulated or broken." It recommended an explicit
+> muted `No detected signals` label on clean rows.
+
+**Not adopted.** The call was made to keep the basics: chips appear only when something
+happened. The substantive half of the objection — that zero, pending, and failed analysis
+must be distinguishable — *is* addressed, via explicit `Analyzing` and `Analysis failed`
+chips, so blank unambiguously means "analyzed, nothing found". If the empty column reads
+as broken once real traffic lands, this is the first thing to revisit.
+
+## Approved Mockups
+
+| Screen | Mockup Path | Direction | Notes |
+| --- | --- | --- | --- |
+| Sessions list | `~/.gstack/projects/opslane-opslane-oss/designs/session-list-20260722/variant-B.png` | Three-column ledger table on Forensic Ledger tokens; eyebrow + h1 + mono record count; flat filter row; two-line rows; square outlined chips | Rated 5/5. Deviations to correct when building: row emails must be `text-text font-semibold` with `hover:text-accent hover:underline` per `IncidentLedgerRow`, not permanently underlined ember; play glyph needs a 44px tap target; play and email must be one link, not two |
+
+## Verification
+
+- `cd packages/ingestion && go build ./... && go test ./db ./handler`
+- `pnpm --filter @opslane/dashboard build` and `pnpm --filter @opslane/dashboard test`
+- `pnpm --filter @opslane/test-e2e test` — **required**, not optional. Root `pnpm test`
+  is `test:repo && test:unit`, and `test:unit` filters out `@opslane/test-e2e`. This
+  change alters user-visible copy and column structure, so the default gate would stay
+  green while CI goes red.
+- **The screenshot suite is NOT a CI gate — do not rely on it.** `ci.yml` allowlists it
+  as a permitted skip: *"an opt-in generator, not a test... only runs when
+  `CAPTURE_DASHBOARD_SCREENSHOTS=1`, which CI never sets... It asserts nothing about
+  product behaviour."* Its anchored `identity: /^Sessions$/i`
+  (`dashboard-screenshots.test.ts:65`) still needs updating for the new h1, but it will
+  skip, not fail. The real gate is `dashboard-design-system.test.ts`, whose `/Sessions/i`
+  is unanchored and survives the rename.
+- **The browser mock proves almost nothing today.** `dashboard-mock-harness.ts:123`
+  returns a single anonymous, zero-signal, unplayable session. Nothing in the e2e suite
+  currently exercises identified rendering, occurrence counts, `With signals`, pagination,
+  or the hint. **Extend the mock to cover: one identified session with multi-occurrence
+  friction and errors, one anonymous clean session, one `closed` (queued) session, and one
+  unplayable session** — otherwise the graded suite passes while every new behaviour is
+  untested.
+- **The 390×844 overflow gate is live.** `dashboard-design-system.test.ts:94` asserts
+  `document.documentElement.scrollWidth <= clientWidth`, exactly one `<main>`, and that
+  focus does not stay on `BODY`, for `/sessions`. Mirroring `ActivityFeed`'s
+  `overflow-x-auto border-y` wrapper is what keeps it green.
+- **`EXPLAIN ANALYZE` the new list query** with `has_signals` on and off. Confirm the
+  planner uses `idx_error_events_session` and the `friction_signals` session-prefixed
+  index inside both LATERAL blocks, and record the p95 baseline for the tripwire above.
+- Grep the built `dist/assets/*.css` for each new Tailwind class. A v3→v4 token rename
+  fails silently: a stale class emits no CSS and the build stays green.
+- Live run: seed friction via the `test-fixtures/vue-app` Friction Lab, then confirm the
+  Signals column renders real counts and that a clean session renders an empty cell.
+
+## Implementation Tasks
+
+Merged from the design review (T-series) and the engineering review (E-series). Where an
+E task supersedes a T task, only the E task is listed. Lane letters map to the
+parallelization table above.
+
+**Lane A — ingestion (independent, start immediately)**
+
+- [ ] **E1 (P1, human: ~4h / CC: ~30min)** — ingestion — Replace the three-query fan-out with two `LEFT JOIN LATERAL` blocks in `sessionSummarySelect`. *Supersedes T1.*
+  - Surfaced by: Step 0 — the select already runs a correlated subquery per row at `sessions_read.go:61`, and `has_signals` forces friction predicates into the main query anyway, so the fan-out read `friction_signals` twice per request
+  - Files: `packages/ingestion/db/sessions_read.go`
+  - Verify: `go test ./db ./handler`; `EXPLAIN ANALYZE` shows index scans inside both LATERALs
+- [ ] **E2 (P1, human: ~30min / CC: ~5min)** — ingestion — Add `fs.project_id = $1` and `ee.project_id = $1` inside both LATERAL blocks
+  - Surfaced by: Architecture 2 — `packages/ingestion/AGENTS.md` requires every db helper to enforce project scope in its own query
+  - Files: `packages/ingestion/db/sessions_read.go`
+  - Verify: extend `TestSessionSummaryAndPlayableChunks_AreFailClosedAndScoped`
+- [ ] **E3 (P1, human: ~1h / CC: ~10min)** — ingestion — Test that re-analysis at a new `rule_version` does not double-count. *Supersedes T2.*
+  - Surfaced by: Failure modes — a silent correctness bug no error handling can surface
+  - Files: `packages/ingestion/db/sessions_read_test.go`
+  - Verify: `go test ./db`
+- [ ] **E5 (P1, human: ~2h / CC: ~15min)** — ingestion — Session id search uses exact PK match; email and `external_user_id` keep `ILIKE`. *Supersedes T6.*
+  - Surfaced by: Performance 6 — `EXPLAIN` on the live DB: `s.id ILIKE` costs 367.86, `s.id =` costs 4.29
+  - Files: `packages/ingestion/db/sessions_read.go`
+  - Verify: `go test ./db`; `EXPLAIN` shows `Index Cond: (id = ...)`
+- [ ] **E13 (P2, human: ~1h / CC: ~10min)** — ingestion — Log list-query duration, record the p95 baseline as the denormalization tripwire
+  - Surfaced by: Architecture 3 — `has_signals` scan cost is `51 / selectivity`
+  - Files: `packages/ingestion/handler/session_read.go`
+  - Verify: hit the endpoint, confirm the duration lands in logs
+
+**Lane B — shared dashboard prep (independent, start immediately)**
+
+- [ ] **E10 (P2, human: ~1h / CC: ~10min)** — dashboard — Consolidate the three duration formatters, fix the `SessionDetail` hour bug
+  - Surfaced by: Code quality 4 — `SessionDetail.vue:41` renders `120m 30s` where the list renders `2h 0m`
+  - Files: `admin-format.ts`, `views/SessionDetail.vue`, `views/SessionsList.vue`
+  - Verify: `pnpm --filter @opslane/dashboard test`; open a >1h session on both screens
+- [ ] **E11 (P2, human: ~30min / CC: ~5min)** — test-e2e — Add `sessions` to `ownedRoots`, register the row in `consumer-matrix.md`
+  - Surfaced by: Test review 5 — a new `components/sessions/` dir escapes gates its sibling is subject to
+  - Files: `test-e2e/dashboard-design-system.test.ts`, `docs/design/dashboard-v1/consumer-matrix.md`
+  - Verify: `pnpm --filter @opslane/test-e2e test`
+
+**Lane C — the screen (waits on A1 + B1)**
+- [ ] **T3 (P1, human: ~4h / CC: ~30min)** — dashboard — Extract `SessionLedgerRow.vue` mirroring `IncidentLedgerRow` and rebuild the three-column table
+  - Surfaced by: Pass 5 Design System — SessionsList uses none of the shared `ui/` components
+  - Files: `packages/dashboard/src/views/SessionsList.vue`, `packages/dashboard/src/components/sessions/SessionLedgerRow.vue`
+  - Verify: `pnpm --filter @opslane/dashboard test`
+- [ ] **T4 (P1, human: ~1h / CC: ~10min)** — dashboard — Make each row one link containing play glyph and identity, 44px tap target
+  - Surfaced by: Pass 1 IA + Codex finding 3 — two competing destinations for one task
+  - Files: `packages/dashboard/src/components/sessions/SessionLedgerRow.vue`
+  - Verify: keyboard-tab one row; exactly one stop
+- [ ] **T5 (P1, human: ~2h / CC: ~15min)** — dashboard — Ship two distinct empty states plus SkeletonBlock loading and InlineAlert error with Retry
+  - Surfaced by: Pass 2 Interaction States — a first-run user is told to change filters they never set
+  - Files: `packages/dashboard/src/views/SessionsList.vue`
+  - Verify: `pnpm --filter @opslane/dashboard test`
+- [ ] **T7 (P2, human: ~1h / CC: ~10min)** — dashboard — Add `frictionSignalRecipe` and render chips via `StatusLabel`
+  - Surfaced by: Pass 5 — SessionsList hand-rolls a `rounded-full` span
+  - Files: `packages/dashboard/src/status-recipes.ts`, `.../SessionLedgerRow.vue`
+  - Verify: `pnpm --filter @opslane/dashboard test`
+- [ ] **T8 (P2, human: ~2h / CC: ~15min)** — dashboard — Implement the breakpoint matrix and assert it element-by-element
+  - Surfaced by: Pass 6 Responsive — jsdom ignores Tailwind media queries, so column-count assertions cannot detect shear
+  - Files: `.../SessionLedgerRow.vue`, `packages/dashboard/src/views/__tests__/SessionsList.test.ts`
+  - Verify: `pnpm --filter @opslane/dashboard test` and `pnpm --filter @opslane/test-e2e test`
+- [ ] **T9 (P2, human: ~1h / CC: ~10min)** — dashboard — Add table `aria-label`, `scope="col"`, `<time datetime>`, focus rings, non-link processing rows
+  - Surfaced by: Pass 6 Accessibility — a disabled `router-link` is not a valid pattern
+  - Files: `.../SessionLedgerRow.vue`, `packages/dashboard/src/views/SessionsList.vue`
+  - Verify: keyboard pass + axe check
+- [ ] **T10 (P2, human: ~30min / CC: ~5min)** — dashboard — Render page path as visible text at `≥1024px` instead of a `title` attribute
+  - Surfaced by: Codex finding 6 — native `title` never appears on touch
+  - Files: `.../SessionLedgerRow.vue`
+  - Verify: manual check at 1024px and 375px
+- [ ] **T11 (P3, human: ~30min / CC: ~5min)** — dashboard — Grep built `dist/assets/*.css` for every new Tailwind class
+  - Surfaced by: Verification — a v3→v4 token rename fails silently and the build stays green
+  - Files: `packages/dashboard/dist/assets`
+  - Verify: `grep` each class in the built CSS
+- [ ] **T12 (P1, human: ~2h / CC: ~15min)** — dashboard — Add the `All / With signals` segmented toggle. *Query side is E1; the `EXISTS` approach in the original T12 is superseded.*
+  - Surfaced by: Design Pass 7 / Codex finding 2 — the screen claims to answer "which session should I watch?" but orders strictly newest-first
+  - Files: `packages/dashboard/src/views/SessionsList.vue`
+  - Verify: paging through a filtered set returns full pages, not short ones
+
+**Added by the outside voice (Codex), verified before adoption**
+
+- [ ] **E16 (P1, human: ~2h / CC: ~15min)** — ingestion + dashboard — Return a project-scoped `has_identified_sessions` boolean and gate the hint on it
+  - Surfaced by: Codex — "every row on this page is anonymous" is invalid in both directions; identified sessions may be on page two, and one identified row suppresses the hint for a project with 198 anonymous sessions
+  - Files: `packages/ingestion/db/sessions_read.go`, `.../handler/session_read.go`, `packages/dashboard/src/views/SessionsList.vue`
+  - Verify: `go test ./db`; hint shows on a project with zero identified sessions and hides on one with any
+- [ ] **E17 (P1, human: ~2h / CC: ~15min)** — test-e2e — Expand the sessions mock to four sessions covering identified+multi-occurrence, anonymous clean, `closed`, and unplayable
+  - Surfaced by: Codex — the mock has one anonymous zero-signal unplayable session, so nothing proves identified rendering, occurrence counts, `With signals`, or the hint
+  - Files: `test-e2e/dashboard-mock-harness.ts`
+  - Verify: `pnpm --filter @opslane/test-e2e test`
+- [ ] **E18 (P1, human: ~1h / CC: ~10min)** — dashboard — Copy-session-id control as a sibling of the row link, not nested inside it
+  - Surfaced by: Codex — a `<button>` inside an `<a>` is invalid HTML and breaks keyboard order; exact-match search needs the full id copyable
+  - Files: `packages/dashboard/src/components/sessions/SessionLedgerRow.vue`
+  - Verify: validate markup; tab order gives link then copy, both reachable
+- [ ] **E19 (P1, human: ~30min / CC: ~5min)** — dashboard — Fix `formatDuration` carry before consolidating onto it
+  - Surfaced by: Codex, verified by execution — 3599.6s renders `59m 60s`, 7199s renders `1h 60m`
+  - Files: `packages/dashboard/src/admin-format.ts`, `admin-format.test.ts`
+  - Verify: boundary tests at 59.5s, 3599.5s, 7199s
+- [ ] **E20 (P1, human: ~1h / CC: ~10min)** — ingestion — Search must also match `account_name` and `external_account_id`
+  - Surfaced by: Codex — the plan removes the Account ID filter while the subtitle still promises browsing "by user, account, and time"
+  - Files: `packages/ingestion/db/sessions_read.go`
+  - Verify: `go test ./db`; searching "Acme" returns that account's sessions
+- [ ] **E21 (P2, human: ~1h / CC: ~10min)** — dashboard — Label the header count `N loaded`, or add a real total to the contract
+  - Surfaced by: Codex — `SessionListResponse` (`types/api.ts:230`) has no total, so `sessions.length` would render "50 records" for a 205-session project
+  - Files: `packages/dashboard/src/views/SessionsList.vue`
+  - Verify: load a project with more than one page; the header must not claim the page size is the corpus size
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR (PLAN) | 18 issues, 3 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 1 | CLEAR (FULL) | score: 4/10 → 10/10, 12 decisions |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+**CODEX:** Outside voice ran twice (gpt-5.6-sol, high). Design pass cleared all 7 hard-rejection criteria, verdict REVISE, 4 findings adopted. Engineering pass found 14 defects, 11 adopted after verification against the code — including three the review itself introduced: `count(*)` instead of `sum(occurrence_count)`, adopting a `formatDuration` that renders `59m 60s`, and two wrong claims that the screenshot suite gates CI.
+
+**CROSS-MODEL:** One unresolved tension, decided by the user. Codex rated the identity-led IA P0-premature given 96.6% anonymous sessions and argued signals should lead. Kept identity-led: the figure comes from a fixture database, not customer traffic, and the anonymous hint plus `setUser` docs address the cause rather than designing around it.
+
+**VERDICT:** ENG + DESIGN CLEARED — ready to implement. 23 tasks across 3 lanes, 3 critical gaps all covered by tests (E3 double-counting, E4 silent filter drop, E6/E18 session-id copy).
+
+NO UNRESOLVED DECISIONS

--- a/packages/dashboard/src/admin-format.test.ts
+++ b/packages/dashboard/src/admin-format.test.ts
@@ -9,6 +9,12 @@ describe('admin formatting', () => {
     expect(formatDuration(3_720)).toBe('1h 2m');
   });
 
+  it('does not carry rounded remainders into impossible duration units', () => {
+    expect(formatDuration(59.5)).toBe('59s');
+    expect(formatDuration(3_599.5)).toBe('59m 59s');
+    expect(formatDuration(7_199)).toBe('1h 59m');
+  });
+
   it('highlights dead letters as failures', () => {
     expect(adminStatusBadgeClass('dead_letter')).toContain('text-danger');
   });

--- a/packages/dashboard/src/admin-format.ts
+++ b/packages/dashboard/src/admin-format.ts
@@ -19,9 +19,9 @@ export interface OnboardingFunnelStage {
 export function formatDuration(seconds: number | null): string {
   if (seconds === null || !Number.isFinite(seconds) || seconds < 0) return '\u2014';
   if (seconds < 1) return '<1s';
-  if (seconds < 60) return `${Math.round(seconds)}s`;
-  if (seconds < 3_600) return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
-  return `${Math.floor(seconds / 3_600)}h ${Math.round((seconds % 3_600) / 60)}m`;
+  if (seconds < 60) return `${Math.floor(seconds)}s`;
+  if (seconds < 3_600) return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`;
+  return `${Math.floor(seconds / 3_600)}h ${Math.floor((seconds % 3_600) / 60)}m`;
 }
 
 export function onboardingFunnelStages(onboarding: AdminOnboardingOverview): OnboardingFunnelStage[] {

--- a/packages/dashboard/src/api-project-settings.test.ts
+++ b/packages/dashboard/src/api-project-settings.test.ts
@@ -104,7 +104,7 @@ describe('project settings API', () => {
 });
 
 describe('environment-filtered API reads', () => {
-  it('threads environment_id through incident and session list queries only when set', async () => {
+  it('threads supported filters through incident and session list queries only when set', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -114,13 +114,17 @@ describe('environment-filtered API reads', () => {
 
     await listIncidents('project-1', { environment_id: 'env-production' });
     await listIncidents('project-1', {});
-    await listSessions('project-1', { environment_id: 'env-staging' });
+    await listSessions('project-1', {
+      environment_id: 'env-staging',
+      search: 'jane@acme.com',
+      has_signals: true,
+    });
     await listSessions('project-1', {});
 
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
       '/api/v1/projects/project-1/incidents?environment_id=env-production',
       '/api/v1/projects/project-1/incidents',
-      '/api/v1/projects/project-1/sessions?environment_id=env-staging',
+      '/api/v1/projects/project-1/sessions?search=jane%40acme.com&has_signals=true&environment_id=env-staging',
       '/api/v1/projects/project-1/sessions',
     ]);
   });

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -610,8 +610,8 @@ export function listSessions(
   cursor?: string,
 ): Promise<SessionListResponse> {
   const params = new URLSearchParams();
-  if (filters?.end_user_id) params.set('end_user_id', filters.end_user_id);
-  if (filters?.account_id) params.set('account_id', filters.account_id);
+  if (filters?.search) params.set('search', filters.search);
+  if (filters?.has_signals) params.set('has_signals', 'true');
   if (filters?.environment_id) params.set('environment_id', filters.environment_id);
   if (filters?.from) params.set('from', filters.from);
   if (filters?.to) params.set('to', filters.to);

--- a/packages/dashboard/src/components/session-list-query.test.ts
+++ b/packages/dashboard/src/components/session-list-query.test.ts
@@ -4,30 +4,32 @@ import { applySessionFilters, sessionPageRequest, snapshotSessionFilters } from 
 
 describe('session list pagination query', () => {
   it('keeps a cursor paired with the filters that produced it', () => {
-    const draft: SessionFilters = { account_id: 'account-a', from: '2026-07-15T00:00:00Z' };
+    const draft: SessionFilters = { search: 'account-a', from: '2026-07-15T00:00:00Z' };
     const applied = snapshotSessionFilters(draft);
-    draft.account_id = 'account-b';
+    draft.search = 'account-b';
 
     expect(sessionPageRequest(applied, 'cursor-a')).toEqual({
-      filters: { account_id: 'account-a', from: '2026-07-15T00:00:00Z' },
+      filters: { search: 'account-a', from: '2026-07-15T00:00:00Z' },
       cursor: 'cursor-a',
     });
   });
 
   it('returns defensive filter copies for page requests', () => {
-    const applied: SessionFilters = { end_user_id: 'user-a' };
+    const applied: SessionFilters = { search: 'user-a' };
     const first = sessionPageRequest(applied, 'cursor-a');
-    first.filters.end_user_id = 'mutated';
-    expect(sessionPageRequest(applied, 'cursor-b').filters.end_user_id).toBe('user-a');
+    first.filters.search = 'mutated';
+    expect(sessionPageRequest(applied, 'cursor-b').filters.search).toBe('user-a');
   });
 
   it('includes environment_id and resets the cursor when filters are applied', () => {
     expect(applySessionFilters({
-      account_id: 'account-a',
+      search: 'account-a',
+      has_signals: true,
       environment_id: 'env-staging',
     })).toEqual({
       filters: {
-        account_id: 'account-a',
+        search: 'account-a',
+        has_signals: true,
         environment_id: 'env-staging',
       },
       cursor: null,

--- a/packages/dashboard/src/components/sessions/SessionLedgerRow.vue
+++ b/packages/dashboard/src/components/sessions/SessionLedgerRow.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { format } from 'date-fns';
+import type { SessionSummary } from '../../types/api';
+import { formatDuration } from '../../admin-format';
+import {
+  frictionSignalRecipe,
+  sessionStatusRecipe,
+  type StatusRecipe,
+} from '../../status-recipes';
+import { safeUrl } from '../../utils';
+import StatusLabel from '../ui/StatusLabel.vue';
+
+const props = defineProps<{
+  session: SessionSummary;
+}>();
+
+const copied = ref(false);
+
+const displayName = computed(() =>
+  props.session.end_user?.email
+  ?? props.session.end_user?.external_user_id
+  ?? 'Anonymous');
+
+const isAnonymous = computed(() => !props.session.end_user);
+const startedLabel = computed(() => {
+  const date = new Date(props.session.started_at);
+  return Number.isNaN(date.getTime()) ? '\u2014' : format(date, 'MMM d, h:mm a');
+});
+const durationLabel = computed(() => {
+  if (!props.session.last_chunk_at) return formatDuration(null);
+  const elapsed = new Date(props.session.last_chunk_at).getTime()
+    - new Date(props.session.started_at).getTime();
+  return formatDuration(elapsed / 1_000);
+});
+const releaseLabel = computed(() => {
+  const release = props.session.sdk_release?.trim();
+  if (!release) return null;
+  return release.startsWith('v') ? release : `v${release}`;
+});
+const metadataSegments = computed(() => {
+  const result: Array<{ text: string; mono?: boolean; accessibleLabel?: string }> = [];
+  if (isAnonymous.value) {
+    result.push({
+      text: props.session.id.slice(-8),
+      mono: true,
+      accessibleLabel: `Session ID ${props.session.id}`,
+    });
+  }
+  const account = props.session.end_user?.account_name
+    ?? props.session.end_user?.external_account_id;
+  if (account) result.push({ text: account });
+  if (releaseLabel.value) result.push({ text: releaseLabel.value });
+  return result;
+});
+const pagePath = computed(() => {
+  const value = safeUrl(props.session.page_url ?? undefined);
+  if (!value) return null;
+  const parsed = new URL(value);
+  return `${parsed.pathname}${parsed.search}`;
+});
+
+const signals = computed<StatusRecipe[]>(() => {
+  const result: StatusRecipe[] = [];
+  if (props.session.error_count > 0) {
+    result.push(frictionSignalRecipe('error', props.session.error_count));
+  }
+  if (props.session.rage_click_count > 0) {
+    result.push(frictionSignalRecipe('rage_click', props.session.rage_click_count));
+  }
+  if (props.session.dead_click_count > 0) {
+    result.push(frictionSignalRecipe('dead_click', props.session.dead_click_count));
+  }
+  if (props.session.form_abandon_count > 0) {
+    result.push(frictionSignalRecipe('form_abandon', props.session.form_abandon_count));
+  }
+
+  switch (props.session.status) {
+    case 'recording':
+      result.push(frictionSignalRecipe('recording'));
+      break;
+    case 'closed':
+      result.push(frictionSignalRecipe('queued'));
+      break;
+    case 'analyzing':
+      result.push(frictionSignalRecipe('analyzing'));
+      break;
+    case 'analysis_failed':
+      result.push(frictionSignalRecipe('analysis_failed'));
+      break;
+    case 'deleting':
+      result.push(sessionStatusRecipe('deleting'));
+      break;
+    case 'analyzed':
+      break;
+  }
+  return result;
+});
+
+const unavailableLabel = computed(() => {
+  if (['recording', 'closed', 'analyzing'].includes(props.session.status)) return 'Processing';
+  if (props.session.status === 'analysis_failed' || props.session.chunk_count > 0) return 'Unavailable';
+  return 'No recording';
+});
+
+const playbackLabel = computed(() =>
+  `Play session for ${displayName.value}, ${durationLabel.value}, ${startedLabel.value}`);
+
+async function copySessionId(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(props.session.id);
+    copied.value = true;
+    window.setTimeout(() => { copied.value = false; }, 2_000);
+  } catch {
+    copied.value = false;
+  }
+}
+</script>
+
+<template>
+  <tr class="group border-b border-border last:border-b-0 hover:bg-surface-subtle">
+    <td class="min-w-0 px-2 py-3 sm:px-4">
+      <div class="flex min-w-0 items-start">
+        <router-link
+          v-if="session.playable_chunk_count > 0"
+          :to="{ name: 'session-detail', params: { sessionId: session.id } }"
+          :aria-label="playbackLabel"
+          class="flex min-w-0 flex-1 items-start gap-2 text-text no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          <span class="flex size-11 shrink-0 items-center justify-center border border-border-strong bg-surface text-text" aria-hidden="true">
+            <span class="ml-0.5 text-base">▶</span>
+          </span>
+          <span class="min-w-0 pt-0.5">
+            <span
+              class="block truncate text-sm font-semibold leading-5 decoration-accent underline-offset-4 hover:text-accent hover:underline"
+              v-text="displayName"
+            ></span>
+            <span class="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted">
+              <template v-for="(segment, index) in metadataSegments" :key="`${segment.text}-${index}`">
+                <span v-if="index > 0" aria-hidden="true">·</span>
+                <span
+                  class="max-w-40 truncate"
+                  :class="segment.mono ? 'font-mono' : ''"
+                  :aria-label="segment.accessibleLabel"
+                  v-text="segment.text"
+                ></span>
+              </template>
+              <span v-if="pagePath && metadataSegments.length" class="hidden lg:inline" aria-hidden="true">·</span>
+              <span v-if="pagePath" class="hidden min-w-0 max-w-48 truncate lg:inline" v-text="pagePath"></span>
+              <span v-if="metadataSegments.length" class="sm:hidden" aria-hidden="true">·</span>
+              <span class="sm:hidden" v-text="durationLabel"></span>
+            </span>
+            <span v-if="signals.length" class="mt-2 flex flex-wrap gap-1.5 sm:hidden">
+              <StatusLabel
+                v-for="signal in signals"
+                :key="signal.label"
+                :tone="signal.tone"
+                :label="signal.label"
+              />
+            </span>
+          </span>
+        </router-link>
+
+        <span
+          v-else
+          aria-disabled="true"
+          :title="unavailableLabel"
+          class="flex min-w-0 flex-1 items-start gap-2 text-text"
+        >
+          <span class="flex size-11 shrink-0 items-center justify-center border border-border bg-surface-subtle text-faint" aria-hidden="true">
+            <span class="ml-0.5 text-base">▶</span>
+          </span>
+          <span class="min-w-0 pt-0.5">
+            <span class="block truncate text-sm font-semibold leading-5" v-text="displayName"></span>
+            <span class="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted">
+              <template v-for="(segment, index) in metadataSegments" :key="`${segment.text}-${index}`">
+                <span v-if="index > 0" aria-hidden="true">·</span>
+                <span
+                  class="max-w-40 truncate"
+                  :class="segment.mono ? 'font-mono' : ''"
+                  :aria-label="segment.accessibleLabel"
+                  v-text="segment.text"
+                ></span>
+              </template>
+              <span v-if="pagePath && metadataSegments.length" class="hidden lg:inline" aria-hidden="true">·</span>
+              <span v-if="pagePath" class="hidden min-w-0 max-w-48 truncate lg:inline" v-text="pagePath"></span>
+              <span v-if="metadataSegments.length" class="sm:hidden" aria-hidden="true">·</span>
+              <span class="sm:hidden" v-text="durationLabel"></span>
+            </span>
+            <span v-if="signals.length" class="mt-2 flex flex-wrap gap-1.5 sm:hidden">
+              <StatusLabel
+                v-for="signal in signals"
+                :key="signal.label"
+                :tone="signal.tone"
+                :label="signal.label"
+              />
+            </span>
+          </span>
+        </span>
+
+        <button
+          type="button"
+          aria-label="Copy session ID"
+          :title="copied ? 'Session ID copied' : 'Copy session ID'"
+          class="ml-1 flex size-9 shrink-0 items-center justify-center text-muted opacity-100 hover:bg-surface-subtle hover:text-text focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+          @click="copySessionId"
+        >
+          <span aria-hidden="true">{{ copied ? '✓' : '⧉' }}</span>
+        </button>
+      </div>
+    </td>
+    <td class="hidden px-3 py-3 align-middle sm:table-cell sm:px-4">
+      <div v-if="signals.length" class="flex flex-wrap gap-1.5">
+        <StatusLabel
+          v-for="signal in signals"
+          :key="signal.label"
+          :tone="signal.tone"
+          :label="signal.label"
+        />
+      </div>
+    </td>
+    <td class="px-2 py-3 align-middle sm:px-4">
+      <time :datetime="session.started_at" class="block whitespace-nowrap text-sm font-medium text-text">
+        {{ startedLabel }}
+      </time>
+      <span class="mt-1.5 hidden text-xs text-muted sm:block" v-text="durationLabel"></span>
+    </td>
+  </tr>
+</template>

--- a/packages/dashboard/src/components/sessions/SessionLedgerRow.vue
+++ b/packages/dashboard/src/components/sessions/SessionLedgerRow.vue
@@ -38,11 +38,25 @@ const releaseLabel = computed(() => {
   if (!release) return null;
   return release.startsWith('v') ? release : `v${release}`;
 });
+/**
+ * Short id for anonymous rows. Takes the HEAD of the id, not the tail: session
+ * ids are client-generated and only *sometimes* random. `crypto.randomUUID()`
+ * and the `sess_`+hex fallback (sdk/src/session.ts:37-46) both survive a tail
+ * slice, but structured ids do not — `sess_sdk_normal_1784676521012577000`
+ * tails to `12577000`, a nanosecond fragment that is near-identical between
+ * sessions started in the same millisecond, and `session-unavailable` tails to
+ * `vailable`. The `sess_` prefix is stripped first so the 8 characters shown
+ * are the distinguishing ones rather than the shared prefix.
+ */
+function shortSessionID(id: string): string {
+  return id.replace(/^sess_/, '').slice(0, 8);
+}
+
 const metadataSegments = computed(() => {
   const result: Array<{ text: string; mono?: boolean; accessibleLabel?: string }> = [];
   if (isAnonymous.value) {
     result.push({
-      text: props.session.id.slice(-8),
+      text: shortSessionID(props.session.id),
       mono: true,
       accessibleLabel: `Session ID ${props.session.id}`,
     });

--- a/packages/dashboard/src/components/ui/SelectField.vue
+++ b/packages/dashboard/src/components/ui/SelectField.vue
@@ -39,7 +39,7 @@ const descriptionId = computed(() => props.error || props.hint ? `${inputId.valu
       v-bind="controlAttrs"
       :id="inputId" :value="modelValue" :disabled="disabled" :required="required"
       :aria-invalid="error ? 'true' : undefined" :aria-describedby="descriptionId"
-      class="min-h-10 max-md:min-h-11 rounded-md border bg-surface px-3 py-2 pr-9 text-text disabled:cursor-not-allowed disabled:opacity-60"
+      class="min-h-10 max-md:min-h-11 rounded-md border bg-surface px-3 py-2 pr-9 text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-60"
       :class="error ? 'border-danger' : 'border-border-strong'"
       @change="emit('update:modelValue', ($event.target as HTMLSelectElement).value)"
     >

--- a/packages/dashboard/src/components/ui/TextInput.vue
+++ b/packages/dashboard/src/components/ui/TextInput.vue
@@ -58,7 +58,7 @@ const descriptionId = computed(() => props.error || props.hint ? `${inputId.valu
       :autocomplete="autocomplete"
       :aria-invalid="error ? 'true' : undefined"
       :aria-describedby="descriptionId"
-      class="min-h-10 max-md:min-h-11 rounded-md border bg-surface px-3 py-2 text-text placeholder:text-faint disabled:cursor-not-allowed disabled:opacity-60"
+      class="min-h-10 max-md:min-h-11 rounded-md border bg-surface px-3 py-2 text-text placeholder:text-faint focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-60"
       :class="error ? 'border-danger' : 'border-border-strong'"
       @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
     />

--- a/packages/dashboard/src/composables/useSessionPlayback.test.ts
+++ b/packages/dashboard/src/composables/useSessionPlayback.test.ts
@@ -42,6 +42,10 @@ const detail = (chunks: SessionChunkMeta[]): SessionDetail => ({
   chunk_count: chunks.length,
   playable_chunk_count: chunks.length,
   bytes_stored: 100,
+  error_count: 0,
+  rage_click_count: 0,
+  dead_click_count: 0,
+  form_abandon_count: 0,
   chunks,
 });
 

--- a/packages/dashboard/src/status-recipes.test.ts
+++ b/packages/dashboard/src/status-recipes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AdminJobStatus, ErrorGroupStatus, SessionStatus } from './types/api';
-import { adminJobStatusRecipe, incidentStatusRecipe, sessionStatusRecipe } from './status-recipes';
+import { adminJobStatusRecipe, frictionSignalRecipe, incidentStatusRecipe, sessionStatusRecipe } from './status-recipes';
 
 describe('typed status recipes', () => {
   it('covers every incident status without motion styling', () => {
@@ -28,6 +28,14 @@ describe('typed status recipes', () => {
     expect(statuses.map(sessionStatusRecipe).map((item) => item.label)).toEqual([
       'Recording', 'Closed', 'Analyzing', 'Analyzed', 'Analysis failed', 'Deleting',
     ]);
+  });
+
+  it('maps session signals to truthful labels and tones', () => {
+    expect(frictionSignalRecipe('error', 3)).toMatchObject({ label: '3 errors', tone: 'danger' });
+    expect(frictionSignalRecipe('rage_click', 1)).toMatchObject({ label: '1 rage click', tone: 'warning' });
+    expect(frictionSignalRecipe('dead_click', 2)).toMatchObject({ label: '2 dead clicks', tone: 'warning' });
+    expect(frictionSignalRecipe('form_abandon', 1)).toMatchObject({ label: '1 form abandon', tone: 'neutral' });
+    expect(frictionSignalRecipe('analysis_failed')).toMatchObject({ label: 'Analysis failed', tone: 'warning' });
   });
 
   it('falls back to a neutral badge instead of throwing on an unknown wire value', () => {

--- a/packages/dashboard/src/status-recipes.ts
+++ b/packages/dashboard/src/status-recipes.ts
@@ -78,6 +78,38 @@ export function sessionStatusRecipe(status: SessionStatus): StatusRecipe {
   return unknownStatusRecipe(status);
 }
 
+export type FrictionSignalKind =
+  | 'error'
+  | 'rage_click'
+  | 'dead_click'
+  | 'form_abandon'
+  | 'recording'
+  | 'queued'
+  | 'analyzing'
+  | 'analysis_failed';
+
+export function frictionSignalRecipe(kind: FrictionSignalKind, count = 1): StatusRecipe {
+  switch (kind) {
+    case 'error':
+      return recipe(`${count} ${count === 1 ? 'error' : 'errors'}`, 'danger');
+    case 'rage_click':
+      return recipe(`${count} rage ${count === 1 ? 'click' : 'clicks'}`, 'warning');
+    case 'dead_click':
+      return recipe(`${count} dead ${count === 1 ? 'click' : 'clicks'}`, 'warning');
+    case 'form_abandon':
+      return recipe(`${count} form ${count === 1 ? 'abandon' : 'abandons'}`, 'neutral');
+    case 'recording':
+      return recipe('Recording', 'progress');
+    case 'queued':
+      return recipe('Queued', 'progress');
+    case 'analyzing':
+      return recipe('Analyzing', 'progress');
+    case 'analysis_failed':
+      return recipe('Analysis failed', 'warning');
+  }
+  return unknownStatusRecipe(kind);
+}
+
 export type IncidentKind = 'error' | 'friction';
 
 export function incidentKindRecipe(kind: IncidentKind): StatusRecipe {

--- a/packages/dashboard/src/types/api.ts
+++ b/packages/dashboard/src/types/api.ts
@@ -212,6 +212,11 @@ export interface SessionSummary {
   bytes_stored: number;
   page_url?: string | null;
   end_user?: SessionEndUser | null;
+  error_count: number;
+  rage_click_count: number;
+  dead_click_count: number;
+  form_abandon_count: number;
+  sdk_release?: string | null;
 }
 
 export interface SessionChunkMeta {
@@ -230,11 +235,12 @@ export interface SessionDetail extends SessionSummary {
 export interface SessionListResponse {
   sessions: SessionSummary[];
   next_cursor?: string | null;
+  has_identified_sessions: boolean;
 }
 
 export interface SessionFilters {
-  end_user_id?: string;
-  account_id?: string;
+  search?: string;
+  has_signals?: boolean;
   environment_id?: string;
   from?: string;
   to?: string;

--- a/packages/dashboard/src/views/SessionDetail.vue
+++ b/packages/dashboard/src/views/SessionDetail.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useRoute } from 'vue-router';
+import { formatDuration } from '../admin-format';
 import ReplayPlayer from '../components/ReplayPlayer.vue';
 import { useSessionPlayback } from '../composables/useSessionPlayback';
 import { formatAbsolute, getProjectId, safeUrl } from '../utils';
@@ -35,10 +36,9 @@ const activeChunksLabel = computed(() => {
 });
 
 function duration(): string {
-  if (!session.value?.last_chunk_at) return '\u2014';
+  if (!session.value?.last_chunk_at) return formatDuration(null);
   const ms = new Date(session.value.last_chunk_at).getTime() - new Date(session.value.started_at).getTime();
-  if (!Number.isFinite(ms) || ms < 0) return '\u2014';
-  return `${Math.floor(ms / 60_000)}m ${Math.floor((ms % 60_000) / 1_000)}s`;
+  return formatDuration(ms / 1_000);
 }
 </script>
 

--- a/packages/dashboard/src/views/SessionsList.test.ts
+++ b/packages/dashboard/src/views/SessionsList.test.ts
@@ -1,41 +1,92 @@
 // @vitest-environment jsdom
 
-import { flushPromises, mount } from '@vue/test-utils';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMemoryHistory, createRouter } from 'vue-router';
 
 import SessionsList from './SessionsList.vue';
 import { listEnvironments, listSessions } from '../api';
-import type { SessionListResponse, SessionSummary } from '../types/api';
+import type { SessionListResponse, SessionStatus, SessionSummary } from '../types/api';
 
 vi.mock('../api', () => ({
   listEnvironments: vi.fn(),
   listSessions: vi.fn(),
 }));
 
-function session(pageUrl: string): SessionSummary {
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
   return {
-    id: `session-${pageUrl.replace(/[^a-z]/g, '').slice(-24)}`,
-    started_at: '2026-07-19T00:00:00Z',
-    status: 'recording',
-    chunk_count: 1,
-    playable_chunk_count: 1,
-    bytes_stored: 100,
-    page_url: pageUrl,
+    id: 'session-full-identifier-123456789',
+    started_at: '2026-07-22T20:00:00Z',
+    last_chunk_at: '2026-07-22T20:07:21Z',
+    status: 'analyzed',
+    chunk_count: 2,
+    playable_chunk_count: 2,
+    bytes_stored: 2_048,
+    page_url: 'https://example.test/checkout?step=payment',
+    end_user: {
+      id: 'end-user-1',
+      external_user_id: 'user-123',
+      email: 'jane@acme.com',
+      external_account_id: 'account-1',
+      account_name: 'Acme Corp',
+    },
+    error_count: 3,
+    rage_click_count: 2,
+    dead_click_count: 1,
+    form_abandon_count: 1,
+    sdk_release: '1.4.2',
+    ...overrides,
+  };
+}
+
+function response(
+  sessions: SessionSummary[],
+  overrides: Partial<SessionListResponse> = {},
+): SessionListResponse {
+  return {
+    sessions,
+    next_cursor: null,
+    has_identified_sessions: true,
+    ...overrides,
   };
 }
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => { resolve = done; });
-  return { promise, resolve };
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
 }
 
-describe('SessionsList environment pagination', () => {
+async function mountView(settle = true): Promise<VueWrapper> {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/sessions', name: 'sessions', component: SessionsList },
+      { path: '/sessions/:sessionId', name: 'session-detail', component: { template: '<div />' } },
+      { path: '/setup', component: { template: '<div />' } },
+    ],
+  });
+  await router.push('/sessions');
+  await router.isReady();
+  const wrapper = mount(SessionsList, { global: { plugins: [router] } });
+  if (settle) await flushPromises();
+  return wrapper;
+}
+
+function visibilityClasses(element: { classes(): string[] }): string[] {
+  return element.classes().filter((value) => value === 'hidden' || /^(sm|md|lg|xl):table-cell$/.test(value));
+}
+
+describe('SessionsList ledger', () => {
   beforeEach(() => {
+    vi.mocked(listSessions).mockReset();
+    vi.mocked(listEnvironments).mockReset();
     localStorage.clear();
     localStorage.setItem('opslane_project_id', 'project-1');
-    localStorage.setItem('opslane_environment_id', 'env-production');
     vi.mocked(listEnvironments).mockResolvedValue({
       environments: [
         { id: 'env-production', project_id: 'project-1', name: 'production', created_at: '' },
@@ -47,59 +98,201 @@ describe('SessionsList environment pagination', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
     localStorage.clear();
   });
 
-  it('drops an in-flight old cursor page when the environment changes', async () => {
-    const initialUnfiltered = deferred<SessionListResponse>();
-    const oldPage = deferred<SessionListResponse>();
-    vi.mocked(listSessions).mockImplementation(async (_projectId, filters, cursor) => {
-      if (cursor === 'cursor-production') return oldPage.promise;
-      if (filters?.environment_id === 'env-production') {
-        return { sessions: [session('https://production.example.test')], next_cursor: 'cursor-production' };
-      }
-      if (filters?.environment_id === 'env-staging') {
-        return { sessions: [session('https://staging.example.test')], next_cursor: null };
-      }
-      return initialUnfiltered.promise;
-    });
+  it('renders identity, accepted signal counts, metadata, and the responsive three-column matrix', async () => {
+    vi.mocked(listSessions).mockResolvedValue(response([session()]));
+    const wrapper = await mountView();
 
-    const router = createRouter({
-      history: createMemoryHistory(),
-      routes: [
-        { path: '/sessions', component: SessionsList },
-        { path: '/sessions/:sessionId', name: 'session-detail', component: { template: '<div />' } },
-      ],
+    expect(wrapper.get('h1').text()).toBe('Recorded sessions');
+    expect(wrapper.text()).toContain('1 loaded');
+    expect(wrapper.text()).toContain('jane@acme.com');
+    expect(wrapper.text()).toContain('Acme Corp');
+    expect(wrapper.text()).toContain('v1.4.2');
+    expect(wrapper.text()).toContain('/checkout?step=payment');
+    expect(wrapper.text()).toContain('3 errors');
+    expect(wrapper.text()).toContain('2 rage clicks');
+    expect(wrapper.text()).toContain('1 dead click');
+    expect(wrapper.text()).toContain('1 form abandon');
+    expect(wrapper.get('table').attributes('aria-label')).toBe('Recorded sessions');
+    expect(wrapper.get('time').attributes('datetime')).toBe('2026-07-22T20:00:00Z');
+
+    const headers = wrapper.findAll('th');
+    const cells = wrapper.findAll('tbody tr')[0]!.findAll('td');
+    expect(headers.map(visibilityClasses)).toEqual([[], ['hidden', 'sm:table-cell'], []]);
+    expect(cells.map(visibilityClasses)).toEqual([[], ['hidden', 'sm:table-cell'], []]);
+    expect(headers.map((header) => header.attributes('scope'))).toEqual(['col', 'col', 'col']);
+
+    const row = wrapper.get('tbody tr');
+    expect(row.findAll('a')).toHaveLength(1);
+    expect(row.get('a').attributes('aria-label')).toContain('Play session for jane@acme.com');
+    expect(row.find('a button').exists()).toBe(false);
+    expect(row.get('button[aria-label="Copy session ID"]').attributes('type')).toBe('button');
+  });
+
+  it('copies the full session id from the sibling copy control', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
     });
-    await router.push('/sessions');
-    await router.isReady();
-    const wrapper = mount(SessionsList, { global: { plugins: [router] } });
+    vi.mocked(listSessions).mockResolvedValue(response([session()]));
+    const wrapper = await mountView();
+
+    await wrapper.get('button[aria-label="Copy session ID"]').trigger('click');
     await flushPromises();
 
-    expect(wrapper.text()).toContain('https://production.example.test');
-    const loadMore = wrapper.findAll('button').find((button) => button.text().includes('Load more'));
-    expect(loadMore).toBeDefined();
-    await loadMore!.trigger('click');
-    const environmentSelect = wrapper.get('select');
-    await environmentSelect.setValue('env-staging');
-    await environmentSelect.trigger('change');
-    await flushPromises();
+    expect(writeText).toHaveBeenCalledWith('session-full-identifier-123456789');
+  });
 
-    expect(wrapper.text()).toContain('https://staging.example.test');
-    expect(wrapper.text()).not.toContain('https://production.example.test');
+  it.each<[SessionStatus, number, string]>([
+    ['recording', 1, 'Processing'],
+    ['closed', 1, 'Processing'],
+    ['analyzing', 1, 'Processing'],
+    ['analysis_failed', 1, 'Unavailable'],
+    ['analyzed', 0, 'No recording'],
+  ])('does not link an unplayable %s session and explains %s', async (status, chunkCount, label) => {
+    vi.mocked(listSessions).mockResolvedValue(response([session({
+      status,
+      chunk_count: chunkCount,
+      playable_chunk_count: 0,
+      error_count: 0,
+      rage_click_count: 0,
+      dead_click_count: 0,
+      form_abandon_count: 0,
+    })]));
+    const wrapper = await mountView();
+
+    expect(wrapper.find('tbody a').exists()).toBe(false);
+    expect(wrapper.get('[aria-disabled="true"]').attributes('title')).toBe(label);
+  });
+
+  it('sends search, date, environment, and has-signals filters and clears them', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-22T20:00:00Z'));
+    vi.mocked(listSessions).mockResolvedValue(response([session()]));
+    const wrapper = await mountView();
+
+    await wrapper.get('input[type="search"]').setValue('Acme');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
     expect(vi.mocked(listSessions)).toHaveBeenLastCalledWith(
       'project-1',
-      expect.objectContaining({ environment_id: 'env-staging' }),
+      expect.objectContaining({
+        search: 'Acme',
+        from: '2026-07-21T20:00:00.000Z',
+      }),
       undefined,
     );
 
-    oldPage.resolve({ sessions: [session('https://stale-page.example.test')], next_cursor: null });
-    initialUnfiltered.resolve({ sessions: [session('https://stale-initial.example.test')], next_cursor: null });
+    await wrapper.findAll('select')[0].setValue('7d');
+    await wrapper.findAll('select')[1].setValue('env-staging');
+    await wrapper.findAll('button').find((button) => button.text() === 'With signals')!.trigger('click');
+    await flushPromises();
+    expect(vi.mocked(listSessions)).toHaveBeenLastCalledWith(
+      'project-1',
+      expect.objectContaining({
+        search: 'Acme',
+        from: '2026-07-15T20:00:00.000Z',
+        environment_id: 'env-staging',
+        has_signals: true,
+      }),
+      undefined,
+    );
+
+    await wrapper.findAll('button').find((button) => button.text() === 'Clear filters')!.trigger('click');
+    await flushPromises();
+    expect(vi.mocked(listSessions)).toHaveBeenLastCalledWith(
+      'project-1',
+      expect.not.objectContaining({
+        search: expect.anything(),
+        environment_id: expect.anything(),
+        has_signals: expect.anything(),
+      }),
+      undefined,
+    );
+  });
+
+  it('keeps existing rows when a filtered request or pagination request fails', async () => {
+    vi.mocked(listSessions)
+      .mockResolvedValueOnce(response([session()], { next_cursor: 'cursor-1' }))
+      .mockRejectedValueOnce(new Error('filter unavailable'));
+    const wrapper = await mountView();
+
+    await wrapper.get('input[type="search"]').setValue('missing');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+    expect(wrapper.text()).toContain('jane@acme.com');
+    expect(wrapper.text()).toContain('Unable to load sessions');
+
+    vi.mocked(listSessions).mockResolvedValueOnce(response([session()], { next_cursor: 'cursor-1' }));
+    await wrapper.findAll('button').find((button) => button.text() === 'Retry')!.trigger('click');
+    await flushPromises();
+    vi.mocked(listSessions).mockRejectedValueOnce(new Error('page unavailable'));
+    await wrapper.findAll('button').find((button) => button.text() === 'Load more')!.trigger('click');
     await flushPromises();
 
-    expect(wrapper.text()).toContain('https://staging.example.test');
-    expect(wrapper.text()).not.toContain('https://stale-page.example.test');
-    expect(wrapper.text()).not.toContain('https://stale-initial.example.test');
-    wrapper.unmount();
+    expect(wrapper.text()).toContain('jane@acme.com');
+    expect(wrapper.text()).toContain('Unable to load more sessions');
+  });
+
+  it('shows loading, retry, and the distinct empty states', async () => {
+    const initial = deferred<SessionListResponse>();
+    vi.mocked(listSessions).mockReturnValueOnce(initial.promise);
+    const wrapper = await mountView(false);
+    expect(wrapper.get('[role="status"]').attributes('aria-busy')).toBe('true');
+    expect(wrapper.findAllComponents({ name: 'SkeletonBlock' })).toHaveLength(3);
+    initial.reject(new Error('network down'));
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Unable to load sessions');
+    expect(wrapper.text()).toContain('Retry');
+
+    vi.mocked(listSessions).mockResolvedValueOnce(response([]));
+    await wrapper.findAll('button').find((button) => button.text() === 'Retry')!.trigger('click');
+    await flushPromises();
+    expect(wrapper.text()).toContain('No sessions recorded yet');
+    expect(wrapper.text()).toContain('Setup guide');
+    expect(wrapper.text()).not.toContain('These sessions have no user attached');
+
+    vi.mocked(listSessions).mockResolvedValueOnce(response([]));
+    await wrapper.findAll('button').find((button) => button.text() === 'With signals')!.trigger('click');
+    await flushPromises();
+    expect(wrapper.text()).toContain('No sessions with signals');
+    expect(wrapper.text()).toContain('Show all sessions');
+
+    vi.mocked(listSessions).mockResolvedValueOnce(response([]));
+    await wrapper.findAll('button').find((button) => button.text() === 'Show all sessions')!.trigger('click');
+    vi.mocked(listSessions).mockResolvedValueOnce(response([]));
+    await wrapper.get('input[type="search"]').setValue('nobody@example.com');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+    expect(wrapper.text()).toContain('No sessions match these filters');
+  });
+
+  it('gates the privacy-aware anonymous hint on project identity coverage and allows dismissal', async () => {
+    vi.mocked(listSessions).mockResolvedValue(response([
+      session({
+        end_user: null,
+        error_count: 0,
+        rage_click_count: 0,
+        dead_click_count: 0,
+        form_abandon_count: 0,
+      }),
+    ], { has_identified_sessions: false }));
+    const wrapper = await mountView();
+
+    expect(wrapper.text()).toContain('These sessions have no user attached');
+    expect(wrapper.text()).toContain('Identifying fields are sent unmasked');
+    expect(wrapper.get('a[href="https://docs.opslane.com/guides/replay-privacy/"]').attributes('rel'))
+      .toBe('noopener noreferrer');
+    expect(wrapper.text()).toContain('Anonymous');
+    expect(wrapper.text()).toContain('23456789');
+
+    await wrapper.get('button[aria-label="Dismiss anonymous recordings notice"]').trigger('click');
+    expect(wrapper.text()).not.toContain('These sessions have no user attached');
   });
 });

--- a/packages/dashboard/src/views/SessionsList.test.ts
+++ b/packages/dashboard/src/views/SessionsList.test.ts
@@ -133,6 +133,36 @@ describe('SessionsList ledger', () => {
     expect(row.get('button[aria-label="Copy session ID"]').attributes('type')).toBe('button');
   });
 
+  // Regression: ISSUE-001 — the anonymous short id sliced the TAIL of the
+  // session id, so structured ids rendered a meaningless fragment:
+  // `sess_sdk_normal_1784676521012577000` showed `12577000` (a nanosecond
+  // fragment, near-identical between sessions started in the same millisecond)
+  // and `session-unavailable` showed `vailable`.
+  // Found by /qa on 2026-07-23
+  // Report: .gstack/qa-reports/qa-report-sessions-2026-07-23.md
+  it('shows the distinguishing head of an anonymous session id, not the tail', async () => {
+    vi.mocked(listSessions).mockResolvedValue(response([
+      session({ id: 'sess_sdk_normal_1784676521012577000', end_user: null }),
+      session({ id: 'ec7a5e89-a2c5-4e7c-a282-00298b7efaed', end_user: null }),
+      session({ id: 'sess_a1b2c3d4e5f60718293a4b5c6d7e8f90', end_user: null }),
+    ]));
+    const wrapper = await mountView();
+
+    expect(wrapper.text()).toContain('sdk_norm');
+    expect(wrapper.text()).not.toContain('12577000');
+
+    // A UUID keeps its recognisable first block rather than its last.
+    expect(wrapper.text()).toContain('ec7a5e89');
+    expect(wrapper.text()).not.toContain('8b7efaed');
+
+    // The shared `sess_` prefix is stripped so the 8 shown characters carry signal.
+    expect(wrapper.text()).toContain('a1b2c3d4');
+
+    // The full id stays available to assistive tech and to the copy control.
+    const rows = wrapper.findAll('tbody tr');
+    expect(rows[0]!.html()).toContain('sess_sdk_normal_1784676521012577000');
+  });
+
   it('copies the full session id from the sibling copy control', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'clipboard', {
@@ -290,7 +320,8 @@ describe('SessionsList ledger', () => {
     expect(wrapper.get('a[href="https://docs.opslane.com/guides/replay-privacy/"]').attributes('rel'))
       .toBe('noopener noreferrer');
     expect(wrapper.text()).toContain('Anonymous');
-    expect(wrapper.text()).toContain('23456789');
+    // Head of the id, not the tail — see the ISSUE-001 regression test above.
+    expect(wrapper.text()).toContain('session-');
 
     await wrapper.get('button[aria-label="Dismiss anonymous recordings notice"]').trigger('click');
     expect(wrapper.text()).not.toContain('These sessions have no user attached');

--- a/packages/dashboard/src/views/SessionsList.vue
+++ b/packages/dashboard/src/views/SessionsList.vue
@@ -1,45 +1,65 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
 import { listSessions } from '../api';
-import type { SessionFilters, SessionStatus, SessionSummary } from '../types/api';
-import { formatDate, getProjectId, safeUrl } from '../utils';
-import { sessionStatusRecipe } from '../status-recipes';
+import type { SessionFilters, SessionSummary } from '../types/api';
+import { getProjectId } from '../utils';
 import { applySessionFilters, sessionPageRequest } from '../components/session-list-query';
 import { useEnvironmentFilter } from '../composables/useEnvironmentFilter';
-import SelectField from '../components/ui/SelectField.vue';
-import TextInput from '../components/ui/TextInput.vue';
+import SessionLedgerRow from '../components/sessions/SessionLedgerRow.vue';
 import Button from '../components/ui/Button.vue';
+import EmptyState from '../components/ui/EmptyState.vue';
+import InlineAlert from '../components/ui/InlineAlert.vue';
+import SelectField from '../components/ui/SelectField.vue';
+import SkeletonBlock from '../components/ui/SkeletonBlock.vue';
+import TextInput from '../components/ui/TextInput.vue';
+
+type DatePreset = '24h' | '7d' | '30d' | 'custom';
 
 const sessions = ref<SessionSummary[]>([]);
 const projectId = ref('');
 const loading = ref(true);
+const hasLoaded = ref(false);
 const loadingMore = ref(false);
 const error = ref<string | null>(null);
+const paginationError = ref<string | null>(null);
 const nextCursor = ref<string | null>(null);
-const endUserId = ref('');
-const accountId = ref('');
-const from = ref('');
-const to = ref('');
+const hasIdentifiedSessions = ref(true);
+const anonymousHintDismissed = ref(false);
+const search = ref('');
+const datePreset = ref<DatePreset>('24h');
+const customFrom = ref('');
+const customTo = ref('');
+const withSignals = ref(false);
 const appliedFilters = ref<SessionFilters>({});
 let fetchGeneration = 0;
+
 const {
   environments,
   rollupReady,
   selectedEnvironmentId,
 } = useEnvironmentFilter(projectId);
+
 const environmentOptions = computed(() => [
   { value: '', label: 'All environments' },
   ...environments.value.map((environment) => ({ value: environment.id, label: environment.name })),
 ]);
-
-function selectEnvironment(value: string): void {
-  selectedEnvironmentId.value = value;
-  applyFilters();
-}
-
-watch(rollupReady, (ready) => {
-  if (ready) applyFilters();
-});
+const dateOptions = [
+  { value: '24h', label: 'Last 24 hours' },
+  { value: '7d', label: 'Last 7 days' },
+  { value: '30d', label: 'Last 30 days' },
+  { value: 'custom', label: 'Custom range' },
+];
+const filtersActive = computed(() =>
+  search.value.trim().length > 0
+  || datePreset.value !== '24h'
+  || selectedEnvironmentId.value.length > 0
+  || withSignals.value);
+const showAnonymousHint = computed(() =>
+  hasLoaded.value
+  && sessions.value.length > 0
+  && !hasIdentifiedSessions.value
+  && !anonymousHintDismissed.value);
+const initialLoading = computed(() => loading.value && !hasLoaded.value);
 
 function isoDate(value: string): string | undefined {
   if (!value) return undefined;
@@ -47,34 +67,56 @@ function isoDate(value: string): string | undefined {
   return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
 }
 
+function presetStart(preset: Exclude<DatePreset, 'custom'>): string {
+  const days = preset === '24h' ? 1 : preset === '7d' ? 7 : 30;
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1_000).toISOString();
+}
+
 function filters(): SessionFilters {
+  if (datePreset.value === 'custom') {
+    return {
+      search: search.value.trim() || undefined,
+      has_signals: withSignals.value || undefined,
+      environment_id: rollupReady.value ? selectedEnvironmentId.value || undefined : undefined,
+      from: isoDate(customFrom.value),
+      to: isoDate(customTo.value),
+    };
+  }
   return {
-    end_user_id: endUserId.value.trim() || undefined,
-    account_id: accountId.value.trim() || undefined,
+    search: search.value.trim() || undefined,
+    has_signals: withSignals.value || undefined,
     environment_id: rollupReady.value ? selectedEnvironmentId.value || undefined : undefined,
-    from: isoDate(from.value),
-    to: isoDate(to.value),
+    from: presetStart(datePreset.value),
+    to: undefined,
   };
 }
 
 async function fetchSessions(cursor?: string): Promise<void> {
   const generation = ++fetchGeneration;
-  if (cursor) loadingMore.value = true;
-  else {
+  if (cursor) {
+    loadingMore.value = true;
+    paginationError.value = null;
+  } else {
     loading.value = true;
-    loadingMore.value = false;
+    error.value = null;
   }
-  error.value = null;
+
   try {
     const request = sessionPageRequest(appliedFilters.value, cursor);
     const response = await listSessions(projectId.value, request.filters, request.cursor);
     if (generation !== fetchGeneration) return;
     sessions.value = cursor ? [...sessions.value, ...response.sessions] : response.sessions;
     nextCursor.value = response.next_cursor ?? null;
+    hasIdentifiedSessions.value = response.has_identified_sessions;
+    hasLoaded.value = true;
   } catch (caught: unknown) {
     if (generation !== fetchGeneration) return;
     const message = caught instanceof Error ? caught.message : String(caught);
-    error.value = `Failed to load sessions: ${message}`;
+    if (cursor) paginationError.value = message;
+    else {
+      error.value = message;
+      hasLoaded.value = true;
+    }
   } finally {
     if (generation === fetchGeneration) {
       loading.value = false;
@@ -84,128 +126,258 @@ async function fetchSessions(cursor?: string): Promise<void> {
 }
 
 function applyFilters(): void {
-  // Invalidate any in-flight page before it can append rows produced by the
-  // previous filter snapshot.
   fetchGeneration++;
   const applied = applySessionFilters(filters());
   appliedFilters.value = applied.filters;
   nextCursor.value = applied.cursor;
+  paginationError.value = null;
   void fetchSessions();
 }
 
-function duration(session: SessionSummary): string {
-  if (!session.last_chunk_at) return '\u2014';
-  const ms = new Date(session.last_chunk_at).getTime() - new Date(session.started_at).getTime();
-  if (!Number.isFinite(ms) || ms < 0) return '\u2014';
-  const seconds = Math.floor(ms / 1_000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainder = seconds % 60;
-  if (minutes < 60) return `${minutes}m ${remainder}s`;
-  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+function selectEnvironment(value: string): void {
+  selectedEnvironmentId.value = value;
+  applyFilters();
 }
 
-function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
-  const units = ['B', 'KB', 'MB', 'GB'];
-  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-  const value = bytes / (1024 ** index);
-  return `${value >= 10 || index === 0 ? value.toFixed(0) : value.toFixed(1)} ${units[index]}`;
+function selectDatePreset(value: string): void {
+  datePreset.value = value as DatePreset;
+  if (datePreset.value !== 'custom') applyFilters();
 }
 
-function sessionBadge(status: SessionStatus): string {
-  return sessionStatusRecipe(status).class;
+function setSignalsFilter(enabled: boolean): void {
+  withSignals.value = enabled;
+  applyFilters();
 }
+
+function clearFilters(): void {
+  search.value = '';
+  datePreset.value = '24h';
+  customFrom.value = '';
+  customTo.value = '';
+  selectedEnvironmentId.value = '';
+  withSignals.value = false;
+  applyFilters();
+}
+
+watch(rollupReady, (ready) => {
+  if (ready && selectedEnvironmentId.value) applyFilters();
+});
 
 onMounted(() => {
   projectId.value = getProjectId();
   if (!projectId.value) {
     error.value = 'No project configured.';
     loading.value = false;
+    hasLoaded.value = true;
     return;
   }
+  appliedFilters.value = filters();
   void fetchSessions();
 });
 </script>
 
 <template>
-  <div>
-    <div class="flex items-center justify-between gap-4 mb-4">
-      <div>
-        <h2 class="text-lg font-medium text-text">Sessions</h2>
-        <p class="mt-1 text-sm text-muted">Browse scrubbed recordings by user, account, and time.</p>
+  <div class="mx-auto w-full max-w-[1120px]">
+    <header class="mb-7 border-b border-border pb-5">
+      <p class="text-xs font-semibold uppercase tracking-[0.18em] text-accent">Session ledger</p>
+      <div class="mt-2 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 class="text-2xl font-semibold tracking-tight text-text">Recorded sessions</h1>
+          <p class="mt-1 max-w-2xl text-sm text-muted">Browse scrubbed recordings by user, account, and time.</p>
+        </div>
+        <p v-if="hasLoaded && (!error || sessions.length)" class="font-mono text-xs text-muted">
+          {{ sessions.length }} loaded
+        </p>
       </div>
-    </div>
+    </header>
 
-    <form class="grid gap-3 mb-5 md:grid-cols-2 xl:grid-cols-6" @submit.prevent="applyFilters">
-      <TextInput v-model="endUserId" label="End-user ID" placeholder="End-user ID" />
-      <TextInput v-model="accountId" label="Account ID" placeholder="Account ID" />
+    <form class="mb-5 flex flex-wrap items-end gap-3" @submit.prevent="applyFilters">
+      <TextInput
+        v-model="search"
+        type="search"
+        label="Search"
+        placeholder="Search by user, email, or session ID"
+        :disabled="loading"
+        class="w-full sm:min-w-72 sm:flex-1"
+      />
+      <SelectField
+        :model-value="datePreset"
+        label="Date range"
+        :options="dateOptions"
+        :disabled="loading"
+        class="min-w-40 flex-1 sm:max-w-52"
+        @update:model-value="selectDatePreset"
+      />
       <SelectField
         v-if="rollupReady"
         :model-value="selectedEnvironmentId"
         label="Environment"
         :options="environmentOptions"
+        :disabled="loading"
+        class="min-w-40 flex-1 sm:max-w-56"
         @update:model-value="selectEnvironment"
       />
-      <TextInput v-model="from" label="From" type="datetime-local" />
-      <TextInput v-model="to" label="To" type="datetime-local" />
-      <Button variant="primary" class="self-end" type="submit" :disabled="loading">Apply filters</Button>
+      <fieldset class="grid gap-1.5">
+        <legend class="text-sm font-medium text-text">Signals</legend>
+        <div class="inline-flex min-h-10 max-md:min-h-11 rounded-md border border-border-strong bg-surface p-0.5">
+          <button
+            type="button"
+            class="px-3 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            :class="!withSignals ? 'bg-text text-surface' : 'text-muted hover:text-text'"
+            :aria-pressed="!withSignals"
+            :disabled="loading"
+            @click="setSignalsFilter(false)"
+          >All</button>
+          <button
+            type="button"
+            class="px-3 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            :class="withSignals ? 'bg-text text-surface' : 'text-muted hover:text-text'"
+            :aria-pressed="withSignals"
+            :disabled="loading"
+            @click="setSignalsFilter(true)"
+          >With signals</button>
+        </div>
+      </fieldset>
+      <button
+        v-if="filtersActive"
+        type="button"
+        class="min-h-10 self-end px-2 text-sm font-medium text-accent underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        :disabled="loading"
+        @click="clearFilters"
+      >Clear filters</button>
+      <button type="submit" class="sr-only" :disabled="loading">Search sessions</button>
+
+      <div v-if="datePreset === 'custom'" class="flex w-full flex-wrap gap-3">
+        <TextInput
+          v-model="customFrom"
+          type="datetime-local"
+          label="From"
+          :disabled="loading"
+          class="min-w-56 flex-1"
+          @change="applyFilters"
+        />
+        <TextInput
+          v-model="customTo"
+          type="datetime-local"
+          label="To"
+          :disabled="loading"
+          class="min-w-56 flex-1"
+          @change="applyFilters"
+        />
+      </div>
     </form>
 
-    <div v-if="loading" class="text-muted">Loading sessions...</div>
-    <div v-else-if="error" class="rounded-md bg-danger/10 border border-danger/20 p-4 text-sm text-danger">
-      <p v-text="error"></p>
-    </div>
-    <div v-else-if="sessions.length === 0" class="py-16 text-center">
-      <h3 class="text-sm font-medium text-text">No sessions found</h3>
-      <p class="mt-1 text-sm text-muted">Recordings appear after their first chunk has been accepted.</p>
-    </div>
-    <div v-else class="border border-border rounded-lg overflow-x-auto">
-      <table class="min-w-full text-sm">
-        <thead>
-          <tr class="border-b border-border bg-surface text-left text-xs font-medium uppercase tracking-wider text-muted">
-            <th class="py-2.5 px-4">Started</th>
-            <th class="py-2.5 px-4">User</th>
-            <th class="py-2.5 px-4">Duration</th>
-            <th class="py-2.5 px-4">Chunks</th>
-            <th class="py-2.5 px-4">Size</th>
-            <th class="py-2.5 px-4">Status</th>
-            <th class="py-2.5 px-4">Page</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="item in sessions" :key="item.id" class="border-b border-border hover:bg-surface transition-colors">
-            <td class="py-2.5 px-4 whitespace-nowrap">
-              <router-link
-                v-if="item.playable_chunk_count > 0"
-                :to="{ name: 'session-detail', params: { sessionId: item.id } }"
-                class="text-accent hover:underline font-medium"
-              >{{ formatDate(item.started_at) }}</router-link>
-              <span v-else>{{ formatDate(item.started_at) }}</span>
-            </td>
-            <td class="py-2.5 px-4 text-muted" v-text="item.end_user?.email || item.end_user?.external_user_id || '\u2014'"></td>
-            <td class="py-2.5 px-4 text-muted whitespace-nowrap">{{ duration(item) }}</td>
-            <td class="py-2.5 px-4 text-muted whitespace-nowrap">
-              {{ item.playable_chunk_count }}/{{ item.chunk_count }}
-              <span v-if="item.playable_chunk_count === 0" class="ml-1 text-warning">processing</span>
-            </td>
-            <td class="py-2.5 px-4 text-muted whitespace-nowrap">{{ formatBytes(item.bytes_stored) }}</td>
-            <td class="py-2.5 px-4">
-              <span class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium" :class="sessionBadge(item.status)" v-text="item.status.replace('_', ' ')"></span>
-            </td>
-            <td class="py-2.5 px-4 max-w-72 truncate">
-              <a v-if="safeUrl(item.page_url ?? undefined)" :href="safeUrl(item.page_url ?? undefined)" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline" v-text="item.page_url"></a>
-              <span v-else class="text-faint">\u2014</span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+    <InlineAlert v-if="showAnonymousHint" title="Anonymous recordings" tone="info" class="mb-5">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <p>
+          These sessions have no user attached. Call <code class="font-mono">setUser()</code> to see who they are.
+          Identifying fields are sent unmasked.
+          <a
+            href="https://docs.opslane.com/guides/replay-privacy/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="font-semibold underline underline-offset-2"
+          >Review replay privacy</a>.
+        </p>
+        <button
+          type="button"
+          class="shrink-0 font-semibold underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          aria-label="Dismiss anonymous recordings notice"
+          @click="anonymousHintDismissed = true"
+        >Dismiss</button>
+      </div>
+    </InlineAlert>
+
+    <div
+      v-if="initialLoading"
+      role="status"
+      aria-busy="true"
+      aria-label="Loading recorded sessions"
+      class="grid gap-3 border-y border-border py-5"
+    >
+      <SkeletonBlock class="h-14" />
+      <SkeletonBlock class="h-14" />
+      <SkeletonBlock class="h-14" />
     </div>
 
-    <div v-if="nextCursor" class="mt-4 text-center">
-      <Button variant="secondary" :disabled="loadingMore" @click="fetchSessions(nextCursor)">
-        {{ loadingMore ? 'Loading...' : 'Load more' }}
-      </Button>
-    </div>
+    <template v-else>
+      <InlineAlert v-if="error" tone="danger" title="Unable to load sessions" class="mb-4">
+        <p v-text="error"></p>
+        <Button class="mt-3" variant="secondary" :disabled="loading" @click="fetchSessions()">Retry</Button>
+      </InlineAlert>
+
+      <EmptyState
+        v-if="!error && sessions.length === 0 && withSignals"
+        title="No sessions with signals"
+        description="No analyzed sessions in this range have accepted errors or friction signals."
+      >
+        <Button variant="secondary" @click="setSignalsFilter(false)">Show all sessions</Button>
+      </EmptyState>
+
+      <EmptyState
+        v-else-if="!error && sessions.length === 0 && filtersActive"
+        title="No sessions match these filters"
+        description="Try widening the date range or clearing the search."
+      >
+        <Button variant="secondary" @click="clearFilters">Clear filters</Button>
+      </EmptyState>
+
+      <EmptyState
+        v-else-if="!error && sessions.length === 0"
+        title="No sessions recorded yet"
+        description="Recordings appear after the SDK sends its first chunk."
+      >
+        <router-link
+          to="/setup"
+          class="inline-flex min-h-10 items-center bg-accent px-4 py-2 text-sm font-semibold text-on-accent hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+        >Setup guide</router-link>
+      </EmptyState>
+
+      <div
+        v-if="sessions.length"
+        class="overflow-x-auto border-y border-border"
+        :aria-busy="loading || loadingMore || undefined"
+      >
+        <table class="min-w-full table-fixed text-sm" aria-label="Recorded sessions">
+          <thead>
+            <tr class="border-b border-border bg-surface-subtle">
+              <th scope="col" class="w-[60%] px-2 py-2.5 text-left text-[11px] font-semibold uppercase tracking-[0.14em] text-muted sm:w-[45%] sm:px-4">
+                Session
+              </th>
+              <th scope="col" class="hidden w-[30%] px-4 py-2.5 text-left text-[11px] font-semibold uppercase tracking-[0.14em] text-muted sm:table-cell">
+                Signals
+              </th>
+              <th scope="col" class="w-[40%] px-2 py-2.5 text-left text-[11px] font-semibold uppercase tracking-[0.14em] text-muted sm:w-[25%] sm:px-4">
+                Started
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <SessionLedgerRow
+              v-for="session in sessions"
+              :key="session.id"
+              :session="session"
+            />
+          </tbody>
+        </table>
+      </div>
+
+      <InlineAlert v-if="paginationError" tone="danger" title="Unable to load more sessions" class="mt-4">
+        <p v-text="paginationError"></p>
+        <Button
+          v-if="nextCursor"
+          class="mt-3"
+          variant="secondary"
+          :disabled="loadingMore"
+          @click="fetchSessions(nextCursor)"
+        >Retry</Button>
+      </InlineAlert>
+
+      <div v-if="nextCursor && !paginationError" class="mt-5 text-center">
+        <Button variant="secondary" :disabled="loadingMore" @click="fetchSessions(nextCursor)">
+          {{ loadingMore ? 'Loading...' : 'Load more' }}
+        </Button>
+      </div>
+    </template>
   </div>
 </template>

--- a/packages/dashboard/src/views/__tests__/SessionDetail.test.ts
+++ b/packages/dashboard/src/views/__tests__/SessionDetail.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionDetail as SessionDetailData } from '../../types/api';
+
+const playback = vi.hoisted(() => ({
+  useSessionPlayback: vi.fn(),
+}));
+
+vi.mock('../../composables/useSessionPlayback', () => playback);
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { sessionId: 'session-1' }, query: {} }),
+}));
+
+import SessionDetail from '../SessionDetail.vue';
+
+const startedAt = '2026-07-22T20:00:00.000Z';
+
+function mountView(durationSeconds: number) {
+  const session: SessionDetailData = {
+    id: 'session-1',
+    started_at: startedAt,
+    last_chunk_at: new Date(new Date(startedAt).getTime() + durationSeconds * 1_000).toISOString(),
+    status: 'analyzed',
+    chunk_count: 1,
+    playable_chunk_count: 1,
+    bytes_stored: 1_024,
+    error_count: 0,
+    rage_click_count: 0,
+    dead_click_count: 0,
+    form_abandon_count: 0,
+    chunks: [],
+  };
+
+  playback.useSessionPlayback.mockReturnValue({
+    state: ref('ready'),
+    session: ref(session),
+    segments: ref([]),
+    activeSegment: ref(0),
+    events: ref([]),
+    seekMs: ref(undefined),
+    missingChunks: ref({ missing: 0, total: 0 }),
+    approximate: ref(false),
+    pollAttempt: ref(0),
+    pollsRemaining: ref(24),
+    terminalUnavailable: ref(false),
+    error: ref(''),
+    loadSegment: vi.fn(),
+    stopPolling: vi.fn(),
+  });
+
+  return mount(SessionDetail, {
+    global: {
+      stubs: {
+        ReplayPlayer: true,
+        RouterLink: { template: '<a><slot /></a>' },
+      },
+    },
+  });
+}
+
+function renderedDuration(durationSeconds: number): string {
+  const wrapper = mountView(durationSeconds);
+  const detail = wrapper.findAll('dl > div').find((row) => row.get('dt').text() === 'Duration');
+  const value = detail?.get('dd').text() ?? '';
+  wrapper.unmount();
+  return value;
+}
+
+describe('SessionDetail duration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('uses the canonical duration formatting for long and sub-second sessions', () => {
+    expect(renderedDuration(7_230)).toBe('2h 0m');
+    expect(renderedDuration(0.4)).toBe('<1s');
+  });
+});

--- a/packages/ingestion/db/sessions_read.go
+++ b/packages/ingestion/db/sessions_read.go
@@ -20,17 +20,24 @@ type SessionSummary struct {
 	PlayableChunkCount int
 	BytesStored        int64
 	PageURL            *string
+	SDKRelease         *string
 	EndUserID          *string
 	ExternalUserID     *string
 	EndUserEmail       *string
 	ExternalAccountID  *string
 	AccountName        *string
+	ErrorCount         int
+	RageClickCount     int
+	DeadClickCount     int
+	FormAbandonCount   int
 }
 
 type SessionFilters struct {
 	EndUserID     string
 	AccountID     string
 	EnvironmentID string
+	Search        string
+	HasSignals    bool
 	From          *time.Time
 	To            *time.Time
 }
@@ -48,20 +55,40 @@ func scanSessionSummary(row sessionScanner) (SessionSummary, error) {
 	var session SessionSummary
 	err := row.Scan(
 		&session.ID, &session.StartedAt, &session.LastChunkAt, &session.Status,
-		&session.ChunkCount, &session.BytesStored, &session.PageURL,
+		&session.ChunkCount, &session.BytesStored, &session.PageURL, &session.SDKRelease,
 		&session.EndUserID, &session.ExternalUserID, &session.EndUserEmail,
 		&session.ExternalAccountID, &session.AccountName, &session.PlayableChunkCount,
+		&session.ErrorCount, &session.RageClickCount, &session.DeadClickCount,
+		&session.FormAbandonCount,
 	)
 	return session, err
 }
 
 const sessionSummarySelect = `SELECT s.id, s.started_at, s.last_chunk_at, s.status,
-       s.chunk_count, s.bytes_stored, s.page_url,
+       s.chunk_count, s.bytes_stored, s.page_url, s.sdk_release,
        eu.id, eu.external_user_id, eu.email, eu.external_account_id, eu.account_name,
        (SELECT count(*) FROM session_chunks c
-         WHERE c.session_id = s.id AND c.scrubbed_at IS NOT NULL)
+         WHERE c.session_id = s.id AND c.scrubbed_at IS NOT NULL),
+       e.errors, f.rage, f.dead, f.abandon
   FROM sessions s
-  LEFT JOIN end_users eu ON eu.id = s.end_user_id`
+  LEFT JOIN end_users eu ON eu.id = s.end_user_id AND eu.project_id = $1
+  LEFT JOIN LATERAL (
+    SELECT COALESCE(sum(fs.occurrence_count) FILTER (WHERE fs.signal_type = 'rage_click'), 0) AS rage,
+           COALESCE(sum(fs.occurrence_count) FILTER (WHERE fs.signal_type = 'dead_click'), 0) AS dead,
+           COALESCE(sum(fs.occurrence_count) FILTER (WHERE fs.signal_type = 'form_abandon'), 0) AS abandon
+      FROM friction_signals fs
+     WHERE fs.session_id = s.id
+       AND fs.project_id = $1
+       AND fs.retracted_at IS NULL
+       AND fs.superseded_by IS NULL
+       AND fs.adjudication_status = 'accepted'
+  ) f ON true
+  LEFT JOIN LATERAL (
+    SELECT count(*) AS errors
+      FROM error_events ee
+     WHERE ee.session_id = s.id
+       AND ee.project_id = $1
+  ) e ON true`
 
 // ListSessions returns non-deleting project sessions newest-first. It fetches
 // one row beyond the requested limit so exactly-full terminal pages do not
@@ -90,9 +117,15 @@ func (q *Queries) ListSessions(ctx context.Context, projectID string, filters Se
    AND ($5::timestamptz IS NULL OR s.started_at <= $5)
    AND ($6 = '' OR s.environment_id = NULLIF($6, '')::uuid)
    AND ($7::timestamptz IS NULL OR (s.started_at, s.id) < ($7, $8))
+   AND ($9 = '' OR eu.email ILIKE '%' || $9 || '%'
+                 OR eu.external_user_id ILIKE '%' || $9 || '%'
+                 OR eu.account_name ILIKE '%' || $9 || '%'
+                 OR eu.external_account_id ILIKE '%' || $9 || '%'
+                 OR s.id = $9)
+   AND ($10 = false OR (f.rage + f.dead + f.abandon + e.errors) > 0)
  ORDER BY s.started_at DESC, s.id DESC
- LIMIT $9`, projectID, filters.EndUserID, filters.AccountID, filters.From, filters.To,
-		filters.EnvironmentID, cursorStartedAt, cursorID, limit+1)
+ LIMIT $11`, projectID, filters.EndUserID, filters.AccountID, filters.From, filters.To,
+		filters.EnvironmentID, cursorStartedAt, cursorID, filters.Search, filters.HasSignals, limit+1)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list sessions: %w", err)
 	}
@@ -117,6 +150,23 @@ func (q *Queries) ListSessions(ctx context.Context, projectID string, filters Se
 		next = &SessionCursor{StartedAt: last.StartedAt, ID: last.ID}
 	}
 	return sessions, next, nil
+}
+
+// HasIdentifiedSessions reports whether the project has any non-deleting
+// session attached to an end user, independently of the current list page.
+func (q *Queries) HasIdentifiedSessions(ctx context.Context, projectID string) (bool, error) {
+	var exists bool
+	err := q.pool.QueryRow(ctx, `SELECT EXISTS(
+		SELECT 1
+		  FROM sessions
+		 WHERE project_id = $1
+		   AND end_user_id IS NOT NULL
+		   AND status <> 'deleting'
+	)`, projectID).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check identified sessions: %w", err)
+	}
+	return exists, nil
 }
 
 // GetSessionSummary returns nil when the session is absent, belongs to another

--- a/packages/ingestion/db/sessions_read_test.go
+++ b/packages/ingestion/db/sessions_read_test.go
@@ -40,6 +40,45 @@ func addReadChunk(t *testing.T, q *db.Queries, sessionID, projectID string, seq 
 	}
 }
 
+func addReadSignal(t *testing.T, pool *pgxpool.Pool, sessionID, projectID, envID, signalType, fingerprint, status string, ruleVersion, occurrenceCount int) string {
+	t.Helper()
+	var id string
+	if err := pool.QueryRow(context.Background(), `
+		INSERT INTO friction_signals (
+			session_id, project_id, environment_id, rule_version, signal_type,
+			fingerprint, page_url_normalized, occurred_at, occurrence_count,
+			adjudication_status
+		) VALUES ($1, $2, $3, $4, $5, $6, '/checkout', now(), $7, $8)
+		RETURNING id`,
+		sessionID, projectID, envID, ruleVersion, signalType, fingerprint,
+		occurrenceCount, status,
+	).Scan(&id); err != nil {
+		t.Fatalf("insert %s signal: %v", signalType, err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM friction_signals WHERE id = $1`, id)
+	})
+	return id
+}
+
+func addReadError(t *testing.T, pool *pgxpool.Pool, sessionID, projectID, envID string) {
+	t.Helper()
+	var id string
+	if err := pool.QueryRow(context.Background(), `
+		INSERT INTO error_events (
+			project_id, environment_id, timestamp, error_type, error_message,
+			stack_trace_raw, session_id
+		) VALUES ($1, $2, now(), 'TypeError', 'boom', 'at test', $3)
+		RETURNING id`,
+		projectID, envID, sessionID,
+	).Scan(&id); err != nil {
+		t.Fatalf("insert error event: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM error_events WHERE id = $1`, id)
+	})
+}
+
 func TestListSessions_FiltersPaginationAndTenantScope(t *testing.T) {
 	q, pool := sessionTestQueries(t)
 	ctx := context.Background()
@@ -109,6 +148,123 @@ func TestListSessions_FiltersPaginationAndTenantScope(t *testing.T) {
 	otherRows, _, err := q.ListSessions(ctx, otherProjectID, db.SessionFilters{}, nil, 50)
 	if err != nil || len(otherRows) != 1 || otherRows[0].ID != "sess_read_other_project" {
 		t.Fatalf("other project rows = %+v err=%v", otherRows, err)
+	}
+}
+
+func TestListSessions_CountsAcceptedActiveSignalsAndSearchesIdentity(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	otherProjectID, otherEnvID := seedSessionProject(t, pool)
+
+	userID, err := q.UpsertEndUser(ctx, projectID, "Customer-123", "acct-789", "Jane@Acme.test", "Acme Corporation")
+	if err != nil {
+		t.Fatalf("upsert end user: %v", err)
+	}
+	base := time.Now().UTC().Truncate(time.Microsecond).Add(-time.Hour)
+	signalSessionID := "sess_signal_search_exact"
+	cleanSessionID := "sess_clean_search_exact"
+	pendingSessionID := "sess_pending_only"
+	insertReadSession(t, q, pool, projectID, envID, &userID, signalSessionID, base.Add(2*time.Minute))
+	insertReadSession(t, q, pool, projectID, envID, nil, cleanSessionID, base.Add(time.Minute))
+	insertReadSession(t, q, pool, projectID, envID, nil, pendingSessionID, base)
+	if _, err := pool.Exec(ctx, `UPDATE sessions SET sdk_release = '@opslane/sdk@1.4.2' WHERE id = $1`, signalSessionID); err != nil {
+		t.Fatalf("set sdk release: %v", err)
+	}
+
+	newRageID := addReadSignal(t, pool, signalSessionID, projectID, envID, "rage_click", "rage-versioned", "accepted", 2, 3)
+	oldRageID := addReadSignal(t, pool, signalSessionID, projectID, envID, "rage_click", "rage-versioned", "accepted", 1, 9)
+	if _, err := pool.Exec(ctx, `UPDATE friction_signals SET superseded_by = $2 WHERE id = $1`, oldRageID, newRageID); err != nil {
+		t.Fatalf("supersede old signal: %v", err)
+	}
+	retractedID := addReadSignal(t, pool, signalSessionID, projectID, envID, "rage_click", "rage-retracted", "accepted", 1, 8)
+	if _, err := pool.Exec(ctx, `UPDATE friction_signals SET retracted_at = now() WHERE id = $1`, retractedID); err != nil {
+		t.Fatalf("retract signal: %v", err)
+	}
+	addReadSignal(t, pool, signalSessionID, projectID, envID, "dead_click", "dead-accepted", "accepted", 1, 2)
+	addReadSignal(t, pool, signalSessionID, projectID, envID, "dead_click", "dead-pending", "pending", 1, 7)
+	addReadSignal(t, pool, signalSessionID, projectID, envID, "form_abandon", "abandon-accepted", "accepted", 1, 5)
+	addReadSignal(t, pool, signalSessionID, projectID, envID, "form_abandon", "abandon-rejected", "rejected", 1, 6)
+	addReadSignal(t, pool, pendingSessionID, projectID, envID, "rage_click", "pending-only", "pending", 1, 12)
+	addReadError(t, pool, signalSessionID, projectID, envID)
+	addReadError(t, pool, signalSessionID, projectID, envID)
+
+	// Deliberately inconsistent tenant columns prove that each LATERAL enforces
+	// project scope instead of relying on the outer sessions predicate.
+	addReadSignal(t, pool, signalSessionID, otherProjectID, otherEnvID, "form_abandon", "cross-project", "accepted", 1, 11)
+	addReadError(t, pool, signalSessionID, otherProjectID, otherEnvID)
+
+	all, _, err := q.ListSessions(ctx, projectID, db.SessionFilters{}, nil, 50)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("sessions len = %d, want 3", len(all))
+	}
+	got := all[0]
+	if got.ID != signalSessionID {
+		t.Fatalf("first session = %q, want %q", got.ID, signalSessionID)
+	}
+	if got.SDKRelease == nil || *got.SDKRelease != "@opslane/sdk@1.4.2" {
+		t.Fatalf("sdk release = %v", got.SDKRelease)
+	}
+	if got.ErrorCount != 2 || got.RageClickCount != 3 || got.DeadClickCount != 2 || got.FormAbandonCount != 5 {
+		t.Fatalf("signal counts = errors:%d rage:%d dead:%d abandon:%d, want 2/3/2/5",
+			got.ErrorCount, got.RageClickCount, got.DeadClickCount, got.FormAbandonCount)
+	}
+	if pendingOnly := all[2]; pendingOnly.ID != pendingSessionID || pendingOnly.RageClickCount != 0 {
+		t.Fatalf("pending-only counts = %+v, want zero visible signals", pendingOnly)
+	}
+
+	detail, err := q.GetSessionSummary(ctx, projectID, signalSessionID)
+	if err != nil || detail == nil || detail.RageClickCount != 3 || detail.ErrorCount != 2 {
+		t.Fatalf("detail counts = %+v err=%v", detail, err)
+	}
+
+	searches := []string{"jane@acme", "CUSTOMER-123", "acme corporation", "ACCT-789", signalSessionID}
+	for _, search := range searches {
+		found, _, searchErr := q.ListSessions(ctx, projectID, db.SessionFilters{Search: search}, nil, 50)
+		if searchErr != nil || len(found) != 1 || found[0].ID != signalSessionID {
+			t.Errorf("search %q = %+v err=%v", search, found, searchErr)
+		}
+	}
+	partialID, _, err := q.ListSessions(ctx, projectID, db.SessionFilters{Search: "sess_signal_search"}, nil, 50)
+	if err != nil || len(partialID) != 0 {
+		t.Fatalf("partial session id search = %+v err=%v, want no exact-id match", partialID, err)
+	}
+
+	withSignals, _, err := q.ListSessions(ctx, projectID, db.SessionFilters{HasSignals: true}, nil, 50)
+	if err != nil || len(withSignals) != 1 || withSignals[0].ID != signalSessionID {
+		t.Fatalf("with-signals filter = %+v err=%v", withSignals, err)
+	}
+}
+
+func TestHasIdentifiedSessions_IsProjectScopedAndIgnoresDeleting(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	otherProjectID, otherEnvID := seedSessionProject(t, pool)
+	userID, err := q.UpsertEndUser(ctx, projectID, "identified", "", "", "")
+	if err != nil {
+		t.Fatalf("upsert end user: %v", err)
+	}
+	insertReadSession(t, q, pool, projectID, envID, &userID, "sess_identified", time.Now())
+	insertReadSession(t, q, pool, otherProjectID, otherEnvID, nil, "sess_other_anonymous", time.Now())
+
+	hasIdentified, err := q.HasIdentifiedSessions(ctx, projectID)
+	if err != nil || !hasIdentified {
+		t.Fatalf("identified project = %v err=%v, want true", hasIdentified, err)
+	}
+	otherHasIdentified, err := q.HasIdentifiedSessions(ctx, otherProjectID)
+	if err != nil || otherHasIdentified {
+		t.Fatalf("anonymous project = %v err=%v, want false", otherHasIdentified, err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE sessions SET status = 'deleting' WHERE id = 'sess_identified'`); err != nil {
+		t.Fatalf("mark identified session deleting: %v", err)
+	}
+	hasIdentified, err = q.HasIdentifiedSessions(ctx, projectID)
+	if err != nil || hasIdentified {
+		t.Fatalf("deleting-only project = %v err=%v, want false", hasIdentified, err)
 	}
 }
 

--- a/packages/ingestion/handler/session_read.go
+++ b/packages/ingestion/handler/session_read.go
@@ -37,6 +37,11 @@ type sessionJSON struct {
 	PlayableChunkCount int                 `json:"playable_chunk_count"`
 	BytesStored        int64               `json:"bytes_stored"`
 	PageURL            *string             `json:"page_url,omitempty"`
+	SDKRelease         *string             `json:"sdk_release,omitempty"`
+	ErrorCount         int                 `json:"error_count"`
+	RageClickCount     int                 `json:"rage_click_count"`
+	DeadClickCount     int                 `json:"dead_click_count"`
+	FormAbandonCount   int                 `json:"form_abandon_count"`
 	EndUser            *sessionEndUserJSON `json:"end_user,omitempty"`
 }
 
@@ -50,8 +55,9 @@ type sessionChunkJSON struct {
 }
 
 type sessionListJSON struct {
-	Sessions   []sessionJSON `json:"sessions"`
-	NextCursor *string       `json:"next_cursor,omitempty"`
+	Sessions              []sessionJSON `json:"sessions"`
+	NextCursor            *string       `json:"next_cursor,omitempty"`
+	HasIdentifiedSessions bool          `json:"has_identified_sessions"`
 }
 
 type sessionDetailJSON struct {
@@ -68,6 +74,11 @@ func toSessionJSON(session db.SessionSummary) sessionJSON {
 		PlayableChunkCount: session.PlayableChunkCount,
 		BytesStored:        session.BytesStored,
 		PageURL:            session.PageURL,
+		SDKRelease:         session.SDKRelease,
+		ErrorCount:         session.ErrorCount,
+		RageClickCount:     session.RageClickCount,
+		DeadClickCount:     session.DeadClickCount,
+		FormAbandonCount:   session.FormAbandonCount,
 	}
 	if session.LastChunkAt != nil {
 		formatted := session.LastChunkAt.Format(time.RFC3339Nano)
@@ -175,13 +186,33 @@ func (d *Dependencies) ListSessionsEndpoint(w http.ResponseWriter, r *http.Reque
 		}
 		limit = max(1, min(200, parsed))
 	}
+	hasSignals := false
+	if rawHasSignals := query.Get("has_signals"); rawHasSignals != "" {
+		parsed, parseErr := strconv.ParseBool(rawHasSignals)
+		if parseErr != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid has_signals")
+			return
+		}
+		hasSignals = parsed
+	}
 
+	queryStartedAt := time.Now()
 	sessions, next, err := d.Queries.ListSessions(r.Context(), projectID, db.SessionFilters{
 		EndUserID: query.Get("end_user_id"), AccountID: query.Get("account_id"), EnvironmentID: environmentID,
-		From: from, To: to,
+		Search: strings.TrimSpace(query.Get("search")), HasSignals: hasSignals, From: from, To: to,
 	}, cursor, limit)
+	queryDuration := time.Since(queryStartedAt)
 	if err != nil {
-		slog.Error("list sessions failed", "error", err, "project_id", projectID)
+		slog.Error("list sessions failed", "error", err, "project_id", projectID,
+			"duration_ms", queryDuration.Milliseconds(), "has_signals", hasSignals)
+		writeJSONError(w, http.StatusInternalServerError, "failed to list sessions")
+		return
+	}
+	slog.Info("session list query completed", "project_id", projectID,
+		"duration_ms", queryDuration.Milliseconds(), "has_signals", hasSignals, "result_count", len(sessions))
+	hasIdentifiedSessions, err := d.Queries.HasIdentifiedSessions(r.Context(), projectID)
+	if err != nil {
+		slog.Error("check identified sessions failed", "error", err, "project_id", projectID)
 		writeJSONError(w, http.StatusInternalServerError, "failed to list sessions")
 		return
 	}
@@ -189,7 +220,9 @@ func (d *Dependencies) ListSessionsEndpoint(w http.ResponseWriter, r *http.Reque
 	for _, session := range sessions {
 		result = append(result, toSessionJSON(session))
 	}
-	writeJSON(w, http.StatusOK, sessionListJSON{Sessions: result, NextCursor: formatSessionCursor(next)})
+	writeJSON(w, http.StatusOK, sessionListJSON{
+		Sessions: result, NextCursor: formatSessionCursor(next), HasIdentifiedSessions: hasIdentifiedSessions,
+	})
 }
 
 // GetSessionEndpoint returns session metadata plus its scrubbed-only manifest.

--- a/packages/ingestion/handler/session_read_test.go
+++ b/packages/ingestion/handler/session_read_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -93,16 +94,45 @@ func TestSessionRead_ListAndDetailRoutes(t *testing.T) {
 			t.Fatalf("insert session: %v", err)
 		}
 	}
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE sessions SET sdk_release = '@opslane/sdk@1.4.2' WHERE id = $1`, listIDs[0]); err != nil {
+		t.Fatalf("seed sdk release: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO friction_signals (
+			session_id, project_id, environment_id, rule_version, signal_type,
+			fingerprint, page_url_normalized, occurred_at, occurrence_count,
+			adjudication_status
+		) VALUES ($1, $2, $3, 1, 'rage_click', 'handler-rage', '/', now(), 4, 'accepted')`,
+		listIDs[0], projectID, envID,
+	); err != nil {
+		t.Fatalf("seed friction signal: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO error_events (
+			project_id, environment_id, timestamp, error_type, error_message,
+			stack_trace_raw, session_id
+		) VALUES ($2, $3, now(), 'TypeError', 'boom', 'at handler test', $1)`,
+		listIDs[0], projectID, envID,
+	); err != nil {
+		t.Fatalf("seed error event: %v", err)
+	}
 	seedHandlerChunk(t, deps.Queries, listIDs[0], projectID, 0, true, 2048)
 	seedHandlerChunk(t, deps.Queries, listIDs[0], projectID, 1, false, 0)
 
-	first := dashboardRequest(t, router, token, "/api/v1/projects/"+projectID+"/sessions?account_id=acme&limit=1")
+	var logOutput bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+	t.Cleanup(func() { slog.SetDefault(originalLogger) })
+
+	first := dashboardRequest(t, router, token, "/api/v1/projects/"+projectID+"/sessions?search=user%40acme.test&has_signals=true&limit=1")
 	if first.Code != http.StatusOK {
 		t.Fatalf("list returned %d: %s", first.Code, first.Body.String())
 	}
 	var list struct {
-		Sessions []map[string]any `json:"sessions"`
-		Next     *string          `json:"next_cursor"`
+		Sessions              []map[string]any `json:"sessions"`
+		Next                  *string          `json:"next_cursor"`
+		HasIdentifiedSessions bool             `json:"has_identified_sessions"`
 	}
 	if err := json.Unmarshal(first.Body.Bytes(), &list); err != nil {
 		t.Fatalf("decode list: %v", err)
@@ -110,11 +140,25 @@ func TestSessionRead_ListAndDetailRoutes(t *testing.T) {
 	if len(list.Sessions) != 1 || list.Sessions[0]["id"] != listIDs[0] {
 		t.Fatalf("filtered sessions = %+v", list.Sessions)
 	}
+	if !list.HasIdentifiedSessions {
+		t.Fatal("has_identified_sessions = false, want project-level true")
+	}
 	if list.Sessions[0]["playable_chunk_count"] != float64(1) || list.Sessions[0]["chunk_count"] != float64(2) {
 		t.Fatalf("chunk counts = %+v", list.Sessions[0])
 	}
+	if list.Sessions[0]["sdk_release"] != "@opslane/sdk@1.4.2" ||
+		list.Sessions[0]["error_count"] != float64(1) ||
+		list.Sessions[0]["rage_click_count"] != float64(4) ||
+		list.Sessions[0]["dead_click_count"] != float64(0) ||
+		list.Sessions[0]["form_abandon_count"] != float64(0) {
+		t.Fatalf("summary fields = %+v", list.Sessions[0])
+	}
 	if _, ok := list.Sessions[0]["end_user"].(map[string]any); !ok {
 		t.Fatalf("end_user shape = %#v", list.Sessions[0]["end_user"])
+	}
+	if logs := logOutput.String(); !strings.Contains(logs, "session list query completed") ||
+		!strings.Contains(logs, "duration_ms=") || !strings.Contains(logs, "project_id="+projectID) {
+		t.Fatalf("list query duration log = %q", logs)
 	}
 	filterValues := url.Values{
 		"end_user_id": {userID},
@@ -142,6 +186,10 @@ func TestSessionRead_ListAndDetailRoutes(t *testing.T) {
 	if malformed.Code != http.StatusBadRequest {
 		t.Fatalf("malformed cursor returned %d", malformed.Code)
 	}
+	badHasSignals := dashboardRequest(t, router, token, "/api/v1/projects/"+projectID+"/sessions?has_signals=maybe")
+	if badHasSignals.Code != http.StatusBadRequest {
+		t.Fatalf("invalid has_signals returned %d", badHasSignals.Code)
+	}
 	wrongProject := dashboardRequest(t, router, token, "/api/v1/projects/"+otherProjectID+"/sessions")
 	if wrongProject.Code != http.StatusForbidden {
 		t.Fatalf("wrong project returned %d", wrongProject.Code)
@@ -154,6 +202,11 @@ func TestSessionRead_ListAndDetailRoutes(t *testing.T) {
 	var detailJSON map[string]any
 	if err := json.Unmarshal(detail.Body.Bytes(), &detailJSON); err != nil {
 		t.Fatalf("decode detail: %v", err)
+	}
+	if detailJSON["sdk_release"] != "@opslane/sdk@1.4.2" ||
+		detailJSON["error_count"] != float64(1) ||
+		detailJSON["rage_click_count"] != float64(4) {
+		t.Fatalf("detail summary fields = %+v", detailJSON)
 	}
 	chunks, ok := detailJSON["chunks"].([]any)
 	if !ok || len(chunks) != 1 {

--- a/test-e2e/dashboard-design-system.test.ts
+++ b/test-e2e/dashboard-design-system.test.ts
@@ -38,7 +38,7 @@ function sourceFiles(directory: string): string[] {
 describe('dashboard V1 safeguards', () => {
   it('requires a documented production consumer for every owned component', () => {
     const matrix = read('docs/design/dashboard-v1/consumer-matrix.md');
-    const ownedRoots = ['ui', 'layout', 'evidence', 'incidents'];
+    const ownedRoots = ['ui', 'layout', 'evidence', 'incidents', 'sessions'];
     const production = sourceFiles(resolve(DASHBOARD, 'src')).filter((path) =>
       !/\.(?:test|spec)\.ts$/.test(path) &&
       !path.includes('/__tests__/') &&
@@ -119,6 +119,33 @@ describe.skipIf(!browserAvailable)('dashboard deterministic Chromium smoke', () 
       harness.assertClean();
     });
   }
+
+  it('renders the session ledger fixture with decision signals and mobile-preserved chips', async () => {
+    await harness.page.setViewportSize({ width: 1440, height: 1000 });
+    await harness.page.goto(`${harness.url}/sessions`);
+    await expect.poll(async () => harness.page.getByRole('heading', { name: 'Recorded sessions' }).count())
+      .toBe(1);
+
+    const table = harness.page.getByRole('table', { name: 'Recorded sessions' });
+    expect(await table.locator('tbody tr').count()).toBe(4);
+    expect(await table.getByText('3 errors', { exact: true }).count()).toBeGreaterThan(0);
+    expect(await table.getByText('2 rage clicks', { exact: true }).count()).toBeGreaterThan(0);
+    expect(await table.getByText('Queued', { exact: true }).count()).toBeGreaterThan(0);
+    expect(await table.getByText('Analysis failed', { exact: true }).count()).toBeGreaterThan(0);
+    expect(await table.locator('tbody tr').nth(3).locator('a').count()).toBe(0);
+    expect(await table.locator('tbody tr').nth(3).locator('[aria-disabled="true"]').count()).toBe(1);
+
+    await harness.page.setViewportSize({ width: 390, height: 844 });
+    expect(await table.locator('th').filter({ hasText: 'Signals' }).evaluate((element) =>
+      getComputedStyle(element).display)).toBe('none');
+    const mobileSignals = table.locator('tbody tr').first().locator('td').first();
+    expect(await mobileSignals.getByText('3 errors', { exact: true }).count()).toBe(1);
+    expect(await harness.page.evaluate(() =>
+      document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
+
+    await harness.page.setViewportSize({ width: 1440, height: 1000 });
+    harness.assertClean();
+  });
 
   it('wires Settings tabs to real tabpanels', async () => {
     await harness.page.goto(`${harness.url}/settings`);

--- a/test-e2e/dashboard-environment-filter.test.ts
+++ b/test-e2e/dashboard-environment-filter.test.ts
@@ -33,6 +33,17 @@ describe.skipIf(!configured || !playwrightAvailable)('dashboard environment filt
   const stagingOnlyTitle = `phase2 staging ${crypto.randomUUID()}`;
   const productionPage = `https://app.example.test/production-${crypto.randomUUID()}`;
   const stagingPage = `https://app.example.test/staging-${crypto.randomUUID()}`;
+  // The session ledger renders the page *path* as text on the row's metadata
+  // line, not the full URL as a link: the whole row is a single link to the
+  // replay, so a second anchor would give one row two competing destinations.
+  // Identify rows by the path the UI actually paints.
+  // Mirrors SessionLedgerRow's pagePath: pathname + search, host dropped.
+  const pageRowPath = (url: string): string => {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}`;
+  };
+  const productionPagePath = pageRowPath(productionPage);
+  const stagingPagePath = pageRowPath(stagingPage);
 
   async function ingest(apiKey: string, message: string): Promise<string> {
     const response = await postEvent(apiKey, {
@@ -100,7 +111,10 @@ describe.skipIf(!configured || !playwrightAvailable)('dashboard environment filt
   it('gates readiness and filters incidents, detail chips, and sessions in real Chromium', async () => {
     const { ingestionUrl } = getConfig();
     const db = getPool();
-    const context = await browser.newContext();
+    // Pinned, not left to Playwright's default: the session row only paints the
+    // page path at >=1024px (`hidden ... lg:inline`), so the assertions below
+    // are width-dependent in a way the old full-URL link assertion was not.
+    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
     await context.addCookies([{
       name: '__opslane_at',
       value: jwt,
@@ -149,18 +163,18 @@ describe.skipIf(!configured || !playwrightAvailable)('dashboard environment filt
       await page.goto(`${ingestionUrl}/sessions`);
       const sessionEnvironment = page.getByLabel('Environment');
       await sessionEnvironment.waitFor();
-      await page.getByRole('link', { name: stagingPage }).waitFor();
+      await page.getByText(stagingPagePath, { exact: true }).waitFor();
       await expect.poll(
-        () => page.getByRole('link', { name: productionPage }).count(),
+        () => page.getByText(productionPagePath, { exact: true }).count(),
       ).toBe(0);
 
       await Promise.all([
         page.waitForResponse((response) => response.url().includes(`environment_id=${tenant.environmentId}`)),
         sessionEnvironment.selectOption(tenant.environmentId),
       ]);
-      await page.getByRole('link', { name: productionPage }).waitFor();
+      await page.getByText(productionPagePath, { exact: true }).waitFor();
       await expect.poll(
-        () => page.getByRole('link', { name: stagingPage }).count(),
+        () => page.getByText(stagingPagePath, { exact: true }).count(),
       ).toBe(0);
     } finally {
       await page.close();

--- a/test-e2e/dashboard-mock-harness.ts
+++ b/test-e2e/dashboard-mock-harness.ts
@@ -60,7 +60,9 @@ export const dashboardMockFixtures = {
     responses: {
       'GET /api/v1/projects/project-1/incidents': { body: [] },
       'GET /api/v1/projects/project-1/accounts': { body: [] },
-      'GET /api/v1/projects/project-1/sessions': { body: { sessions: [], next_cursor: null } },
+      'GET /api/v1/projects/project-1/sessions': {
+        body: { sessions: [], next_cursor: null, has_identified_sessions: false },
+      },
     },
   },
   // The incident list fails while everything else succeeds, so the ledger's
@@ -120,7 +122,9 @@ function defaultBody(method: string, pathname: string): unknown {
   if (/\/accounts$/.test(pathname) && method === 'GET') return [mockAccount()];
   if (/\/accounts\/[^/]+\/incidents$/.test(pathname)) return [mockIncident()];
   if (/\/accounts\/[^/]+$/.test(pathname)) return mockAccount();
-  if (/\/sessions$/.test(pathname)) return { sessions: [mockSession()], next_cursor: null };
+  if (/\/sessions$/.test(pathname)) {
+    return { sessions: mockSessions(), next_cursor: null, has_identified_sessions: true };
+  }
   if (/\/sessions\/[^/]+\/chunks\/[0-9]+$/.test(pathname)) return { events: [] };
   if (/\/sessions\/[^/]+$/.test(pathname)) return { ...mockSession(), chunks: [] };
   if (/\/replays\/[^/]+$/.test(pathname)) return { events: [], meta: {} };
@@ -158,7 +162,85 @@ function mockAccount(): Record<string, unknown> {
 }
 
 function mockSession(): Record<string, unknown> {
-  return { id: 'session-1', started_at: '2026-01-01T00:00:00Z', last_chunk_at: '2026-01-01T00:00:05Z', status: 'closed', chunk_count: 0, playable_chunk_count: 0, bytes_stored: 0, page_url: 'https://example.test/mock' };
+  return mockSessions()[0]!;
+}
+
+function mockSessions(): Array<Record<string, unknown>> {
+  const base = {
+    bytes_stored: 2_048,
+    page_url: 'https://example.test/checkout?step=payment',
+    sdk_release: '1.4.2',
+  };
+  return [
+    {
+      ...base,
+      id: 'session-1',
+      started_at: '2026-07-22T20:02:00Z',
+      last_chunk_at: '2026-07-22T20:09:21Z',
+      status: 'analyzed',
+      chunk_count: 2,
+      playable_chunk_count: 2,
+      error_count: 3,
+      rage_click_count: 2,
+      dead_click_count: 0,
+      form_abandon_count: 0,
+      end_user: {
+        id: 'end-user-1',
+        external_user_id: 'user-123',
+        email: 'jane@acme.com',
+        external_account_id: 'account-1',
+        account_name: 'Acme Corp',
+      },
+    },
+    {
+      ...base,
+      id: 'session-anonymous-clean-8f3a2c1b',
+      started_at: '2026-07-22T19:31:00Z',
+      last_chunk_at: '2026-07-22T19:33:48Z',
+      status: 'analyzed',
+      chunk_count: 1,
+      playable_chunk_count: 1,
+      error_count: 0,
+      rage_click_count: 0,
+      dead_click_count: 0,
+      form_abandon_count: 0,
+      end_user: null,
+    },
+    {
+      ...base,
+      id: 'session-queued',
+      started_at: '2026-07-22T19:18:00Z',
+      last_chunk_at: '2026-07-22T19:19:05Z',
+      status: 'closed',
+      chunk_count: 1,
+      playable_chunk_count: 1,
+      error_count: 0,
+      rage_click_count: 0,
+      dead_click_count: 0,
+      form_abandon_count: 0,
+      end_user: {
+        id: 'end-user-2',
+        external_user_id: 'user-queued',
+        email: null,
+        external_account_id: 'account-1',
+        account_name: 'Acme Corp',
+      },
+    },
+    {
+      ...base,
+      id: 'session-unavailable',
+      started_at: '2026-07-22T18:59:00Z',
+      last_chunk_at: null,
+      status: 'analysis_failed',
+      chunk_count: 2,
+      playable_chunk_count: 0,
+      error_count: 1,
+      rage_click_count: 0,
+      dead_click_count: 1,
+      form_abandon_count: 0,
+      end_user: null,
+    },
+  ];
 }
 
 function mockAdminOverview(): Record<string, unknown> {

--- a/test-e2e/dashboard-mock-harness.ts
+++ b/test-e2e/dashboard-mock-harness.ts
@@ -194,7 +194,11 @@ function mockSessions(): Array<Record<string, unknown>> {
     },
     {
       ...base,
-      id: 'session-anonymous-clean-8f3a2c1b',
+      // Real shape, not a descriptive slug: the SDK emits either
+      // crypto.randomUUID() or `sess_`+32 hex (sdk/src/session.ts:37-46). A
+      // descriptive id makes the row's short-id rendering unrepresentative of
+      // what any user sees, and two slugs sharing a prefix collide on screen.
+      id: '8f3a2c1b-4d6e-4a91-b0c7-2e5f1a9d3b84',
       started_at: '2026-07-22T19:31:00Z',
       last_chunk_at: '2026-07-22T19:33:48Z',
       status: 'analyzed',
@@ -228,7 +232,8 @@ function mockSessions(): Array<Record<string, unknown>> {
     },
     {
       ...base,
-      id: 'session-unavailable',
+      // The `sess_`+hex fallback the SDK uses outside a secure context.
+      id: 'sess_c47d90a1e6b25f38047ac1d9e83b6f52',
       started_at: '2026-07-22T18:59:00Z',
       last_chunk_at: null,
       status: 'analysis_failed',

--- a/test-e2e/dashboard-screenshots.test.ts
+++ b/test-e2e/dashboard-screenshots.test.ts
@@ -62,7 +62,7 @@ describe.skipIf(!browserAvailable || !captureEnabled)('dashboard approved-fixtur
     { path: '/incidents/incident-1', fixture: 'incident-pr-created-mock', identity: /Mock incident title/i, harness: 'success' },
     { path: '/accounts', fixture: 'accounts-success-mock', identity: /^Accounts$/i, harness: 'success' },
     { path: '/accounts/account-1', fixture: 'account-detail-success-mock', identity: /Mock Account/i, harness: 'success' },
-    { path: '/sessions', fixture: 'sessions-success-mock', identity: /^Sessions$/i, harness: 'success' },
+    { path: '/sessions', fixture: 'sessions-success-mock', identity: /^Recorded sessions$/i, harness: 'success' },
     { path: '/sessions/session-1', fixture: 'session-detail-success-mock', identity: /Session details/i, harness: 'success' },
     { path: '/settings', fixture: 'settings-success-mock', identity: /^Settings$/i, harness: 'success' },
     { path: '/admin', fixture: 'admin-success-mock', identity: /System observability/i, harness: 'success' },


### PR DESCRIPTION
## Problem

`/sessions` showed how a recording was **stored**, not what happened **inside** it. Five of seven columns carried no decision-changing signal: `Chunks 2/2`, `Size 2.4 KB`, an always-`analyzed` status, the first page URL (identical on every row), and a `User` column that was empty whenever the SDK never called `identify()`. The click target was the relative timestamp. The filters asked for raw UUIDs nobody knows by heart.

Opslane is an error-resolution engine. This screen has to answer one question — **which session should I watch?** — and storage columns cannot answer it.

## What changed

Three columns, two lines per row: **Session / Signals / Started**.

- **Signals** surfaces per-session error and friction counts that were already in the database and never exposed — `friction_signals` (rage clicks, dead clicks, form abandons) and `error_events.session_id`.
- **Identity follows PostHog/LogRocket terminology.** The identifier (`external_user_id`) is required and stable; email and account are *traits*. Display name resolves `email` → `external_user_id` → `Anonymous`. The column is **User**, never "Email".
- **One click target per row.** The play glyph and the display name are a single link with a 44px tap target. The copy-session-id control is an explicit sibling, never nested inside the anchor.
- **Filters: five controls to four.** One search box matching user, email, account, or session id; a date-range preset; environment; and an `All / With signals` toggle that turns the redesign from nicer rows into actual triage.
- **Anonymous is the common case, and the screen says so.** The dev database is 198 anonymous of 205 sessions, because `setUser()` appears in neither `docs/install.md` nor the quickstart. A one-time, dismissible, project-scoped hint links to the docs and states that identifying fields are sent unmasked.

## Data access

One query, not three. An earlier draft fanned out into a page query plus two follow-ups; that reasoning did not hold, because `sessionSummarySelect` already runs a correlated subquery per row and the `has_signals` filter forces friction predicates into the paginating query anyway, leaving `friction_signals` read twice per request. Two `LEFT JOIN LATERAL` blocks give the counts and the filter from a single read, and `GetSessionSummary` inherits them for free.

Three rules in that SQL are load-bearing and each has a test:

- `sum(occurrence_count)`, not `count(*)` — repeats within a session live in `occurrence_count` (`004_friction.sql:47`). `count(*)` would render three rage clicks on one button as "1 rage click".
- `adjudication_status = 'accepted'` — keyless deployments skip adjudication and *"signals stay pending and invisible"* (`worker/src/index.ts:628`). Counting unadjudicated rows would make this screen disagree with the incident ledger.
- `project_id` inside both LATERALs, per `packages/ingestion/AGENTS.md`.

Session-id search matches the primary key exactly. `EXPLAIN` on the live database: `s.id ILIKE 'abc%'` costs **367.86** (full index scan plus filter) against **4.29** for exact match. Email keeps `ILIKE` — the project index already bounds it, and `ILIKE` never takes an `Index Cond` on a plain btree regardless of anchoring.

## Verification

Query semantics were checked against the real database (205 sessions) by seeding friction signals inside a transaction and rolling back:

| Rule | Expected | Got |
|---|---|---|
| `sum(occurrence_count)` | 3 | **3** (`count(*)` gives 1) |
| pending + rejected excluded | 0 | **0** |
| retracted excluded | 0 | **0** |

Browser pass against the built dashboard: zero console errors, zero page errors, zero unexpected requests. Row link 432×44. No `a > button` nesting. At 390×844 there is no horizontal overflow and the Signals chips fold into the Session cell rather than disappearing.

```
go build ./... && go test ./db ./handler     ok
pnpm --filter @opslane/dashboard test        47 files, 235 tests
pnpm --filter @opslane/dashboard build       built in 1.07s
dashboard-design-system.test.ts              14 passed (incl. /sessions at 390x844)
```

## QA findings, fixed in this branch

- **ISSUE-001** — the anonymous short id used `id.slice(-8)`, rendering `12577000` (a nanosecond fragment) for `sess_sdk_normal_1784676521012577000` and `vailable` for `session-unavailable`. Now takes the distinguishing head. Random UUIDs were unaffected either way.
- **ISSUE-002** — that fix then collided two mock rows on `session-`. Root cause was the fixture: the SDK emits `crypto.randomUUID()` or `sess_`+32hex, so descriptive slugs made the e2e screenshots unrepresentative. Replaced with real id shapes.

## Not verified

- **No live end-to-end.** The ingestion container on `:8082` runs an older binary and is shared across worktrees, so it was not rebuilt. The query was verified directly against the database and the UI against the built dashboard with mocked responses — both halves, but not joined.
- **Friction chips have never rendered real data.** The database holds zero `friction_signals` rows. Error counts did render from real rows (485 `error_events` carry a `session_id`).
- **8 of 17 e2e files were skipped** — they need `DATABASE_URL` and seed tenants into the shared Postgres.

## Follow-ups worth filing

- `setUser()` is missing from `docs/install.md` and the quickstart. That is the root cause of the 3.4% identification rate, and the hint in this PR only points at the symptom.
- `has_signals` scan cost scales as `51 / selectivity`. Accepted with an explicit tripwire: p95 above 200ms means denormalize `sessions.has_signals` with a partial index.
- rrweb is ~194KB and 40% of the entry chunk, shipped to `/sessions` which never plays a recording, because `IncidentDetail.vue` statically imports `ReplayPlayer.vue`.

Plan and full review history: `docs/plans/2026-07-22-session-list-redesign.md`. Cleared by `/plan-design-review` (4/10 → 10/10) and `/plan-eng-review` (18 findings, 3 critical gaps all covered by tests).
