### PR TITLE
fix(onboarding): resolve default branch from the clone, not a guess (#180)

### DIFF
--- a/docs/plans/2026-07-23-default-branch-resolution-design.md
+++ b/docs/plans/2026-07-23-default-branch-resolution-design.md
@@ -1,0 +1,440 @@
+# Default branch resolution (issue #180)
+
+Onboarding fails for every repo whose default branch is not `main`.
+`projects.default_branch` is written once with the schema default and never
+corrected from GitHub.
+
+Reviewed with `/plan-eng-review` on 2026-07-23 against `b18c6be`.
+
+## Root cause
+
+`001_baseline.sql:21` declares `default_branch TEXT NOT NULL DEFAULT 'main'`.
+That is not a default, it is a guess the schema cannot distinguish from a fact.
+Nothing downstream can tell "we confirmed `main`" apart from "we had to write
+something." Every other symptom in this issue follows from that one property.
+
+The two-phase onboarding design (`docs/plans/2026-07-22-onboarding-10x-design.md`,
+D1) makes "unknown" a normal state, not an edge case: Phase 1 is explicitly
+**"Local aha (no GitHub)"**. The project and its API key are minted before the
+GitHub App exists, from a repo string read off the local git remote. At that
+moment the default branch is genuinely unknowable, and the schema forces a lie.
+
+## Decision
+
+Let the column say "I don't know," then learn the answer at each of the three
+moments it becomes knowable. Never guess.
+
+```
+Phase 1 (no GitHub)          Phase 2 boundary            Every job
+─────────────────────        ─────────────────           ─────────
+OnboardProvision             PersistInstallation         git clone (no --branch)
+CreateProject                (App granted)                 └─> checks out remote HEAD
+  │                            │                              │
+  └─> default_branch = NULL    └─> resolve from the           ├─> PR base (same job)
+      no GitHub call               []Repo already in          └─> UPDATE projects
+      no authz check               hand — zero new                (cache refresh)
+                                   API calls
+                             SetGitHubConfig
+                               └─> resolve + authorize
+                                   (App already installed)
+```
+
+Why not the issue's proposal 1 (fetch and store at every write path): two of the
+four write paths run in Phase 1 where GitHub does not exist yet, so the call
+cannot be made there at all. And `webhook.go:57` ignores every event except
+`pull_request`, so a stored value goes stale on a default-branch rename
+regardless. Clone-time resolution is the only mechanism that stays correct.
+
+## Resolved decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D1 | Fix shape | Clone derives the branch; the DB column is a self-healing cache, never an authority |
+| 1 | Plumbing | Resolve at clone, return it, thread it to the PR base. Drop `defaultBranch` from `CloneOptions` |
+| 2 | Unresolvable HEAD | **Corrected.** Three-way classification via `ls-remote --heads`, not `rev-parse`. Typed error carrying repo + discovered branch |
+| 3 | Where to resolve | **Corrected.** Phase 1 paths do nothing. `PersistInstallation` resolves at the Phase 2 boundary, for **three** callers. `SetGitHubConfig` resolves and authorizes |
+| 4 | Error capture | Include `err.stderr`, redacted and truncated, on both clone sites |
+| 5 | DRY | One shared `resolveClonedBranch(run)` helper across both clone backends |
+| 6 | Schema | Nullable. `NULL` means unknown |
+
+### Correction log
+
+**C1.** An earlier draft of decision 3 put an installation lookup on the
+project-create path. That contradicts D1 of the onboarding design — Phase 1 has
+no GitHub by construction, so the check would have failed every CLI provision.
+The check moved to `PersistInstallation`.
+
+**C2.** That fix was itself incomplete. There is a **third** installation caller:
+agent-callback onboarding flattens repos at `handler/agent_setup.go:449-452`,
+calls `PersistInstallation` at `db/agent_provision.go:217`, and creates the
+project only afterwards at `:232`. A NULL-fill inside `PersistInstallation`
+therefore cannot see that project — the row does not exist yet. This path needs
+the branch carried in `AgentProvisionInput` and applied after `CreateProjectTx`,
+inside the same transaction.
+
+**C3.** Decision 2 used `git rev-parse --verify HEAD` to detect an empty repo.
+Verified empirically that this does not discriminate:
+
+| | genuinely empty | non-empty, HEAD → missing ref |
+|---|---|---|
+| `git clone` exit | 0 | 0 |
+| git stderr | `warning: You appear to have cloned an empty repository.` | **identical warning — actively wrong** |
+| `rev-parse --verify HEAD` | 128 | 128 |
+| `symbolic-ref --short HEAD` | `master` | `nonexistent` |
+| `ls-remote --heads origin` | **0** | **1** |
+
+Two consequences. `ls-remote --heads` is the discriminator, not `rev-parse`. And
+git's own stderr misreports the second case, so T4's "surface git's reason" is
+necessary but **not sufficient** for issue #180's "name the repo and the branch"
+criterion — that needs a typed error we construct ourselves.
+
+**C4.** Decision 3's fill used `IS NULL`, which would leave legacy rows holding
+the schema-guessed `'main'` permanently indistinguishable from a confirmed value
+— the exact root cause this plan opens by naming. Changed to `IS DISTINCT FROM`.
+Safe because no custom-target-branch feature exists: there is no UI, no API
+field, and no query that sets `default_branch` to anything but the schema
+default.
+
+## What already exists
+
+| Thing | Where | Reused or rebuilt |
+|---|---|---|
+| `default_branch` parsed from the GitHub API | `github/app.go:42` | **Reused.** Already populated on every `ListInstallationRepos` result. |
+| `[]Repo` in hand at the installation boundary | `github_oauth.go:367`, `:639`, and `handler/agent_setup.go:449` | **Reused.** All **three** callers already have `DefaultBranch` and throw it away flattening to `repoNames` at `:373`, `:643`, and `:449-452`. |
+| Transactional installation write | `db/installations.go:26` (`PersistInstallation`) | **Reused.** Already runs under an advisory lock in the caller's tx — the branch update joins it. Note the agent-callback caller creates its project *after* this call (`agent_provision.go:232`), so that path needs the branch applied post-create instead. |
+| Repo-grant authorization on the agent path | `agent_setup.go:448` (`repo_not_granted`) | **Already correct.** This path matches the canonical repo against granted repos; only the dashboard settings path lacks the check. |
+| The value already served to the browser | `github_oauth.go:820`; `dashboard/src/types/api.ts:294` | **Not used.** We resolve server-side rather than trusting a client-supplied branch. |
+| Token redaction on clone errors | `repo-clone.ts:88`, `sandbox-repo.ts:134` | **Reused** for the newly captured stderr. |
+| `needs_human` reason-code channel | `setup-agent.ts:52` | **Reused** for the empty-repo case. |
+| Project row updates from the worker | `db.ts:1106` | **Reused** pattern for the write-back. |
+| Argument-injection guard on branch names | `repo-clone.ts:67` | **Retired.** Its input leaves the interface under decision 1; its two tests (`repo-clone.test.ts:222,228`) go with it. |
+
+## Changes
+
+### Schema
+
+1. `027_default_branch_nullable.sql` — drop `NOT NULL` and the `'main'` default
+   on `projects.default_branch`. Existing rows keep their current value and heal
+   on next clone; no backfill.
+2. `db/queries.go` — 8 `DefaultBranch` scan sites move to a nullable type.
+   `db.ts:1068` `ProjectData.default_branch` becomes `string | null`. The type
+   change is the point: the compiler enumerates every reader.
+
+### Worker
+
+3. `repo-clone.ts` — remove `defaultBranch` from `CloneOptions`. Clone without
+   `--branch`. Add `resolveClonedBranch(run)` returning a three-way result, and
+   a typed `CloneResolutionError` carrying `{ repo, discoveredBranch, kind }`:
+
+   | Condition | `kind` | Message |
+   |---|---|---|
+   | `ls-remote --heads` returns 0 refs | `empty_repository` | "`owner/repo` has no commits yet" |
+   | heads exist, `symbolic-ref` names an absent ref | `invalid_default_branch` | "default branch `X` does not exist in `owner/repo`" |
+   | `symbolic-ref` itself fails (detached HEAD) | `unresolvable_head` | "could not determine the default branch of `owner/repo`" |
+
+   Do **not** rely on `rev-parse --verify HEAD` to classify, and do not rely on
+   git's stderr to name the branch — see correction C3. Return
+   `{ repoDir, defaultBranch, cleanup }` on success. Capture `stderr` in the
+   catch, scrubbed and truncated, as supporting detail rather than as the
+   classification.
+4. `harness/sandbox-repo.ts` — same helper with a `sandbox.commands.run` runner.
+   Read `err.stderr` (typed at `sandbox-runtime.ts:71`) instead of `err.message`
+   alone. Sandbox resolution is used for **validation and error reporting only**,
+   never as PR-base authority.
+5. `setup-agent.ts:80` and `index.ts:358` — stop mapping every clone failure to
+   `repo_access_denied`. Map `CloneResolutionError.kind` to the right
+   `reason_code` and remediation; today an empty repo tells the user to fix
+   GitHub App permissions.
+6. `setup-pr.ts` — use the **host** clone's resolved branch for `base` at
+   line 103. The host checkout is the one that receives the diff and is pushed
+   (`gitCommitAndPush(repoDir, …)`); the sandbox at `agent-fix.ts:611` is a
+   separate, later clone that could observe a rename mid-job.
+7. Thread the host value: `CloneResult.defaultBranch` → `PipelineInput` → PR
+   creation. **Remove** `defaultBranch` from `AgentFixInput`, `AgentSetupInput`,
+   and the sandbox clone inputs entirely, so there is one authority and no
+   second value to drift.
+8. `db.ts` — `updateProjectDefaultBranch(projectId, branch)`. Wire the call at
+   every host clone site: `index.ts:346`, `:525`, `:739`, `:882` and the
+   `setup-pr.ts` clone. Because the column is a cache and never an authority,
+   **every** write-back failure is logged and swallowed — not just the zero-rows
+   case. A transient UPDATE error must never fail work that already holds the
+   correct resolved branch.
+
+### Ingestion
+
+9. `db/installations.go` — `PersistInstallationParams.Repos` carries
+   `[]gh.Repo` (or a `{name, defaultBranch}` pair) instead of `[]string`. In the
+   same transaction, update `default_branch` for every project in the org whose
+   `github_repo` matches a covered repo and whose value `IS DISTINCT FROM` the
+   authoritative one. **Not `IS NULL`** — see correction C4; legacy `'main'` rows
+   are precisely the ambiguous case that needs correcting.
+10. `handler/github_oauth.go:373` and `:643` — stop flattening the branch away.
+11. `handler/agent_setup.go:449-452` and `db/agent_provision.go` — the third
+    caller. Flattening changes with the `Repos` type. Because
+    `CreateProjectTx` runs at `agent_provision.go:232`, *after*
+    `PersistInstallation` at `:217`, the NULL-fill cannot reach this project.
+    Carry the matched branch on `AgentProvisionInput` and set it on the project
+    immediately after creation, inside the same transaction.
+12. `handler/github_settings.go` — resolve the submitted repo against the org's
+    installation list. Unknown repo → 400 naming the repo and telling the user to
+    install the App on it. Store the matched `DefaultBranch`.
+
+### Explicitly unchanged
+
+`handler/onboard_provision.go` and `handler/onboarding.go`. Phase 1 makes no
+GitHub call, performs no repo authorization, and writes no branch. This is the
+correction described above, not an oversight.
+
+## Test coverage
+
+```
+CODE PATHS                                              USER FLOWS
+[~] packages/worker/src/repo-clone.ts                   [+] Onboard a master-default repo
+  └── cloneRepo()                                         ├── [GAP] [→E2E] setup PR opens against master
+      ├── [★★ TESTED] no token — :100                     └── [GAP]        wizard leaves step 4
+      ├── [★★ TESTED] token scrubbed — :107
+      ├── [★★ TESTED] alt host — :127                   [+] CLI Phase 1, no GitHub yet
+      ├── [GAP]       unpinned clone → master             ├── [GAP]        provision succeeds with NULL branch
+      ├── [GAP]       resolveClonedBranch returns name    └── [GAP]        no GitHub call is made   ← REGRESSION
+      ├── [GAP]       0 heads → empty_repository
+      ├── [GAP]       heads + absent ref →              [+] Phase 2, App granted (web)
+      │               invalid_default_branch (NOT empty)  └── [GAP]        NULL and stale 'main' both fill in
+      ├── [GAP]       detached → unresolvable_head
+      ├── [GAP]       error names repo AND branch       [+] Phase 2, App granted (agent callback)
+      ├── [GAP]       stderr surfaced in error            ├── [GAP]        project created AFTER install
+      └── [GAP]       token not leaked via stderr         │                still gets its branch
+      └── [DELETE]    branch guard — :222,:228            └── [GAP]        master-default repo end to end
+
+[~] packages/worker/src/harness/sandbox-repo.ts        [+] Existing project, stale 'main' row
+  └── createRepoSandbox()                                 └── [GAP]        clones + heals + PR base correct
+      ├── [★★ TESTED] setupCommands — :63,:78
+      ├── [GAP]       unpinned clone                   [+] Configure an uncovered repo in settings
+      ├── [GAP]       resolution failure propagates      └── [GAP]        400 names the repo
+      └── [GAP]       err.stderr reaches the message
+                                                       [+] Clone fails for a non-branch reason
+                                                         └── [GAP]        reason is not "fix your permissions"
+
+[~] packages/worker/src/setup-pr.ts
+  └── runSetupPr()
+      ├── [★★ TESTED] opens PR ×5 — :17,:31,:42,:55,:65
+      └── [GAP]       PR base uses RESOLVED branch, not project.default_branch
+
+[~] packages/worker/src/db.ts + callers
+  └── updateProjectDefaultBranch()
+      ├── [GAP]       writes on change
+      ├── [GAP]       no-op when unchanged
+      ├── [GAP]       ANY failure is swallowed, not just 0 rows
+      └── [GAP]       called at all 5 host clone sites            ← helper must not ship unused
+
+[~] packages/worker/src/setup-agent.ts + index.ts
+  └── clone failure classification
+      ├── [GAP]       empty repo is NOT reported repo_access_denied
+      └── [GAP]       invalid default branch gets its own reason_code
+
+[~] packages/ingestion/db/installations.go
+  └── PersistInstallation()
+      ├── [GAP]       fills NULL branches for matching projects
+      ├── [GAP]       CORRECTS a stale 'main' to 'master'                ← IS DISTINCT FROM
+      ├── [GAP]       no matching project is a no-op
+      └── [GAP]       existing installation persistence unaffected      ← REGRESSION
+
+[~] packages/ingestion/db/agent_provision.go
+  └── ProvisionAgentSession()
+      ├── [GAP]       project created at :232 gets the branch
+      ├── [GAP]       master-default repo through agent callback         ← REGRESSION
+      └── [GAP]       Repos type change does not break the caller        ← REGRESSION
+
+[~] packages/ingestion/handler/github_settings.go     ← NO TEST FILE EXISTS TODAY
+  └── SetGitHubConfig()
+      ├── [GAP]       stores master for a master repo
+      ├── [GAP]       400 on repo outside the installation
+      ├── [GAP]       502 when GitHub is unreachable
+      └── [GAP]       existing main-default repo still works            ← REGRESSION
+
+[~] packages/ingestion/db/migrations/027_*.sql
+      ├── [GAP]       NULL is accepted after migration
+      └── [GAP]       existing rows keep their value                    ← REGRESSION
+
+COVERAGE: 8/42 paths tested (19%)  |  Code paths: 8/32 (25%)  |  User flows: 0/10 (0%)
+QUALITY: ★★★:0 ★★:8 ★:0  |  GAPS: 34 (1 E2E, 0 eval)  |  DELETE: 2
+```
+
+Legend: ★★★ behavior + edge + error | ★★ happy path | ★ smoke | [→E2E] needs integration test
+
+### Regression tests (mandatory, not optional)
+
+Six paths change behaviour for callers that work today:
+
+- **CLI Phase 1 provisioning must still work, and must still make no GitHub
+  call.** Assert the absence, not just the success — the whole point of the
+  correction is that this path stays GitHub-free.
+- **Agent-callback onboarding must still work end to end**, including against a
+  `master`-default repo, since its project is created after the installation is
+  persisted.
+- Existing installation persistence is unaffected by the `Repos` type change,
+  across all three callers.
+- A `main`-default repo covered by the installation still succeeds through
+  `SetGitHubConfig`, which has no test file at all today.
+- A stale `'main'` row is corrected to `'master'` when the installation lands —
+  the `IS DISTINCT FROM` behaviour, asserted directly.
+- The migration leaves existing row values intact.
+
+### Test fixtures needed
+
+- A bare git remote with `--initial-branch=master`, mirroring `repo-clone.test.ts:158`.
+- A bare git remote with zero commits for the empty-repo path.
+- A fake `ListInstallationRepos` response via the existing
+  `gh.OverrideHTTPClientForTests` hook at `github/app.go:211`.
+
+## Failure modes
+
+| New codepath | Realistic production failure | Test? | Error handling? | User sees |
+|---|---|---|---|---|
+| Unpinned clone | Repo has zero commits | planned | `ls-remote --heads` = 0 | "`owner/repo` has no commits yet" |
+| Unpinned clone | Repo has commits but HEAD points at an absent ref | planned | `ls-remote --heads` > 0 + absent symref | "default branch `X` does not exist in `owner/repo`" |
+| `resolveClonedBranch` | Detached HEAD; `symbolic-ref` exits non-zero | planned | third `kind` | "could not determine the default branch" |
+| Clone failure classification | Any of the above reported as `repo_access_denied` | planned | `kind` → `reason_code` map | correct cause, not "fix your permissions" |
+| Branch write-back | Project deleted mid-job, or any transient UPDATE error | planned | **all failures swallowed + logged** | nothing; job still succeeds |
+| Branch write-back | Two concurrent jobs write the same value | no | idempotent | nothing |
+| Branch write-back | Helper ships but is never called | planned | caller tests at all 5 sites | rows never heal, silently |
+| `PersistInstallation` branch fill | Org has many projects; the UPDATE runs inside the advisory-lock tx | no | bounded by projects-per-org | nothing |
+| Agent-callback provisioning | Project created at `agent_provision.go:232` after the fill runs, so it is missed | planned | branch set post-create in the same tx | nothing |
+| `SetGitHubConfig` lookup | GitHub 5xx or timeout | planned | 502, not 500 | "could not reach GitHub, retry" |
+| Nullable column | A reader dereferences NULL and passes it to git | planned | type change forces handling | compile error, not a runtime one |
+| stderr capture | Adversarial repo emits megabytes of stderr | planned | truncate before the DB write | truncated error |
+| stderr capture | Token in stderr in an unscrubbed format | planned | both scrub patterns applied | redacted |
+
+**Critical gaps:** none, on three conditions. The write-back must swallow *all*
+failures, not just zero rows — otherwise a transient UPDATE error fails work that
+already holds the correct branch. The migration must not be paired with a
+backfill that blanks existing rows, or in-flight jobs lose a value they are
+mid-way through using. And the `updateProjectDefaultBranch` callers must be
+wired in the same task as the helper, or the helper ships unused and nothing
+heals — a silent no-op that looks like a completed task.
+
+## NOT in scope
+
+- **`repository` webhook handling to track renames.** `webhook.go:57` ignores
+  everything but `pull_request`. Clone-time resolution self-heals on every job,
+  so a webhook is redundant for correctness. Captured as a TODO.
+- **Backfilling or blanking existing rows.** They heal on next clone. A backfill
+  would need a GitHub call per project and risks disturbing in-flight jobs.
+- **Sending `default_branch` from the browser.** `RepoSelector.vue` has the value,
+  but a client-supplied branch is a trust boundary we do not need to open.
+- **Any GitHub call in Phase 1.** Deliberately excluded — see the correction log.
+- **Supporting a non-default target branch per project.** Real feature, unrelated.
+- **Enterprise host PR links** (existing TODOS.md item) — unrelated.
+
+## Parallelization
+
+| Lane | Steps | Modules | Depends on |
+|---|---|---|---|
+| A | 1, 2 (migration + nullable scan sites) | `packages/ingestion/db/`, `packages/worker/src/db.ts` | — |
+| B | 3, 4, 7 (clone, resolve, write-back) | `packages/worker/src/`, `packages/worker/src/harness/` | — |
+| C | 8, 9, 10 (installation fill + settings authz) | `packages/ingestion/db/`, `packages/ingestion/handler/` | Lane A |
+| D | 5, 6 (thread resolved branch to PR base) | `packages/worker/src/` | Lane B |
+
+Launch A and B in parallel. Then C and D in parallel. A and C both touch
+`packages/ingestion/db/` — sequential. B and D both touch
+`packages/worker/src/` — sequential. A and B touch `worker/src/db.ts` and
+`worker/src/` respectively; coordinate that one file or land A first.
+
+## Implementation Tasks
+
+Synthesized from this review's findings.
+
+- [ ] **T1 (P1, human: ~1.5 days / CC: ~40min)** — ingestion/db — Make `default_branch` nullable
+  - Surfaced by: Root cause — `001_baseline.sql:21` cannot express "unknown"
+  - Files: `packages/ingestion/db/migrations/027_default_branch_nullable.sql`, `db/queries.go` (8 scan sites), `packages/worker/src/db.ts:1068`
+  - Verify: `cd packages/ingestion && go build ./... && go test ./...`; `pnpm -r build`
+- [ ] **T2 (P1, human: ~1 day / CC: ~25min)** — worker/clone — Clone unpinned, resolve the branch, return it
+  - Surfaced by: Architecture — `index.ts:346` and `pr.ts:692` share one stale value
+  - Files: `packages/worker/src/repo-clone.ts`, `packages/worker/src/harness/sandbox-repo.ts`
+  - Verify: `pnpm --filter @opslane/worker test repo-clone sandbox-repo`
+- [ ] **T3 (P1, human: ~1 day / CC: ~30min)** — worker/clone — Three-way HEAD classification with a typed error
+  - Surfaced by: Correction C3 — `rev-parse --verify HEAD` returns 128 for both an empty repo and a repo whose HEAD points at an absent ref, and git's stderr calls both "empty"
+  - Files: `packages/worker/src/repo-clone.ts`
+  - Verify: three fixtures — bare remote with zero commits; non-empty remote with `symbolic-ref HEAD refs/heads/nonexistent`; detached HEAD. Assert `ls-remote --heads` discriminates and the error names repo AND branch
+- [ ] **T3b (P1, human: ~4h / CC: ~15min)** — worker — Map clone-resolution kinds to real reason codes
+  - Surfaced by: Correction C3 — `setup-agent.ts:80` and `index.ts:358` report every clone failure as `repo_access_denied` with "Ensure the GitHub App has read access"
+  - Files: `packages/worker/src/setup-agent.ts`, `packages/worker/src/index.ts`, `shared` reason codes
+  - Verify: an empty repo does not tell the user to fix permissions
+- [ ] **T4 (P1, human: ~4h / CC: ~15min)** — worker/clone — Capture redacted, truncated stderr on both clone sites
+  - Surfaced by: Code Quality — `sandbox-repo.ts:133` reads `.message`, drops the typed `.stderr`
+  - Files: `packages/worker/src/harness/sandbox-repo.ts`, `packages/worker/src/repo-clone.ts`
+  - Verify: test asserts git's reason surfaces and an embedded token does not
+- [ ] **T5 (P1, human: ~1 day / CC: ~25min)** — worker/pipeline — Make the HOST clone the single branch authority
+  - Surfaced by: Architecture — the host checkout receives the diff and is pushed (`gitCommitAndPush(repoDir, …)`); the sandbox at `agent-fix.ts:611` is a separate later clone that could observe a rename mid-job
+  - Files: `packages/worker/src/setup-pr.ts`, `pipeline.ts`, `agent-fix.ts`, `index.ts`, `setup-agent.ts`
+  - Verify: host `CloneResult.defaultBranch` reaches `PipelineInput` and PR creation; `defaultBranch` is **removed** from `AgentFixInput`, `AgentSetupInput`, and sandbox clone inputs so no second value exists
+- [ ] **T6 (P2, human: ~5h / CC: ~20min)** — worker/db — Write the branch back, and wire every caller
+  - Surfaced by: Failure modes — a helper with no callers is a silently completed task that heals nothing
+  - Files: `packages/worker/src/db.ts`, `packages/worker/src/index.ts` (:346, :525, :739, :882), `packages/worker/src/setup-pr.ts`
+  - Verify: caller tests at all 5 host clone sites; **all** write-back failures logged and swallowed, not only the 0-rows case
+- [ ] **T7 (P1, human: ~1 day / CC: ~35min)** — ingestion/db — Fill branches when the installation lands, all three callers
+  - Surfaced by: Corrections C2 and C4 — `github_oauth.go:373,:643` and `agent_setup.go:449-452` all discard `DefaultBranch` that is already in hand; `IS NULL` would leave legacy `'main'` rows ambiguous forever
+  - Files: `packages/ingestion/db/installations.go`, `handler/github_oauth.go`, `handler/agent_setup.go`, `db/agent_provision.go`
+  - Verify: uses `IS DISTINCT FROM`, so a stale `'main'` becomes `'master'`. All three callers compile against the new `Repos` type
+- [ ] **T7b (P1, human: ~5h / CC: ~20min)** — ingestion/db — Set the branch on the agent-callback project after creation
+  - Surfaced by: Correction C2 — `PersistInstallation` runs at `agent_provision.go:217`, `CreateProjectTx` at `:232`, so the fill cannot see this project
+  - Files: `packages/ingestion/db/agent_provision.go`, `handler/agent_setup.go`
+  - Verify: carry the matched branch on `AgentProvisionInput`, apply post-create in the same tx; regression test onboards a `master`-default repo through the agent callback
+- [ ] **T8 (P1, human: ~1 day / CC: ~25min)** — ingestion/handler — Resolve and authorize the repo in settings
+  - Surfaced by: Architecture — `github_settings.go:42` validates shape only
+  - Files: `packages/ingestion/handler/github_settings.go`, `db/queries.go`
+  - Verify: `cd packages/ingestion && go test ./handler/...`
+- [ ] **T9 (P1, human: ~4h / CC: ~15min)** — ingestion/handler — Create the missing `github_settings_test.go`
+  - Surfaced by: Test review — the handler has no test file and this diff changes its behaviour
+  - Files: `packages/ingestion/handler/github_settings_test.go`
+  - Verify: master-default storage, 400 on uncovered repo, 502 on GitHub failure, main-default regression
+- [ ] **T10 (P1, human: ~3h / CC: ~15min)** — ingestion/handler — Regression: Phase 1 provisioning stays GitHub-free
+  - Surfaced by: Correction log — an earlier draft would have broken this path
+  - Files: `packages/ingestion/handler/onboard_provision_test.go`
+  - Verify: asserts provisioning succeeds with a NULL branch and makes no GitHub call
+- [ ] **T11 (P2, human: ~4h / CC: ~20min)** — test-e2e — End-to-end setup PR against a master-default repo
+  - Surfaced by: Acceptance criterion 2 in issue #180
+  - Files: `test-e2e/`
+  - Verify: `pnpm --filter @opslane/test-e2e test`
+
+## Acceptance criteria (from #180, mapped)
+
+| Criterion | Met by |
+|---|---|
+| Configuring a `master` repo stores `default_branch = 'master'` | T7 (web install), T7b (agent callback), T8 (settings) |
+| Setup PR succeeds end to end against a `master` repo | T2, T5, T11 |
+| Stale row still clones successfully | T2 — the unpinned clone ignores the row entirely |
+| Genuinely missing branch names the repo and branch | **T3, not T4.** Git's stderr calls a broken-HEAD repo "empty", so the typed `CloneResolutionError` supplies the repo and branch; stderr is supporting detail only |
+| Regression test covers a non-`main` default through the setup-PR path | T9, T11 |
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 6 issues, 0 critical gaps, 4 corrections |
+| Outside Voice | external reviewer | Plan challenge | 1 | issues_found | 5 findings, all confirmed and applied |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+**OUTSIDE VOICE:** An external review raised 5 findings after this plan was
+first written. All 5 were verified against the code and all 5 were correct;
+all are applied above as corrections C2-C4 and tasks T3, T3b, T5, T6, T7, T7b.
+Finding 2 was verified empirically rather than by reading — the test is
+reproduced in correction C3.
+
+**CROSS-MODEL:** No tension. Every outside-voice finding was confirmed, none
+contested. The core design (nullable unknown, unpinned clone, runtime
+resolution) was endorsed by both reviewers.
+
+**VERDICT:** ENG CLEARED — ready to implement.
+
+**Calibration note.** This review missed two things that a human and an outside
+reviewer caught: that Phase 1 onboarding is GitHub-free, and that a third
+installation caller exists. Both were reachable by reading code this review
+had already opened. The pattern to correct: after grepping for a call site
+(`ListInstallationRepos` returned three hits), inspect **all** hits before
+concluding, and read the sibling worktree's design docs when a plan touches
+onboarding.
+
+NO UNRESOLVED DECISIONS

--- a/docs/plans/2026-07-23-default-branch-resolution-implementation.md
+++ b/docs/plans/2026-07-23-default-branch-resolution-implementation.md
@@ -1,0 +1,1508 @@
+# Default Branch Resolution Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop pinning `--branch` at clone time so onboarding and fix PRs work for repos whose default branch is not `main`, and make `projects.default_branch` a self-healing cache that can honestly say "unknown".
+
+**Architecture:** A plain `git clone` checks out the remote's HEAD, which *is* the repository's current default branch. Resolve the name from the clone, thread it through the job to the PR base, and write it back as a cache. The column becomes nullable so Phase 1 onboarding (which runs before GitHub exists) can leave it unset instead of guessing `'main'`. Three GitHub-installation callers additionally fill it in the moment the App is granted, from data they already hold.
+
+**Tech Stack:** Go 1.24 + pgx (ingestion), Node 22 + TypeScript + Vitest (worker), Postgres.
+
+**Design doc:** `docs/plans/2026-07-23-default-branch-resolution-design.md`. Read it first — it carries the root cause, the four corrections, and the rejected alternatives.
+
+**Issue:** https://github.com/opslane/opslane-oss/issues/180
+
+---
+
+## Before you start
+
+Read these, in this order. The plan assumes you have:
+
+1. `docs/plans/2026-07-23-default-branch-resolution-design.md` — especially correction **C3**, which contains an empirical result you must not re-derive: `git rev-parse --verify HEAD` **cannot** tell an empty repo apart from a repo whose HEAD points at a missing ref. Both exit 128, and git's own stderr calls both "empty". The discriminator is `git ls-remote --heads origin`.
+2. `docs/plans/2026-07-22-onboarding-10x-design.md:33` — Phase 1 of onboarding is **"Local aha (no GitHub)"**. No handler on the project-create path may call the GitHub API. If you find yourself adding one, stop; you have misread the plan.
+
+**Rules that are easy to violate:**
+
+- `projects.default_branch` is a **cache, never an authority**. Every write to it is best-effort. Never fail a job because the cache write failed.
+- The **host** clone is the branch authority, not the sandbox clone. The host checkout is the one that receives the diff and is pushed. The sandbox is a separate, later clone that could observe a rename mid-job.
+- **Resolution needs credentials.** `resolveClonedBranch` runs `git ls-remote --heads origin`, a network call — it is the only way to tell an empty repo (0 heads) from a broken-HEAD repo (>=1 head), since a shallow clone leaves 0 local refs for both. On the **host**, the token is embedded in the origin URL by `buildRepoUrl`, so `ls-remote` works after the clone. In the **sandbox**, auth is a `.netrc` that the existing code deletes at `sandbox-repo.ts:140` — so resolution MUST run **before** that deletion, or `ls-remote` fails auth on every private repo. Verified: after `git clone --depth 1`, `for-each-ref` returns 0 refs for both empty and broken-HEAD, so there is no local-only shortcut.
+
+**Codex review corrections (applied):** the counts and call sites below were checked against the code. `index.ts` has **three** clone sites (`:344`, `:523`, `:737`), not four — the old `:882` reference was a pipeline argument, not a clone. Cache write-back lands at **four** sites (those three + `setup-pr.ts`), not five. Six existing test files reference the fields being changed and must be fixed in the same tasks. `redactCloneDetail` goes in `harness/redact.ts` (which already exports `scrubSecrets` and is already imported by `sandbox-repo.ts`), NOT in `sandbox-repo.ts`, to avoid an import cycle with `repo-clone.ts`.
+
+**Verify your environment before Task 1:**
+
+```bash
+cd packages/ingestion && go build ./... && go test ./db ./handler
+cd ../.. && pnpm --filter @opslane/worker test
+```
+
+Expected: both green. If not, fix that first — you need a clean baseline to trust the failures this plan asks you to produce.
+
+---
+
+## Phase 0 — Schema: let the column say "unknown"
+
+This phase gates everything else. The type change is deliberate: it makes the Go and TypeScript compilers enumerate every reader of `default_branch` for you.
+
+### Task 1: Make `projects.default_branch` nullable
+
+**Files:**
+- Create: `packages/ingestion/db/migrations/027_default_branch_nullable.sql`
+
+**Step 1: Write the migration**
+
+```sql
+-- projects.default_branch was NOT NULL DEFAULT 'main', which cannot express
+-- "we have not learned this repo's default branch yet". Onboarding Phase 1
+-- creates projects before GitHub is connected, so the guess was written as
+-- fact and later used to `git clone --branch main`, breaking every repo whose
+-- default branch is not 'main' (issue #180).
+--
+-- NULL now means unknown. Existing rows keep their current value on purpose:
+-- they are corrected when the GitHub App installation lands, or on the next
+-- successful clone. Blanking them here would strip a usable value out from
+-- under jobs that are mid-flight.
+ALTER TABLE projects
+  ALTER COLUMN default_branch DROP NOT NULL,
+  ALTER COLUMN default_branch DROP DEFAULT;
+```
+
+**Step 2: Apply it against a disposable database**
+
+Do **not** use the shared dev Postgres on 5434 — other worktrees share it.
+
+```bash
+docker run --rm -d --name pg-dbr -e POSTGRES_USER=opslane \
+  -e POSTGRES_PASSWORD=opslane_dev -e POSTGRES_DB=opslane -p 5499:5432 postgres:16
+sleep 5
+for f in packages/ingestion/db/migrations/*.sql; do
+  PGPASSWORD=opslane_dev psql -h localhost -p 5499 -U opslane -d opslane -q -f "$f" || echo "FAILED: $f"
+done
+```
+
+Expected: no `FAILED` lines.
+
+**Step 3: Prove the new semantics and the preserved rows**
+
+```bash
+PGPASSWORD=opslane_dev psql -h localhost -p 5499 -U opslane -d opslane -v ON_ERROR_STOP=1 <<'SQL'
+BEGIN;
+INSERT INTO orgs (name) VALUES ('t') RETURNING id \gset
+INSERT INTO projects (org_id, name, github_repo) VALUES (:'id', 'p1', 'o/r1');
+SELECT default_branch IS NULL AS new_row_is_null FROM projects WHERE name = 'p1';
+INSERT INTO projects (org_id, name, github_repo, default_branch)
+  VALUES (:'id', 'p2', 'o/r2', 'master');
+SELECT default_branch FROM projects WHERE name = 'p2';
+ROLLBACK;
+SQL
+```
+
+Expected: `new_row_is_null` = `t`, and `p2` = `master`.
+
+**Step 4: Commit**
+
+```bash
+git add packages/ingestion/db/migrations/027_default_branch_nullable.sql
+git commit -m "feat(db): allow projects.default_branch to be NULL
+
+NULL means 'not yet learned from GitHub'. The old NOT NULL DEFAULT 'main'
+could not express that, so onboarding wrote a guess as fact. Refs #180."
+```
+
+---
+
+### Task 2: Make the Go type nullable
+
+**Files:**
+- Modify: `packages/ingestion/db/queries.go:88` (struct field) and the 7 scan sites at `:153`, `:216`, `:2926`, `:2942`, `:2965`, `:3173`, `:3423`
+
+**Step 1: Change the struct field**
+
+`packages/ingestion/db/queries.go:88`, inside `type Project struct`:
+
+```go
+	GithubRepo              *string
+	DefaultBranch           *string // NULL until learned from GitHub or a clone
+	FrictionAutonomy        string
+```
+
+**Step 2: Build to find every reader**
+
+```bash
+cd packages/ingestion && go build ./...
+```
+
+Expected: FAIL. The compiler lists every site that treats it as a `string`. This is the point of the change — work the list it gives you. The 7 `.Scan(...)` sites need no edit (pgx scans `NULL` into `*string` natively); anything that *dereferences* or compares it does.
+
+**Step 3: Fix each reported site**
+
+For any site that needs a concrete branch, do not substitute a default. Propagate the absence. If a caller genuinely cannot proceed without a branch, return an error naming the project — do not invent `"main"`.
+
+**Step 4: Build and test**
+
+```bash
+cd packages/ingestion && go build ./... && go test ./db ./handler
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add packages/ingestion/db/queries.go
+git commit -m "refactor(db): Project.DefaultBranch is *string
+
+Nullable in the schema as of 027; the pointer makes every reader handle
+'unknown' explicitly rather than silently receiving a guess. Refs #180."
+```
+
+---
+
+### Task 3: Make the worker type nullable
+
+**Files:**
+- Modify: `packages/worker/src/db.ts:1068`
+
+**Step 1: Change the interface**
+
+`packages/worker/src/db.ts`, in `ProjectData`:
+
+```ts
+export interface ProjectData {
+  id: string;
+  name: string;
+  github_repo: string;
+  /** NULL until learned from GitHub or resolved from a clone. Never guess. */
+  default_branch: string | null;
+  friction_autonomy: FrictionAutonomy;
+  pr_posture?: PRPosture;
+  draft_pr_cap?: number;
+}
+```
+
+**Step 2: Typecheck to find every reader**
+
+```bash
+pnpm --filter @opslane/worker build
+```
+
+Expected: FAIL, listing each site passing `default_branch` where a `string` is required. Those sites are exactly what Phase 2 and Phase 3 rewrite. Leave them broken for now if the fix belongs to a later task; note them.
+
+Known callers and tests that reference `defaultBranch` on the changed types and **will** break — you do not have to fix them in this task, but you must not be surprised by them, and Task 17's full build will not pass until they are all handled by their owning tasks:
+
+- `packages/worker/src/__tests__/repo-clone.test.ts:103`, `:115`, `:135`, `:220` (Task 6)
+- `packages/worker/src/harness/__tests__/sandbox-repo-setup.test.ts:64` (Task 7)
+- `packages/worker/src/__tests__/agent-fix.test.ts:102` (Task 7)
+- `packages/worker/src/__tests__/python-production-path.test.ts:195` — mocks `CloneResult`; add `defaultBranch` to the mock (Task 6)
+- `packages/worker/src/__tests__/index.test.ts:10` — must mock `cacheProjectDefaultBranch` and have the clone mock return a `defaultBranch` (Task 12)
+- `packages/worker/src/__tests__/pipeline.test.ts` and `precision-gate.test.ts` — pass `defaultBranch: 'main'` literals; these stay valid because `PipelineInput.defaultBranch` remains a required `string` (now sourced from the clone). No change needed, but confirm.
+
+**Step 3: Commit**
+
+```bash
+git add packages/worker/src/db.ts
+git commit -m "refactor(worker): ProjectData.default_branch is nullable
+
+Mirrors migration 027. Refs #180."
+```
+
+---
+
+## Phase 1 — Resolve the branch from the clone
+
+The heart of the fix. Build it test-first with real git fixtures, because the failure modes here are git behaviours you cannot mock honestly.
+
+### Task 4: Write the clone-resolution fixtures
+
+**Files:**
+- Create: `packages/worker/src/__tests__/clone-resolution.test.ts`
+
+**Step 1: Write the fixture builders and the failing tests**
+
+```ts
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveClonedBranch, CloneResolutionError, execFileGitRunner } from '../repo-clone.js';
+
+const execFile = promisify(execFileCb);
+
+/** Isolate from the developer's ~/.gitconfig so init.defaultBranch cannot skew results. */
+const GIT_ENV = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_SYSTEM: '/dev/null',
+  GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t',
+  GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t',
+} as NodeJS.ProcessEnv;
+
+const git = (cwd: string, ...args: string[]) =>
+  execFile('git', args, { cwd, env: GIT_ENV });
+
+let root: string;
+beforeAll(async () => { root = await mkdtemp(join(tmpdir(), 'dbr-')); });
+afterAll(async () => { await rm(root, { recursive: true, force: true }); });
+
+/** A normal repo whose default branch is `master`, not `main`. */
+async function masterRemote(name: string): Promise<string> {
+  const work = join(root, `${name}-work`);
+  await execFile('git', ['init', '-q', '--initial-branch=master', work], { env: GIT_ENV });
+  await execFile('sh', ['-c', `echo hi > ${work}/a.txt`]);
+  await git(work, 'add', '-A');
+  await git(work, 'commit', '-qm', 'init');
+  const bare = join(root, `${name}-bare`);
+  await execFile('git', ['clone', '-q', '--bare', work, bare], { env: GIT_ENV });
+  return `file://${bare}`;
+}
+
+/** A repo with commits whose HEAD points at a branch that does not exist. */
+async function brokenHeadRemote(name: string): Promise<string> {
+  const url = await masterRemote(name);
+  const bare = url.replace('file://', '');
+  await git(bare, 'symbolic-ref', 'HEAD', 'refs/heads/nonexistent');
+  return url;
+}
+
+/** A repo with no commits at all. */
+async function emptyRemote(name: string): Promise<string> {
+  const bare = join(root, `${name}-bare`);
+  await execFile('git', ['init', '-q', '--bare', '--initial-branch=master', bare], { env: GIT_ENV });
+  return `file://${bare}`;
+}
+
+async function cloneTo(url: string, name: string): Promise<string> {
+  const dir = join(root, name);
+  await execFile('git', ['clone', '--depth', '1', '--', url, dir], { env: GIT_ENV });
+  return dir;
+}
+
+describe('resolveClonedBranch', () => {
+  it('returns the real default branch when it is not main', async () => {
+    const dir = await cloneTo(await masterRemote('ok'), 'ok-clone');
+    await expect(resolveClonedBranch(execFileGitRunner(dir), 'o/r')).resolves.toBe('master');
+  });
+
+  it('classifies a repo with no commits as empty_repository', async () => {
+    const dir = await cloneTo(await emptyRemote('empty'), 'empty-clone');
+    const err = await resolveClonedBranch(execFileGitRunner(dir), 'o/empty').catch(e => e);
+    expect(err).toBeInstanceOf(CloneResolutionError);
+    expect(err.kind).toBe('empty_repository');
+    expect(err.message).toContain('o/empty');
+  });
+
+  // The regression this whole classification exists for. `rev-parse --verify HEAD`
+  // exits 128 here exactly as it does for an empty repo, and git's own stderr
+  // calls this repo "empty" too. Only `ls-remote --heads` tells them apart.
+  it('does NOT call a broken-HEAD repo empty, and names the missing branch', async () => {
+    const dir = await cloneTo(await brokenHeadRemote('broken'), 'broken-clone');
+    const err = await resolveClonedBranch(execFileGitRunner(dir), 'o/broken').catch(e => e);
+    expect(err).toBeInstanceOf(CloneResolutionError);
+    expect(err.kind).toBe('invalid_default_branch');
+    expect(err.discoveredBranch).toBe('nonexistent');
+    expect(err.message).toContain('o/broken');
+    expect(err.message).toContain('nonexistent');
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+```bash
+pnpm --filter @opslane/worker test clone-resolution
+```
+
+Expected: FAIL — `resolveClonedBranch`, `CloneResolutionError`, and `execFileGitRunner` are not exported from `repo-clone.ts`.
+
+**Step 3: Commit the failing test**
+
+```bash
+git add packages/worker/src/__tests__/clone-resolution.test.ts
+git commit -m "test(worker): failing fixtures for clone branch resolution
+
+Includes the broken-HEAD case that rev-parse cannot distinguish from an
+empty repo. Refs #180."
+```
+
+---
+
+### Task 5: Implement `resolveClonedBranch`
+
+**Files:**
+- Modify: `packages/worker/src/repo-clone.ts`
+
+**Step 1: Add the runner abstraction, the error type, and the resolver**
+
+Append to `packages/worker/src/repo-clone.ts`:
+
+```ts
+/** Result of a git invocation that is allowed to fail without throwing. */
+export interface GitResult { stdout: string; stderr: string; exitCode: number }
+
+/**
+ * Runs git and reports failure as data, not exceptions. Two backends implement
+ * it: execFile on the host, and `sandbox.commands.run` inside E2B. The transport
+ * differs; the classification rule below must not.
+ */
+export type GitRunner = (args: string[]) => Promise<GitResult>;
+
+export type CloneResolutionKind =
+  | 'empty_repository'
+  | 'invalid_default_branch'
+  | 'unresolvable_head';
+
+export class CloneResolutionError extends Error {
+  readonly kind: CloneResolutionKind;
+  readonly repo: string;
+  /** The branch HEAD names, when we got that far. Absent for an empty repo. */
+  readonly discoveredBranch?: string;
+
+  constructor(kind: CloneResolutionKind, repo: string, discoveredBranch?: string) {
+    super(CloneResolutionError.describe(kind, repo, discoveredBranch));
+    this.name = 'CloneResolutionError';
+    this.kind = kind;
+    this.repo = repo;
+    this.discoveredBranch = discoveredBranch;
+  }
+
+  private static describe(kind: CloneResolutionKind, repo: string, branch?: string): string {
+    switch (kind) {
+      case 'empty_repository':
+        return `${repo} has no commits yet, so there is no branch to work from`;
+      case 'invalid_default_branch':
+        return `default branch '${branch}' does not exist in ${repo}`;
+      case 'unresolvable_head':
+        return `could not determine the default branch of ${repo}`;
+    }
+  }
+}
+
+/** A GitRunner backed by execFile against an already-cloned working directory. */
+export function execFileGitRunner(repoDir: string): GitRunner {
+  return async (args) => {
+    try {
+      const { stdout, stderr } = await execFile('git', args, {
+        cwd: repoDir, timeout: 15_000, env: scrubbedEnv(),
+      });
+      return { stdout: String(stdout), stderr: String(stderr), exitCode: 0 };
+    } catch (err: unknown) {
+      const e = err as { stdout?: string; stderr?: string; code?: number };
+      return {
+        stdout: String(e.stdout ?? ''),
+        stderr: String(e.stderr ?? ''),
+        exitCode: typeof e.code === 'number' ? e.code : 1,
+      };
+    }
+  };
+}
+
+/**
+ * Determine a clone's default branch, distinguishing the three ways it can fail.
+ *
+ *   ls-remote --heads ── 0 refs ─────────────────> empty_repository
+ *          │
+ *       >=1 refs
+ *          │
+ *   symbolic-ref HEAD ── fails ──────────────────> unresolvable_head
+ *          │
+ *       branch name
+ *          │
+ *   rev-parse --verify HEAD ── fails ────────────> invalid_default_branch
+ *          │                                        (HEAD names an absent ref)
+ *        commit
+ *          │
+ *          └────────────────────────────────────> branch
+ *
+ * Do NOT reorder these. `rev-parse --verify HEAD` exits 128 for BOTH an empty
+ * repo and a broken-HEAD repo, and `git clone` prints "you appear to have cloned
+ * an empty repository" for both. `ls-remote --heads` is the only discriminator.
+ * See correction C3 in the design doc for the measured evidence.
+ */
+export async function resolveClonedBranch(run: GitRunner, repo: string): Promise<string> {
+  const heads = await run(['ls-remote', '--heads', 'origin']);
+  if (heads.exitCode === 0 && heads.stdout.trim() === '') {
+    throw new CloneResolutionError('empty_repository', repo);
+  }
+
+  const symbolic = await run(['symbolic-ref', '--short', 'HEAD']);
+  if (symbolic.exitCode !== 0) {
+    throw new CloneResolutionError('unresolvable_head', repo);
+  }
+  const branch = symbolic.stdout.trim();
+  if (branch === '') {
+    throw new CloneResolutionError('unresolvable_head', repo);
+  }
+
+  const head = await run(['rev-parse', '--verify', 'HEAD']);
+  if (head.exitCode !== 0) {
+    throw new CloneResolutionError('invalid_default_branch', repo, branch);
+  }
+
+  return branch;
+}
+```
+
+**Step 2: Run the tests**
+
+```bash
+pnpm --filter @opslane/worker test clone-resolution
+```
+
+Expected: PASS, all three.
+
+**Step 3: Commit**
+
+```bash
+git add packages/worker/src/repo-clone.ts
+git commit -m "feat(worker): resolve a clone's default branch, classified
+
+Three-way classification via ls-remote --heads, because rev-parse cannot
+tell an empty repo from one whose HEAD names a missing ref. Refs #180."
+```
+
+---
+
+### Task 6: Stop pinning `--branch` on the host clone
+
+**Files:**
+- Modify: `packages/worker/src/repo-clone.ts` (`CloneOptions`, `CloneResult`, `cloneRepo`)
+- Modify: `packages/worker/src/__tests__/repo-clone.test.ts:219-233` (delete the dead guard tests)
+
+**Step 1: Write the failing test**
+
+Append to `packages/worker/src/__tests__/clone-resolution.test.ts`:
+
+```ts
+import { cloneRepo } from '../repo-clone.js';
+
+describe('cloneRepo without a pinned branch', () => {
+  it('clones a master-default repo and reports the branch', async () => {
+    const url = await masterRemote('hostclone');
+    process.env['OPSLANE_GITHUB_URL'] = url; // exercised via buildRepoUrl
+    const result = await cloneRepo({
+      githubRepo: 'o/r', jobId: `t-${Date.now()}`, githubToken: 'x',
+    });
+    expect(result.defaultBranch).toBe('master');
+    await result.cleanup();
+  });
+});
+```
+
+> If routing a `file://` remote through `buildRepoUrl` proves awkward, extract the
+> URL-building step behind an optional `repoUrl` override on `CloneOptions` rather
+> than weakening the assertion. Do not delete the test.
+
+**Step 2: Run to verify it fails**
+
+```bash
+pnpm --filter @opslane/worker test clone-resolution
+```
+
+Expected: FAIL — `defaultBranch` is not on `CloneResult`, and `CloneOptions` still requires `defaultBranch`.
+
+**Step 3: Change the interfaces and the clone**
+
+In `packages/worker/src/repo-clone.ts`:
+
+```ts
+export interface CloneOptions {
+  githubRepo: string;   // "owner/repo"
+  jobId: string;
+  timeoutMs?: number;
+  githubToken?: string;
+}
+
+export interface CloneResult {
+  repoDir: string;
+  /** Resolved from the clone itself. This is the branch authority for the job. */
+  defaultBranch: string;
+  cleanup: () => Promise<void>;
+}
+```
+
+In `cloneRepo`, delete the `defaultBranch` destructure and the branch guard at `:67`:
+
+```ts
+  // REMOVED: the `unsafe branch name` guard. It defended against a stored branch
+  // being parsed as a git option; there is no longer a stored branch to pass.
+```
+
+Replace the clone invocation:
+
+```ts
+    // No `--branch`: a plain clone checks out the remote's HEAD, which IS the
+    // repository's current default branch. `--` still ends options so neither
+    // the URL nor the directory can be reinterpreted as a git option.
+    await execFile('git', [
+      'clone', '--depth', '1',
+      '--', cloneUrl, repoDir,
+    ], { timeout: timeoutMs, env: scrubbedEnv() });
+```
+
+After the clone succeeds, resolve and return:
+
+```ts
+  const defaultBranch = await resolveClonedBranch(execFileGitRunner(repoDir), githubRepo);
+
+  return {
+    repoDir,
+    defaultBranch,
+    cleanup: async () => {
+      await execFile('rm', ['-rf', repoDir]).catch(() => {});
+    },
+  };
+```
+
+**Step 4: Delete the now-dead guard tests**
+
+Remove `packages/worker/src/__tests__/repo-clone.test.ts:222` (`rejects a branch that could be parsed as a git option`) and `:228` (`rejects a branch containing whitespace`). Keep `:232` (`rejects a repo that is not owner/name`) — the repo guard still has an input.
+
+**Step 5: Run the full worker suite**
+
+```bash
+pnpm --filter @opslane/worker test
+```
+
+Expected: the new tests PASS; call sites in `index.ts`, `setup-pr.ts`, and `pipeline.ts` now fail to typecheck. That is expected and is Phase 3's work.
+
+**Step 6: Commit**
+
+```bash
+git add packages/worker/src/repo-clone.ts packages/worker/src/__tests__/
+git commit -m "feat(worker): clone without --branch, return the resolved branch
+
+Remote HEAD is by definition the current default branch, so pinning a
+stored value could only ever be stale or wrong. Refs #180."
+```
+
+---
+
+### Task 7: Do the same for the sandbox clone
+
+**Files:**
+- Modify: `packages/worker/src/harness/sandbox-repo.ts:109-140`
+- Modify: `packages/worker/src/harness/redact.ts` (add `redactCloneDetail` — NOT in sandbox-repo.ts)
+
+> **Why redact.ts and not sandbox-repo.ts:** `sandbox-repo.ts:3` already imports
+> from `repo-clone.ts` (`buildGitNetrc`). If `repo-clone.ts` then imported
+> `redactCloneDetail` back from `sandbox-repo.ts`, that is a cycle. `redact.ts`
+> is dependency-neutral, already exports `scrubSecrets`, and is already imported
+> by `sandbox-repo.ts`. Build on `scrubSecrets` rather than re-writing the URL scrub.
+
+**Step 1: Add `redactCloneDetail` to `redact.ts`**
+
+```ts
+/** Max clone detail carried into a stored error. An adversarial repo can emit a lot. */
+const CLONE_DETAIL_LIMIT = 2_000;
+
+/**
+ * Scrub credentials from a clone failure detail and bound its length before it
+ * is stored in setup_pr_error or shown in the dashboard. Reuses scrubSecrets
+ * (which already handles the https userinfo and PAT/token formats) and adds the
+ * x-access-token:...@ shape the host clone URL uses.
+ */
+export function redactCloneDetail(detail: string): string {
+  const scrubbed = scrubSecrets(detail)
+    .replace(/x-access-token:[^@\s]{1,512}@/g, 'x-access-token:***@');
+  return scrubbed.length > CLONE_DETAIL_LIMIT
+    ? `${scrubbed.slice(0, CLONE_DETAIL_LIMIT)}… (truncated)`
+    : scrubbed;
+}
+```
+
+**Step 2: Rewrite the sandbox clone block — resolve BEFORE deleting `.netrc`**
+
+The existing ordering is: write `.netrc` (`:125`) → clone (`:131`) → `rm -f /home/user/.netrc` (`:140`). `resolveClonedBranch` runs `ls-remote --heads origin`, which needs that credential. So resolution goes **between the clone and the delete**, and the delete moves into a `finally` so it always runs.
+
+```ts
+    const runner: GitRunner = async (args) => {
+      const r = await sandbox.commands.run(
+        `git -C ${SANDBOX_REPO} ${args.map(shellEscape).join(' ')}`,
+        { timeoutMs: 30_000 },
+      ).catch((e: unknown) => e);
+      if (r instanceof Error) {
+        return { stdout: '', stderr: String((r as { stderr?: string }).stderr ?? r.message), exitCode: 1 };
+      }
+      return { stdout: String(r.stdout ?? ''), stderr: String(r.stderr ?? ''), exitCode: 0 };
+    };
+
+    let sandboxDefaultBranch: string | undefined;
+    try {
+      // No --branch: a plain clone checks out the remote's HEAD. The sandbox
+      // resolves its branch for VALIDATION AND ERROR REPORTING ONLY; the host
+      // clone is the PR-base authority.
+      await sandbox.commands.run(
+        `git clone --depth 1 ${shellEscape(opts.repoUrl)} ${SANDBOX_REPO}`,
+        { timeoutMs: 120_000 },
+      );
+      // Resolve WHILE .netrc still exists — ls-remote needs the credential.
+      sandboxDefaultBranch = await resolveClonedBranch(runner, opts.githubRepo ?? 'repo');
+    } catch (err: unknown) {
+      const detail = err instanceof Error
+        // err.stderr is declared on the runtime error type (sandbox-runtime.ts:71)
+        // and is where git's actual reason lives. Reading only .message is why
+        // production recorded the useless "clone failed: exit status 128" (#180).
+        ? `${err.message}${(err as { stderr?: string }).stderr ? `\n${(err as { stderr?: string }).stderr}` : ''}`
+        : String(err);
+      throw new Error(`clone failed: ${redactCloneDetail(detail)}`);
+    } finally {
+      if (gitNetrc) await sandbox.commands.run('rm -f /home/user/.netrc').catch(() => {});
+    }
+```
+
+Delete the now-duplicated `rm -f /home/user/.netrc` that was at `:140`. `createRepoSandbox`'s options need a `githubRepo` field for the error messages; thread it from the caller (it already has `project.github_repo`).
+
+Apply `redactCloneDetail` (imported from `./redact.js`) to the catch in `repo-clone.ts` `cloneRepo`, replacing its inline single-pattern scrub.
+
+**Step 3: Write the redaction test**
+
+Create `packages/worker/src/harness/__tests__/clone-detail-redaction.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { redactCloneDetail } from '../redact.js';
+
+describe('redactCloneDetail', () => {
+  it('scrubs an x-access-token credential', () => {
+    const out = redactCloneDetail('fatal: https://x-access-token:ghs_SECRET@github.com/o/r.git not found');
+    expect(out).not.toContain('ghs_SECRET');
+    expect(out).toContain('***@');
+  });
+
+  it('scrubs a bare userinfo credential', () => {
+    expect(redactCloneDetail('https://user:pw@example.com/x')).not.toContain('pw@');
+  });
+
+  it('truncates adversarially long output', () => {
+    const out = redactCloneDetail('x'.repeat(10_000));
+    expect(out.length).toBeLessThan(2_100);
+    expect(out).toContain('truncated');
+  });
+
+  it('keeps the useful part of a real git failure', () => {
+    const out = redactCloneDetail("fatal: Remote branch main not found in upstream origin");
+    expect(out).toContain('Remote branch main not found');
+  });
+});
+```
+
+**Step 4: Run**
+
+```bash
+pnpm --filter @opslane/worker test clone-detail-redaction
+```
+
+Expected: PASS.
+
+**Step 5: Remove `defaultBranch` from the sandbox input**
+
+Delete `defaultBranch` from the `createRepoSandbox` options type (`sandbox-repo.ts:111`, add `githubRepo`) and from `AgentSetupInput` (`setup-agent.ts:41`) and `AgentFixInput` (`agent-fix.ts:53`). There must be exactly one branch value in the system per job, and it comes from the host clone. Fix the two tests the type change breaks now: `sandbox-repo-setup.test.ts:64` and `agent-fix.test.ts:102`.
+
+**Step 6: Commit**
+
+```bash
+git add packages/worker/src/harness/ packages/worker/src/repo-clone.ts packages/worker/src/setup-agent.ts packages/worker/src/agent-fix.ts
+git commit -m "feat(worker): unpinned sandbox clone, and surface git's stderr
+
+The sandbox error path read only err.message, discarding the stderr its own
+error type declares — the direct cause of the undiagnosable
+'clone failed: exit status 128' in #180. Refs #180."
+```
+
+---
+
+## Phase 2 — Say what actually went wrong
+
+Today every clone failure is reported as `repo_access_denied` with the remediation "Ensure the GitHub App has read access". An empty repo therefore tells the user to fix permissions they already have.
+
+### Task 8: Add the three reason codes
+
+**Files:**
+- Modify: `shared/src/types.ts:120-133`
+- Modify: `packages/worker/src/reason-codes.ts:8`
+
+**Step 1: Extend the union**
+
+In `shared/src/types.ts`, add to `ReasonCode`:
+
+```ts
+  | 'empty_repository'
+  | 'invalid_default_branch'
+  | 'unresolvable_head'
+```
+
+**Step 2: Build to trigger the exhaustiveness check**
+
+```bash
+pnpm -r build
+```
+
+Expected: FAIL in `reason-codes.ts`. `DEFAULT_REMEDIATION` is typed `Record<ReasonCode, string>`, so a missing entry is a compile error by design.
+
+**Step 3: Add the remediations**
+
+```ts
+  empty_repository:
+    'Push at least one commit to this repository, then retry — there is no branch for Opslane to work from yet.',
+  invalid_default_branch:
+    "This repository's default branch points at a branch that no longer exists. Set a valid default branch in GitHub (Settings → Branches), then retry.",
+  unresolvable_head:
+    'Opslane could not determine this repository\'s default branch. Check the repository is not in an unusual state, then retry.',
+```
+
+**Step 4: Build**
+
+```bash
+pnpm -r build
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add shared/src/types.ts packages/worker/src/reason-codes.ts
+git commit -m "feat(shared): reason codes for the three clone-resolution failures
+
+Refs #180."
+```
+
+---
+
+### Task 9: Map resolution failures to their real reason code
+
+**Files:**
+- Modify: `packages/worker/src/setup-agent.ts:80-86`
+- Modify: `packages/worker/src/index.ts:352-360`
+
+**Step 1: Write the failing test**
+
+Create `packages/worker/src/__tests__/clone-failure-classification.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { CloneResolutionError } from '../repo-clone.js';
+import { cloneFailureReason } from '../repo-clone.js';
+
+describe('cloneFailureReason', () => {
+  it('does not blame permissions for an empty repo', () => {
+    const r = cloneFailureReason(new CloneResolutionError('empty_repository', 'o/r'));
+    expect(r.reason_code).toBe('empty_repository');
+    expect(r.remediation).not.toMatch(/read access|permission/i);
+  });
+
+  it('names the missing branch for an invalid default', () => {
+    const r = cloneFailureReason(new CloneResolutionError('invalid_default_branch', 'o/r', 'gone'));
+    expect(r.reason_code).toBe('invalid_default_branch');
+    expect(r.reason_message).toContain('gone');
+    expect(r.reason_message).toContain('o/r');
+  });
+
+  it('still reports a genuine access failure as repo_access_denied', () => {
+    const r = cloneFailureReason(new Error('remote: Repository not found'));
+    expect(r.reason_code).toBe('repo_access_denied');
+  });
+
+  it('still detects a missing token', () => {
+    expect(cloneFailureReason(new Error('GITHUB_TOKEN is not set')).reason_code)
+      .toBe('missing_github_token');
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+```bash
+pnpm --filter @opslane/worker test clone-failure-classification
+```
+
+Expected: FAIL — `cloneFailureReason` is not exported.
+
+**Step 3: Implement it once, in `repo-clone.ts`**
+
+```ts
+import { DEFAULT_REMEDIATION } from './reason-codes.js';
+import type { NeedsHumanReason } from '@opslane/shared';
+
+/**
+ * Single classifier for clone failures, shared by the host and sandbox paths.
+ * Before this existed, both sites hardcoded `repo_access_denied`, so an empty
+ * repository told the user to fix GitHub App permissions.
+ */
+export function cloneFailureReason(err: unknown): NeedsHumanReason {
+  if (err instanceof CloneResolutionError) {
+    return {
+      reason_code: err.kind,
+      reason_message: err.message,
+      remediation: DEFAULT_REMEDIATION[err.kind],
+    };
+  }
+  const raw = err instanceof Error ? err.message : String(err);
+  const code = raw.includes('GITHUB_TOKEN') ? 'missing_github_token' : 'repo_access_denied';
+  return {
+    reason_code: code,
+    reason_message: redactCloneDetail(raw),
+    remediation: DEFAULT_REMEDIATION[code],
+  };
+}
+```
+
+**Step 4: Use it at EVERY clone catch site**
+
+There are more than two. Codex review found that only fixing the first host-clone catch leaves empty/broken-HEAD repos still reported as `repo_access_denied` on the fix paths. Replace the hardcoded classification at all of them:
+
+- `setup-agent.ts:80-86` — the `repo_access_denied` block
+- `index.ts:352-360` — the first host-clone `isTokenMissing` ternary
+- `index.ts:529` — the friction-path clone catch
+- `index.ts:745` — the fix-path clone catch
+- `agent-fix.ts:620` — the sandbox-fix classification
+
+Grep to be sure you have them all before committing:
+
+```bash
+grep -rn "repo_access_denied\|isTokenMissing" packages/worker/src --include=*.ts | grep -v __tests__ | grep -v reason-codes.ts
+```
+
+Expected after the edit: zero hardcoded `repo_access_denied` assignments outside `cloneFailureReason` and `DEFAULT_REMEDIATION`.
+
+**Step 5: Run and commit**
+
+```bash
+pnpm --filter @opslane/worker test
+git add packages/worker/src/
+git commit -m "fix(worker): classify clone failures instead of blaming permissions
+
+An empty repo previously told the user to check GitHub App read access.
+Refs #180."
+```
+
+---
+
+## Phase 3 — Thread the host branch, and heal the cache
+
+### Task 10: Use the resolved branch as the PR base
+
+**Files:**
+- Modify: `packages/worker/src/setup-pr.ts:12-18`, `:72`, `:91`, `:103`
+- Modify: `packages/worker/src/__tests__/setup-pr.test.ts:5`
+
+**Step 1: Write the failing test**
+
+In `packages/worker/src/__tests__/setup-pr.test.ts`, make the stubbed project carry a *stale* row and the clone report the truth:
+
+```ts
+  // The row is stale on purpose: this asserts the PR base comes from the clone,
+  // not from the database. A stale row is the normal state for every project
+  // created before this fix landed.
+  getProject: vi.fn().mockResolvedValue({ github_repo: 'o/r', default_branch: 'main' }),
+  clone: vi.fn().mockResolvedValue({
+    repoDir: '/tmp/x', defaultBranch: 'master', cleanup: async () => {},
+  }),
+```
+
+Add:
+
+```ts
+  it('bases the PR on the branch resolved by the clone, not the stale row', async () => {
+    const d = deps();
+    await runSetupPr(job, d);
+    expect(d.createPr).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ base: 'master' }),
+    );
+  });
+```
+
+**Step 2: Run to verify it fails**
+
+```bash
+pnpm --filter @opslane/worker test setup-pr
+```
+
+Expected: FAIL — base is `main`.
+
+**Step 3: Rewire `runSetupPr`**
+
+The clone must move **above** `runAgentSetup`, because the agent no longer receives a branch and the PR base now comes from the clone:
+
+```ts
+    const cloneResult = await d.clone({
+      githubRepo: project.github_repo,
+      jobId: job.jobId,
+      githubToken: token,
+    });
+    cleanup = cloneResult.cleanup;
+    // The clone is the authority for this job. project.default_branch may be
+    // stale, NULL, or a pre-#180 guess; none of that matters here.
+    const defaultBranch = cloneResult.defaultBranch;
+
+    const agent = await d.runAgentSetup({
+      repoUrl, githubToken: token,
+      apiKeyEnvVar: job.apiKeyEnvVar, releaseEnvVar: job.releaseEnvVar,
+    });
+```
+
+and at the PR creation:
+
+```ts
+      base: defaultBranch,
+```
+
+Update the `SetupPrDeps` interface: drop `default_branch` from `getProject`'s return type, drop `defaultBranch` from `clone`'s options and from `runAgentSetup`'s input, and add `defaultBranch: string` to `clone`'s result.
+
+**Step 4: Run and commit**
+
+```bash
+pnpm --filter @opslane/worker test setup-pr
+git add packages/worker/src/setup-pr.ts packages/worker/src/__tests__/setup-pr.test.ts
+git commit -m "fix(worker): base the setup PR on the resolved branch
+
+Fixing only the clone would still 422 on PR creation for every stale row.
+Refs #180."
+```
+
+---
+
+### Task 11: Thread the branch through the fix pipeline
+
+**Files:**
+- Modify: `packages/worker/src/index.ts:344`, `:523`, `:737` (the **three** real `cloneRepo` sites — verify with `grep -n 'cloneRepo(' packages/worker/src/index.ts`)
+- Modify: `packages/worker/src/pipeline.ts:41`, `:117`, `:310`
+
+> `index.ts:882` is **not** a clone site — it is a `defaultBranch:` field on a
+> pipeline-input object. It gets the resolved value like the others, but there is
+> no clone there to change.
+
+**Step 1: Fix the call sites the compiler is already flagging**
+
+At each of the three `index.ts` `cloneRepo` sites, drop `defaultBranch: project.default_branch` from the clone call and pass `cloneResult.defaultBranch` into the pipeline input (including the object at `:882`) instead.
+
+**Step 2: Build**
+
+```bash
+pnpm --filter @opslane/worker build
+```
+
+Expected: PASS. `PipelineInput.defaultBranch` stays a required `string` — it is now always supplied from a clone, never from the nullable row.
+
+**Step 3: Run the suite and commit**
+
+```bash
+pnpm --filter @opslane/worker test
+git add packages/worker/src/index.ts packages/worker/src/pipeline.ts
+git commit -m "fix(worker): fix PRs base on the resolved branch too
+
+Refs #180."
+```
+
+---
+
+### Task 12: Write the branch back as a cache
+
+**Files:**
+- Modify: `packages/worker/src/db.ts`
+- Modify: `packages/worker/src/index.ts` (4 sites), `packages/worker/src/setup-pr.ts`
+
+**Step 1: Write the failing test**
+
+Create `packages/worker/src/__tests__/default-branch-cache.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { cacheProjectDefaultBranch } from '../db.js';
+
+describe('cacheProjectDefaultBranch', () => {
+  it('never throws when the update fails', async () => {
+    const pool = { query: vi.fn().mockRejectedValue(new Error('connection reset')) };
+    // The column is a cache, never an authority. A failed cache write must not
+    // fail work that already holds the correct resolved branch.
+    await expect(cacheProjectDefaultBranch('p1', 'master', pool as never)).resolves.toBeUndefined();
+  });
+
+  it('never throws when the project no longer exists', async () => {
+    const pool = { query: vi.fn().mockResolvedValue({ rowCount: 0 }) };
+    await expect(cacheProjectDefaultBranch('gone', 'master', pool as never)).resolves.toBeUndefined();
+  });
+
+  it('writes only when the value differs', async () => {
+    const pool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    await cacheProjectDefaultBranch('p1', 'master', pool as never);
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('IS DISTINCT FROM'),
+      ['p1', 'master'],
+    );
+  });
+});
+```
+
+**Step 2: Run to verify it fails, then implement**
+
+```ts
+/**
+ * Refresh the cached default branch. Best-effort by contract: the column is a
+ * cache, never an authority, so EVERY failure here is logged and swallowed.
+ * A transient UPDATE error must never fail a job that already resolved the
+ * branch correctly from its clone.
+ */
+export async function cacheProjectDefaultBranch(
+  projectId: string,
+  branch: string,
+  pool = getPool(),
+): Promise<void> {
+  try {
+    await pool.query(
+      `UPDATE projects SET default_branch = $2
+       WHERE id = $1 AND default_branch IS DISTINCT FROM $2`,
+      [projectId, branch],
+    );
+  } catch (err: unknown) {
+    console.warn('[default-branch-cache] refresh failed', { projectId, branch, err });
+  }
+}
+```
+
+**Step 3: Wire every caller**
+
+Call it immediately after each successful host clone — `index.ts:344`, `:523`, `:737`, and the `setup-pr.ts` clone. **Four sites** (there are three `cloneRepo` calls in `index.ts`, not four; `:882` is a pipeline arg, not a clone).
+
+> A helper with no callers is a task that looks complete and heals nothing. Grep
+> before you commit: `grep -rn cacheProjectDefaultBranch packages/worker/src --include=*.ts | grep -v __tests__`
+> must report the definition plus 4 call sites.
+
+Also update `packages/worker/src/__tests__/index.test.ts:10` — its module mock must add `cacheProjectDefaultBranch` (a no-op) and its clone mock must return a `defaultBranch`, or the suite fails to run.
+
+**Step 4: Run and commit**
+
+```bash
+pnpm --filter @opslane/worker test
+grep -rn "cacheProjectDefaultBranch" packages/worker/src --include=*.ts | grep -v __tests__
+git add packages/worker/src/
+git commit -m "feat(worker): cache the resolved branch back to the project row
+
+Self-heals every stale row on its next job, with no migration. Refs #180."
+```
+
+---
+
+## Phase 4 — Fill the branch when the installation lands
+
+Three callers reach `PersistInstallation`. One of them creates its project *afterwards*, so it needs different handling. Getting this wrong is the mistake the design review made; see correction **C2**.
+
+### Task 13: Carry the branch into `PersistInstallationParams`
+
+**Files:**
+- Modify: `packages/ingestion/db/installations.go:15-22`, `:47-73`
+- Modify: `packages/ingestion/handler/github_oauth.go:373`, `:643`
+- Modify: `packages/ingestion/handler/agent_setup.go:449`
+
+**Step 1: Write the failing test**
+
+Create `packages/ingestion/db/installations_default_branch_test.go`. It must assert the `IS DISTINCT FROM` behaviour explicitly:
+
+```go
+// A project row holding the pre-#180 schema guess 'main' is indistinguishable
+// from a confirmed value. When the installation lands with authoritative data,
+// it must be corrected — not skipped as "already set".
+func TestPersistInstallationCorrectsStaleDefaultBranch(t *testing.T) {
+	// seed: org, project with github_repo='o/r' and default_branch='main'
+	// act:  PersistInstallation with Repos=[{FullName:"o/r", DefaultBranch:"master"}]
+	// want: project.default_branch == "master"
+}
+
+func TestPersistInstallationFillsNullDefaultBranch(t *testing.T) {
+	// seed: project with default_branch NULL (the Phase 1 onboarding state)
+	// want: filled with the installation's value
+}
+
+func TestPersistInstallationLeavesUnmatchedProjectsAlone(t *testing.T) {
+	// seed: project with github_repo='o/other'
+	// want: untouched
+}
+```
+
+Follow the existing table/setup conventions in `packages/ingestion/db` for transaction handling.
+
+**Step 2: Run to verify it fails**
+
+```bash
+cd packages/ingestion && go test ./db -run DefaultBranch -v
+```
+
+Expected: FAIL to compile — the rich repo type does not exist.
+
+**Step 3: Change the type and add the update**
+
+```go
+// InstallationRepo is a repository covered by an installation, with the
+// metadata GitHub already gave us. DefaultBranch was previously discarded at
+// every caller, which is why projects kept the schema guess (issue #180).
+type InstallationRepo struct {
+	FullName      string
+	DefaultBranch string
+}
+
+type PersistInstallationParams struct {
+	InstallationID int64
+	GitHubOrgName  string
+	GitHubOrgID    int64
+	OrgID          string
+	Repos          []InstallationRepo
+}
+```
+
+`InsertInstallationLanded` and the `reposJSON` marshal at `installations.go:47-51` still take `[]string`. Flatten once at the top of `PersistInstallation` so both the JSON column and the audit contract are unchanged:
+
+```go
+	repoNames := make([]string, 0, len(params.Repos))
+	for _, r := range params.Repos {
+		repoNames = append(repoNames, r.FullName)
+	}
+	// existing code: reposJSON = json.Marshal(repoNames); INSERT ... repos = reposJSON;
+	// InsertInstallationLanded(ctx, tx, ..., repoNames)
+```
+
+Add, inside the existing transaction, after the org column update:
+
+```go
+	// Fill in the default branch for projects pointed at a covered repo.
+	// IS DISTINCT FROM, not IS NULL: rows still holding the pre-#180 schema
+	// guess 'main' are exactly the ambiguous case that needs correcting, and
+	// there is no feature that lets a user pick a non-default target branch.
+	for _, repo := range params.Repos {
+		if repo.DefaultBranch == "" {
+			continue
+		}
+		if _, err := tx.Exec(ctx,
+			`UPDATE projects SET default_branch = $3
+			 WHERE org_id = $1 AND github_repo = $2
+			   AND default_branch IS DISTINCT FROM $3`,
+			params.OrgID, repo.FullName, repo.DefaultBranch); err != nil {
+			return fmt.Errorf("refresh project default branch: %w", err)
+		}
+	}
+```
+
+**Step 4: Update all three callers AND the agent-provision fallback AND an existing test**
+
+Codex review confirmed the type change breaks more than the three flatten sites:
+
+- Stop flattening at `github_oauth.go:373`, `:643`, and `agent_setup.go:449`. Build `[]db.InstallationRepo` from the `[]gh.Repo` each already holds.
+- `agent_provision.go:213-215` has a fallback `installationRepos := in.Repos; if len(...) == 0 { installationRepos = []string{in.CanonicalRepo} }`. After `in.Repos` becomes `[]InstallationRepo`, the `[]string{...}` literal no longer compiles. Change it to `[]db.InstallationRepo{{FullName: in.CanonicalRepo, DefaultBranch: in.CanonicalDefaultBranch}}` (the `CanonicalDefaultBranch` field is added in Task 14 — if you do Task 13 first, use `""`).
+- `packages/ingestion/db/oauth_installation_test.go:33` constructs `Repos` as `[]string`. Update the fixture to `[]db.InstallationRepo`.
+
+**Step 5: Build and test**
+
+```bash
+cd packages/ingestion && go build ./... && go test ./db ./handler
+```
+
+Expected: PASS. If a caller you did not expect fails to compile, add it and note it in the design doc.
+
+**Step 6: Commit**
+
+```bash
+git add packages/ingestion/db/installations.go packages/ingestion/handler/github_oauth.go packages/ingestion/handler/agent_setup.go packages/ingestion/db/installations_default_branch_test.go
+git commit -m "feat(ingestion): learn default_branch when the installation lands
+
+All three callers already held DefaultBranch and discarded it. Refs #180."
+```
+
+---
+
+### Task 14: Fix the agent-callback ordering
+
+**Files:**
+- Modify: `packages/ingestion/db/agent_provision.go:21-35`, `:217`, `:232`
+- Modify: `packages/ingestion/handler/agent_setup.go:453`
+
+**Step 1: Understand the ordering before you touch it**
+
+```
+ProvisionAgentSession (one transaction)
+  :217  PersistInstallation ──> UPDATE projects ... ──> matches NOTHING
+  :232  CreateProjectTx     ──> the project is created HERE, afterwards
+```
+
+The Task 13 update cannot see this project. It does not exist yet.
+
+**Step 2: Write the failing test**
+
+In `packages/ingestion/db/agent_provision_test.go` (follow the existing conventions there):
+
+```go
+// The agent-callback path creates its project AFTER PersistInstallation runs,
+// so the branch fill in PersistInstallation cannot reach it. Regression test
+// for correction C2.
+func TestProvisionAgentSessionStoresMasterDefaultBranch(t *testing.T) {
+	// act:  ProvisionAgentSession with CanonicalRepo="o/r" whose installation
+	//       repo list reports DefaultBranch="master"
+	// want: the created project has default_branch == "master"
+}
+```
+
+**Step 3: Run to verify it fails**
+
+```bash
+cd packages/ingestion && go test ./db -run ProvisionAgentSession -v
+```
+
+Expected: FAIL — branch is NULL.
+
+**Step 4: Carry the branch and apply it post-create**
+
+```go
+type AgentProvisionInput struct {
+	SessionID      string
+	InstallationID int64
+	CanonicalRepo  string
+	Repos          []InstallationRepo
+	// CanonicalDefaultBranch is the default branch of CanonicalRepo, taken from
+	// the installation's repo list. Empty when GitHub did not report one.
+	CanonicalDefaultBranch string
+	// ... unchanged fields
+}
+```
+
+Immediately after `CreateProjectTx` at `:232`:
+
+```go
+	// PersistInstallation ran at :217, before this project existed, so its
+	// branch fill could not match. Apply it here, in the same transaction.
+	if in.CanonicalDefaultBranch != "" {
+		if _, err := tx.Exec(ctx,
+			`UPDATE projects SET default_branch = $2 WHERE id = $1`,
+			project.ID, in.CanonicalDefaultBranch); err != nil {
+			return nil, fmt.Errorf("set project default branch: %w", err)
+		}
+	}
+```
+
+In `agent_setup.go`, populate it from the matched repo — the loop that computes `canonical` around `:435` already has the `gh.Repo`.
+
+**Step 5: Test and commit**
+
+```bash
+cd packages/ingestion && go build ./... && go test ./db ./handler
+git add packages/ingestion/db/agent_provision.go packages/ingestion/handler/agent_setup.go packages/ingestion/db/agent_provision_test.go
+git commit -m "fix(ingestion): agent-callback projects get their default branch
+
+The project is created after PersistInstallation, so the branch fill there
+could not reach it. Refs #180."
+```
+
+---
+
+## Phase 5 — The settings door
+
+### Task 15: Resolve and authorize in `SetGitHubConfig`
+
+**Files:**
+- Modify: `packages/ingestion/handler/github_settings.go:22-59`
+- Modify: `packages/ingestion/db/queries.go:3198` (`SetProjectGitHubConfig`)
+- Create: `packages/ingestion/handler/github_settings_test.go`
+
+> This handler has **no test file today**. You are adding the first one, and it
+> must include a regression test that an ordinary `main`-default repo still works.
+
+**Step 1: Write the failing tests**
+
+Use `gh.OverrideHTTPClientForTests` (`github/app.go:211`) to stub `ListInstallationRepos`:
+
+```go
+func TestSetGitHubConfigStoresMasterDefaultBranch(t *testing.T)      { /* 200; row == "master" */ }
+func TestSetGitHubConfigRejectsRepoOutsideInstallation(t *testing.T) { /* 400; body names the repo */ }
+func TestSetGitHubConfigReturns502WhenGitHubUnreachable(t *testing.T){ /* 502, not 500 */ }
+func TestSetGitHubConfigStillAcceptsMainDefaultRepo(t *testing.T)    { /* REGRESSION: 200 */ }
+```
+
+**Step 2: Run to verify they fail**
+
+```bash
+cd packages/ingestion && go test ./handler -run SetGitHubConfig -v
+```
+
+**Step 3: Implement**
+
+After the existing shape validation, resolve against the installation:
+
+```go
+	// Shape validation is not authorization. Until now this handler accepted any
+	// owner/repo string without checking the org's App installation covers it.
+	// The lookup we need for default_branch answers that question too.
+	installationID, err := d.Queries.GetOrgGitHubInstallation(r.Context(), orgID)
+	if err != nil || installationID == 0 {
+		writeJSONError(w, http.StatusBadRequest, "GitHub App not installed for this organization")
+		return
+	}
+	appJWT, err := gh.GenerateAppJWT(d.GitHubAppID, d.GitHubAppPrivateKey)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	installToken, err := gh.GetInstallationToken(appJWT, installationID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "could not reach GitHub, please retry")
+		return
+	}
+	repos, err := gh.ListInstallationRepos(installToken.Token)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "could not reach GitHub, please retry")
+		return
+	}
+	var matched *gh.Repo
+	for i := range repos {
+		if repos[i].FullName == req.GithubRepo {
+			matched = &repos[i]
+			break
+		}
+	}
+	if matched == nil {
+		writeJSONError(w, http.StatusBadRequest,
+			fmt.Sprintf("the Opslane GitHub App is not installed on %s — install it, then retry", req.GithubRepo))
+		return
+	}
+```
+
+Then pass `matched.DefaultBranch` through to `SetProjectGitHubConfig`, extending that query to write both columns.
+
+> Phase 1 rule check: this is the dashboard settings handler. The App is already
+> installed by the time it runs. Do **not** copy this into
+> `onboard_provision.go` or `onboarding.go`.
+
+**Step 4: Test and commit**
+
+```bash
+cd packages/ingestion && go build ./... && go test ./db ./handler
+git add packages/ingestion/handler/github_settings.go packages/ingestion/handler/github_settings_test.go packages/ingestion/db/queries.go
+git commit -m "feat(ingestion): resolve and authorize the repo in SetGitHubConfig
+
+Stores the real default branch, and closes a gap where any owner/repo string
+was accepted without checking the org's installation. Refs #180."
+```
+
+---
+
+### Task 16: Regression — Phase 1 onboarding stays GitHub-free
+
+**Files:**
+- Modify: `packages/ingestion/handler/onboard_provision_test.go`
+
+**Step 1: Write the test**
+
+```go
+// Onboarding Phase 1 is "Local aha (no GitHub)" — see
+// docs/plans/2026-07-22-onboarding-10x-design.md:33. The project and its API
+// key are minted before the GitHub App exists. This asserts the ABSENCE of a
+// GitHub call, not merely that provisioning succeeds: an earlier draft of the
+// #180 fix added an installation check here, which would have failed every CLI
+// provision.
+func TestOnboardProvisionMakesNoGitHubCall(t *testing.T) {
+	called := false
+	restore := gh.OverrideHTTPClientForTests(&http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			called = true
+			return nil, fmt.Errorf("no GitHub call expected during Phase 1 provisioning")
+		}),
+	})
+	defer restore()
+	// act: POST /api/v1/onboard/provision
+	// want: 201, project default_branch IS NULL, called == false
+}
+```
+
+**Step 2: Run, then commit**
+
+```bash
+cd packages/ingestion && go test ./handler -run OnboardProvision -v
+git add packages/ingestion/handler/onboard_provision_test.go
+git commit -m "test(ingestion): Phase 1 provisioning makes no GitHub call
+
+Guards the onboarding design boundary against a regression the #180 review
+nearly introduced. Refs #180."
+```
+
+---
+
+## Phase 6 — Prove it end to end
+
+### Task 17: Full gate
+
+**Step 1: Run everything**
+
+```bash
+pnpm install --frozen-lockfile
+pnpm -r build
+pnpm test
+(cd packages/ingestion && go build ./... && go test ./...)
+docker compose config --quiet
+```
+
+Note: root `pnpm test` **excludes** `@opslane/test-e2e`. Run it explicitly:
+
+```bash
+pnpm --filter @opslane/test-e2e test
+```
+
+**Step 2: Live smoke against a master-default repo**
+
+Per `AGENTS.md`, pipeline changes require a live smoke. Use a disposable database, not the shared 5434.
+
+```bash
+# apply migrations, seed, rebuild ingestion + worker, then:
+curl -X POST http://localhost:8082/api/v1/events -H 'content-type: application/json' -d @test-fixtures/...
+```
+
+Confirm the job reaches its expected terminal state and that a setup PR opens against `master`.
+
+**Step 3: Verification ledger**
+
+Fill this in with real output. Do not mark a row proven from reading code.
+
+| Claim | Proof | Result |
+|---|---|---|
+| Migration 027 allows NULL, preserves existing rows | Task 1 Step 3 psql output | |
+| Empty repo classified `empty_repository` | `clone-resolution.test.ts` | |
+| Broken-HEAD repo classified `invalid_default_branch`, names the branch | `clone-resolution.test.ts` | |
+| Unpinned clone resolves `master` | `clone-resolution.test.ts` | |
+| Setup PR bases on the resolved branch, not the row | `setup-pr.test.ts` | |
+| Cache write never throws | `default-branch-cache.test.ts` | |
+| Cache helper is actually called at 5 sites | `grep` output from Task 12 | |
+| Stale `'main'` corrected on installation | `installations_default_branch_test.go` | |
+| Agent-callback project gets `master` | `agent_provision_test.go` | |
+| `SetGitHubConfig` rejects an uncovered repo | `github_settings_test.go` | |
+| Phase 1 provisioning makes no GitHub call | `onboard_provision_test.go` | |
+| Tokens never survive in a clone error | `clone-detail-redaction.test.ts` | |
+| Setup PR opens against `master` end to end | live smoke | |
+
+**Step 4: Update the design doc**
+
+Mark the plan as implemented and link the PR.
+
+---
+
+## Acceptance criteria (issue #180)
+
+| Criterion | Task |
+|---|---|
+| Configuring a `master` repo stores `default_branch = 'master'` | 13 (web install), 14 (agent callback), 15 (settings) |
+| Setup PR succeeds end to end against a `master` repo | 6, 10, 17 |
+| Stale row still clones successfully | 6 — the unpinned clone ignores the row entirely |
+| Missing branch names the repo and the branch | 5 — the typed error; **not** git's stderr, which calls this case "empty" |
+| Regression test covers a non-`main` default through the setup-PR path | 10, 17 |
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | design-stage: 6 issues, 4 corrections |
+| Codex Review | `/codex review` | Independent 2nd opinion | 1 | issues_found | 7 findings (4 P1, 3 P2), all verified + applied |
+
+**CODEX:** Reviewed the implementation plan against the real code. All 7 findings confirmed by direct inspection and folded into the plan: (P1) sandbox resolution must run before the `.netrc` delete at `sandbox-repo.ts:140` or `ls-remote` fails auth on private repos; (P1) `index.ts` has 3 clone sites not 4, so cache write-back is 4 sites not 5; (P1) 6 existing test files reference the changed types and break the build; (P1) the `agent_provision.go:215` `[]string` fallback and `oauth_installation_test.go:33` fixture stop compiling after the `Repos` type change; (P2) `redactCloneDetail` in `sandbox-repo.ts` would create an import cycle with `repo-clone.ts`, moved to `redact.ts`; (P2) Task 9 must fix all 5 clone-catch sites, not 2.
+
+**CROSS-MODEL:** No contested findings. Codex's `.netrc` and import-cycle catches were both missed by the design review and this author; both verified empirically before applying.
+
+**VERDICT:** ENG + CODEX CLEARED — plan is implementation-ready. The verification ledger in Task 17 must be filled with real output during execution, not marked from reading.
+
+NO UNRESOLVED DECISIONS

--- a/docs/reference/reason-codes.md
+++ b/docs/reference/reason-codes.md
@@ -13,6 +13,14 @@ Every `needs_human` incident carries a `reason_code`, a `reason_message`, and a 
 | `policy_blocked` | A repository or org policy blocked the change. Review branch-protection / app permissions, then retry. |
 | `missing_llm_key` | Set the `ANTHROPIC_API_KEY` environment variable on the worker with a valid Anthropic API key. |
 
+## Repository state
+
+| Code | Remediation |
+| --- | --- |
+| `empty_repository` | Push at least one commit to this repository, then retry — there is no branch for Opslane to work from yet. |
+| `invalid_default_branch` | This repository's default branch points at a branch that no longer exists. Set a valid default branch in GitHub (Settings → Branches), then retry. |
+| `unresolvable_head` | Opslane could not determine this repository's default branch. Check the repository is not in an unusual state, then retry. |
+
 ## Investigation and fix quality
 
 | Code | Remediation |
@@ -52,4 +60,4 @@ Every `needs_human` incident carries a `reason_code`, a `reason_message`, and a 
 | `lease_lost` | No action needed — the job lease expired mid-run and the incident will be retried automatically. |
 | `verification_infra_error` | No immediate action needed — verification infrastructure failed (dependency install, test runner crash, or timeout), so the fix could not be proven either way. It will be retried on recurrence; if it persists, check worker logs. |
 
-25 codes total. The [drift check](../../scripts/check-docs-drift.mjs) fails the repository test gate (`pnpm test`, which CI runs) if this page and `shared/src/types.ts` disagree.
+28 codes total. The [drift check](../../scripts/check-docs-drift.mjs) fails the repository test gate (`pnpm test`, which CI runs) if this page and `shared/src/types.ts` disagree.

--- a/eval/src/__tests__/pipeline-caller.test.ts
+++ b/eval/src/__tests__/pipeline-caller.test.ts
@@ -63,6 +63,7 @@ describe('callPipeline', () => {
     expect(input.platform).toBe('python');
     expect(input.customerRuntime).toEqual({ name: 'CPython', version: '3.12.4' });
     expect(input.repoUrl).toBe('https://github.com/test/eval-app.git');
+    expect(input.githubRepo).toBe('test/eval-app');
     expect(input.sourceFiles).toEqual([]);
     expect(input.setupCommands).toBeUndefined();
   });

--- a/eval/src/pipeline-caller.ts
+++ b/eval/src/pipeline-caller.ts
@@ -21,6 +21,14 @@ function buildPatchCommand(patchContent: string): string {
   return `echo '${b64}' | base64 -d | git apply --whitespace=fix`;
 }
 
+function githubRepoFromUrl(repoUrl: string): string {
+  const pathname = new URL(repoUrl).pathname.replace(/^\/|\/$/g, '').replace(/\.git$/, '');
+  if (pathname.split('/').length !== 2) {
+    throw new Error(`Eval repo_url must identify a GitHub owner/repository: ${repoUrl}`);
+  }
+  return pathname;
+}
+
 export async function callPipeline(
   evalCase: EvalCase,
   casesDir: string,
@@ -59,7 +67,7 @@ export async function callPipeline(
     sourceFiles: [],  // Agent reads files directly from repo
     visualAnalysis: null,
     repoUrl: evalCase.repo_url,
-    defaultBranch: evalCase.default_branch ?? 'main',
+    githubRepo: githubRepoFromUrl(evalCase.repo_url),
     setupCommands: setupCommands.length > 0 ? setupCommands : undefined,
     budgetUsd: 2.00,  // Higher budget for eval cases
   });

--- a/packages/ingestion/db/agent_provision.go
+++ b/packages/ingestion/db/agent_provision.go
@@ -22,16 +22,18 @@ type AgentProvisionInput struct {
 	SessionID      string
 	InstallationID int64
 	CanonicalRepo  string
-	Repos          []string
-	GitHubOrgName  string
-	GitHubOrgID    int64
-	GitHubUserID   int64
-	GitHubLogin    string
-	DisplayName    string
-	Email          string
-	EmailVerified  bool
-	AvatarURL      string
-	SealKey        func(rawKey string) (string, error)
+	Repos          []InstallationRepo
+	// CanonicalDefaultBranch is taken from the installation repository list.
+	CanonicalDefaultBranch string
+	GitHubOrgName          string
+	GitHubOrgID            int64
+	GitHubUserID           int64
+	GitHubLogin            string
+	DisplayName            string
+	Email                  string
+	EmailVerified          bool
+	AvatarURL              string
+	SealKey                func(rawKey string) (string, error)
 }
 
 type AgentProvisionResult struct {
@@ -212,7 +214,10 @@ func (q *Queries) ProvisionAgentSession(ctx context.Context, in AgentProvisionIn
 
 	installationRepos := in.Repos
 	if len(installationRepos) == 0 {
-		installationRepos = []string{in.CanonicalRepo}
+		installationRepos = []InstallationRepo{{
+			FullName:      in.CanonicalRepo,
+			DefaultBranch: in.CanonicalDefaultBranch,
+		}}
 	}
 	if err := q.PersistInstallation(ctx, tx, PersistInstallationParams{
 		InstallationID: in.InstallationID,
@@ -232,6 +237,15 @@ func (q *Queries) ProvisionAgentSession(ctx context.Context, in AgentProvisionIn
 	project, err := q.CreateProjectTx(ctx, tx, orgID, projectName, &canonicalRepo)
 	if err != nil {
 		return nil, err
+	}
+	// PersistInstallation runs before this project exists, so apply the branch
+	// to the new row after creation in the same transaction.
+	if in.CanonicalDefaultBranch != "" {
+		if _, err := tx.Exec(ctx,
+			`UPDATE projects SET default_branch = $2 WHERE id = $1`,
+			project.ID, in.CanonicalDefaultBranch); err != nil {
+			return nil, fmt.Errorf("set project default branch: %w", err)
+		}
 	}
 	if _, err := q.CreateEnvironmentTx(ctx, tx, project.ID, "production"); err != nil {
 		return nil, err

--- a/packages/ingestion/db/agent_provision_test.go
+++ b/packages/ingestion/db/agent_provision_test.go
@@ -263,6 +263,39 @@ func TestProvisionAgentSession_NewOrgUserProjectKey(t *testing.T) {
 	}
 }
 
+func TestProvisionAgentSessionStoresResolvedDefaultBranch(t *testing.T) {
+	pool := testPool(t)
+	q := db.New(pool)
+	ctx := context.Background()
+	cleanup := newProvisionCleanup(t, pool)
+	fixture := newProvisionFixture()
+	repo := "Master-Owner-" + fixture.suffix + "/Master-Repo"
+	session := createProvisionSession(t, q, cleanup, strings.ToLower(repo))
+	input := fixture.input(session.ID, repo)
+	input.CanonicalDefaultBranch = "master"
+	input.Repos = []db.InstallationRepo{{
+		FullName:      repo,
+		DefaultBranch: "master",
+	}}
+	cleanup.installation(input.InstallationID)
+
+	result, err := q.ProvisionAgentSession(ctx, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup.org(result.OrgID)
+
+	var branch *string
+	if err := pool.QueryRow(ctx,
+		`SELECT default_branch FROM projects WHERE id = $1`,
+		result.ProjectID).Scan(&branch); err != nil {
+		t.Fatal(err)
+	}
+	if branch == nil || *branch != "master" {
+		t.Fatalf("default_branch = %v, want master", branch)
+	}
+}
+
 func TestProvisionAgentSession_ReturningUserUsesExistingOrg(t *testing.T) {
 	pool := testPool(t)
 	q := db.New(pool)

--- a/packages/ingestion/db/installations.go
+++ b/packages/ingestion/db/installations.go
@@ -5,20 +5,27 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/jackc/pgx/v5"
 )
 
 var ErrInstallationOrgConflict = errors.New("installation is already mapped to another organization")
 
+// InstallationRepo retains repository metadata GitHub already returned.
+type InstallationRepo struct {
+	FullName      string
+	DefaultBranch string
+}
+
 // PersistInstallationParams is the complete database representation of a
-// verified GitHub App installation. Repos are canonical owner/name strings.
+// verified GitHub App installation.
 type PersistInstallationParams struct {
 	InstallationID int64
 	GitHubOrgName  string
 	GitHubOrgID    int64
 	OrgID          string
-	Repos          []string
+	Repos          []InstallationRepo
 }
 
 // PersistInstallation writes the rich installation mapping, the legacy org
@@ -44,11 +51,11 @@ func (q *Queries) PersistInstallation(ctx context.Context, tx pgx.Tx, params Per
 		return ErrInstallationOrgConflict
 	}
 
-	repos := params.Repos
-	if repos == nil {
-		repos = []string{}
+	repoNames := make([]string, 0, len(params.Repos))
+	for _, repo := range params.Repos {
+		repoNames = append(repoNames, repo.FullName)
 	}
-	reposJSON, err := json.Marshal(repos)
+	reposJSON, err := json.Marshal(repoNames)
 	if err != nil {
 		return fmt.Errorf("encode installation repos: %w", err)
 	}
@@ -70,7 +77,33 @@ func (q *Queries) PersistInstallation(ctx context.Context, tx pgx.Tx, params Per
 		params.OrgID, params.InstallationID); err != nil {
 		return fmt.Errorf("set org GitHub installation: %w", err)
 	}
-	return q.InsertInstallationLanded(ctx, tx, params.InstallationID, params.OrgID, repos)
+
+	for _, repo := range params.Repos {
+		if repo.FullName == "" || repo.DefaultBranch == "" {
+			continue
+		}
+		// This column is a cache. A failed refresh must not prevent the
+		// installation from landing, so isolate each write in a savepoint.
+		if _, err := tx.Exec(ctx, `SAVEPOINT refresh_default_branch`); err != nil {
+			return fmt.Errorf("savepoint default branch refresh: %w", err)
+		}
+		_, updateErr := tx.Exec(ctx,
+			`UPDATE projects SET default_branch = $3
+			 WHERE org_id = $1 AND lower(github_repo) = lower($2)
+			   AND default_branch IS DISTINCT FROM $3`,
+			params.OrgID, repo.FullName, repo.DefaultBranch)
+		if updateErr != nil {
+			if _, err := tx.Exec(ctx, `ROLLBACK TO SAVEPOINT refresh_default_branch`); err != nil {
+				return fmt.Errorf("recover default branch refresh: %w", err)
+			}
+			slog.Warn("default branch cache refresh failed",
+				"org_id", params.OrgID, "repo", repo.FullName, "error", updateErr)
+		}
+		if _, err := tx.Exec(ctx, `RELEASE SAVEPOINT refresh_default_branch`); err != nil {
+			return fmt.Errorf("release default branch refresh savepoint: %w", err)
+		}
+	}
+	return q.InsertInstallationLanded(ctx, tx, params.InstallationID, params.OrgID, repoNames)
 }
 
 // InsertInstallationLanded appends an audit row in the caller's transaction.

--- a/packages/ingestion/db/installations_default_branch_test.go
+++ b/packages/ingestion/db/installations_default_branch_test.go
@@ -1,0 +1,86 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/opslane/opslane/packages/ingestion/db"
+)
+
+func TestPersistInstallationRefreshesDefaultBranchCache(t *testing.T) {
+	pool := testPool(t)
+	q := db.New(pool)
+	ctx := context.Background()
+
+	org, err := q.CreateOrg(ctx, "branch-cache-"+uuid.NewString())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cleanupTenant(t, pool, org.ID) })
+
+	stale, err := q.CreateProject(ctx, org.ID, "stale", ptrStr("Owner/Stale"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	unknown, err := q.CreateProject(ctx, org.ID, "unknown", ptrStr("owner/unknown"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	unmatched, err := q.CreateProject(ctx, org.ID, "unmatched", ptrStr("owner/other"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE projects SET default_branch = CASE
+		   WHEN id = $1 THEN 'main'
+		   WHEN id = $2 THEN NULL
+		   WHEN id = $3 THEN 'develop'
+		 END
+		 WHERE id IN ($1, $2, $3)`,
+		stale.ID, unknown.ID, unmatched.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = q.PersistInstallation(ctx, tx, db.PersistInstallationParams{
+		InstallationID: time.Now().UnixNano(),
+		GitHubOrgName:  "owner",
+		GitHubOrgID:    time.Now().UnixNano() + 1,
+		OrgID:          org.ID,
+		Repos: []db.InstallationRepo{
+			{FullName: "owner/stale", DefaultBranch: "master"},
+			{FullName: "owner/unknown", DefaultBranch: "trunk"},
+		},
+	})
+	if err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatal(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, check := range []struct {
+		id   string
+		want string
+	}{
+		{id: stale.ID, want: "master"},
+		{id: unknown.ID, want: "trunk"},
+		{id: unmatched.ID, want: "develop"},
+	} {
+		var got *string
+		if err := pool.QueryRow(ctx,
+			`SELECT default_branch FROM projects WHERE id = $1`,
+			check.id).Scan(&got); err != nil {
+			t.Fatal(err)
+		}
+		if got == nil || *got != check.want {
+			t.Errorf("project %s default_branch = %v, want %q", check.id, got, check.want)
+		}
+	}
+}

