### PR TITLE
Onboard account provisioning

### DIFF
--- a/docs/architecture/trust.md
+++ b/docs/architecture/trust.md
@@ -74,7 +74,7 @@ See [replay privacy and masking](../guides/replay-privacy.md) for what replay da
 - **Passwords** (when password authentication is enabled) are not stored locally — registration, authentication, and reset are handled by the configured identity provider (WorkOS).
 - **GitHub App private key** and worker credentials are environment variables — supplied by your deployment, never written to the database.
 - **Notification webhook URLs** are encrypted at rest in the database; the encryption key is supplied as an environment variable.
-- **Agent onboarding sessions** store poll tokens as hashes and API keys sealed with ephemeral agent public keys (24-hour expiry); raw values are shown once at provisioning.
+- **Agent onboarding sessions** store poll tokens as hashes and API keys sealed with ephemeral agent public keys (24-hour expiry); raw values are shown once at provisioning. Provisioning requires admin role.
 - **Pending OAuth verification tokens** from identity providers are sealed and stored temporarily (10-minute TTL) during email verification flows; the encryption key is supplied as an environment variable.
 
 ## Honest gaps (current state)
@@ -89,4 +89,3 @@ These are known, tracked, and stated here so you can make an informed deployment
 ## Why the prompts are public
 
 The investigation and fix prompts live in this repository (`packages/worker/src`), not behind an API. That is intentional: you can read exactly what instructions the agent operates under, what it is told never to do, and how untrusted error text is fenced (`<untrusted_user_data>` delimiters in the fix loop) before you let it near your code.
-

--- a/packages/ingestion/db/migrations/026_agent_session_actor.sql
+++ b/packages/ingestion/db/migrations/026_agent_session_actor.sql
@@ -1,3 +1,22 @@
 -- Record the authenticated user who provisioned an onboarding agent session.
+-- ON DELETE SET NULL keeps the session row (and its status/expiry contract)
+-- intact when the actor is deleted; without an explicit rule the default
+-- NO ACTION makes any provisioning user undeletable.
 ALTER TABLE agent_sessions
-  ADD COLUMN IF NOT EXISTS provisioned_by_user_id UUID REFERENCES users(id);
+  ADD COLUMN IF NOT EXISTS provisioned_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL;
+
+-- ProvisionOnboardSession expires prior sessions with
+-- WHERE org_id = $1 AND project_id = $2 AND provisioned_by_user_id IS NOT NULL
+-- AND status IN (...) while holding the project row lock. The only other
+-- indexes on this table are partial on status = 'pending' and on created_at,
+-- so without this the expiry sequentially scans agent_sessions inside the
+-- provisioning transaction.
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_provisioned_actor
+  ON agent_sessions (org_id, project_id, status)
+  WHERE provisioned_by_user_id IS NOT NULL;
+
+-- An unindexed foreign key forces a full scan of the child table on every
+-- users(id) delete.
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_provisioned_by
+  ON agent_sessions (provisioned_by_user_id)
+  WHERE provisioned_by_user_id IS NOT NULL;

--- a/packages/ingestion/handler/onboard_provision.go
+++ b/packages/ingestion/handler/onboard_provision.go
@@ -11,6 +11,11 @@ import (
 
 var onboardProvisionLimiter = newRateLimiter(10)
 
+const (
+	maxOnboardRepoURLLen   = 200
+	maxOnboardAgentNameLen = 64
+)
+
 // OnboardProvision creates or reuses a project for an authenticated user's
 // organization and returns a freshly rotated API key plus poll credentials.
 //
@@ -43,6 +48,16 @@ func (d *Dependencies) OnboardProvision(w http.ResponseWriter, r *http.Request) 
 	}
 	if !repoURLPattern.MatchString(req.RepoURL) {
 		writeJSONError(w, http.StatusBadRequest, "repo_url must be in owner/repo format")
+		return
+	}
+	// The repo becomes part of the project idempotency token, which is indexed;
+	// an unbounded value would fail deep in Postgres as a 500 instead of a 400.
+	if len(req.RepoURL) > maxOnboardRepoURLLen {
+		writeJSONError(w, http.StatusBadRequest, "repo_url must be 200 characters or less")
+		return
+	}
+	if len(req.AgentName) > maxOnboardAgentNameLen {
+		writeJSONError(w, http.StatusBadRequest, "agent_name must be 64 characters or less")
 		return
 	}
 	var agentName *string