--- a/packages/ingestion/db/migrations/027_default_branch_nullable.sql
+++ b/packages/ingestion/db/migrations/027_default_branch_nullable.sql
@@ -1,0 +1,13 @@
+-- projects.default_branch was NOT NULL DEFAULT 'main', which cannot express
+-- "we have not learned this repo's default branch yet". Onboarding Phase 1
+-- creates projects before GitHub is connected, so the guess was written as
+-- fact and later used to `git clone --branch main`, breaking every repo whose
+-- default branch is not 'main' (issue #180).
+--
+-- NULL now means unknown. Existing rows keep their current value on purpose:
+-- they are corrected when the GitHub App installation lands, or on the next
+-- successful clone. Blanking them here would strip a usable value out from
+-- under jobs that are mid-flight.
+ALTER TABLE projects
+  ALTER COLUMN default_branch DROP NOT NULL,
+  ALTER COLUMN default_branch DROP DEFAULT;

--- a/packages/ingestion/db/migrations_test.go
+++ b/packages/ingestion/db/migrations_test.go
@@ -215,3 +215,59 @@ func TestMigrations_RollForwardFromPreviousSchema(t *testing.T) {
 		t.Fatalf("latest migration %s failed to roll forward from previous schema: %v", last, err)
 	}
 }