--- a/packages/ingestion/handler/onboard_provision_integration_test.go
+++ b/packages/ingestion/handler/onboard_provision_integration_test.go
@@ -35,9 +35,20 @@ func TestOnboardProvisionRealRouterAuthorizationAndLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	admin, err := queries.CreateUserGitHub(ctx, org.ID,
+		fmt.Sprintf("onboard-admin-%s@example.com", uuid.NewString()),
+		"Onboard Admin", time.Now().UnixNano(), "onboard-admin", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := queries.CreateMembership(ctx, admin.ID, org.ID, "admin"); err != nil {
+		t.Fatal(err)
+	}
+	// Provisioning mints and rotates a production key, so it is admin-gated
+	// like every sibling key route; a plain org member must be refused.
 	member, err := queries.CreateUserGitHub(ctx, org.ID,
 		fmt.Sprintf("onboard-member-%s@example.com", uuid.NewString()),
-		"Onboard Member", time.Now().UnixNano(), "onboard-member", "")
+		"Onboard Member", time.Now().UnixNano()+1, "onboard-member", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +57,7 @@ func TestOnboardProvisionRealRouterAuthorizationAndLifecycle(t *testing.T) {
 	}
 	nonMember, err := queries.CreateUserGitHub(ctx, org.ID,
 		fmt.Sprintf("onboard-outsider-%s@example.com", uuid.NewString()),
-		"Onboard Outsider", time.Now().UnixNano()+1, "onboard-outsider", "")
+		"Onboard Outsider", time.Now().UnixNano()+2, "onboard-outsider", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,6 +69,12 @@ func TestOnboardProvisionRealRouterAuthorizationAndLifecycle(t *testing.T) {
 		cleanupTenantHandler(t, pool, org.ID)
 	})
 