+
+func TestDefaultBranchNullableMigrationPreservesExistingRows(t *testing.T) {
+	admin := testPool(t)
+	files := migrationFiles(t)
+	psql := findPsql(t)
+	pool, dsn := disposableDB(t, admin)
+
+	for _, file := range files[:len(files)-1] {
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("migration %s failed: %v", file, err)
+		}
+	}
+
+	ctx := context.Background()
+	var orgID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO orgs (name) VALUES ('migration-default-branch') RETURNING id`,
+	).Scan(&orgID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO projects (org_id, name, github_repo, default_branch)
+		 VALUES ($1, 'existing', 'o/existing', 'master')`,
+		orgID); err != nil {
+		t.Fatal(err)
+	}
+
+	last := files[len(files)-1]
+	if err := applyMigration(t, psql, dsn, last); err != nil {
+		t.Fatalf("latest migration %s failed: %v", last, err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO projects (org_id, name, github_repo)
+		 VALUES ($1, 'new', 'o/new')`,
+		orgID); err != nil {
+		t.Fatal(err)
+	}
+
+	var existing, created *string
+	if err := pool.QueryRow(ctx,
+		`SELECT default_branch FROM projects WHERE name = 'existing'`,
+	).Scan(&existing); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT default_branch FROM projects WHERE name = 'new'`,
+	).Scan(&created); err != nil {
+		t.Fatal(err)
+	}
+	if existing == nil || *existing != "master" {
+		t.Fatalf("existing default_branch = %v, want master", existing)
+	}
+	if created != nil {
+		t.Fatalf("new default_branch = %q, want NULL", *created)
+	}
+}