+	adminToken, err := auth.SignAccessToken(
+		[]byte(authTestJWTSecret), admin.ID, org.ID, admin.Email,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	memberToken, err := auth.SignAccessToken(
 		[]byte(authTestJWTSecret), member.ID, org.ID, member.Email,
 	)
@@ -103,10 +120,13 @@ func TestOnboardProvisionRealRouterAuthorizationAndLifecycle(t *testing.T) {
 	if response := postProvision(nonMemberToken); response.Code != http.StatusForbidden {
 		t.Fatalf("non-member status=%d body=%s", response.Code, response.Body.String())
 	}
+	if response := postProvision(memberToken); response.Code != http.StatusForbidden {
+		t.Fatalf("non-admin member status=%d body=%s", response.Code, response.Body.String())
+	}
 
-	provisionResponse := postProvision(memberToken)
+	provisionResponse := postProvision(adminToken)
 	if provisionResponse.Code != http.StatusCreated {
-		t.Fatalf("member status=%d body=%s", provisionResponse.Code, provisionResponse.Body.String())
+		t.Fatalf("admin status=%d body=%s", provisionResponse.Code, provisionResponse.Body.String())
 	}
 	if got := provisionResponse.Header().Get("Cache-Control"); got != "no-store" {
 		t.Fatalf("Cache-Control=%q, want no-store", got)
@@ -131,8 +151,8 @@ func TestOnboardProvisionRealRouterAuthorizationAndLifecycle(t *testing.T) {
 	).Scan(&actorID, &sessionStatus, &createdAt, &expiresAt, &keyClaimedAt); err != nil {
 		t.Fatal(err)
 	}
-	if actorID != member.ID || sessionStatus != "provisioned" {
-		t.Fatalf("actor/status=%s/%s, want %s/provisioned", actorID, sessionStatus, member.ID)
+	if actorID != admin.ID || sessionStatus != "provisioned" {
+		t.Fatalf("actor/status=%s/%s, want %s/provisioned", actorID, sessionStatus, admin.ID)
 	}
 	if keyClaimedAt != nil {
 		t.Fatal("synchronous provisioning must not mark the key claimed before the CLI polls")
@@ -205,7 +225,7 @@ func TestOnboardProvisionRealRouterAuthorizationAndLifecycle(t *testing.T) {
 		t.Fatalf("reporting poll status=%d payload=%v", code, payload)
 	}
 
-	repeatResponse := postProvision(memberToken)
+	repeatResponse := postProvision(adminToken)
 	if repeatResponse.Code != http.StatusCreated {
 		t.Fatalf("repeat status=%d body=%s", repeatResponse.Code, repeatResponse.Body.String())
 	}

--- a/packages/ingestion/handler/routes.go
+++ b/packages/ingestion/handler/routes.go
@@ -110,7 +110,7 @@ func NewRouterWithPool(deps *Dependencies, pool *pgxpool.Pool) *chi.Mux {
 		r.With(deps.AuthenticateUserSession, deps.RequireAdmin).Get("/admin/jobs", deps.AdminJobs)
 
 		// Onboarding
-		r.With(deps.AuthenticateUserSession).Post("/onboard/provision", deps.OnboardProvision)
+		r.With(deps.AuthenticateUserSession, deps.RequireRoleIfCloud("admin")).Post("/onboard/provision", deps.OnboardProvision)
 		r.With(deps.AuthenticateUserSession, deps.RequireRoleIfCloud("admin")).Post("/onboarding/setup", deps.OnboardingSetup)
 
 		// Project CRUD


### PR DESCRIPTION
Milestone 0.5 of the onboarding work: a `POST /api/v1/onboard/provision` endpoint that provisions an org-scoped project for a repo and hands the CLI a one-time API key, without requiring a GitHub App installation.

Bottom of a two-PR stack. The Detect stage sits on top of this.

## What it does

`ProvisionOnboardSession` (`packages/ingestion/db/onboard_provision.go`) runs one transaction that:

1. upserts the org's project for the repo, keyed on the idempotency token `onboard:<lowercased repo>`, and rotates its provisioning key;
2. expires every older account-provisioned session for that project, unsealing `api_key_sealed`, so an older CLI gets an actionable 410 instead of dead credentials;
3. inserts the replacement session and seals the raw key against the caller's ephemeral agent public key (24-hour TTL).

Key rotation, prior-session invalidation, and replacement-session creation share the project row lock, which serializes concurrent onboarding attempts on the same repo. `ProvisionProject` was split into a thin wrapper over `provisionProjectTx` so a caller-owned transaction can reuse the body.

Migration `026` adds `agent_sessions.provisioned_by_user_id` with `ON DELETE SET NULL`, plus partial indexes for the prior-session expiry (which runs under the project row lock) and for the foreign key.

## Security posture

- Admin-gated in cloud mode via `RequireRoleIfCloud("admin")`, matching `POST /projects`, `POST /environments/{envID}/api-keys`, and `POST /onboarding/setup`. Without it any org member could re-provision an onboarded repo and revoke the live ingest key.
- Rate limited to 10/min per user; `Cache-Control: no-store`; 64 KB body cap.
- `repo_url` bounded to 200 characters (it becomes part of an indexed idempotency token, so an unbounded value failed as a Postgres btree error and surfaced as a 500) and `agent_name` to 64.
- Poll tokens stored as hashes; API keys sealed with the ephemeral agent public key. Recorded in `docs/architecture/trust.md`.

## Known follow-up

[#181](https://github.com/opslane/opslane-oss/issues/181) — repo ownership is not verified, and this flow can create a second project row for a repo already onboarded through the GitHub App path (that flow inserts with a NULL `idempotency_token`, so the token-based upsert does not see it).

## Verification

`go build ./...`, `go test ./db ./handler -count=1` — both green, including the migration replay that the db tests perform.