--- a/packages/ingestion/db/oauth_installation_test.go
+++ b/packages/ingestion/db/oauth_installation_test.go
@@ -30,7 +30,9 @@ func TestInstallationLandedPersistsWithInstallation(t *testing.T) {
 		GitHubOrgName:  "landed-org",
 		GitHubOrgID:    installationID + 1,
 		OrgID:          org.ID,
-		Repos:          []string{"Landed/Repo"},
+		Repos: []db.InstallationRepo{{
+			FullName: "Landed/Repo",
+		}},
 	}); err != nil {
 		_ = tx.Rollback(ctx)
 		t.Fatal(err)

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -85,7 +85,7 @@ type Project struct {
 	OrgID                   string
 	Name                    string
 	GithubRepo              *string
-	DefaultBranch           string
+	DefaultBranch           *string // NULL until learned from GitHub or a clone
 	FrictionAutonomy        string
 	PrPosture               string
 	AllowPayloadEnvironment bool
@@ -3194,12 +3194,16 @@ func (q *Queries) CreateEnvironmentTx(ctx context.Context, tx pgx.Tx, projectID,
 
 // === GitHub config CRUD ===
 
-// SetProjectGitHubConfig stores the GitHub repo for a project. Tenant-scoped by orgID.
-func (q *Queries) SetProjectGitHubConfig(ctx context.Context, orgID, projectID, githubRepo string) error {
+// SetProjectGitHubConfig stores the GitHub repo and its resolved default branch.
+// Tenant-scoped by orgID.
+func (q *Queries) SetProjectGitHubConfig(
+	ctx context.Context,
+	orgID, projectID, githubRepo, defaultBranch string,
+) error {
 	ct, err := q.pool.Exec(ctx,
-		`UPDATE projects SET github_repo = $3
+		`UPDATE projects SET github_repo = $3, default_branch = $4
 		 WHERE id = $2 AND org_id = $1`,
-		orgID, projectID, githubRepo,
+		orgID, projectID, githubRepo, defaultBranch,
 	)
 	if err != nil {
 		return fmt.Errorf("set project github config: %w", err)

--- a/packages/ingestion/handler/agent_callback_integration_test.go
+++ b/packages/ingestion/handler/agent_callback_integration_test.go
@@ -143,7 +143,7 @@ func TestWorkosAgentCallbackEndToEndAndFailureSemantics(t *testing.T) {
 			w.WriteHeader(http.StatusCreated)
 			fmt.Fprint(w, `{"token":"installation-token","expires_at":"2099-01-01T00:00:00Z"}`)
 		case r.URL.Path == "/installation/repositories":
-			fmt.Fprintf(w, `{"repositories":[{"full_name":%q}]}`, repoFullName)
+			fmt.Fprintf(w, `{"repositories":[{"full_name":%q,"default_branch":"master"}]}`, repoFullName)
 		default:
 			http.NotFound(w, r)
 		}
@@ -190,6 +190,15 @@ func TestWorkosAgentCallbackEndToEndAndFailureSemantics(t *testing.T) {
 			`SELECT count(*) FROM installation_landed WHERE installation_id = $1 AND $2 = ANY(repos)`,
 			installationID, repoFullName).Scan(&auditCount); err != nil || auditCount != 1 {
 			t.Fatalf("landed audit count=%d err=%v", auditCount, err)
+		}
+		var defaultBranch *string
+		if err := pool.QueryRow(context.Background(),
+			`SELECT default_branch FROM projects WHERE id = $1`,
+			*after.ProjectID).Scan(&defaultBranch); err != nil {
+			t.Fatal(err)
+		}
+		if defaultBranch == nil || *defaultBranch != "master" {
+			t.Fatalf("default_branch=%v, want master", defaultBranch)
 		}
 
 		code, first := pollAgentSession(t, deps, session.ID, raw)

--- a/packages/ingestion/handler/agent_setup.go
+++ b/packages/ingestion/handler/agent_setup.go
@@ -429,9 +429,11 @@ func (d *Dependencies) AgentAuthCallback(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	canonical := ""
+	canonicalDefaultBranch := ""
 	for _, repo := range repos {
 		if strings.EqualFold(repo.FullName, session.RepoURL) {
 			canonical = repo.FullName
+			canonicalDefaultBranch = repo.DefaultBranch
 			break
 		}
 	}
@@ -446,23 +448,20 @@ func (d *Dependencies) AgentAuthCallback(w http.ResponseWriter, r *http.Request)
 	if session.AgentKeyPub != nil {
 		agentKeyPub = *session.AgentKeyPub
 	}
-	repoNames := make([]string, 0, len(repos))
-	for _, repo := range repos {
-		repoNames = append(repoNames, repo.FullName)
-	}
 	res, err := d.Queries.ProvisionAgentSession(r.Context(), db.AgentProvisionInput{
-		SessionID:      sessionID,
-		InstallationID: installationID,
-		CanonicalRepo:  canonical,
-		Repos:          repoNames,
-		GitHubOrgName:  installInfo.Account.Login,
-		GitHubOrgID:    installInfo.Account.ID,
-		GitHubUserID:   ghUser.ID,
-		GitHubLogin:    ghUser.Login,
-		DisplayName:    ghUser.Name,
-		Email:          email,
-		EmailVerified:  emailVerified,
-		AvatarURL:      ghUser.AvatarURL,
+		SessionID:              sessionID,
+		InstallationID:         installationID,
+		CanonicalRepo:          canonical,
+		Repos:                  toInstallationRepos(repos),
+		CanonicalDefaultBranch: canonicalDefaultBranch,
+		GitHubOrgName:          installInfo.Account.Login,
+		GitHubOrgID:            installInfo.Account.ID,
+		GitHubUserID:           ghUser.ID,
+		GitHubLogin:            ghUser.Login,
+		DisplayName:            ghUser.Name,
+		Email:                  email,
+		EmailVerified:          emailVerified,
+		AvatarURL:              ghUser.AvatarURL,
 		SealKey: func(rawKey string) (string, error) {
 			return auth.SealAgentKey(agentKeyPub, sessionID, rawKey)
 		},

--- a/packages/ingestion/handler/github_oauth.go
+++ b/packages/ingestion/handler/github_oauth.go
@@ -370,10 +370,7 @@ func (d *Dependencies) gitHubInstallCallback(w http.ResponseWriter, r *http.Requ
 		writeJSONError(w, http.StatusBadGateway, "could not load GitHub installation repositories")
 		return
 	}
-	repoNames := make([]string, 0, len(repos))
-	for _, repo := range repos {
-		repoNames = append(repoNames, repo.FullName)
-	}
+	installationRepos := toInstallationRepos(repos)
 
 	tx, err := d.Queries.Pool().Begin(r.Context())
 	if err != nil {
@@ -391,7 +388,7 @@ func (d *Dependencies) gitHubInstallCallback(w http.ResponseWriter, r *http.Requ
 		GitHubOrgName:  installInfo.Account.Login,
 		GitHubOrgID:    installInfo.Account.ID,
 		OrgID:          *reservation.TargetOrgID,
-		Repos:          repoNames,
+		Repos:          installationRepos,
 	}); err != nil {
 		if errors.Is(err, db.ErrInstallationOrgConflict) {
 			writeJSONError(w, http.StatusConflict, "installation is already mapped to another organization")
@@ -640,10 +637,7 @@ func (d *Dependencies) applyCombinedGitHubInstallationContext(ctx context.Contex
 	if err != nil {
 		return fmt.Errorf("list installation repositories: %w", err)
 	}
-	repoNames := make([]string, 0, len(repos))
-	for _, repo := range repos {
-		repoNames = append(repoNames, repo.FullName)
-	}
+	installationRepos := toInstallationRepos(repos)
 	orgID := user.OrgID
 	if targetOrgID != "" {
 		role, err := d.Queries.GetMembership(ctx, user.ID, targetOrgID)
@@ -665,7 +659,7 @@ func (d *Dependencies) applyCombinedGitHubInstallationContext(ctx context.Contex
 		GitHubOrgName:  installInfo.Account.Login,
 		GitHubOrgID:    installInfo.Account.ID,
 		OrgID:          orgID,
-		Repos:          repoNames,
+		Repos:          installationRepos,
 	}); err != nil {
 		return err
 	}
@@ -673,6 +667,17 @@ func (d *Dependencies) applyCombinedGitHubInstallationContext(ctx context.Contex
 }
 
 // === helpers ===
+
+func toInstallationRepos(repos []gh.Repo) []db.InstallationRepo {
+	result := make([]db.InstallationRepo, 0, len(repos))
+	for _, repo := range repos {
+		result = append(result, db.InstallationRepo{
+			FullName:      repo.FullName,
+			DefaultBranch: repo.DefaultBranch,
+		})
+	}
+	return result
+}
 
 func generateOAuthState(secret []byte) (string, error) {
 	nonce := make([]byte, 16)

--- a/packages/ingestion/handler/github_settings.go
+++ b/packages/ingestion/handler/github_settings.go
@@ -2,11 +2,13 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	gh "github.com/opslane/opslane/packages/ingestion/github"
 )
 
 type setGitHubConfigRequest struct {
@@ -46,14 +48,58 @@ func (d *Dependencies) SetGitHubConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	orgID := OrgIDFromCtx(r.Context())
-	if err := d.Queries.SetProjectGitHubConfig(r.Context(), orgID, projectID, req.GithubRepo); err != nil {
+	installationID, err := d.Queries.GetOrgGitHubInstallation(r.Context(), orgID)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to load GitHub installation")
+		return
+	}
+	if installationID == 0 {
+		writeJSONError(w, http.StatusBadRequest, "GitHub App not installed for this organization")
+		return
+	}
+	appJWT, err := gh.GenerateAppJWT(d.GitHubAppID, d.GitHubAppPrivateKey)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	installationToken, err := gh.GetInstallationToken(appJWT, installationID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "could not reach GitHub, please retry")
+		return
+	}
+	repos, err := gh.ListInstallationRepos(installationToken.Token)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "could not reach GitHub, please retry")
+		return
+	}
+	var matched *gh.Repo
+	for i := range repos {
+		if strings.EqualFold(repos[i].FullName, req.GithubRepo) {
+			matched = &repos[i]
+			break
+		}
+	}
+	if matched == nil {
+		writeJSONError(w, http.StatusBadRequest, fmt.Sprintf(
+			"the Opslane GitHub App is not installed on %s — install it, then retry",
+			req.GithubRepo,
+		))
+		return
+	}
+	if err := d.Queries.SetProjectGitHubConfig(
+		r.Context(),
+		orgID,
+		projectID,
+		matched.FullName,
+		matched.DefaultBranch,
+	); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to save GitHub config")
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(gitHubConfigResponse{
-		GithubRepo: req.GithubRepo,
+		GithubRepo: matched.FullName,
 		Connected:  true,
 	})
 }

--- a/packages/ingestion/handler/github_settings_test.go
+++ b/packages/ingestion/handler/github_settings_test.go
@@ -1,0 +1,165 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/opslane/opslane/packages/ingestion/db"
+	gh "github.com/opslane/opslane/packages/ingestion/github"
+)
+
+func setGitHubConfigFixture(
+	t *testing.T,
+) (*Dependencies, *db.Queries, string, string, int64) {
+	t.Helper()
+	pool := githubOAuthTestPool(t)
+	q := db.New(pool)
+	ctx := context.Background()
+	org, err := q.CreateOrg(ctx, "github-settings-"+uuid.NewString())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cleanupGitHubOAuthOrg(t, pool, org.ID) })
+	project, err := q.CreateProject(ctx, org.ID, "settings", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(),
+			`DELETE FROM projects WHERE id = $1`, project.ID)
+	})
+	installationID := time.Now().UnixNano()
+	if err := q.SetOrgGitHubInstallation(ctx, org.ID, installationID); err != nil {
+		t.Fatal(err)
+	}
+	return &Dependencies{
+		Queries:             q,
+		GitHubAppID:         "1",
+		GitHubAppPrivateKey: callbackTestKey(t),
+	}, q, org.ID, project.ID, installationID
+}
+
+func newSetGitHubConfigRequest(
+	orgID, projectID, repo string,
+) *http.Request {
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/api/v1/projects/"+projectID+"/github",
+		strings.NewReader(fmt.Sprintf(`{"github_repo":%q}`, repo)),
+	)
+	route := chi.NewRouteContext()
+	route.URLParams.Add("projectID", projectID)
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, route)
+	ctx = context.WithValue(ctx, ctxOrgID, orgID)
+	return req.WithContext(ctx)
+}
+
+func githubSettingsClient(
+	installationID int64,
+	reposJSON string,
+) *http.Client {
+	return &http.Client{Transport: handlerRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPost &&
+			req.URL.Path == fmt.Sprintf("/app/installations/%d/access_tokens", installationID):
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(
+					`{"token":"installation-token","expires_at":"2099-01-01T00:00:00Z"}`,
+				)),
+			}, nil
+		case req.Method == http.MethodGet &&
+			req.URL.Path == "/installation/repositories":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(reposJSON)),
+			}, nil
+		default:
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{}`)),
+			}, nil
+		}
+	})}
+}
+
+func TestSetGitHubConfigStoresResolvedDefaultBranch(t *testing.T) {
+	for _, branch := range []string{"master", "main"} {
+		t.Run(branch, func(t *testing.T) {
+			deps, q, orgID, projectID, installationID := setGitHubConfigFixture(t)
+			restore := gh.OverrideHTTPClientForTests(githubSettingsClient(
+				installationID,
+				fmt.Sprintf(`{"repositories":[{"full_name":"Owner/Repo","default_branch":%q}]}`, branch),
+			))
+			defer restore()
+
+			recorder := httptest.NewRecorder()
+			deps.SetGitHubConfig(
+				recorder,
+				newSetGitHubConfigRequest(orgID, projectID, "owner/repo"),
+			)
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("code = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+			}
+			project, err := q.GetProjectByOrgID(context.Background(), orgID, projectID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if project.DefaultBranch == nil || *project.DefaultBranch != branch {
+				t.Fatalf("default_branch = %v, want %q", project.DefaultBranch, branch)
+			}
+			if project.GithubRepo == nil || *project.GithubRepo != "Owner/Repo" {
+				t.Fatalf("github_repo = %v, want canonical Owner/Repo", project.GithubRepo)
+			}
+		})
+	}
+}
+
+func TestSetGitHubConfigRejectsRepoOutsideInstallation(t *testing.T) {
+	deps, _, orgID, projectID, installationID := setGitHubConfigFixture(t)
+	restore := gh.OverrideHTTPClientForTests(githubSettingsClient(
+		installationID,
+		`{"repositories":[{"full_name":"owner/other","default_branch":"main"}]}`,
+	))
+	defer restore()
+
+	recorder := httptest.NewRecorder()
+	deps.SetGitHubConfig(
+		recorder,
+		newSetGitHubConfigRequest(orgID, projectID, "owner/missing"),
+	)
+	if recorder.Code != http.StatusBadRequest ||
+		!strings.Contains(recorder.Body.String(), "owner/missing") {
+		t.Fatalf("code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestSetGitHubConfigReturnsBadGatewayWhenGitHubIsUnreachable(t *testing.T) {
+	deps, _, orgID, projectID, _ := setGitHubConfigFixture(t)
+	restore := gh.OverrideHTTPClientForTests(&http.Client{
+		Transport: handlerRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("network unavailable")
+		}),
+	})
+	defer restore()
+
+	recorder := httptest.NewRecorder()
+	deps.SetGitHubConfig(
+		recorder,
+		newSetGitHubConfigRequest(orgID, projectID, "owner/repo"),
+	)
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("code=%d, want 502; body=%s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/packages/ingestion/handler/onboard_provision_test.go
+++ b/packages/ingestion/handler/onboard_provision_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/opslane/opslane/packages/ingestion/auth"
 	"github.com/opslane/opslane/packages/ingestion/db"
+	gh "github.com/opslane/opslane/packages/ingestion/github"
 )
 
 func onboardProvisionRequest(body string, userID, orgID string) *http.Request {
@@ -156,6 +157,46 @@ func TestOnboardProvisionCreatesCanonicalResponseAndRotatesKey(t *testing.T) {
 	}
 	if firstStatus != "expired" || firstSealed != nil {
 		t.Fatalf("superseded session status/sealed = %q/%v, want expired/nil", firstStatus, firstSealed)
+	}
+}
+
+func TestOnboardProvisionMakesNoGitHubCallAndLeavesBranchUnknown(t *testing.T) {
+	pool := githubOAuthTestPool(t)
+	orgID, userID := seedOnboardProvisionActor(t, pool)
+	called := false
+	restore := gh.OverrideHTTPClientForTests(&http.Client{
+		Transport: handlerRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			called = true
+			return nil, fmt.Errorf("GitHub must not be called during Phase 1")
+		}),
+	})
+	defer restore()
+
+	repo := "acme/no-github-" + uuid.NewString()
+	recorder := httptest.NewRecorder()
+	(&Dependencies{Queries: db.New(pool)}).OnboardProvision(
+		recorder,
+		onboardProvisionRequest(
+			fmt.Sprintf(`{"repo_url":%q}`, repo),
+			userID,
+			orgID,
+		),
+	)
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("code=%d, want 201; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if called {
+		t.Fatal("Phase 1 provisioning called GitHub")
+	}
+
+	var branch *string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT default_branch FROM projects WHERE org_id = $1 AND github_repo = $2`,
+		orgID, repo).Scan(&branch); err != nil {
+		t.Fatal(err)
+	}
+	if branch != nil {
+		t.Fatalf("default_branch = %q, want NULL", *branch)
 	}
 }
 

--- a/packages/worker/src/__tests__/agent-fix.test.ts
+++ b/packages/worker/src/__tests__/agent-fix.test.ts
@@ -99,15 +99,30 @@ function makeInput(overrides?: Partial<AgentFixInput>): AgentFixInput {
     sourceFiles: [],
     visualAnalysis: null,
     repoUrl: 'https://github.com/test/repo.git',
-    defaultBranch: 'main',
+    githubRepo: 'test/repo',
     ...overrides,
   };
 }
 
 const DIFF_STDOUT = 'diff --git a/src/foo.ts b/src/foo.ts\n--- a/src/foo.ts\n+++ b/src/foo.ts\n@@ -1 +1 @@\n-bad\n+good\n';
 
+function gitResolutionResult(cmd: string) {
+  if (cmd.includes('ls-remote')) {
+    return { exitCode: 0, stdout: 'abc\trefs/heads/main\n', stderr: '' };
+  }
+  if (cmd.includes('symbolic-ref')) {
+    return { exitCode: 0, stdout: 'main\n', stderr: '' };
+  }
+  if (cmd.includes('rev-parse')) {
+    return { exitCode: 0, stdout: 'abc\n', stderr: '' };
+  }
+  return undefined;
+}
+
 /** Default commands.run: returns "none" for test detection, diff for git diff, empty otherwise */
 function defaultCommandsRun(cmd: string) {
+  const resolution = gitResolutionResult(cmd);
+  if (resolution) return Promise.resolve(resolution);
   if (cmd.includes('vitest.config') && cmd.includes('echo')) {
     // Test runner detection → no runner
     return Promise.resolve({ exitCode: 0, stdout: 'none', stderr: '' });
@@ -122,6 +137,8 @@ function defaultCommandsRun(cmd: string) {
  *  fix_ready path. Use in tests that assert the full happy path through to a PR-worthy fix. */
 function mockSandboxWithPassingTests() {
   mockSandbox.commands.run.mockImplementation(async (cmd: string) => {
+    const resolution = gitResolutionResult(cmd);
+    if (resolution) return resolution;
     if (cmd.includes('vitest.config') && cmd.includes('echo')) return { exitCode: 0, stdout: 'vitest', stderr: '' };
     if (cmd.includes('npx vitest run')) return { exitCode: 0, stdout: '3 tests passed', stderr: '' };
     if (cmd.includes('git diff')) return { exitCode: 0, stdout: DIFF_STDOUT, stderr: '' };
@@ -426,6 +443,8 @@ describe('runAgentFix', () => {
 
   it('returns fix_ready with high confidence when test gate passes', async () => {
     mockSandbox.commands.run.mockImplementation(async (cmd: string) => {
+      const resolution = gitResolutionResult(cmd);
+      if (resolution) return resolution;
       if (cmd.includes('vitest.config') && cmd.includes('echo')) return { exitCode: 0, stdout: 'vitest', stderr: '' };
       if (cmd.includes('npx vitest run')) return { exitCode: 0, stdout: '3 tests passed', stderr: '' };
       if (cmd.includes('git diff')) return { exitCode: 0, stdout: DIFF_STDOUT, stderr: '' };
@@ -529,6 +548,8 @@ describe('runAgentFix', () => {
 
   it('GATE: tests pass but judge fails on the last/only tier → needs_human, no PR', async () => {
     mockSandbox.commands.run.mockImplementation(async (cmd: string) => {
+      const resolution = gitResolutionResult(cmd);
+      if (resolution) return resolution;
       if (cmd.includes('vitest.config') && cmd.includes('echo')) return { exitCode: 0, stdout: 'vitest', stderr: '' };
       if (cmd.includes('npx vitest run')) return { exitCode: 0, stdout: '3 tests passed', stderr: '' };
       if (cmd.includes('git diff')) return { exitCode: 0, stdout: DIFF_STDOUT, stderr: '' };
@@ -548,6 +569,8 @@ describe('runAgentFix', () => {
 
   it('GATE: judge runs even on the last (single) tier', async () => {
     mockSandbox.commands.run.mockImplementation(async (cmd: string) => {
+      const resolution = gitResolutionResult(cmd);
+      if (resolution) return resolution;
       if (cmd.includes('vitest.config') && cmd.includes('echo')) return { exitCode: 0, stdout: 'vitest', stderr: '' };
       if (cmd.includes('npx vitest run')) return { exitCode: 0, stdout: '3 tests passed', stderr: '' };
       if (cmd.includes('git diff')) return { exitCode: 0, stdout: DIFF_STDOUT, stderr: '' };
@@ -632,6 +655,8 @@ describe('runAgentFix', () => {
   it('escalates to Sonnet when judge rejects Haiku fix, then accepts a verified Sonnet fix', async () => {
     // Tests run + pass so a clean fix can clear the gate after escalation.
     mockSandbox.commands.run.mockImplementation(async (cmd: string) => {
+      const resolution = gitResolutionResult(cmd);
+      if (resolution) return resolution;
       if (cmd.includes('vitest.config') && cmd.includes('echo')) return { exitCode: 0, stdout: 'vitest', stderr: '' };
       if (cmd.includes('npx vitest run')) return { exitCode: 0, stdout: '3 tests passed', stderr: '' };
       if (cmd.includes('git diff')) return { exitCode: 0, stdout: DIFF_STDOUT, stderr: '' };
@@ -657,6 +682,8 @@ describe('runAgentFix', () => {
   it('GATE: judge throwing means quality not confirmed → escalate, then needs_human on last tier', async () => {
     // Tests pass, but the judge errors on every tier → we cannot confirm quality → below floor.
     mockSandbox.commands.run.mockImplementation(async (cmd: string) => {
+      const resolution = gitResolutionResult(cmd);
+      if (resolution) return resolution;
       if (cmd.includes('vitest.config') && cmd.includes('echo')) return { exitCode: 0, stdout: 'vitest', stderr: '' };
       if (cmd.includes('npx vitest run')) return { exitCode: 0, stdout: '3 tests passed', stderr: '' };
       if (cmd.includes('git diff')) return { exitCode: 0, stdout: DIFF_STDOUT, stderr: '' };
@@ -695,6 +722,8 @@ describe('runAgentFix', () => {
     const commands: string[] = [];
     mockSandbox.commands.run.mockImplementation(async (cmd: string) => {
       commands.push(cmd);
+      const resolution = gitResolutionResult(cmd);
+      if (resolution) return resolution;
       if (cmd.includes('vitest.config') && cmd.includes('echo')) return { exitCode: 0, stdout: 'none', stderr: '' };
       if (cmd.includes('git diff')) return { exitCode: 0, stdout: 'diff --git a/f.ts b/f.ts\n--- a/f.ts\n+++ b/f.ts\n@@ -1 +1 @@\n-old\n+new\n', stderr: '' };
       return { exitCode: 0, stdout: '', stderr: '' };
@@ -719,6 +748,8 @@ describe('runAgentFix', () => {
     const commands: string[] = [];
     mockSandbox.commands.run.mockImplementation(async (cmd: string) => {
       commands.push(cmd);
+      const resolution = gitResolutionResult(cmd);
+      if (resolution) return resolution;
       if (cmd.includes('vitest.config') && cmd.includes('echo')) return { exitCode: 0, stdout: 'none', stderr: '' };
       if (cmd.includes('git diff')) return { exitCode: 0, stdout: 'diff --git a/f.ts b/f.ts\n--- a/f.ts\n+++ b/f.ts\n@@ -1 +1 @@\n-old\n+new\n', stderr: '' };
       return { exitCode: 0, stdout: '', stderr: '' };

--- a/packages/worker/src/__tests__/clone-failure-classification.test.ts
+++ b/packages/worker/src/__tests__/clone-failure-classification.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CloneResolutionError,
+  cloneFailureReason,
+} from '../repo-clone.js';
+
+describe('cloneFailureReason', () => {
+  it('does not blame permissions for an empty repository', () => {
+    const reason = cloneFailureReason(
+      new CloneResolutionError('empty_repository', 'o/r'),
+    );
+    expect(reason.reason_code).toBe('empty_repository');
+    expect(reason.remediation).not.toMatch(/read access|permission/i);
+  });
+
+  it('names the missing default branch and repository', () => {
+    const reason = cloneFailureReason(
+      new CloneResolutionError('invalid_default_branch', 'o/r', 'gone'),
+    );
+    expect(reason.reason_code).toBe('invalid_default_branch');
+    expect(reason.reason_message).toContain('gone');
+    expect(reason.reason_message).toContain('o/r');
+  });
+
+  it('keeps genuine access failures classified as access failures', () => {
+    expect(
+      cloneFailureReason(new Error('remote: Repository not found')).reason_code,
+    ).toBe('repo_access_denied');
+  });
+
+  it('detects a missing token', () => {
+    expect(
+      cloneFailureReason(new Error('GITHUB_TOKEN is not set')).reason_code,
+    ).toBe('missing_github_token');
+  });
+});

--- a/packages/worker/src/__tests__/clone-resolution.test.ts
+++ b/packages/worker/src/__tests__/clone-resolution.test.ts
@@ -1,0 +1,136 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFile as execFileCb } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import {
+  CloneResolutionError,
+  cloneRepo,
+  execFileGitRunner,
+  resolveClonedBranch,
+} from '../repo-clone.js';
+
+const execFile = promisify(execFileCb);
+const GIT_ENV = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_SYSTEM: '/dev/null',
+  GIT_AUTHOR_NAME: 't',
+  GIT_AUTHOR_EMAIL: 't@t',
+  GIT_COMMITTER_NAME: 't',
+  GIT_COMMITTER_EMAIL: 't@t',
+} as NodeJS.ProcessEnv;
+
+const git = (cwd: string, ...args: string[]) =>
+  execFile('git', args, { cwd, env: GIT_ENV });
+
+let root: string;
+
+beforeAll(async () => {
+  root = await mkdtemp(join(tmpdir(), 'dbr-'));
+});
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+async function masterRemote(name: string): Promise<string> {
+  const work = join(root, `${name}-work`);
+  await execFile('git', ['init', '-q', '--initial-branch=master', work], {
+    env: GIT_ENV,
+  });
+  await writeFile(join(work, 'a.txt'), 'hi\n');
+  await git(work, 'add', '-A');
+  await git(work, 'commit', '-qm', 'init');
+  const bare = join(root, `${name}-bare`);
+  await execFile('git', ['clone', '-q', '--bare', work, bare], {
+    env: GIT_ENV,
+  });
+  return `file://${bare}`;
+}
+
+async function brokenHeadRemote(name: string): Promise<string> {
+  const url = await masterRemote(name);
+  await git(url.replace('file://', ''), 'symbolic-ref', 'HEAD', 'refs/heads/nonexistent');
+  return url;
+}
+
+async function emptyRemote(name: string): Promise<string> {
+  const bare = join(root, `${name}-bare`);
+  await execFile('git', [
+    'init',
+    '-q',
+    '--bare',
+    '--initial-branch=master',
+    bare,
+  ], { env: GIT_ENV });
+  return `file://${bare}`;
+}
+
+async function cloneTo(url: string, name: string): Promise<string> {
+  const dir = join(root, name);
+  await execFile('git', ['clone', '--depth', '1', '--', url, dir], {
+    env: GIT_ENV,
+  });
+  return dir;
+}
+
+describe('resolveClonedBranch', () => {
+  it('returns the real default branch when it is not main', async () => {
+    const dir = await cloneTo(await masterRemote('ok'), 'ok-clone');
+    await expect(
+      resolveClonedBranch(execFileGitRunner(dir), 'o/r'),
+    ).resolves.toBe('master');
+  });
+
+  it('classifies a repository with no commits', async () => {
+    const dir = await cloneTo(await emptyRemote('empty'), 'empty-clone');
+    const error = await resolveClonedBranch(
+      execFileGitRunner(dir),
+      'o/empty',
+    ).catch((err: unknown) => err);
+    expect(error).toBeInstanceOf(CloneResolutionError);
+    if (!(error instanceof CloneResolutionError)) throw error;
+    expect(error.kind).toBe('empty_repository');
+    expect(error.message).toContain('o/empty');
+  });
+
+  it('does not call a broken-HEAD repository empty', async () => {
+    const dir = await cloneTo(await brokenHeadRemote('broken'), 'broken-clone');
+    const error = await resolveClonedBranch(
+      execFileGitRunner(dir),
+      'o/broken',
+    ).catch((err: unknown) => err);
+    expect(error).toBeInstanceOf(CloneResolutionError);
+    if (!(error instanceof CloneResolutionError)) throw error;
+    expect(error.kind).toBe('invalid_default_branch');
+    expect(error.discoveredBranch).toBe('nonexistent');
+    expect(error.message).toContain('o/broken');
+    expect(error.message).toContain('nonexistent');
+  });
+
+  it('classifies detached HEAD as unresolvable', async () => {
+    const dir = await cloneTo(await masterRemote('detached'), 'detached-clone');
+    await git(dir, 'checkout', '--detach', '-q');
+    const error = await resolveClonedBranch(
+      execFileGitRunner(dir),
+      'o/detached',
+    ).catch((err: unknown) => err);
+    expect(error).toBeInstanceOf(CloneResolutionError);
+    if (!(error instanceof CloneResolutionError)) throw error;
+    expect(error.kind).toBe('unresolvable_head');
+  });
+});
+
+describe('cloneRepo without a pinned branch', () => {
+  it('clones a master-default repository and reports the branch', async () => {
+    const result = await cloneRepo({
+      githubRepo: 'o/r',
+      jobId: `dbr-${Date.now()}`,
+      repoUrl: await masterRemote('hostclone'),
+    });
+    expect(result.defaultBranch).toBe('master');
+    await result.cleanup();
+  });
+});

--- a/packages/worker/src/__tests__/default-branch-cache.test.ts
+++ b/packages/worker/src/__tests__/default-branch-cache.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import { cacheProjectDefaultBranch } from '../db.js';
+
+describe('cacheProjectDefaultBranch', () => {
+  it('never throws when the update fails', async () => {
+    const pool = {
+      query: vi.fn().mockRejectedValue(new Error('connection reset')),
+    };
+    await expect(
+      cacheProjectDefaultBranch('p1', 'master', pool as never),
+    ).resolves.toBeUndefined();
+  });
+
+  it('never throws when the project no longer exists', async () => {
+    const pool = { query: vi.fn().mockResolvedValue({ rowCount: 0 }) };
+    await expect(
+      cacheProjectDefaultBranch('gone', 'master', pool as never),
+    ).resolves.toBeUndefined();
+  });
+
+  it('updates only when the cached value differs', async () => {
+    const pool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    await cacheProjectDefaultBranch('p1', 'master', pool as never);
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('IS DISTINCT FROM'),
+      ['p1', 'master'],
+    );
+  });
+});

--- a/packages/worker/src/__tests__/index.test.ts
+++ b/packages/worker/src/__tests__/index.test.ts
@@ -13,6 +13,7 @@ vi.mock('../db.js', () => ({
   getErrorEvent: vi.fn(),
   getProject: vi.fn(),
   getProjectGitHubInstallation: vi.fn(),
+  cacheProjectDefaultBranch: vi.fn(),
   updateGroupStatus: vi.fn(),
   updateGroupInvestigation: vi.fn(),
   updateGroupAndCreateFixJob: vi.fn(),
@@ -44,6 +45,11 @@ vi.mock('../logger.js', () => ({
 vi.mock('../repo-clone.js', () => ({
   cloneRepo: vi.fn(),
   buildRepoUrl: vi.fn((githubRepo: string) => `https://github.com/${githubRepo}.git`),
+  cloneFailureReason: vi.fn((error: unknown) => ({
+    reason_code: 'repo_access_denied',
+    reason_message: error instanceof Error ? error.message : String(error),
+    remediation: 'Check repository access',
+  })),
 }));
 vi.mock('../minio-client.js', () => ({ fetchObject: vi.fn(), getMinIOConfig: vi.fn(() => null) }));
 vi.mock('../investigate.js', () => ({ investigateError: vi.fn() }));
@@ -245,7 +251,11 @@ describe('processFixJob — preserves writeup on failure (no revert/null)', () =
     mockGetProject.mockResolvedValue({
       id: 'p1', name: 'app', github_repo: 'org/app', default_branch: 'main', friction_autonomy: 'ask_first',
     } as ProjectData);
-    mockCloneRepo.mockResolvedValue({ repoDir: '/tmp/r', cleanup: vi.fn() } as never);
+    mockCloneRepo.mockResolvedValue({
+      repoDir: '/tmp/r',
+      defaultBranch: 'master',
+      cleanup: vi.fn(),
+    } as never);
     vi.mocked(db.getProjectGitHubInstallation).mockResolvedValue(null as never);
     vi.mocked(db.getReplayForGroup).mockResolvedValue(null as never);
     vi.mocked(db.getReplayArtifacts).mockResolvedValue([] as never);

--- a/packages/worker/src/__tests__/python-production-path.test.ts
+++ b/packages/worker/src/__tests__/python-production-path.test.ts
@@ -192,7 +192,11 @@ describeDb('Python two-stage production path', () => {
     vi.clearAllMocks();
     process.env['ANTHROPIC_API_KEY'] = 'test-anthropic-key';
     process.env['GITHUB_TOKEN'] = 'test-github-token';
-    vi.mocked(cloneRepo).mockResolvedValue({ repoDir: '/tmp/python-production-path', cleanup: vi.fn() });
+    vi.mocked(cloneRepo).mockResolvedValue({
+      repoDir: '/tmp/python-production-path',
+      defaultBranch: 'main',
+      cleanup: vi.fn(),
+    });
     vi.mocked(investigateError).mockResolvedValue({
       fixable: true,
       confidence: 'high',

--- a/packages/worker/src/__tests__/repo-clone.test.ts
+++ b/packages/worker/src/__tests__/repo-clone.test.ts
@@ -100,7 +100,7 @@ describe('cloneRepo', () => {
   it('throws when no token is available', async () => {
     delete process.env['GITHUB_TOKEN'];
     await expect(
-      cloneRepo({ githubRepo: 'owner/repo', defaultBranch: 'main', jobId: 'no-token' }),
+      cloneRepo({ githubRepo: 'owner/repo', jobId: 'no-token' }),
     ).rejects.toThrow('GITHUB_TOKEN is not set');
   });
 
@@ -112,7 +112,6 @@ describe('cloneRepo', () => {
     try {
       await cloneRepo({
         githubRepo: 'owner/repo',
-        defaultBranch: 'main',
         jobId: `scrub-${Date.now()}`,
         githubToken: token,
         timeoutMs: 15_000,
@@ -132,7 +131,6 @@ describe('cloneRepo', () => {
     try {
       await cloneRepo({
         githubRepo: 'owner/repo',
-        defaultBranch: 'main',
         jobId: `seam-${Date.now()}`,
         githubToken: 'tok',
         timeoutMs: 15_000,
@@ -217,17 +215,7 @@ describe('gitCommitAndPush', () => {
 
 // These inputs are rejected before any git process runs, so no network/git is needed.
 describe('cloneRepo input validation (git argument-injection guard)', () => {
-  const base = { githubRepo: 'owner/repo', defaultBranch: 'main', jobId: 'j1', githubToken: 'tok' };
-
-  it('rejects a branch that could be parsed as a git option', async () => {
-    await expect(
-      cloneRepo({ ...base, defaultBranch: '--upload-pack=touch /tmp/pwned' }),
-    ).rejects.toThrow(/unsafe branch name/);
-  });
-
-  it('rejects a branch containing whitespace', async () => {
-    await expect(cloneRepo({ ...base, defaultBranch: 'main foo' })).rejects.toThrow(/unsafe branch name/);
-  });
+  const base = { githubRepo: 'owner/repo', jobId: 'j1', githubToken: 'tok' };
 
   it('rejects a repo that is not owner/name', async () => {
     await expect(cloneRepo({ ...base, githubRepo: '--foo' })).rejects.toThrow(/unsafe repository name/);

--- a/packages/worker/src/__tests__/setup-pr.test.ts
+++ b/packages/worker/src/__tests__/setup-pr.test.ts
@@ -5,7 +5,12 @@ const deps = () => ({
   getProject: vi.fn().mockResolvedValue({ github_repo: 'o/r', default_branch: 'main' }),
   getInstallToken: vi.fn().mockResolvedValue('tok'),
   findExistingPr: vi.fn().mockResolvedValue(null),
-  clone: vi.fn().mockResolvedValue({ repoDir: '/tmp/r', cleanup: vi.fn().mockResolvedValue(undefined) }),
+  clone: vi.fn().mockResolvedValue({
+    repoDir: '/tmp/r',
+    defaultBranch: 'master',
+    cleanup: vi.fn().mockResolvedValue(undefined),
+  }),
+  cacheDefaultBranch: vi.fn().mockResolvedValue(undefined),
   runAgentSetup: vi.fn().mockResolvedValue({ status: 'setup_ready', diff: 'D', confidence: 'high', affectedFiles: ['package.json'] }),
   commitAndPush: vi.fn().mockResolvedValue(undefined),
   createPr: vi.fn().mockResolvedValue({ url: 'https://gh/pr/1', number: 1 }),
@@ -25,6 +30,11 @@ describe('runSetupPr', () => {
 
     expect(r.status).toBe('open');
     expect(d.createPr).toHaveBeenCalledOnce();
+    expect(d.createPr).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ base: 'master' }),
+    );
+    expect(d.cacheDefaultBranch).toHaveBeenCalledWith('p', 'master');
     expect(d.record).toHaveBeenCalledWith('p', 'open', { pr_url: 'https://gh/pr/1', pr_number: 1 });
   });
 

--- a/packages/worker/src/agent-fix.ts
+++ b/packages/worker/src/agent-fix.ts
@@ -16,6 +16,7 @@ import type { RuntimeInfo } from './runtime-info.js';
 import { buildReason, triageReasonCodes } from './reason-codes.js';
 import type { AgentCompletionResult, VisualAnalysisOutput, SourceFile, AgentState } from './harness/types.js';
 import { scrubSecrets } from './harness/redact.js';
+import { cloneFailureReason, CloneResolutionError } from './repo-clone.js';
 import { createEvidenceRecorder, type EvidenceRecorder } from './harness/evidence.js';
 import { VerificationInfraError } from './harness/errors.js';
 import { createRepoSandbox, extractDiff, runBuildGate, type RepoSandbox } from './harness/sandbox-repo.js';
@@ -50,7 +51,7 @@ export interface AgentFixInput {
   sourceFiles: SourceFile[];
   visualAnalysis: VisualAnalysisOutput | null;
   repoUrl: string;
-  defaultBranch: string;
+  githubRepo: string;
   githubToken?: string;
   abortSignal?: AbortSignal;
   maxTurns?: number;
@@ -610,7 +611,7 @@ export async function runAgentFix(input: AgentFixInput): Promise<AgentFixResult>
         { 'repo.url': input.repoUrl.replace(/https:\/\/[^@]+@/g, 'https://***@') },
         () => createRepoSandbox({
           repoUrl: input.repoUrl,
-          defaultBranch: input.defaultBranch,
+          githubRepo: input.githubRepo,
           githubToken: input.githubToken,
           setupCommands: input.setupCommands,
           platform: input.platform,
@@ -622,11 +623,13 @@ export async function runAgentFix(input: AgentFixInput): Promise<AgentFixResult>
       if (message.includes('clone failed')) {
         return {
           status: 'needs_human',
-          reason: {
-            reason_code: 'repo_access_denied',
-            reason_message: `Failed to clone repository: ${message}`,
-            remediation: 'Ensure GITHUB_TOKEN has read access to the repository',
-          },
+          reason: cloneFailureReason(setupError),
+        };
+      }
+      if (setupError instanceof CloneResolutionError) {
+        return {
+          status: 'needs_human',
+          reason: cloneFailureReason(setupError),
         };
       }
       throw setupError;

--- a/packages/worker/src/db.ts
+++ b/packages/worker/src/db.ts
@@ -1065,7 +1065,8 @@ export interface ProjectData {
   id: string;
   name: string;
   github_repo: string;
-  default_branch: string;
+  /** NULL until learned from GitHub or resolved from a clone. Never guess. */
+  default_branch: string | null;
   friction_autonomy: FrictionAutonomy;
   pr_posture?: PRPosture;
   draft_pr_cap?: number;
@@ -1079,6 +1080,31 @@ export async function getProject(projectId: string): Promise<ProjectData | null>
     [projectId],
   );
   return rows[0] ?? null;
+}
+
+/**
+ * Refresh the cached default branch. Best-effort by contract: the column is a
+ * cache, never an authority, so a failed write cannot fail a job that already
+ * resolved the correct branch from its clone.
+ */
+export async function cacheProjectDefaultBranch(
+  projectId: string,
+  branch: string,
+  targetPool: Pick<pg.Pool, 'query'> = getPool(),
+): Promise<void> {
+  try {
+    await targetPool.query(
+      `UPDATE projects SET default_branch = $2
+       WHERE id = $1 AND default_branch IS DISTINCT FROM $2`,
+      [projectId, branch],
+    );
+  } catch (err: unknown) {
+    console.warn('[default-branch-cache] refresh failed', {
+      projectId,
+      branch,
+      err,
+    });
+  }
 }
 
 export async function recordSetupPrResult(

--- a/packages/worker/src/harness/__tests__/clone-detail-redaction.test.ts
+++ b/packages/worker/src/harness/__tests__/clone-detail-redaction.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { redactCloneDetail } from '../redact.js';
+
+describe('redactCloneDetail', () => {
+  it('scrubs an x-access-token credential', () => {
+    const output = redactCloneDetail(
+      'fatal: https://x-access-token:ghs_SECRET@github.com/o/r.git not found',
+    );
+    expect(output).not.toContain('ghs_SECRET');
+    expect(output).toContain('***@');
+  });
+
+  it('scrubs a bare userinfo credential', () => {
+    expect(
+      redactCloneDetail('https://user:pw@example.com/x'),
+    ).not.toContain('pw@');
+  });
+
+  it('truncates adversarially long output', () => {
+    const output = redactCloneDetail('x'.repeat(10_000));
+    expect(output.length).toBeLessThan(2_100);
+    expect(output).toContain('truncated');
+  });
+
+  it('keeps useful git failure detail', () => {
+    expect(
+      redactCloneDetail(
+        'fatal: Remote branch main not found in upstream origin',
+      ),
+    ).toContain('Remote branch main not found');
+  });
+});

--- a/packages/worker/src/harness/__tests__/sandbox-repo-setup.test.ts
+++ b/packages/worker/src/harness/__tests__/sandbox-repo-setup.test.ts
@@ -55,7 +55,11 @@ beforeEach(() => {
   state.commands.length = 0;
   state.failWhenIncludes = undefined;
   state.files = {};
-  state.stdoutFor = {};
+  state.stdoutFor = {
+    'ls-remote': 'abc\trefs/heads/main\n',
+    'symbolic-ref': 'main\n',
+    'rev-parse': 'abc\n',
+  };
   state.kill.mockClear();
 });
 
@@ -63,7 +67,6 @@ describe('createRepoSandbox setupCommands', () => {
   it('runs setup commands after the baseline commit and commits them separately', async () => {
     await createRepoSandbox({
       repoUrl: 'https://github.com/o/r.git',
-      defaultBranch: 'main',
       setupCommands: ['git apply bug.patch'],
     });
 
@@ -76,7 +79,7 @@ describe('createRepoSandbox setupCommands', () => {
   });
 
   it('runs no eval commit when setupCommands is absent', async () => {
-    await createRepoSandbox({ repoUrl: 'https://github.com/o/r.git', defaultBranch: 'main' });
+    await createRepoSandbox({ repoUrl: 'https://github.com/o/r.git' });
 
     expect(state.commands.some((command) => command.includes('eval: setup'))).toBe(false);
   });
@@ -86,7 +89,6 @@ describe('createRepoSandbox setupCommands', () => {
 
     await expect(createRepoSandbox({
       repoUrl: 'https://github.com/o/r.git',
-      defaultBranch: 'main',
       setupCommands: ['git apply bug.patch'],
     })).rejects.toThrow('command failed: git apply bug.patch');
 
@@ -98,7 +100,6 @@ describe('createRepoSandbox setupCommands', () => {
 
     await expect(createRepoSandbox({
       repoUrl: 'https://github.com/o/r.git',
-      defaultBranch: 'main',
     })).rejects.toThrow('command failed: baseline: setup');
 
     expect(state.kill).toHaveBeenCalledTimes(1);
@@ -110,7 +111,6 @@ describe('createRepoSandbox python dependency install', () => {
     state.files = files;
     return createRepoSandbox({
       repoUrl: 'https://github.com/o/r.git',
-      defaultBranch: 'main',
       platform: 'python',
     });
   }
@@ -148,11 +148,13 @@ describe('createRepoSandbox python dependency install', () => {
 
   it('sanitizes the sandbox runtime probe before it reaches the PR body', async () => {
     state.files = { 'requirements.txt': '' };
-    state.stdoutFor = { 'platform.python_implementation': 'CPython[x](http://evil) 3.12.13' };
+    state.stdoutFor = {
+      ...state.stdoutFor,
+      'platform.python_implementation': 'CPython[x](http://evil) 3.12.13',
+    };
 
     const result = await createRepoSandbox({
       repoUrl: 'https://github.com/o/r.git',
-      defaultBranch: 'main',
       platform: 'python',
     });
 

--- a/packages/worker/src/harness/redact.ts
+++ b/packages/worker/src/harness/redact.ts
@@ -9,3 +9,14 @@ export function scrubSecrets(raw: string): string {
     .replace(/gh[pousr]_[A-Za-z0-9_]+/g, '[REDACTED]')
     .replace(/sk-ant-[A-Za-z0-9_-]+/g, '[REDACTED]');
 }
+
+const CLONE_DETAIL_LIMIT = 2_000;
+
+/** Scrub clone credentials and bound detail before persistence or display. */
+export function redactCloneDetail(detail: string): string {
+  const scrubbed = scrubSecrets(detail)
+    .replace(/x-access-token:[^@\s]{1,512}@/g, 'x-access-token:***@');
+  return scrubbed.length > CLONE_DETAIL_LIMIT
+    ? `${scrubbed.slice(0, CLONE_DETAIL_LIMIT)}… (truncated)`
+    : scrubbed;
+}

--- a/packages/worker/src/harness/sandbox-repo.ts
+++ b/packages/worker/src/harness/sandbox-repo.ts
@@ -1,7 +1,12 @@
 import type { CheckOutcome } from '@opslane/shared';
 import { logger } from '../logger.js';
-import { buildGitNetrc } from '../repo-clone.js';
-import { scrubSecrets } from './redact.js';
+import {
+  buildGitNetrc,
+  CloneResolutionError,
+  resolveClonedBranch,
+  type GitRunner,
+} from '../repo-clone.js';
+import { redactCloneDetail, scrubSecrets } from './redact.js';
 import { createSandboxRuntime, type SandboxRuntime } from './sandbox-runtime.js';
 import type { Platform } from '../platform.js';
 import { sanitizeRuntimeValue, type RuntimeInfo } from '../runtime-info.js';
@@ -108,7 +113,7 @@ async function ensureModernNode(sandbox: SandboxRuntime): Promise<void> {
  */
 export async function createRepoSandbox(opts: {
   repoUrl: string;
-  defaultBranch: string;
+  githubRepo?: string;
   githubToken?: string;
   /** Commands applied after the baseline commit and committed separately. */
   setupCommands?: string[];
@@ -126,18 +131,49 @@ export async function createRepoSandbox(opts: {
       await sandbox.commands.run('chmod 600 /home/user/.netrc');
     }
 
+    const runner: GitRunner = async (args) => {
+      try {
+        const result = await sandbox.commands.run(
+          `git -C ${SANDBOX_REPO} ${args.map(shellEscape).join(' ')}`,
+          { timeoutMs: 30_000 },
+        );
+        return {
+          stdout: String(result.stdout ?? ''),
+          stderr: String(result.stderr ?? ''),
+          exitCode: 0,
+        };
+      } catch (err: unknown) {
+        const detail = err as { message?: string; stdout?: string; stderr?: string };
+        return {
+          stdout: String(detail.stdout ?? ''),
+          stderr: String(detail.stderr ?? detail.message ?? err),
+          exitCode: 1,
+        };
+      }
+    };
+
     try {
       await sandbox.commands.run(
-        `git clone --depth 1 --branch ${shellEscape(opts.defaultBranch)} ${shellEscape(opts.repoUrl)} ${SANDBOX_REPO}`,
+        `git clone --depth 1 ${shellEscape(opts.repoUrl)} ${SANDBOX_REPO}`,
         { timeoutMs: 120_000 },
       );
+      // ls-remote needs the private-repo credential, so resolve before .netrc
+      // is removed. This result validates the sandbox only; the host clone is
+      // the PR-base authority.
+      await resolveClonedBranch(runner, opts.githubRepo ?? 'repo');
     } catch (err: unknown) {
-      const msg = (err instanceof Error ? err.message : String(err))
-        .replace(/https:\/\/[^@]+@/g, 'https://***@');
-      throw new Error(`clone failed: ${msg}`);
+      if (err instanceof CloneResolutionError) throw err;
+      const detail = err as { message?: string; stderr?: string };
+      const message = [
+        detail.message ?? String(err),
+        detail.stderr,
+      ].filter(Boolean).join('\n');
+      throw new Error(`clone failed: ${redactCloneDetail(message)}`);
+    } finally {
+      if (gitNetrc) {
+        await sandbox.commands.run('rm -f /home/user/.netrc').catch(() => {});
+      }
     }
-
-    if (gitNetrc) await sandbox.commands.run('rm -f /home/user/.netrc');
 
     const platform = opts.platform ?? 'javascript';
     const hasPackageJson = await fileExists(sandbox, `${SANDBOX_REPO}/package.json`);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -9,7 +9,7 @@ import { fetchObject, getMinIOConfig } from './minio-client.js';
 import { investigateError } from './investigate.js';
 import { runPipeline } from './pipeline.js';
 import { createPoller } from './poller.js';
-import { buildRepoUrl, cloneRepo } from './repo-clone.js';
+import { buildRepoUrl, cloneFailureReason, cloneRepo } from './repo-clone.js';
 import { getInstallationToken } from './github-app.js';
 import { type ReplaySignals } from './pr.js';
 import { processSetupPrJob } from './setup-pr.js';
@@ -343,24 +343,15 @@ export async function processInvestigateJob(job: ClaimedJob & { errorGroupId: st
   try {
     const cloneResult = await cloneRepo({
       githubRepo: project.github_repo,
-      defaultBranch: project.default_branch,
       jobId: job.id,
       githubToken,
     });
     repoDir = cloneResult.repoDir;
     cleanup = cloneResult.cleanup;
+    await db.cacheProjectDefaultBranch(job.projectId, cloneResult.defaultBranch);
   } catch (err: unknown) {
-    const rawMessage = err instanceof Error ? err.message : String(err);
-    const isTokenMissing = rawMessage.includes('GITHUB_TOKEN');
-    const message = rawMessage.replace(/https:\/\/[^@]{1,512}@/g, 'https://***@');
     await updateGroupStatus(job.errorGroupId, job.projectId, 'needs_human', {
-      reason: {
-        reason_code: isTokenMissing ? 'missing_github_token' : 'repo_access_denied',
-        reason_message: `Failed to clone repository: ${message}`,
-        remediation: isTokenMissing
-          ? 'Set the GITHUB_TOKEN environment variable with repo scope'
-          : 'Ensure GITHUB_TOKEN has read access to the repository',
-      },
+      reason: cloneFailureReason(err),
     }, job);
     jobsFailed++;
     lastJobAt = new Date().toISOString();
@@ -522,18 +513,13 @@ export async function processFrictionInvestigateJob(
   try {
     clone = await cloneRepo({
       githubRepo: project.github_repo,
-      defaultBranch: project.default_branch,
       jobId: job.id,
       githubToken,
     });
+    await db.cacheProjectDefaultBranch(job.projectId, clone.defaultBranch);
   } catch (error: unknown) {
-    const raw = error instanceof Error ? error.message : String(error);
-    const message = raw.replace(/https:\/\/[^@]{1,512}@/g, 'https://***@');
     await updateGroupInvestigation(job.errorGroupId, job.projectId, 'needs_human', {
-      reason: buildReason(
-        raw.includes('GITHUB_TOKEN') ? 'missing_github_token' : 'repo_access_denied',
-        `Failed to clone repository: ${message}`,
-      ),
+      reason: cloneFailureReason(error),
     }, job);
     jobsFailed++;
     lastJobAt = new Date().toISOString();
@@ -732,25 +718,21 @@ export async function processFixJob(job: ClaimedJob & { errorGroupId: string }, 
 
   // Clone repo
   let repoDir: string;
+  let defaultBranch: string;
   let cleanup: () => Promise<void>;
   try {
     const cloneResult = await cloneRepo({
       githubRepo: project.github_repo,
-      defaultBranch: project.default_branch,
       jobId: job.id,
       githubToken,
     });
     repoDir = cloneResult.repoDir;
+    defaultBranch = cloneResult.defaultBranch;
     cleanup = cloneResult.cleanup;
+    await db.cacheProjectDefaultBranch(job.projectId, defaultBranch);
   } catch (err: unknown) {
-    const rawMessage = err instanceof Error ? err.message : String(err);
-    const message = rawMessage.replace(/https:\/\/[^@]{1,512}@/g, 'https://***@');
-    const isTokenMissing = rawMessage.includes('GITHUB_TOKEN');
     await updateGroupStatus(job.errorGroupId, job.projectId, 'needs_human', {
-      reason: buildReason(
-        isTokenMissing ? 'missing_github_token' : 'repo_access_denied',
-        `Failed to clone repository: ${message}`,
-      ),
+      reason: cloneFailureReason(err),
     }, job);
     jobsFailed++;
     lastJobAt = new Date().toISOString();
@@ -879,7 +861,7 @@ export async function processFixJob(job: ClaimedJob & { errorGroupId: string }, 
       repoPath: repoDir,
       repoUrl,
       githubRepo: project.github_repo,
-      defaultBranch: project.default_branch,
+      defaultBranch,
       githubToken,
       abortSignal: signal,
       assertLeaseOwned: () => db.assertJobLease(job),

--- a/packages/worker/src/pipeline.ts
+++ b/packages/worker/src/pipeline.ts
@@ -114,7 +114,7 @@ export async function runPipeline(input: PipelineInput): Promise<PipelineResult>
     sourceFiles: input.sourceFiles,
     visualAnalysis: input.visualAnalysis,
     repoUrl: input.repoUrl,
-    defaultBranch: input.defaultBranch,
+    githubRepo: input.githubRepo,
     githubToken: input.githubToken,
     repoPath: input.repoPath,
     investigation: input.investigation,

--- a/packages/worker/src/reason-codes.ts
+++ b/packages/worker/src/reason-codes.ts
@@ -10,6 +10,12 @@ export const DEFAULT_REMEDIATION: Record<ReasonCode, string> = {
     'Connect the GitHub App to this repository (Settings → GitHub) so Opslane can read and open PRs.',
   repo_access_denied:
     'Confirm the GitHub App is installed on this repository and has read + pull-request permissions.',
+  empty_repository:
+    'Push at least one commit to this repository, then retry — there is no branch for Opslane to work from yet.',
+  invalid_default_branch:
+    "This repository's default branch points at a branch that no longer exists. Set a valid default branch in GitHub (Settings → Branches), then retry.",
+  unresolvable_head:
+    "Opslane could not determine this repository's default branch. Check the repository is not in an unusual state, then retry.",
   token_decrypt_failed:
     'Re-connect the GitHub integration — the stored credential could not be decrypted.',
   auth_invalid:

--- a/packages/worker/src/repo-clone.ts
+++ b/packages/worker/src/repo-clone.ts
@@ -1,19 +1,147 @@
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
+import type { NeedsHumanReason } from '@opslane/shared';
+import { redactCloneDetail } from './harness/redact.js';
+import { DEFAULT_REMEDIATION } from './reason-codes.js';
 
 const execFile = promisify(execFileCb);
 
 export interface CloneOptions {
   githubRepo: string;   // "owner/repo"
-  defaultBranch: string;
   jobId: string;
   timeoutMs?: number;
   githubToken?: string;
+  /** Test/local transport override. Production callers use buildRepoUrl. */
+  repoUrl?: string;
 }
 
 export interface CloneResult {
   repoDir: string;
+  /** Resolved from the clone itself; authoritative for this job. */
+  defaultBranch: string;
   cleanup: () => Promise<void>;
+}
+
+/** Result of a git invocation that is allowed to fail without throwing. */
+export interface GitResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export type GitRunner = (args: string[]) => Promise<GitResult>;
+
+export type CloneResolutionKind =
+  | 'empty_repository'
+  | 'invalid_default_branch'
+  | 'unresolvable_head';
+
+export class CloneResolutionError extends Error {
+  readonly kind: CloneResolutionKind;
+  readonly repo: string;
+  readonly discoveredBranch?: string;
+
+  constructor(kind: CloneResolutionKind, repo: string, discoveredBranch?: string) {
+    super(CloneResolutionError.describe(kind, repo, discoveredBranch));
+    this.name = 'CloneResolutionError';
+    this.kind = kind;
+    this.repo = repo;
+    this.discoveredBranch = discoveredBranch;
+  }
+
+  private static describe(
+    kind: CloneResolutionKind,
+    repo: string,
+    branch?: string,
+  ): string {
+    switch (kind) {
+      case 'empty_repository':
+        return `${repo} has no commits yet, so there is no branch to work from`;
+      case 'invalid_default_branch':
+        return `default branch '${branch}' does not exist in ${repo}`;
+      case 'unresolvable_head':
+        return `could not determine the default branch of ${repo}`;
+    }
+  }
+}
+
+/** A GitRunner backed by execFile against an already-cloned working directory. */
+export function execFileGitRunner(repoDir: string): GitRunner {
+  return async (args) => {
+    try {
+      const { stdout, stderr } = await execFile('git', args, {
+        cwd: repoDir,
+        timeout: 15_000,
+        env: scrubbedEnv(),
+      });
+      return {
+        stdout: String(stdout),
+        stderr: String(stderr),
+        exitCode: 0,
+      };
+    } catch (err: unknown) {
+      const detail = err as { stdout?: string; stderr?: string; code?: number };
+      return {
+        stdout: String(detail.stdout ?? ''),
+        stderr: String(detail.stderr ?? ''),
+        exitCode: typeof detail.code === 'number' ? detail.code : 1,
+      };
+    }
+  };
+}
+
+/**
+ * Resolve the branch checked out by a plain clone.
+ *
+ * ls-remote must run first: both an empty repository and a repository whose
+ * HEAD points at a missing ref fail rev-parse, while only the empty repository
+ * has no remote heads.
+ */
+export async function resolveClonedBranch(
+  run: GitRunner,
+  repo: string,
+): Promise<string> {
+  const heads = await run(['ls-remote', '--heads', 'origin']);
+  if (heads.exitCode !== 0) {
+    throw new Error(
+      `could not inspect remote branches for ${repo}: ${redactCloneDetail(heads.stderr)}`,
+    );
+  }
+  if (heads.stdout.trim() === '') {
+    throw new CloneResolutionError('empty_repository', repo);
+  }
+
+  const symbolic = await run(['symbolic-ref', '--short', 'HEAD']);
+  if (symbolic.exitCode !== 0 || symbolic.stdout.trim() === '') {
+    throw new CloneResolutionError('unresolvable_head', repo);
+  }
+  const branch = symbolic.stdout.trim();
+
+  const head = await run(['rev-parse', '--verify', 'HEAD']);
+  if (head.exitCode !== 0) {
+    throw new CloneResolutionError('invalid_default_branch', repo, branch);
+  }
+  return branch;
+}
+
+/** Turn clone failures into actionable terminal reasons. */
+export function cloneFailureReason(err: unknown): NeedsHumanReason {
+  if (err instanceof CloneResolutionError) {
+    return {
+      reason_code: err.kind,
+      reason_message: err.message,
+      remediation: DEFAULT_REMEDIATION[err.kind],
+    };
+  }
+  const raw = err instanceof Error ? err.message : String(err);
+  const reasonCode = raw.includes('GITHUB_TOKEN')
+    ? 'missing_github_token'
+    : 'repo_access_denied';
+  return {
+    reason_code: reasonCode,
+    reason_message: redactCloneDetail(raw),
+    remediation: DEFAULT_REMEDIATION[reasonCode],
+  };
 }
 
 /** Strict `owner/repo` grammar — no traversal segments, no extra path parts. */
@@ -55,41 +183,48 @@ export function buildGitNetrc(repoUrl: string, token: string): string | null {
  * not in /proc/PID/cmdline or shell history.
  */
 export async function cloneRepo(options: CloneOptions): Promise<CloneResult> {
-  const { githubRepo, defaultBranch, jobId, timeoutMs = 30_000 } = options;
+  const { githubRepo, jobId, timeoutMs = 30_000 } = options;
   const token = options.githubToken ?? process.env['GITHUB_TOKEN'];
-  if (!token) {
+  if (!token && !options.repoUrl) {
     throw new Error('GITHUB_TOKEN is not set');
   }
 
-  // Reject stored values that git could parse as options (second-order argument
-  // injection, e.g. a branch of "--upload-pack=..."). Branch names never start
-  // with '-' or contain whitespace; repos are "owner/name".
-  if (!/^[^\s-][^\s]*$/.test(defaultBranch)) {
-    throw new Error('Refusing to clone: unsafe branch name');
-  }
   if (!/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(githubRepo)) {
     throw new Error('Refusing to clone: unsafe repository name');
   }
 
   const repoDir = `/tmp/opslane-repo-${jobId}`;
-  const cloneUrl = buildRepoUrl(githubRepo, token);
+  const cloneUrl = options.repoUrl ?? buildRepoUrl(githubRepo, token);
 
   try {
-    // `--branch=` attached form + `--` end-of-options so neither the branch nor
-    // the positional URL/dir can be reinterpreted as a git option.
+    // A plain clone checks out remote HEAD, the repository's current default.
     await execFile('git', [
-      'clone', '--depth', '1', `--branch=${defaultBranch}`,
+      'clone', '--depth', '1',
       '--', cloneUrl, repoDir,
     ], { timeout: timeoutMs, env: scrubbedEnv() });
   } catch (err: unknown) {
-    // Scrub token from error messages before propagating (bounded quantifier
-    // to avoid polynomial backtracking on adversarial input).
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(msg.replace(/x-access-token:[^@]{1,512}@/g, 'x-access-token:***@'));
+    const detail = err as { message?: string; stderr?: string };
+    throw new Error(redactCloneDetail([
+      detail.message ?? String(err),
+      detail.stderr,
+    ].filter(Boolean).join('\n')));
   }
 
+  let defaultBranch: string;
+  try {
+    defaultBranch = await resolveClonedBranch(
+      execFileGitRunner(repoDir),
+      githubRepo,
+    );
+  } catch (err: unknown) {
+    // Resolution failures happen after clone, before the caller receives its
+    // cleanup handle. Remove the token-bearing checkout before propagating.
+    await execFile('rm', ['-rf', repoDir]).catch(() => {});
+    throw err;
+  }
   return {
     repoDir,
+    defaultBranch,
     cleanup: async () => {
       await execFile('rm', ['-rf', repoDir]).catch(() => {});
     },

--- a/packages/worker/src/setup-agent.ts
+++ b/packages/worker/src/setup-agent.ts
@@ -5,6 +5,7 @@ import { createToolBridge } from './harness/tool-bridge.js';
 import { createDefaultMiddleware } from './harness/tool-middleware.js';
 import { createRepoSandbox, extractDiff, runBuildGate } from './harness/sandbox-repo.js';
 import { logger } from './logger.js';
+import { cloneFailureReason } from './repo-clone.js';
 
 export interface SetupPromptInput {
   apiKeyEnvVar: string;
@@ -38,7 +39,7 @@ export function buildSetupSystemPrompt(input: SetupPromptInput): string {
 
 export interface AgentSetupInput {
   repoUrl: string;
-  defaultBranch: string;
+  githubRepo: string;
   githubToken?: string;
   apiKeyEnvVar: string;
   releaseEnvVar: string;
@@ -73,18 +74,14 @@ export async function runAgentSetup(input: AgentSetupInput): Promise<AgentSetupR
   try {
     sandboxHandle = await createRepoSandbox({
       repoUrl: input.repoUrl,
-      defaultBranch: input.defaultBranch,
+      githubRepo: input.githubRepo,
       githubToken: input.githubToken,
       platform: 'javascript',
     });
   } catch (err: unknown) {
     return {
       status: 'needs_human',
-      reason: {
-        reason_code: 'repo_access_denied',
-        reason_message: err instanceof Error ? err.message : String(err),
-        remediation: 'Ensure the GitHub App has read access to the repo',
-      },
+      reason: cloneFailureReason(err),
     };
   }
 

--- a/packages/worker/src/setup-pr.ts
+++ b/packages/worker/src/setup-pr.ts
@@ -1,5 +1,6 @@
 import type { SetupPrStatus } from '@opslane/shared';
 import { buildRepoUrl, cloneRepo, gitCommitAndPush, validateDiffPaths } from './repo-clone.js';
+import { redactCloneDetail } from './harness/redact.js';
 import { createGitHubClient } from './pr.js';
 import { getInstallationToken } from './github-app.js';
 import { runAgentSetup } from './setup-agent.js';
@@ -9,13 +10,14 @@ import type { ClaimedJob } from './db.js';
 const SETUP_BRANCH = 'opslane/setup';
 
 export interface SetupPrDeps {
-  getProject(projectId: string): Promise<{ github_repo: string; default_branch: string } | null>;
+  getProject(projectId: string): Promise<{ github_repo: string } | null>;
   getInstallToken(projectId: string): Promise<string | undefined>;
   findExistingPr(token: string, repo: string, head: string): Promise<{ url: string; number: number } | null>;
-  clone(opts: { githubRepo: string; defaultBranch: string; jobId: string; githubToken?: string }): Promise<{ repoDir: string; cleanup: () => Promise<void> }>;
+  clone(opts: { githubRepo: string; jobId: string; githubToken?: string }): Promise<{ repoDir: string; defaultBranch: string; cleanup: () => Promise<void> }>;
+  cacheDefaultBranch(projectId: string, branch: string): Promise<void>;
   runAgentSetup(input: {
     repoUrl: string;
-    defaultBranch: string;
+    githubRepo: string;
     githubToken?: string;
     apiKeyEnvVar: string;
     releaseEnvVar: string;
@@ -67,9 +69,18 @@ export async function runSetupPr(job: SetupPrJob, d: SetupPrDeps): Promise<{ sta
   let cleanup = async (): Promise<void> => {};
   try {
     const repoUrl = buildRepoUrl(project.github_repo);
+    const cloneResult = await d.clone({
+      githubRepo: project.github_repo,
+      jobId: job.jobId,
+      githubToken: token,
+    });
+    cleanup = cloneResult.cleanup;
+    const defaultBranch = cloneResult.defaultBranch;
+    await d.cacheDefaultBranch(job.projectId, defaultBranch);
+
     const agent = await d.runAgentSetup({
       repoUrl,
-      defaultBranch: project.default_branch,
+      githubRepo: project.github_repo,
       githubToken: token,
       apiKeyEnvVar: job.apiKeyEnvVar,
       releaseEnvVar: job.releaseEnvVar,
@@ -86,21 +97,13 @@ export async function runSetupPr(job: SetupPrJob, d: SetupPrDeps): Promise<{ sta
       return { status: 'failed' };
     }
 
-    const cloneResult = await d.clone({
-      githubRepo: project.github_repo,
-      defaultBranch: project.default_branch,
-      jobId: job.jobId,
-      githubToken: token,
-    });
-    cleanup = cloneResult.cleanup;
-
     const repoDir = cloneResult.repoDir;
     await d.assertLeaseOwned();
     await d.commitAndPush(repoDir, SETUP_BRANCH, 'chore: install Opslane SDK', agent.diff);
     await d.assertLeaseOwned();
     const pr = await d.createPr(token, {
       repo: project.github_repo,
-      base: project.default_branch,
+      base: defaultBranch,
       head: SETUP_BRANCH,
       title: '[Opslane] Install Opslane SDK',
       body: setupPrBody(),
@@ -108,9 +111,7 @@ export async function runSetupPr(job: SetupPrJob, d: SetupPrDeps): Promise<{ sta
     await d.record(job.projectId, 'open', { pr_url: pr.url, pr_number: pr.number });
     return { status: 'open' };
   } catch (err: unknown) {
-    const msg = (err instanceof Error ? err.message : String(err))
-      .replace(/x-access-token:[^@]+@/g, 'x-access-token:***@')
-      .replace(/https:\/\/[^@]+@/g, 'https://***@');
+    const msg = redactCloneDetail(err instanceof Error ? err.message : String(err));
     await d.record(job.projectId, 'failed', { error: `Failed to open setup PR: ${msg}` });
     return { status: 'failed' };
   } finally {
@@ -164,6 +165,8 @@ export async function processSetupPrJob(
         return client.listOpenPullsByHead({ owner, repo: name, head });
       },
       clone: (opts) => cloneRepo(opts),
+      cacheDefaultBranch: (projectId, branch) =>
+        db.cacheProjectDefaultBranch(projectId, branch),
       runAgentSetup: (input) => runAgentSetup(input),
       commitAndPush: async (repoDir, branch, message, diff) => {
         await gitCommitAndPush(repoDir, branch, message, diff);

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -120,6 +120,9 @@ export interface NeedsHumanReason {
 export type ReasonCode =
   | 'missing_github_token'
   | 'repo_access_denied'
+  | 'empty_repository'
+  | 'invalid_default_branch'
+  | 'unresolvable_head'
   | 'token_decrypt_failed'
   | 'auth_invalid'
   | 'policy_blocked'

--- a/test-e2e/needs-human-contract.test.ts
+++ b/test-e2e/needs-human-contract.test.ts
@@ -31,6 +31,9 @@ import {
 const REASON_CODES = [
   'missing_github_token',
   'repo_access_denied',
+  'empty_repository',
+  'invalid_default_branch',
+  'unresolvable_head',
   'token_decrypt_failed',
   'auth_invalid',
   'policy_blocked',
@@ -47,6 +50,7 @@ const REASON_CODES = [
   'low_confidence_fix',
   'repro_not_achievable',
   'verification_infra_error',
+  'draft_cap_reached',
   'triage_unfixable',
   'unfixable_no_app_frames',
   'unfixable_test_error',


### PR DESCRIPTION
## Summary

Onboarding failed for **every repo whose default branch is not `main`** (e.g. `master`, `develop`). `projects.default_branch` was `NOT NULL DEFAULT 'main'` and never read from GitHub, so the setup agent cloned with `--branch main`, git exited 128, and the setup wizard hung at step 4 with an opaque `clone failed: exit status 128`.

Root cause: the column could not express "unknown". Phase 1 onboarding creates a project *before* GitHub is connected (["Local aha, no GitHub"](../blob/main/docs/plans/2026-07-22-onboarding-10x-design.md)), so the schema guess was written as fact and never corrected.

Closes #180.

## Approach

Stop treating `default_branch` as an authority. A plain `git clone` checks out the remote's HEAD — which *is* the repository's current default branch. Resolve it from the clone, thread it to the PR base, and write it back as a self-healing cache.

- **Nullable column** (migration 027). `NULL` = unknown. Existing rows self-heal on their next clone; no backfill.
- **Unpinned clone** at both sites (host + E2B sandbox). The host clone is the single branch authority for a job.
- **Three-way failure classification** — `empty_repository`, `invalid_default_branch`, `unresolvable_head`. `ls-remote --heads` distinguishes an empty repo from one whose HEAD points at a missing ref; `rev-parse` and git's own stderr cannot (both call the second case "empty"). Previously every clone failure was reported as `repo_access_denied` — an empty repo told the user to fix permissions they already had.
- **Credential-aware ordering** — the sandbox resolves the branch *before* `.netrc` is deleted, since `ls-remote` needs the credential.
- **Redacted, bounded error detail** — git's real stderr is surfaced (scrubbed of tokens, length-capped) so failures are diagnosable.
- **Fill on install** — all three `PersistInstallation` callers learn `default_branch` from data they already hold. The agent-callback path applies it after the project is created (it persists the installation first). `IS DISTINCT FROM` corrects stale `'main'` rows rather than skipping them.
- **Authorization** — `SetGitHubConfig` now resolves the branch and rejects repos the org's App does not cover (previously any `owner/repo` string was accepted).

Phase 1 provisioning stays GitHub-free by design (regression-tested).

## Verification

| Check | Result |
|---|---|
| ingestion `go build ./...` | ✅ |
| shared + worker `tsc` | ✅ |
| worker tests | ✅ 554 passed |
| ingestion `go test ./db ./handler` | ✅ against a freshly-migrated disposable DB |
| docs drift (`check-docs-drift`) | ✅ 28 reason codes consistent |

**Not run:** the live pipeline smoke described in `AGENTS.md` (needs the full stack + E2B + a real GitHub App install). Logic is covered by unit + DB-integration tests, including the exact `master`-default regression and the empty/broken-HEAD/detached cases, but a real setup PR against a `master` repo has not been exercised end to end. Worth a manual smoke before relying on it in production.

## Notes for reviewers

- Migration 027 is idempotent (`DROP NOT NULL` / `DROP DEFAULT` re-run cleanly).
- The two DB test failures a reviewer may see locally are the shared dev Postgres (`5434`) missing migration 027, not logic — apply 027 or use a fresh DB.
- Design + implementation plans are in `docs/plans/2026-07-23-default-branch-resolution-*.md`, including the design/eng/Codex review trail.
