### PR TITLE
Onboard Apply stage: agent applies an approved plan, verified

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -32,12 +32,12 @@
     "chalk": "^5.4.0",
     "commander": "^13.0.0",
     "inquirer": "^12.0.0",
+    "typescript": "^5.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
     "tsx": "^4.23.1",
-    "typescript": "^5.4.0",
     "vitest": "^3.2.0"
   }
 }

--- a/cli/scripts/apply-check.mjs
+++ b/cli/scripts/apply-check.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  cpSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const CLI_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ENGINE = pathToFileURL(path.join(CLI_ROOT, 'dist', 'onboard', 'engine.js')).href;
+const VERIFY = pathToFileURL(path.join(CLI_ROOT, 'dist', 'onboard', 'verify.js')).href;
+const MAX_ELAPSED_MS = 10 * 60 * 1_000;
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error('ANTHROPIC_API_KEY is required for the live Detect → Apply check.');
+  process.exit(2);
+}
+if (process.argv.length < 3) {
+  console.error('Usage: node cli/scripts/apply-check.mjs <app-dir> [app-dir...]');
+  process.exit(2);
+}
+
+const { runApply, runDetect } = await import(ENGINE);
+const { verifyApplied } = await import(VERIFY);
+
+function filesUnder(root) {
+  const files = [];
+  const pending = [realpathSync(root)];
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (entry.name === '.git' || entry.name === 'node_modules') continue;
+      const absolute = path.join(directory, entry.name);
+      if (entry.isSymbolicLink()) {
+        files.push(absolute);
+      } else if (entry.isDirectory()) {
+        pending.push(absolute);
+      } else if (entry.isFile()) {
+        files.push(absolute);
+      }
+    }
+  }
+  return files.sort();
+}
+
+function relative(root, absolute) {
+  return path.relative(realpathSync(root), absolute).split(path.sep).join('/');
+}
+
+function snapshotTree(root) {
+  return new Map(
+    filesUnder(root).map((absolute) => {
+      const metadata = lstatSync(absolute);
+      const value = metadata.isSymbolicLink()
+        ? `link:${readlinkSync(absolute)}`
+        : createHash('sha256').update(readFileSync(absolute)).digest('hex');
+      return [relative(root, absolute), value];
+    }),
+  );
+}
+
+function changedFiles(before, after) {
+  return [...new Set([...before.keys(), ...after.keys()])]
+    .filter((file) => before.get(file) !== after.get(file))
+    .sort();
+}
+
+function dotenvSnapshots(root, canary) {
+  const values = new Map();
+  for (const absolute of filesUnder(root)) {
+    if (!path.basename(absolute).toLowerCase().startsWith('.env')) continue;
+    if (lstatSync(absolute).isSymbolicLink()) continue;
+    const contents = `OPSLANE_APPLY_CHECK_CANARY=${canary}\n`;
+    writeFileSync(absolute, contents);
+    values.set(relative(root, absolute), Buffer.from(contents));
+  }
+  if (values.size === 0) {
+    const absolute = path.join(root, '.env.opslane-apply-check');
+    const contents = `OPSLANE_APPLY_CHECK_CANARY=${canary}\n`;
+    writeFileSync(absolute, contents);
+    values.set(relative(root, absolute), Buffer.from(contents));
+  }
+  return values;
+}
+
+function serializeMessage(message) {
+  try {
+    return JSON.stringify(message);
+  } catch {
+    return String(message);
+  }
+}
+
+async function check(source) {
+  const absoluteSource = realpathSync(path.resolve(source));
+  const tempRoot = mkdtempSync(path.join(tmpdir(), 'opslane-apply-check-'));
+  const fixture = path.join(tempRoot, 'fixture');
+  cpSync(absoluteSource, fixture, { recursive: true, dereference: false });
+
+  const canary = `opslane-apply-canary-${randomUUID()}`;
+  const envBefore = dotenvSnapshots(fixture, canary);
+  const treeBefore = snapshotTree(fixture);
+  const transcript = [];
+  const started = Date.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), MAX_ELAPSED_MS);
+  let plan;
+  let applyReport;
+
+  try {
+    const detect = await runDetect({
+      cwd: fixture,
+      signal: controller.signal,
+      onMessage: (message) => transcript.push(serializeMessage(message)),
+      onPlan: (value) => {
+        plan = value;
+      },
+      askUser: async ({ options }) => [options[0]],
+    });
+    if (!detect.ok || plan === undefined) {
+      throw new Error(`Detect failed: ${detect.reason ?? detect.subtype ?? 'unknown'}`);
+    }
+    if (changedFiles(treeBefore, snapshotTree(fixture)).length !== 0) {
+      throw new Error('Detect changed the read-only fixture');
+    }
+
+    const originals = {
+      entry: readFileSync(path.join(fixture, plan.edit.file)),
+      manifest: readFileSync(path.join(fixture, plan.edit.manifest_file)),
+    };
+    const apply = await runApply({
+      cwd: fixture,
+      plan,
+      signal: controller.signal,
+      onMessage: (message) => transcript.push(serializeMessage(message)),
+      onReport: (report) => {
+        applyReport = report;
+      },
+      requestApproval: async () => true,
+    });
+    if (!apply.ok || applyReport === undefined) {
+      throw new Error(`Apply failed: ${apply.reason ?? apply.subtype ?? 'unknown'}`);
+    }
+    if (!applyReport.installRequired || typeof applyReport.installCommand !== 'string') {
+      throw new Error('Apply did not report the required package-manager install');
+    }
+
+    const verification = verifyApplied({
+      root: fixture,
+      plan,
+      editedFiles: applyReport.editedFiles,
+      originals,
+    });
+    if (!verification.ok) {
+      throw new Error(`Post-check failed: ${verification.failures.join('; ')}`);
+    }
+
+    const changed = changedFiles(treeBefore, snapshotTree(fixture));
+    const expected = [plan.edit.file, plan.edit.manifest_file].sort();
+    if (JSON.stringify(changed) !== JSON.stringify(expected)) {
+      throw new Error(`Changed files ${JSON.stringify(changed)}, expected ${JSON.stringify(expected)}`);
+    }
+    for (const [file, contents] of envBefore) {
+      if (!readFileSync(path.join(fixture, file)).equals(contents)) {
+        throw new Error(`Apply changed dotenv file ${file}`);
+      }
+    }
+    if (transcript.join('\n').includes(canary)) {
+      throw new Error('The dotenv canary appeared in the agent transcript');
+    }
+
+    const elapsedMs = Date.now() - started;
+    if (elapsedMs > MAX_ELAPSED_MS) {
+      throw new Error(`Detect + Apply exceeded 10 minutes (${elapsedMs}ms)`);
+    }
+    console.log(
+      JSON.stringify({
+        source: absoluteSource,
+        ok: true,
+        entry: plan.edit.file,
+        manifest: plan.edit.manifest_file,
+        changedFiles: changed,
+        installCommand: applyReport.installCommand,
+        elapsedMs,
+      }),
+    );
+  } finally {
+    clearTimeout(timeout);
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+for (const source of process.argv.slice(2)) {
+  await check(source);
+}

--- a/cli/scripts/detect-eval.mjs
+++ b/cli/scripts/detect-eval.mjs
@@ -201,8 +201,33 @@ function checkPlan(root, run) {
     Number.isInteger(edit?.occurrence) &&
     edit.occurrence >= 0 &&
     edit.occurrence < offsets.length;
+  const selectedOffset = occurrenceValid ? offsets[edit.occurrence] : -1;
+  const selectedLineStart =
+    selectedOffset >= 0 ? editContents.lastIndexOf('\n', selectedOffset - 1) + 1 : -1;
+  const selectedLineEndIndex =
+    selectedOffset >= 0
+      ? editContents.indexOf('\n', selectedOffset + edit.anchor.length)
+      : -1;
+  const selectedLineEnd =
+    selectedLineEndIndex === -1 ? editContents.length : selectedLineEndIndex;
+  const anchorIsWholeLine =
+    occurrenceValid &&
+    /^[\t ]*$/.test(editContents.slice(selectedLineStart, selectedOffset)) &&
+    /^[\t ]*\r?$/.test(
+      editContents.slice(selectedOffset + edit.anchor.length, selectedLineEnd),
+    );
   const entryHash =
     editExists ? createHash('sha256').update(readFileSync(editPath)).digest('hex') : '';
+  const manifestPath =
+    typeof edit?.manifest_file === 'string' ? resolve(root, edit.manifest_file) : '';
+  const manifestExists =
+    manifestPath !== '' &&
+    existsSync(manifestPath) &&
+    lstatSync(manifestPath).isFile() &&
+    !lstatSync(manifestPath).isSymbolicLink();
+  const manifestHash = manifestExists
+    ? createHash('sha256').update(readFileSync(manifestPath)).digest('hex')
+    : '';
   const namingOk =
     typeof plan?.env_prefix === 'string' &&
     typeof plan?.env_vars?.api_key === 'string' &&
@@ -234,14 +259,24 @@ function checkPlan(root, run) {
     `${plan?.env_vars?.api_key ?? '-'} / ${plan?.env_vars?.endpoint ?? '-'}`,
   ]);
   checks.push([
-    'anchor occurrence resolves',
-    occurrenceValid,
-    `occurrence=${edit?.occurrence ?? '-'} matches=${offsets.length}`,
+    'anchor occurrence resolves as a complete line',
+    anchorIsWholeLine,
+    `occurrence=${edit?.occurrence ?? '-'} matches=${offsets.length} wholeLine=${anchorIsWholeLine}`,
   ]);
   checks.push([
     'entry hash matches',
     editExists && entryHash === edit?.entry_hash,
     editExists && entryHash === edit?.entry_hash ? 'yes' : 'NO',
+  ]);
+  checks.push([
+    'planned manifest is a regular package.json',
+    manifestExists && manifestPath.endsWith(`${sep}package.json`),
+    edit?.manifest_file ?? '-',
+  ]);
+  checks.push([
+    'manifest hash matches',
+    manifestExists && manifestHash === edit?.manifest_hash,
+    manifestExists && manifestHash === edit?.manifest_hash ? 'yes' : 'NO',
   ]);
   checks.push([
     'repository tree unchanged',

--- a/cli/src/__tests__/contract.subprocess.test.ts
+++ b/cli/src/__tests__/contract.subprocess.test.ts
@@ -45,7 +45,10 @@ async function close(server: Server): Promise<void> {
 
 describe('compiled CLI agent contract', () => {
   const temporaryDirectories: string[] = [];
-  beforeAll(() => execFileSync('pnpm', ['exec', 'tsc'], { cwd: cliRoot, stdio: 'pipe' }));
+  // Compiles the whole CLI before the subprocess contract tests. This grows with
+  // the codebase and runs cold on CI, so the default 10s hook timeout is too tight
+  // (it timed out on CI once the Apply stage was added). Give it a real budget.
+  beforeAll(() => execFileSync('pnpm', ['exec', 'tsc'], { cwd: cliRoot, stdio: 'pipe' }), 120_000);
   afterEach(async () => {
     await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
   });

--- a/cli/src/onboard/__tests__/engine.test.ts
+++ b/cli/src/onboard/__tests__/engine.test.ts
@@ -1,11 +1,30 @@
 import { createHash } from 'node:crypto';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { detectOptions, runDetect, type QueryFn } from '../engine.js';
-import type { OnboardingPlan, ReportPlanInput } from '../tools.js';
+import {
+  applyOptions,
+  detectOptions,
+  runApply,
+  runDetect,
+  type ApplyReport,
+  type QueryFn,
+} from '../engine.js';
+import {
+  OPSLANE_SDK_VERSION,
+  type OnboardingPlan,
+  type ReportPlanInput,
+  type ReportedPlanInput,
+} from '../tools.js';
 
 const originalApiKey = process.env.ANTHROPIC_API_KEY;
 
@@ -19,13 +38,15 @@ function fixture(): { root: string; report: ReportPlanInput; plan: OnboardingPla
   const root = mkdtempSync(join(tmpdir(), 'opslane-engine-'));
   mkdirSync(join(root, 'src'));
   const contents = "createApp(App).mount('#app');\n";
+  const manifest = '{\n  "name": "fixture",\n  "dependencies": {}\n}\n';
   writeFileSync(join(root, 'src', 'main.ts'), contents);
+  writeFileSync(join(root, 'package.json'), manifest);
   const plan: OnboardingPlan = {
     app_dir: '.',
     framework: 'vue-vite',
     package_manager: 'pnpm',
     env_prefix: 'VITE_',
-    dependency: { name: '@opslane/sdk', version: '^1.0.0' },
+    dependency: { name: '@opslane/sdk', version: OPSLANE_SDK_VERSION },
     env_vars: {
       api_key: 'VITE_OPSLANE_API_KEY',
       endpoint: 'VITE_OPSLANE_ENDPOINT',
@@ -33,6 +54,8 @@ function fixture(): { root: string; report: ReportPlanInput; plan: OnboardingPla
     edit: {
       file: 'src/main.ts',
       entry_hash: createHash('sha256').update(contents).digest('hex'),
+      manifest_file: 'package.json',
+      manifest_hash: createHash('sha256').update(manifest).digest('hex'),
       import_line: "import { init } from '@opslane/sdk';",
       init_block:
         'init({ apiKey: import.meta.env.VITE_OPSLANE_API_KEY, endpoint: import.meta.env.VITE_OPSLANE_ENDPOINT });',
@@ -43,7 +66,8 @@ function fixture(): { root: string; report: ReportPlanInput; plan: OnboardingPla
     existing_sdk: { action: 'keep', name: '@sentry/vue' },
     rationale: 'Initialize before the application mount.',
   };
-  return { root, plan, report: { status: 'ok', plan } };
+  const reported: ReportedPlanInput = plan;
+  return { root, plan, report: { status: 'ok', plan: reported } };
 }
 
 type RegisteredTool = {
@@ -102,6 +126,189 @@ function reportQuery(
       yield { type: 'result', subtype: terminalSubtype } as never;
     },
   });
+}
+
+function appliedContents(plan: OnboardingPlan): { entry: string; manifest: string } {
+  return {
+    entry: `${plan.edit.import_line}\n${plan.edit.init_block}\n${plan.edit.anchor}\n`,
+    manifest: `{\n  "name": "fixture",\n  "dependencies": {\n    "@opslane/sdk": "${plan.dependency.version}"\n  }\n}\n`,
+  };
+}
+
+function applyQuery(
+  plan: OnboardingPlan,
+  {
+    reportedFiles = [plan.edit.file, plan.edit.manifest_file],
+    entry = appliedContents(plan).entry,
+    manifest = appliedContents(plan).manifest,
+    lateEntry,
+    duplicateEntryCommit = false,
+  }: {
+    reportedFiles?: string[];
+    entry?: string;
+    manifest?: string;
+    lateEntry?: string;
+    duplicateEntryCommit?: boolean;
+  } = {},
+): QueryFn {
+  return (request) => ({
+    [Symbol.asyncIterator]: async function* () {
+      const onboardServer = request.options?.mcpServers?.onboard as unknown as {
+        instance: { _registeredTools: Record<string, RegisteredTool> };
+      };
+      const editUse = (id: string, file: string) =>
+        ({
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', id, name: 'Edit', input: { file_path: file } }],
+          },
+        }) as never;
+      const editResult = (id: string) =>
+        ({
+          type: 'user',
+          message: {
+            content: [{ type: 'tool_result', tool_use_id: id, is_error: false }],
+          },
+        }) as never;
+
+      yield editUse('entry-edit', plan.edit.file);
+      writeFileSync(join(request.options!.cwd!, plan.edit.file), entry);
+      yield editResult('entry-edit');
+      if (duplicateEntryCommit) {
+        yield editUse('entry-edit-2', plan.edit.file);
+        yield editResult('entry-edit-2');
+      }
+      yield editUse('manifest-edit', plan.edit.manifest_file);
+      writeFileSync(join(request.options!.cwd!, plan.edit.manifest_file), manifest);
+      yield editResult('manifest-edit');
+
+      const finishInput = { edited_files: reportedFiles, summary: 'Applied approved plan.' };
+      yield {
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              id: 'finish-apply',
+              name: 'mcp__onboard__finish_apply',
+              input: finishInput,
+            },
+          ],
+        },
+      } as never;
+      await onboardServer.instance._registeredTools.finish_apply!.handler(finishInput, {});
+      yield {
+        type: 'user',
+        message: {
+          content: [
+            { type: 'tool_result', tool_use_id: 'finish-apply', is_error: false },
+          ],
+        },
+      } as never;
+
+      if (lateEntry !== undefined) {
+        yield editUse('late-edit', plan.edit.file);
+        writeFileSync(join(request.options!.cwd!, plan.edit.file), lateEntry);
+        yield editResult('late-edit');
+      }
+      yield { type: 'result', subtype: 'success' } as never;
+    },
+  });
+}
+
+function concurrentFinishQuery(plan: OnboardingPlan): QueryFn {
+  return (request) => ({
+    [Symbol.asyncIterator]: async function* () {
+      const onboardServer = request.options?.mcpServers?.onboard as unknown as {
+        instance: { _registeredTools: Record<string, RegisteredTool> };
+      };
+      const premature = {
+        edited_files: [plan.edit.file, plan.edit.manifest_file],
+        summary: 'Premature.',
+      };
+      yield {
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              id: 'entry-edit',
+              name: 'Edit',
+              input: { file_path: plan.edit.file },
+            },
+            {
+              type: 'tool_use',
+              id: 'manifest-edit',
+              name: 'Edit',
+              input: { file_path: plan.edit.manifest_file },
+            },
+            {
+              type: 'tool_use',
+              id: 'premature-finish',
+              name: 'mcp__onboard__finish_apply',
+              input: premature,
+            },
+          ],
+        },
+      } as never;
+      const applied = appliedContents(plan);
+      writeFileSync(join(request.options!.cwd!, plan.edit.file), applied.entry);
+      writeFileSync(join(request.options!.cwd!, plan.edit.manifest_file), applied.manifest);
+      await expect(
+        onboardServer.instance._registeredTools.finish_apply!.handler(premature, {}),
+      ).rejects.toThrow(/unsettled/i);
+      yield {
+        type: 'user',
+        message: {
+          content: [
+            { type: 'tool_result', tool_use_id: 'premature-finish', is_error: true },
+            { type: 'tool_result', tool_use_id: 'entry-edit', is_error: false },
+            { type: 'tool_result', tool_use_id: 'manifest-edit', is_error: false },
+          ],
+        },
+      } as never;
+
+      const accepted = { ...premature, summary: 'Applied after edits settled.' };
+      yield {
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              id: 'accepted-finish',
+              name: 'mcp__onboard__finish_apply',
+              input: accepted,
+            },
+          ],
+        },
+      } as never;
+      await onboardServer.instance._registeredTools.finish_apply!.handler(accepted, {});
+      yield {
+        type: 'user',
+        message: {
+          content: [
+            { type: 'tool_result', tool_use_id: 'accepted-finish', is_error: false },
+          ],
+        },
+      } as never;
+      yield { type: 'result', subtype: 'success' } as never;
+    },
+  });
+}
+
+function rehashPlan(root: string, plan: OnboardingPlan): OnboardingPlan {
+  return {
+    ...plan,
+    edit: {
+      ...plan.edit,
+      entry_hash: createHash('sha256')
+        .update(readFileSync(join(root, plan.edit.file)))
+        .digest('hex'),
+      manifest_hash: createHash('sha256')
+        .update(readFileSync(join(root, plan.edit.manifest_file)))
+        .digest('hex'),
+    },
+  };
 }
 
 describe('detect-stage engine', () => {
@@ -445,5 +652,458 @@ describe('detect-stage engine', () => {
 
     expect(result).toMatchObject({ ok: false, aborted: false });
     expect(result.reason).toMatch(/shadowed.*Edit/i);
+  });
+});
+
+describe('apply-stage engine', () => {
+  beforeAll(() => {
+    process.env.ANTHROPIC_API_KEY = 'test-only';
+  });
+
+  afterAll(() => {
+    if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalApiKey;
+  });
+
+  it('locks the SDK permission and tool gates', async () => {
+    const options = applyOptions({
+      cwd: '/r',
+      hook: async () => ({}),
+      mcpServers: {},
+      canUseTool: async () => ({ behavior: 'deny', message: 'test' }),
+      abortController: new AbortController(),
+    });
+
+    expect(options.cwd).toBe('/r');
+    expect(options.permissionMode).toBe('default');
+    expect(options.settingSources).toEqual([]);
+    expect(options.strictMcpConfig).toBe(true);
+    expect(options.allowedTools).toEqual([]);
+    expect(options.tools).toEqual(['Read', 'Edit', 'Write']);
+    expect(options.disallowedTools).toEqual(
+      expect.arrayContaining(['Grep', 'Glob', 'MultiEdit', 'Bash', 'WebFetch', 'WebSearch']),
+    );
+    expect(options.maxTurns).toBe(30);
+  });
+
+  it.each([
+    ['entry hash', (plan: OnboardingPlan) => ({ ...plan, edit: { ...plan.edit, entry_hash: 'stale' } }), 'stale_plan'],
+    [
+      'manifest hash',
+      (plan: OnboardingPlan) => ({ ...plan, edit: { ...plan.edit, manifest_hash: 'stale' } }),
+      'stale_manifest',
+    ],
+    [
+      'anchor',
+      (plan: OnboardingPlan) => ({ ...plan, edit: { ...plan.edit, anchor: 'moved anchor' } }),
+      'anchor_moved',
+    ],
+    [
+      'migration',
+      (plan: OnboardingPlan) => ({
+        ...plan,
+        existing_sdk: { action: 'migrate' as const, name: '@sentry/vue' },
+      }),
+      'migrate_unsupported',
+    ],
+    [
+      'manifest outside the app directory',
+      (plan: OnboardingPlan) => ({ ...plan, app_dir: 'src' }),
+      'invalid_manifest',
+    ],
+    [
+      'untrusted dependency version',
+      (plan: OnboardingPlan) => ({
+        ...plan,
+        dependency: { ...plan.dependency, version: 'npm:attacker@latest' },
+      }),
+      'invalid_dependency',
+    ],
+    [
+      'untrusted package manager',
+      (plan: OnboardingPlan) => ({
+        ...plan,
+        package_manager: 'curl | sh' as OnboardingPlan['package_manager'],
+      }),
+      'invalid_package_manager',
+    ],
+  ])('rejects stale or unsupported %s before querying', async (_name, mutate, reason) => {
+    const { root, plan } = fixture();
+    let queried = false;
+
+    const result = await runApply({
+      cwd: root,
+      plan: mutate(plan),
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: () => {
+        queried = true;
+        return stub([]);
+      },
+    });
+
+    expect(result).toMatchObject({ ok: false, reason });
+    expect(queried).toBe(false);
+  });
+
+  it('mechanically confirms no-op as a distinct already-onboarded outcome', async () => {
+    const { root, plan: original } = fixture();
+    const applied = appliedContents(original);
+    writeFileSync(join(root, original.edit.file), applied.entry);
+    writeFileSync(join(root, original.edit.manifest_file), applied.manifest);
+    const plan = rehashPlan(root, {
+      ...original,
+      existing_sdk: { action: 'no_op', name: null },
+    });
+    const reports: ApplyReport[] = [];
+
+    const result = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: (report) => reports.push(report),
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: () => {
+        throw new Error('no-op must not query');
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      subtype: 'already_onboarded',
+      editedFiles: [],
+      installRequired: false,
+    });
+    expect(reports).toHaveLength(1);
+  });
+
+  it('rejects a package manager that conflicts with the nearest lockfile', async () => {
+    const { root, plan } = fixture();
+    writeFileSync(join(root, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+
+    const result = await runApply({
+      cwd: root,
+      plan: { ...plan, package_manager: 'npm' },
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: () => {
+        throw new Error('lockfile mismatch must not query');
+      },
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'invalid_package_manager' });
+  });
+
+  it('rejects an unproven no-op without querying', async () => {
+    const { root, plan } = fixture();
+
+    const result = await runApply({
+      cwd: root,
+      plan: { ...plan, existing_sdk: { action: 'no_op', name: null } },
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: () => {
+        throw new Error('invalid no-op must not query');
+      },
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'invalid_no_op' });
+  });
+
+  it('applies, verifies, reconciles, and reports trusted install follow-up', async () => {
+    const { root, plan } = fixture();
+    const reports: ApplyReport[] = [];
+
+    const result = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: (report) => reports.push(report),
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: applyQuery(plan),
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      subtype: 'success',
+      editedFiles: ['src/main.ts', 'package.json'],
+      installRequired: true,
+      installCommand: 'pnpm install',
+      installCwd: '.',
+    });
+    expect(reports).toEqual([
+      {
+        editedFiles: ['src/main.ts', 'package.json'],
+        summary: 'Applied approved plan.',
+        installRequired: true,
+        installCommand: 'pnpm install',
+        installCwd: '.',
+      },
+    ]);
+  });
+
+  it('reconciles duplicate committed edits to one file as canonical sets', async () => {
+    const { root, plan } = fixture();
+
+    const result = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: applyQuery(plan, { duplicateEntryCommit: true }),
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects finish issued concurrently with unsettled edits, then accepts a retry', async () => {
+    const { root, plan } = fixture();
+
+    const result = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: concurrentFinishQuery(plan),
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('rolls both files back when report reconciliation fails', async () => {
+    const { root, plan } = fixture();
+    const beforeEntry = readFileSync(join(root, plan.edit.file));
+    const beforeManifest = readFileSync(join(root, plan.edit.manifest_file));
+
+    const result = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: applyQuery(plan, { reportedFiles: [plan.edit.file] }),
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'edit_reconciliation_failed' });
+    expect(readFileSync(join(root, plan.edit.file))).toEqual(beforeEntry);
+    expect(readFileSync(join(root, plan.edit.manifest_file))).toEqual(beforeManifest);
+  });
+
+  it('rolls back a verified apply when the external report callback fails', async () => {
+    const { root, plan } = fixture();
+    const beforeEntry = readFileSync(join(root, plan.edit.file));
+    const beforeManifest = readFileSync(join(root, plan.edit.manifest_file));
+
+    const result = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: () => {
+        throw new Error('report sink unavailable');
+      },
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: applyQuery(plan),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'report_callback_failed: report sink unavailable',
+    });
+    expect(readFileSync(join(root, plan.edit.file))).toEqual(beforeEntry);
+    expect(readFileSync(join(root, plan.edit.manifest_file))).toEqual(beforeManifest);
+  });
+
+  it('rejects a clean terminal result with no apply report', async () => {
+    const { root, plan } = fixture();
+
+    const result = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: () => stub([{ type: 'result', subtype: 'success' }]),
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'no_apply_report' });
+  });
+
+  it('rejects an edit committed after finish and restores the snapshot', async () => {
+    const { root, plan } = fixture();
+    const beforeEntry = readFileSync(join(root, plan.edit.file));
+
+    const result = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: applyQuery(plan, { lateEntry: 'late mutation\n' }),
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'edits_after_finish' });
+    expect(readFileSync(join(root, plan.edit.file))).toEqual(beforeEntry);
+  });
+
+  it('rolls back exact bytes when deterministic verification fails', async () => {
+    const { root, plan } = fixture();
+    const beforeEntry = readFileSync(join(root, plan.edit.file));
+    const beforeManifest = readFileSync(join(root, plan.edit.manifest_file));
+
+    const result = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: applyQuery(plan, { entry: `${appliedContents(plan).entry}{` }),
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'verification_failed' });
+    expect(result.failures).toContain('entry file has a syntax error');
+    expect(readFileSync(join(root, plan.edit.file))).toEqual(beforeEntry);
+    expect(readFileSync(join(root, plan.edit.manifest_file))).toEqual(beforeManifest);
+  });
+
+  it('restores the snapshot when the agent lifecycle throws after an edit', async () => {
+    const { root, plan } = fixture();
+    const beforeEntry = readFileSync(join(root, plan.edit.file));
+    const queryFn: QueryFn = (request) => ({
+      [Symbol.asyncIterator]: async function* () {
+        writeFileSync(join(request.options!.cwd!, plan.edit.file), 'partial mutation\n');
+        throw new Error('agent crashed');
+      },
+    });
+
+    const result = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn,
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'agent crashed' });
+    expect(readFileSync(join(root, plan.edit.file))).toEqual(beforeEntry);
+  });
+
+  it('restores the snapshot when the caller aborts after a partial edit', async () => {
+    const { root, plan } = fixture();
+    const beforeEntry = readFileSync(join(root, plan.edit.file));
+    const controller = new AbortController();
+    const queryFn: QueryFn = (request) => ({
+      [Symbol.asyncIterator]: async function* () {
+        writeFileSync(join(request.options!.cwd!, plan.edit.file), 'partial mutation\n');
+        controller.abort();
+        yield { type: 'result', subtype: 'success' } as never;
+      },
+    });
+
+    const result = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: controller.signal,
+      queryFn,
+    });
+
+    expect(result).toMatchObject({ ok: false, aborted: true, reason: 'aborted' });
+    expect(readFileSync(join(root, plan.edit.file))).toEqual(beforeEntry);
+  });
+
+  it('returns a distinct restore failure without following a swapped symlink', async () => {
+    const { root, plan } = fixture();
+    const outside = mkdtempSync(join(tmpdir(), 'opslane-restore-outside-'));
+    const outsideFile = join(outside, 'outside.ts');
+    writeFileSync(outsideFile, 'outside remains unchanged\n');
+    const queryFn: QueryFn = (request) => ({
+      [Symbol.asyncIterator]: async function* () {
+        const entry = join(request.options!.cwd!, plan.edit.file);
+        unlinkSync(entry);
+        symlinkSync(outsideFile, entry);
+        throw new Error('agent failed after path swap');
+      },
+    });
+
+    const result = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn,
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'restore_failed' });
+    expect(result.restoreFailures?.[0]).toMatch(/src\/main\.ts/);
+    expect(readFileSync(outsideFile, 'utf8')).toBe('outside remains unchanged\n');
+  });
+});
+
+describe('Detect → Apply controller integration', () => {
+  beforeAll(() => {
+    process.env.ANTHROPIC_API_KEY = 'test-only';
+  });
+
+  afterAll(() => {
+    if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalApiKey;
+  });
+
+  it('hands the host-validated plan into the exact apply path', async () => {
+    const { root, report } = fixture();
+    let detected: OnboardingPlan | undefined;
+
+    const detect = await runDetect({
+      cwd: root,
+      onMessage: () => undefined,
+      onPlan: (plan) => {
+        detected = plan;
+      },
+      signal: new AbortController().signal,
+      queryFn: reportQuery(report),
+    });
+    expect(detect.ok).toBe(true);
+    expect(detected).toBeDefined();
+
+    const plan = detected!;
+    const apply = await runApply({
+      cwd: root,
+      plan,
+      onMessage: () => undefined,
+      onReport: () => undefined,
+      requestApproval: async () => true,
+      signal: new AbortController().signal,
+      queryFn: applyQuery(plan),
+    });
+
+    expect(apply).toMatchObject({
+      ok: true,
+      installRequired: true,
+      installCommand: 'pnpm install',
+    });
+    expect(readFileSync(join(root, plan.edit.file), 'utf8')).toContain(plan.edit.init_block);
   });
 });

--- a/cli/src/onboard/__tests__/events.test.ts
+++ b/cli/src/onboard/__tests__/events.test.ts
@@ -1,6 +1,10 @@
+import { mkdirSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
-import { labelFor, reduceTasks, type TaskLine } from '../events.js';
+import { EditTracker, labelFor, reduceTasks, type TaskLine } from '../events.js';
 
 const assistant = (blocks: unknown[]) => ({ type: 'assistant', message: { content: blocks } });
 const toolUse = (id: string, name: string, input: Record<string, unknown>) => ({
@@ -45,5 +49,61 @@ describe('onboarding task reducer', () => {
     expect(labelFor('Read', { file_path: '/r/src/main.ts' })).toMatch(/read.*main\.ts/i);
     expect(labelFor('mcp__onboard__report_plan', {})).toMatch(/report.*plan/i);
     expect(labelFor('mcp__onboard__search', {})).toMatch(/search/i);
+  });
+});
+
+describe('EditTracker', () => {
+  const fixtureRoot = () => {
+    const root = mkdtempSync(join(tmpdir(), 'opslane-edit-tracker-'));
+    mkdirSync(join(root, 'src'));
+    return root;
+  };
+
+  it('orders committed edits around the successful finish result', () => {
+    const root = fixtureRoot();
+    const tracker = new EditTracker(root);
+
+    tracker.onMessage(assistant([toolUse('edit-1', 'Edit', { file_path: join(root, 'src/main.ts') })]));
+    tracker.onMessage(user([toolResult('edit-1')]));
+    tracker.onMessage(
+      assistant([toolUse('finish-1', 'mcp__onboard__finish_apply', { edited_files: [] })]),
+    );
+    tracker.onMessage(user([toolResult('finish-1')]));
+    tracker.onMessage(assistant([toolUse('edit-2', 'Write', { file_path: join(root, 'src/late.ts') })]));
+    tracker.onMessage(user([toolResult('edit-2')]));
+
+    expect(tracker.committedBeforeFinish()).toEqual(['src/main.ts']);
+    expect(tracker.editsAfterFinish()).toEqual(['src/late.ts']);
+  });
+
+  it('does not commit errored edits and preserves duplicate file commits', () => {
+    const root = fixtureRoot();
+    const tracker = new EditTracker(root);
+
+    tracker.onMessage(
+      assistant([
+        toolUse('edit-1', 'Edit', { file_path: join(root, 'src/main.ts') }),
+        toolUse('edit-2', 'Edit', { file_path: join(root, 'src/main.ts') }),
+        toolUse('edit-3', 'Write', { file_path: join(root, 'src/error.ts') }),
+      ]),
+    );
+    expect(tracker.hasUnsettledEdits()).toBe(true);
+    tracker.onMessage(user([toolResult('edit-1'), toolResult('edit-2'), toolResult('edit-3', true)]));
+    tracker.markFinished('finish-1');
+
+    expect(tracker.hasUnsettledEdits()).toBe(false);
+    expect(tracker.committedBeforeFinish()).toEqual(['src/main.ts', 'src/main.ts']);
+    expect(tracker.editsAfterFinish()).toEqual([]);
+  });
+
+  it('keeps an edit unsettled until its matching tool result arrives', () => {
+    const root = fixtureRoot();
+    const tracker = new EditTracker(root);
+
+    tracker.onMessage(assistant([toolUse('edit-1', 'Edit', { file_path: join(root, 'src/main.ts') })]));
+
+    expect(tracker.hasUnsettledEdits()).toBe(true);
+    tracker.onMessage(user([toolResult('edit-1')]));
+    expect(tracker.hasUnsettledEdits()).toBe(false);
   });
 });

--- a/cli/src/onboard/__tests__/policy.test.ts
+++ b/cli/src/onboard/__tests__/policy.test.ts
@@ -87,6 +87,28 @@ describe('onboarding hard-denial hook', () => {
     expect(denied(await run(finished, 'Edit', { file_path: join(root, 'a.ts') }))).toBe(true);
     expect(denied(await run(finished, 'mcp__onboard__ask_user', {}))).toBe(false);
   });
+
+  it('restricts mutations to the exact canonical writable paths while retaining safe reads', async () => {
+    writeFileSync(join(root, 'package.json'), '{}\n');
+    writeFileSync(join(root, 'src', 'other.ts'), '');
+    const restricted = onboardPreToolUseHook({
+      root,
+      writablePaths: ['src/main.ts', 'package.json'],
+    });
+
+    expect(
+      denied(await run(restricted, 'Edit', { file_path: join(root, 'src', '..', 'src', 'main.ts') })),
+    ).toBe(false);
+    expect(denied(await run(restricted, 'Write', { file_path: join(root, 'package.json') }))).toBe(
+      false,
+    );
+    expect(denied(await run(restricted, 'Edit', { file_path: join(root, 'src', 'other.ts') }))).toBe(
+      true,
+    );
+    expect(denied(await run(restricted, 'Read', { file_path: join(root, 'src', 'other.ts') }))).toBe(
+      false,
+    );
+  });
 });
 
 describe('onboarding approval callback', () => {
@@ -115,5 +137,16 @@ describe('onboarding approval callback', () => {
       behavior: 'allow',
     });
     expect(calls).toBe(0);
+  });
+
+  it('fails closed for tools outside the stage allowlist', async () => {
+    const approval = createOnboardApproval({
+      requestApproval: async () => true,
+      allowedTools: ['Read', 'Edit'],
+    });
+
+    await expect(approval('WebFetch', {}, {} as never)).resolves.toMatchObject({
+      behavior: 'deny',
+    });
   });
 });

--- a/cli/src/onboard/__tests__/spec.test.ts
+++ b/cli/src/onboard/__tests__/spec.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { renderDetectSpec } from '../spec.js';
+import { renderApplySpec, renderDetectSpec } from '../spec.js';
+import type { OnboardingPlan } from '../tools.js';
 
 describe('detect-stage agent specification', () => {
   it('frames a read-only repository investigation and report', () => {
@@ -34,6 +35,74 @@ describe('detect-stage agent specification', () => {
     expect(spec).toMatch(/coexist/i);
     expect(spec).toContain('import_line');
     expect(spec).toContain('init_block');
+    expect(spec).toMatch(/anchor[\s\S]{0,100}init block|init block[\s\S]{0,100}anchor/i);
+    expect(spec).toMatch(/import_line[\s\S]{0,100}module top level/i);
+    expect(spec).toContain('manifest_file');
+    expect(spec).toMatch(/host pins the SDK version/i);
     expect(spec).not.toMatch(/\bedit or write\b/i);
+  });
+});
+
+describe('apply-stage agent specification', () => {
+  const plan: OnboardingPlan = {
+    app_dir: 'web',
+    framework: 'vue-vite',
+    package_manager: 'pnpm',
+    env_prefix: 'VITE_',
+    dependency: { name: '@opslane/sdk', version: '^1.2.0' },
+    env_vars: {
+      api_key: 'VITE_OPSLANE_API_KEY',
+      endpoint: 'VITE_OPSLANE_ENDPOINT',
+    },
+    edit: {
+      file: 'web/src/main.ts',
+      entry_hash: 'entry-hash',
+      manifest_file: 'web/package.json',
+      manifest_hash: 'manifest-hash',
+      import_line: "import { init } from '@opslane/sdk';",
+      init_block:
+        'init({ apiKey: import.meta.env.VITE_OPSLANE_API_KEY, endpoint: import.meta.env.VITE_OPSLANE_ENDPOINT });',
+      anchor: "createApp(App).mount('#app');",
+      position: 'before',
+      occurrence: 0,
+    },
+    existing_sdk: { action: 'none', name: null },
+    rationale: 'Initialize before mount.',
+  };
+
+  it('renders the exact approved operations and narrow safety contract', () => {
+    const spec = renderApplySpec({ cwd: '/repo/x', plan });
+
+    for (const required of [
+      '/repo/x',
+      plan.edit.file,
+      plan.edit.manifest_file,
+      plan.edit.import_line,
+      plan.edit.init_block,
+      plan.edit.anchor,
+      plan.dependency.version,
+      'finish_apply',
+      'top level',
+      'Change nothing else',
+      'Do not run installs',
+      'Migration is unsupported',
+    ]) {
+      expect(spec).toContain(required);
+    }
+    expect(spec).toMatch(/do not reformat unrelated/i);
+    expect(spec).toMatch(/make no edits or other tool calls after finish_apply/i);
+  });
+
+  it('renders an explicit migrate refusal', () => {
+    const spec = renderApplySpec({
+      cwd: '/repo/x',
+      plan: {
+        ...plan,
+        existing_sdk: { action: 'migrate', name: '@sentry/vue' },
+      },
+    });
+
+    expect(spec).toMatch(/migration is unsupported/i);
+    expect(spec).toMatch(/never attempt a partial migration/i);
   });
 });

--- a/cli/src/onboard/__tests__/tools.test.ts
+++ b/cli/src/onboard/__tests__/tools.test.ts
@@ -1,13 +1,15 @@
 import { createHash } from 'node:crypto';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   createAskUserTool,
+  createFinishApplyTool,
   createOnboardServer,
   createReportPlanTool,
+  OPSLANE_SDK_VERSION,
   type OnboardingPlan,
   type ReportedPlanInput,
 } from '../tools.js';
@@ -40,6 +42,7 @@ describe('report_plan', () => {
   let root: string;
   let entryFile: string;
   let entryContents: string;
+  let manifestContents: string;
   let plan: ReportedPlanInput;
 
   beforeEach(() => {
@@ -47,19 +50,22 @@ describe('report_plan', () => {
     mkdirSync(join(root, 'web', 'src'), { recursive: true });
     entryFile = join(root, 'web', 'src', 'main.ts');
     entryContents = "import App from './App.vue';\ncreateApp(App).mount('#app');\n";
+    manifestContents = '{\n  "name": "web",\n  "dependencies": {}\n}\n';
     writeFileSync(entryFile, entryContents);
+    writeFileSync(join(root, 'web', 'package.json'), manifestContents);
     plan = {
       app_dir: 'web',
       framework: 'vue-vite',
       package_manager: 'pnpm',
       env_prefix: 'VITE_',
-      dependency: { name: '@opslane/sdk', version: '^1.0.0' },
+      dependency: { name: '@opslane/sdk' },
       env_vars: {
         api_key: 'VITE_OPSLANE_API_KEY',
         endpoint: 'VITE_OPSLANE_ENDPOINT',
       },
       edit: {
         file: 'web/src/main.ts',
+        manifest_file: 'web/package.json',
         import_line: "import { init } from '@opslane/sdk';",
         init_block:
           'init({ apiKey: import.meta.env.VITE_OPSLANE_API_KEY, endpoint: import.meta.env.VITE_OPSLANE_ENDPOINT });',
@@ -99,7 +105,9 @@ describe('report_plan', () => {
       edit: {
         ...plan.edit,
         entry_hash: createHash('sha256').update(entryContents).digest('hex'),
+        manifest_hash: createHash('sha256').update(manifestContents).digest('hex'),
       },
+      dependency: { name: '@opslane/sdk', version: OPSLANE_SDK_VERSION },
     });
     await expect(call(tool, { status: 'ok', plan })).rejects.toThrow(/already/i);
   });
@@ -137,6 +145,33 @@ describe('report_plan', () => {
     ],
     ['a missing edit file', () => ({ ...plan, edit: { ...plan.edit, file: 'web/src/nope.ts' } }), /exist/i],
     [
+      'a manifest outside app_dir',
+      () => {
+        writeFileSync(join(root, 'package.json'), '{}\n');
+        return { ...plan, edit: { ...plan.edit, manifest_file: 'package.json' } };
+      },
+      /app_dir/i,
+    ],
+    [
+      'a non-package manifest',
+      () => {
+        writeFileSync(join(root, 'web', 'manifest.json'), '{}\n');
+        return { ...plan, edit: { ...plan.edit, manifest_file: 'web/manifest.json' } };
+      },
+      /package\.json/i,
+    ],
+    [
+      'a symlinked manifest escape',
+      () => {
+        const outside = mkdtempSync(join(tmpdir(), 'opslane-outside-'));
+        writeFileSync(join(outside, 'package.json'), '{}\n');
+        unlinkSync(join(root, 'web', 'package.json'));
+        symlinkSync(join(outside, 'package.json'), join(root, 'web', 'package.json'));
+        return plan;
+      },
+      /contain|regular/i,
+    ],
+    [
       'a variable outside the app prefix',
       () => ({ ...plan, env_vars: { ...plan.env_vars, api_key: 'NEXT_PUBLIC_OPSLANE_API_KEY' } }),
       /prefix/i,
@@ -149,6 +184,11 @@ describe('report_plan', () => {
     ['an unknown package manager', () => ({ ...plan, package_manager: 'curl|sh' }), /package manager/i],
     ['an absent anchor', () => ({ ...plan, edit: { ...plan.edit, anchor: 'not in the file' } }), /anchor/i],
     [
+      'a partial-line anchor',
+      () => ({ ...plan, edit: { ...plan.edit, anchor: 'createApp(App)' } }),
+      /complete non-whitespace content/i,
+    ],
+    [
       'an unavailable anchor occurrence',
       () => ({ ...plan, edit: { ...plan.edit, occurrence: 1 } }),
       /occurrence/i,
@@ -157,6 +197,41 @@ describe('report_plan', () => {
       'an unknown existing SDK action',
       () => ({ ...plan, existing_sdk: { ...plan.existing_sdk, action: 'replace_everything' } }),
       /existing SDK action/i,
+    ],
+    [
+      'an init block with an extra executable statement',
+      () => ({
+        ...plan,
+        edit: {
+          ...plan.edit,
+          init_block: `${plan.edit.init_block}\nfetch('https://attacker.invalid');`,
+        },
+      }),
+      /one direct Opslane init call/i,
+    ],
+    [
+      'a side effect hidden inside an init option',
+      () => ({
+        ...plan,
+        edit: {
+          ...plan.edit,
+          init_block:
+            "init({ apiKey: (fetch('https://attacker.invalid'), import.meta.env.VITE_OPSLANE_API_KEY), endpoint: import.meta.env.VITE_OPSLANE_ENDPOINT });",
+        },
+      }),
+      /apiKey option must directly reference/i,
+    ],
+    [
+      'a bare variable instead of a concrete environment lookup',
+      () => ({
+        ...plan,
+        edit: {
+          ...plan.edit,
+          init_block:
+            'init({ apiKey: VITE_OPSLANE_API_KEY, endpoint: VITE_OPSLANE_ENDPOINT });',
+        },
+      }),
+      /apiKey option must directly reference/i,
     ],
   ])('rejects %s', async (_name, makePlan, message) => {
     await expect(report({ status: 'ok', plan: makePlan() })).rejects.toThrow(message);
@@ -200,5 +275,76 @@ describe('report_plan', () => {
     )._registeredTools;
 
     expect(registered.report_plan?.inputSchema).toBeDefined();
+  });
+
+  it('host-pins the SDK version even when the model includes an attacker-controlled value', async () => {
+    let captured: OnboardingPlan | undefined;
+    await report(
+      {
+        status: 'ok',
+        plan: {
+          ...plan,
+          dependency: { name: '@opslane/sdk', version: 'npm:attacker@latest' },
+        },
+      },
+      (accepted) => {
+        captured = accepted;
+      },
+    );
+
+    expect(captured?.dependency.version).toBe(OPSLANE_SDK_VERSION);
+    expect(JSON.stringify(captured)).not.toContain('attacker');
+  });
+
+  it('requires the reported package manager to match the nearest lockfile', async () => {
+    writeFileSync(join(root, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+
+    await expect(
+      report({ status: 'ok', plan: { ...plan, package_manager: 'npm' } }),
+    ).rejects.toThrow(/match pnpm lockfile/i);
+  });
+});
+
+describe('finish_apply', () => {
+  const root = mkdtempSync(join(tmpdir(), 'opslane-finish-'));
+  const state = () => ({ finished: false });
+
+  it('canonicalizes a valid report and finishes only once', async () => {
+    const runState = state();
+    const reports: unknown[] = [];
+    const finish = createFinishApplyTool(root, runState, (report) => reports.push(report));
+
+    await call(finish, { edited_files: [join(root, 'src/main.ts')], summary: 'Applied plan.' });
+
+    expect(reports).toEqual([
+      { editedFiles: ['src/main.ts'], summary: 'Applied plan.' },
+    ]);
+    expect(runState.finished).toBe(true);
+    await expect(
+      call(finish, { edited_files: ['src/main.ts'], summary: 'Again.' }),
+    ).rejects.toThrow(/already|finished/i);
+  });
+
+  it.each([
+    [{ edited_files: [], summary: 'None.' }, /too small|at least|array/i],
+    [{ edited_files: ['../outside.ts'], summary: 'Escape.' }, /contain/i],
+    [{ edited_files: ['.env.production'], summary: 'Secret.' }, /secret/i],
+    [{ edited_files: ['src/main.ts', 'src/main.ts'], summary: 'Duplicate.' }, /duplicate/i],
+  ])('rejects an invalid report without flipping state', async (input, message) => {
+    const runState = state();
+    const finish = createFinishApplyTool(root, runState, () => undefined);
+
+    await expect(call(finish, input)).rejects.toThrow(message);
+    expect(runState.finished).toBe(false);
+  });
+
+  it('rejects finish while an edit is unsettled', async () => {
+    const runState = state();
+    const finish = createFinishApplyTool(root, runState, () => undefined, () => false);
+
+    await expect(
+      call(finish, { edited_files: ['src/main.ts'], summary: 'Too soon.' }),
+    ).rejects.toThrow(/unsettled/i);
+    expect(runState.finished).toBe(false);
   });
 });

--- a/cli/src/onboard/__tests__/verify.test.ts
+++ b/cli/src/onboard/__tests__/verify.test.ts
@@ -1,0 +1,486 @@
+import { createHash } from 'node:crypto';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  verifyAlreadyOnboarded,
+  verifyApplied,
+  type VerifiableOnboardingPlan,
+} from '../verify.js';
+
+const hash = (value: Buffer | string) =>
+  createHash('sha256').update(value).digest('hex');
+
+describe('deterministic apply verification', () => {
+  let root: string;
+  let originalEntry: Buffer;
+  let originalManifest: Buffer;
+  let plan: VerifiableOnboardingPlan;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'opslane-verify-'));
+    mkdirSync(join(root, 'src'));
+    originalEntry = Buffer.from(
+      [
+        "import App from './App.vue';",
+        '',
+        'async function start() {',
+        "\tcreateApp(App).mount('#app');",
+        '}',
+        '',
+      ].join('\n'),
+    );
+    originalManifest = Buffer.from(
+      [
+        '{',
+        '  "name": "fixture",',
+        '  "dependencies": {',
+        '    "vue": "^3.5.0"',
+        '  }',
+        '}',
+        '',
+      ].join('\n'),
+    );
+    writeFileSync(join(root, 'src', 'main.ts'), originalEntry);
+    writeFileSync(join(root, 'package.json'), originalManifest);
+
+    plan = {
+      app_dir: '.',
+      framework: 'vue-vite',
+      package_manager: 'pnpm',
+      env_prefix: 'VITE_',
+      dependency: { name: '@opslane/sdk', version: '^1.2.0' },
+      env_vars: {
+        api_key: 'VITE_OPSLANE_API_KEY',
+        endpoint: 'VITE_OPSLANE_ENDPOINT',
+      },
+      edit: {
+        file: 'src/main.ts',
+        entry_hash: hash(originalEntry),
+        manifest_file: 'package.json',
+        manifest_hash: hash(originalManifest),
+        import_line: "import { init } from '@opslane/sdk';",
+        init_block: [
+          'init({',
+          '  apiKey: import.meta.env.VITE_OPSLANE_API_KEY,',
+          '  endpoint: import.meta.env.VITE_OPSLANE_ENDPOINT,',
+          '});',
+        ].join('\n'),
+        anchor: "createApp(App).mount('#app');",
+        position: 'before',
+        occurrence: 0,
+      },
+      existing_sdk: { action: 'none', name: null },
+      rationale: 'Initialize immediately before mounting the application.',
+    };
+  });
+
+  function applyFixture(customPlan = plan): void {
+    const entry = originalEntry
+      .toString('utf8')
+      .replace(
+        "import App from './App.vue';\n",
+        `import App from './App.vue';\n${customPlan.edit.import_line}\n`,
+      )
+      .replace(
+        "\tcreateApp(App).mount('#app');",
+        `\t${customPlan.edit.init_block.replaceAll('\n', '\n\t')}\n\tcreateApp(App).mount('#app');`,
+      );
+    const manifest = originalManifest
+      .toString('utf8')
+      .replace(
+        '    "vue": "^3.5.0"',
+        `    "vue": "^3.5.0",\n    "@opslane/sdk": "${customPlan.dependency.version}"`,
+      );
+    writeFileSync(join(root, customPlan.edit.file), entry);
+    writeFileSync(join(root, customPlan.edit.manifest_file), manifest);
+  }
+
+  const verify = (customPlan = plan, editedFiles = ['src/main.ts', 'package.json']) =>
+    verifyApplied({
+      root,
+      plan: customPlan,
+      editedFiles,
+      originals: { entry: originalEntry, manifest: originalManifest },
+    });
+
+  it('accepts exactly the planned top-level import, indented init, and pinned dependency', () => {
+    applyFixture();
+
+    expect(verify()).toEqual({ ok: true, failures: [] });
+  });
+
+  // Codex QA P0 #4: an invalid byte would decode to U+FFFD, so a lossy string
+  // comparison could hide a change. verify must reject non-UTF-8 rather than
+  // silently pass it.
+  it('rejects an entry file that is not valid UTF-8', () => {
+    applyFixture();
+    const applied = readFileSync(join(root, 'src', 'main.ts'));
+    writeFileSync(join(root, 'src', 'main.ts'), Buffer.concat([applied, Buffer.from([0xff, 0xfe])]));
+
+    const result = verify();
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('entry file is not valid UTF-8');
+  });
+
+  // Codex QA P1 #5: a leading BOM must not make a correctly-applied file fail.
+  // Detect hashes the real (BOM-bearing) bytes, so the snapshot hash reflects them.
+  it('accepts a correctly applied entry that carries a leading BOM', () => {
+    const bomOriginal = Buffer.concat([Buffer.from('﻿', 'utf8'), originalEntry]);
+    const bomPlan = { ...plan, edit: { ...plan.edit, entry_hash: hash(bomOriginal) } };
+    applyFixture(bomPlan);
+    const applied = readFileSync(join(root, 'src', 'main.ts'), 'utf8');
+    writeFileSync(join(root, 'src', 'main.ts'), Buffer.from('﻿' + applied, 'utf8'));
+
+    const result = verifyApplied({
+      root,
+      plan: bomPlan,
+      editedFiles: ['src/main.ts', 'package.json'],
+      originals: { entry: bomOriginal, manifest: originalManifest },
+    });
+    expect(result).toEqual({ ok: true, failures: [] });
+  });
+
+  it('accepts an init block placed after a complete-line anchor', () => {
+    plan = { ...plan, edit: { ...plan.edit, position: 'after' } };
+    const entry = originalEntry
+      .toString('utf8')
+      .replace(
+        "import App from './App.vue';\n",
+        `import App from './App.vue';\n${plan.edit.import_line}\n`,
+      )
+      .replace(
+        "\tcreateApp(App).mount('#app');",
+        `\tcreateApp(App).mount('#app');\n\t${plan.edit.init_block.replaceAll('\n', '\n\t')}`,
+      );
+    writeFileSync(join(root, 'src', 'main.ts'), entry);
+    writeFileSync(
+      join(root, 'package.json'),
+      originalManifest
+        .toString('utf8')
+        .replace(
+          '    "vue": "^3.5.0"',
+          '    "vue": "^3.5.0",\n    "@opslane/sdk": "^1.2.0"',
+        ),
+    );
+
+    expect(verify()).toEqual({ ok: true, failures: [] });
+  });
+
+  it('accepts creating dependencies and updating an older Opslane version', () => {
+    originalManifest = Buffer.from('{\n  "name": "fixture"\n}\n');
+    plan = {
+      ...plan,
+      edit: { ...plan.edit, manifest_hash: hash(originalManifest) },
+    };
+    writeFileSync(join(root, 'package.json'), originalManifest);
+    const entry = originalEntry
+      .toString('utf8')
+      .replace(
+        "import App from './App.vue';\n",
+        `import App from './App.vue';\n${plan.edit.import_line}\n`,
+      )
+      .replace(
+        "\tcreateApp(App).mount('#app');",
+        `\t${plan.edit.init_block.replaceAll('\n', '\n\t')}\n\tcreateApp(App).mount('#app');`,
+      );
+    writeFileSync(join(root, 'src', 'main.ts'), entry);
+    writeFileSync(
+      join(root, 'package.json'),
+      '{\n  "name": "fixture",\n  "dependencies": {\n    "@opslane/sdk": "^1.2.0"\n  }\n}\n',
+    );
+    expect(verify()).toEqual({ ok: true, failures: [] });
+
+    originalManifest = Buffer.from(
+      '{\n  "name": "fixture",\n  "dependencies": {\n    "@opslane/sdk": "^1.0.0"\n  }\n}\n',
+    );
+    plan = {
+      ...plan,
+      edit: { ...plan.edit, manifest_hash: hash(originalManifest) },
+    };
+    writeFileSync(
+      join(root, 'package.json'),
+      originalManifest.toString('utf8').replace('^1.0.0', '^1.2.0'),
+    );
+    expect(verify()).toEqual({ ok: true, failures: [] });
+  });
+
+  it('rejects an edited-file set containing an unapproved third file', () => {
+    applyFixture();
+    writeFileSync(join(root, 'README.md'), 'changed');
+
+    const result = verify(plan, ['src/main.ts', 'package.json', 'README.md']);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('edited file set does not match the approved plan');
+  });
+
+  it('rejects unrelated entry changes and a mis-indented init independently', () => {
+    applyFixture();
+    const file = join(root, 'src', 'main.ts');
+    writeFileSync(
+      file,
+      read(file)
+        .replace('async function start()', 'async function renamed()')
+        .replace('\tinit({', '  init({'),
+    );
+
+    const result = verify();
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain(
+      'entry file differs by more than the planned import and init insertion',
+    );
+  });
+
+  it('requires environment references inside the sole initializer call', () => {
+    plan = {
+      ...plan,
+      edit: {
+        ...plan.edit,
+        init_block: [
+          "init({ apiKey: 'literal', endpoint: 'literal' });",
+          'const VITE_OPSLANE_API_KEY = 1, VITE_OPSLANE_ENDPOINT = 1;',
+        ].join('\n'),
+      },
+    };
+    applyFixture();
+
+    const result = verify();
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain(
+      'planned init block must be one direct Opslane init call with one object',
+    );
+  });
+
+  it('rejects a planned import placed inside a block', () => {
+    const entry = originalEntry
+      .toString('utf8')
+      .replace(
+        'async function start() {\n',
+        `async function start() {\n${plan.edit.import_line}\n`,
+      )
+      .replace(
+        "\tcreateApp(App).mount('#app');",
+        `\t${plan.edit.init_block.replaceAll('\n', '\n\t')}\n\tcreateApp(App).mount('#app');`,
+      );
+    writeFileSync(join(root, 'src', 'main.ts'), entry);
+    writeFileSync(
+      join(root, 'package.json'),
+      originalManifest
+        .toString('utf8')
+        .replace(
+          '    "vue": "^3.5.0"',
+          '    "vue": "^3.5.0",\n    "@opslane/sdk": "^1.2.0"',
+        ),
+    );
+
+    const result = verify();
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.some((failure) => /syntax|top[- ]level/i.test(failure))).toBe(true);
+  });
+
+  it('rejects a top-level import placed away from the module import section', () => {
+    const entry = originalEntry
+      .toString('utf8')
+      .replace(
+        "\tcreateApp(App).mount('#app');",
+        `\t${plan.edit.init_block.replaceAll('\n', '\n\t')}\n\tcreateApp(App).mount('#app');`,
+      )
+      .replace(/}\n$/, `}\n${plan.edit.import_line}\n`);
+    writeFileSync(join(root, 'src', 'main.ts'), entry);
+    writeFileSync(
+      join(root, 'package.json'),
+      originalManifest
+        .toString('utf8')
+        .replace(
+          '    "vue": "^3.5.0"',
+          '    "vue": "^3.5.0",\n    "@opslane/sdk": "^1.2.0"',
+        ),
+    );
+
+    const result = verify();
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain(
+      'planned Opslane import is not in the module top-level import section',
+    );
+  });
+
+  it('rejects a syntactically broken entry file', () => {
+    applyFixture();
+    writeFileSync(join(root, 'src', 'main.ts'), `${read(join(root, 'src', 'main.ts'))}\n{`);
+
+    const result = verify();
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('entry file has a syntax error');
+  });
+
+  it('rejects unrelated manifest semantics and whole-file reformatting', () => {
+    applyFixture();
+    const manifestPath = join(root, 'package.json');
+    const parsed = JSON.parse(read(manifestPath)) as Record<string, unknown>;
+    writeFileSync(manifestPath, JSON.stringify({ ...parsed, private: true }));
+
+    const unrelated = verify();
+    expect(unrelated.ok).toBe(false);
+    expect(unrelated.failures).toContain(
+      'manifest has changes other than the pinned Opslane dependency',
+    );
+
+    applyFixture();
+    writeFileSync(
+      manifestPath,
+      JSON.stringify(JSON.parse(read(manifestPath)), null, 4) + '\n',
+    );
+    const reformatted = verify();
+    expect(reformatted.ok).toBe(false);
+    expect(reformatted.failures).toContain('manifest rewrote existing bytes');
+  });
+
+  it('scans only added bytes for dotenv values and redacts the value', () => {
+    const secret = 'canary-never-print-this-value';
+    writeFileSync(join(root, '.env.local'), `PRIVATE_TOKEN=${secret}\n`);
+    plan = {
+      ...plan,
+      edit: {
+        ...plan.edit,
+        init_block: `${plan.edit.init_block.slice(0, -3)}  release: '${secret}',\n});`,
+      },
+    };
+    applyFixture();
+
+    const result = verify();
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain(
+      'newly added content contains the value of dotenv variable PRIVATE_TOKEN',
+    );
+    expect(result.failures.join(' ')).not.toContain(secret);
+  });
+
+  it('does not reject a dotenv value that existed only in unchanged bytes', () => {
+    const existing = 'preexisting-canary-value';
+    originalEntry = Buffer.from(`// ${existing}\n${originalEntry.toString('utf8')}`);
+    plan = {
+      ...plan,
+      edit: { ...plan.edit, entry_hash: hash(originalEntry) },
+    };
+    writeFileSync(join(root, 'src', 'main.ts'), originalEntry);
+    writeFileSync(join(root, '.env'), `PRIVATE_TOKEN=${existing}\n`);
+    applyFixture();
+
+    expect(verify()).toEqual({ ok: true, failures: [] });
+  });
+
+  it('does not follow a symlinked dotenv file outside the repository', () => {
+    const outside = mkdtempSync(join(tmpdir(), 'opslane-outside-'));
+    writeFileSync(join(outside, 'secret'), 'PRIVATE_TOKEN=outside-canary-value\n');
+    symlinkSync(join(outside, 'secret'), join(root, '.env.link'));
+    applyFixture();
+
+    expect(verify()).toEqual({ ok: true, failures: [] });
+  });
+
+  it('rejects unsupported entry extensions instead of skipping parsing', () => {
+    const unsupported = join(root, 'src', 'main.vue');
+    writeFileSync(unsupported, originalEntry);
+    plan = {
+      ...plan,
+      edit: {
+        ...plan.edit,
+        file: 'src/main.vue',
+        entry_hash: hash(originalEntry),
+      },
+    };
+    applyFixture();
+
+    const result = verify(plan, ['src/main.vue', 'package.json']);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('unsupported entry extension: .vue');
+  });
+
+  it('confirms no-op only when the dependency and its imported initializer call exist', () => {
+    applyFixture();
+
+    expect(verifyAlreadyOnboarded({ root, plan })).toEqual({
+      ok: true,
+      failures: [],
+    });
+
+    writeFileSync(
+      join(root, 'src', 'main.ts'),
+      [
+        "import App from './App.vue';",
+        "// import { init } from '@opslane/sdk';",
+        "const note = 'init()';",
+        "createApp(App).mount('#app');",
+      ].join('\n'),
+    );
+    const rejected = verifyAlreadyOnboarded({ root, plan });
+    expect(rejected.ok).toBe(false);
+    expect(rejected.failures).toContain('entry file has no top-level Opslane SDK import');
+  });
+
+  // Codex QA P0 #1: `import type { init }` is erased at runtime and cannot
+  // initialize the SDK, so it must not satisfy the no-op existence check.
+  it('rejects no-op when the SDK import is type-only', () => {
+    applyFixture(); // installs the dependency in package.json
+    writeFileSync(
+      join(root, 'src', 'main.ts'),
+      [
+        "import App from './App.vue';",
+        "import type { init } from '@opslane/sdk';",
+        'init();',
+        "createApp(App).mount('#app');",
+      ].join('\n'),
+    );
+    const rejected = verifyAlreadyOnboarded({ root, plan });
+    expect(rejected.ok).toBe(false);
+    expect(rejected.failures).toContain('entry file has no top-level Opslane SDK import');
+  });
+
+  it('rejects no-op for an identity-broken SDK version or a nonexistent default export', () => {
+    applyFixture();
+    const manifest = join(root, 'package.json');
+    writeFileSync(manifest, read(manifest).replace('^1.2.0', '^1.0.0'));
+
+    const oldVersion = verifyAlreadyOnboarded({ root, plan });
+    expect(oldVersion.ok).toBe(false);
+    expect(oldVersion.failures[0]).toMatch(/identity-capable.*>=1\.2\.0/i);
+
+    writeFileSync(manifest, read(manifest).replace('^1.0.0', '1.2.0-beta.1'));
+    expect(verifyAlreadyOnboarded({ root, plan }).ok).toBe(false);
+
+    writeFileSync(manifest, read(manifest).replace('1.2.0-beta.1', '^1.2.0'));
+    writeFileSync(
+      join(root, 'src', 'main.ts'),
+      [
+        "import Opslane from '@opslane/sdk';",
+        'Opslane.init({',
+        '  apiKey: import.meta.env.VITE_OPSLANE_API_KEY,',
+        '  endpoint: import.meta.env.VITE_OPSLANE_ENDPOINT,',
+        '});',
+      ].join('\n'),
+    );
+    const defaultImport = verifyAlreadyOnboarded({ root, plan });
+    expect(defaultImport.ok).toBe(false);
+    expect(defaultImport.failures).toContain('entry file has no top-level Opslane SDK import');
+  });
+});
+
+function read(file: string): string {
+  return readFileSync(file, 'utf8');
+}

--- a/cli/src/onboard/engine.ts
+++ b/cli/src/onboard/engine.ts
@@ -1,3 +1,17 @@
+import { createHash } from 'node:crypto';
+import {
+  closeSync,
+  constants,
+  existsSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+
 import {
   query,
   type HookCallback,
@@ -6,16 +20,27 @@ import {
   type SDKMessage,
 } from '@anthropic-ai/claude-agent-sdk';
 
-import { onboardPreToolUseHook } from './policy.js';
+import { EditTracker } from './events.js';
+import {
+  createOnboardApproval,
+  onboardPreToolUseHook,
+  type ApprovalRequest,
+} from './policy.js';
+import { containedRepoRelative, hasSecretSegment } from './paths.js';
 import { createSearchTool } from './search-tool.js';
-import { renderDetectSpec } from './spec.js';
+import { renderApplySpec, renderDetectSpec } from './spec.js';
 import {
   createAskUserTool,
+  createFinishApplyTool,
   createOnboardServer,
   createReportPlanTool,
+  OPSLANE_SDK_VERSION,
+  packageManagerForRepo,
   type AskUserResolver,
+  type FinishApplyReport,
   type OnboardingPlan,
 } from './tools.js';
+import { verifyAlreadyOnboarded, verifyApplied } from './verify.js';
 
 const SHADOW_WARNING = 'CLAUDE_SDK_CAN_USE_TOOL_SHADOWED';
 const INTENTIONALLY_SHADOWED_TOOLS = new Set([
@@ -23,6 +48,9 @@ const INTENTIONALLY_SHADOWED_TOOLS = new Set([
   'mcp__onboard__ask_user',
 ]);
 const REPORT_PLAN_TOOL = 'mcp__onboard__report_plan';
+const PACKAGE_MANAGERS = new Set(['npm', 'pnpm', 'yarn', 'bun']);
+const MAX_ENTRY_BYTES = 4 * 1024 * 1024;
+const MAX_MANIFEST_BYTES = 1024 * 1024;
 
 export type QueryFn = (request: {
   prompt: string;
@@ -34,6 +62,21 @@ export interface EngineResult {
   aborted: boolean;
   subtype?: string;
   reason?: string;
+}
+
+export interface ApplyReport extends FinishApplyReport {
+  installRequired: boolean;
+  installCommand?: string;
+  installCwd: string;
+}
+
+export interface ApplyResult extends EngineResult {
+  editedFiles?: string[];
+  installRequired?: boolean;
+  installCommand?: string;
+  installCwd?: string;
+  failures?: string[];
+  restoreFailures?: string[];
 }
 
 export function detectOptions({
@@ -78,6 +121,42 @@ export function detectOptions({
     },
     abortController,
     maxTurns: 50,
+  };
+}
+
+export function applyOptions({
+  cwd,
+  hook,
+  mcpServers,
+  canUseTool,
+  abortController,
+}: {
+  cwd: string;
+  hook: HookCallback;
+  mcpServers: Record<string, McpServerConfig>;
+  canUseTool: NonNullable<Options['canUseTool']>;
+  abortController: AbortController;
+}): Options {
+  return {
+    cwd,
+    permissionMode: 'default',
+    settingSources: [],
+    strictMcpConfig: true,
+    allowedTools: [],
+    tools: ['Read', 'Edit', 'Write'],
+    disallowedTools: [
+      'Grep',
+      'Glob',
+      'MultiEdit',
+      'Bash',
+      'WebFetch',
+      'WebSearch',
+    ],
+    mcpServers,
+    hooks: { PreToolUse: [{ hooks: [hook] }] },
+    canUseTool,
+    abortController,
+    maxTurns: 30,
   };
 }
 
@@ -153,20 +232,18 @@ function updateReportStream(message: unknown, state: ReportStreamState): void {
   }
 }
 
-export async function runDetect({
-  cwd,
+export async function runAgentCore({
+  prompt,
+  options,
   onMessage,
-  onPlan,
   signal,
-  askUser = null,
-  queryFn = (request) => query(request),
+  queryFn,
 }: {
-  cwd: string;
+  prompt: string;
+  options: (abortController: AbortController) => Options;
   onMessage: (message: SDKMessage) => void;
-  onPlan: (plan: OnboardingPlan) => void;
   signal: AbortSignal;
-  askUser?: AskUserResolver | null;
-  queryFn?: QueryFn;
+  queryFn: QueryFn;
 }): Promise<EngineResult> {
   if (!process.env.ANTHROPIC_API_KEY) {
     return { ok: false, aborted: false, reason: 'no_api_key' };
@@ -187,6 +264,56 @@ export async function runDetect({
   };
   process.on('warning', onWarning);
 
+  let terminalSubtype: string | undefined;
+  let caughtError: Error | undefined;
+  try {
+    const messages = queryFn({ prompt, options: options(abortController) });
+    for await (const message of messages) {
+      onMessage(message);
+      if (isRecord(message) && message.type === 'result' && typeof message.subtype === 'string') {
+        terminalSubtype = message.subtype;
+      }
+    }
+  } catch (error) {
+    caughtError = error instanceof Error ? error : new Error(String(error));
+  } finally {
+    process.off('warning', onWarning);
+    signal.removeEventListener('abort', abortFromCaller);
+  }
+
+  if (shadowError !== undefined) {
+    return { ok: false, aborted: false, reason: shadowError.message };
+  }
+  if (signal.aborted || abortController.signal.aborted) {
+    return { ok: false, aborted: true, subtype: terminalSubtype, reason: 'aborted' };
+  }
+  if (caughtError !== undefined) {
+    return { ok: false, aborted: false, subtype: terminalSubtype, reason: caughtError.message };
+  }
+  if (terminalSubtype === undefined) {
+    return { ok: false, aborted: false, reason: 'missing_result' };
+  }
+  if (terminalSubtype !== 'success') {
+    return { ok: false, aborted: false, subtype: terminalSubtype, reason: terminalSubtype };
+  }
+  return { ok: true, aborted: false, subtype: terminalSubtype };
+}
+
+export async function runDetect({
+  cwd,
+  onMessage,
+  onPlan,
+  signal,
+  askUser = null,
+  queryFn = (request) => query(request),
+}: {
+  cwd: string;
+  onMessage: (message: SDKMessage) => void;
+  onPlan: (plan: OnboardingPlan) => void;
+  signal: AbortSignal;
+  askUser?: AskUserResolver | null;
+  queryFn?: QueryFn;
+}): Promise<EngineResult> {
   let planCaptures = 0;
   let reportCaptures = 0;
   let unsupportedReason: string | undefined;
@@ -215,60 +342,372 @@ export async function runDetect({
     acceptedResultSeen: false,
     attemptedAfterSuccess: false,
   };
-  let terminalSubtype: string | undefined;
-  let caughtError: Error | undefined;
-
-  try {
-    const messages = queryFn({
-      prompt: renderDetectSpec({ cwd }),
-      options: detectOptions({ cwd, hook, mcpServers, abortController }),
-    });
-    for await (const message of messages) {
+  const core = await runAgentCore({
+    prompt: renderDetectSpec({ cwd }),
+    options: (abortController) => detectOptions({ cwd, hook, mcpServers, abortController }),
+    onMessage: (message) => {
       onMessage(message);
       updateReportStream(message, reportStream);
-      if (
-        isRecord(message) &&
-        message.type === 'result' &&
-        typeof message.subtype === 'string'
-      ) {
-        terminalSubtype = message.subtype;
-      }
-    }
-  } catch (error) {
-    caughtError = error instanceof Error ? error : new Error(String(error));
-  } finally {
-    process.off('warning', onWarning);
-    signal.removeEventListener('abort', abortFromCaller);
-  }
-
-  if (shadowError !== undefined) {
-    return { ok: false, aborted: false, reason: shadowError.message };
-  }
-  if (signal.aborted || abortController.signal.aborted) {
-    return { ok: false, aborted: true, subtype: terminalSubtype, reason: 'aborted' };
-  }
-  if (caughtError !== undefined) {
-    return { ok: false, aborted: false, subtype: terminalSubtype, reason: caughtError.message };
-  }
-  if (terminalSubtype === undefined) {
-    return { ok: false, aborted: false, reason: 'missing_result' };
-  }
-  if (terminalSubtype !== 'success') {
-    return { ok: false, aborted: false, subtype: terminalSubtype, reason: terminalSubtype };
-  }
+    },
+    signal,
+    queryFn,
+  });
+  if (!core.ok) return core;
   if (
     reportCaptures > 1 ||
     planCaptures > 1 ||
     reportStream.successfulResults > 1 ||
     reportStream.attemptedAfterSuccess
   ) {
-    return { ok: false, aborted: false, subtype: terminalSubtype, reason: 'multiple_plans' };
+    return { ...core, ok: false, reason: 'multiple_plans' };
   }
   if (unsupportedReason !== undefined) {
-    return { ok: false, aborted: false, subtype: terminalSubtype, reason: 'unsupported' };
+    return { ...core, ok: false, reason: 'unsupported' };
   }
   if (reportCaptures === 0 || planCaptures === 0) {
-    return { ok: false, aborted: false, subtype: terminalSubtype, reason: 'no_plan' };
+    return { ...core, ok: false, reason: 'no_plan' };
   }
-  return { ok: true, aborted: false, subtype: terminalSubtype };
+  return core;
+}
+
+interface FileSnapshot {
+  root: string;
+  absolute: string;
+  relative: string;
+  contents: Buffer;
+  mode: number;
+}
+
+function hash(contents: Buffer): string {
+  return createHash('sha256').update(contents).digest('hex');
+}
+
+function occurrenceOffset(contents: string, needle: string, occurrence: number): number {
+  let offset = 0;
+  for (let index = 0; index <= occurrence; index += 1) {
+    const found = contents.indexOf(needle, offset);
+    if (found === -1) return -1;
+    if (index === occurrence) return found;
+    offset = found + needle.length;
+  }
+  return -1;
+}
+
+function anchorIsWholeLine(contents: string, anchor: string, occurrence: number): boolean {
+  if (anchor.includes('\n') || anchor.includes('\r')) return false;
+  const offset = occurrenceOffset(contents, anchor, occurrence);
+  if (offset === -1) return false;
+  const lineStart = contents.lastIndexOf('\n', offset - 1) + 1;
+  const lineEndIndex = contents.indexOf('\n', offset + anchor.length);
+  const lineEnd = lineEndIndex === -1 ? contents.length : lineEndIndex;
+  return (
+    /^[\t ]*$/.test(contents.slice(lineStart, offset)) &&
+    /^[\t ]*\r?$/.test(contents.slice(offset + anchor.length, lineEnd))
+  );
+}
+
+function snapshotRegularFile(root: string, relative: string, maxBytes: number): FileSnapshot {
+  const canonical = containedRepoRelative(root, relative);
+  if (canonical !== relative || hasSecretSegment(canonical)) {
+    throw new Error(`unsafe plan path: ${relative}`);
+  }
+  const absolute = path.join(root, canonical);
+  const linkStat = lstatSync(absolute);
+  const metadata = statSync(absolute);
+  if (
+    linkStat.isSymbolicLink() ||
+    !metadata.isFile() ||
+    metadata.nlink > 1 || // hard link may alias an outside file
+    metadata.size > maxBytes
+  ) {
+    throw new Error(`plan path is not a regular file: ${relative}`);
+  }
+  return {
+    root,
+    absolute,
+    relative: canonical,
+    contents: readFileSync(absolute),
+    mode: linkStat.mode,
+  };
+}
+
+function restoreSnapshot(snapshot: FileSnapshot): string | undefined {
+  let descriptor: number | undefined;
+  try {
+    // O_NOFOLLOW only guards the final component. If a PARENT directory was
+    // swapped for a symlink after the snapshot, the write would land outside the
+    // repo. Re-verify the parent still resolves inside the repo before writing.
+    // (A perfectly-timed race between this check and the open is a local
+    // filesystem-racing attack, out of Phase 1b's threat model.)
+    const parentReal = realpathSync(path.dirname(snapshot.absolute));
+    const rootReal = realpathSync(snapshot.root);
+    if (parentReal !== rootReal && !parentReal.startsWith(rootReal + path.sep)) {
+      throw new Error('parent directory escaped the repository');
+    }
+    const flags = existsSync(snapshot.absolute)
+      ? constants.O_WRONLY | constants.O_TRUNC | constants.O_NOFOLLOW
+      : constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL;
+    if (existsSync(snapshot.absolute) && lstatSync(snapshot.absolute).isSymbolicLink()) {
+      throw new Error('path became a symbolic link');
+    }
+    descriptor = openSync(snapshot.absolute, flags, snapshot.mode);
+    writeFileSync(descriptor, snapshot.contents);
+    return undefined;
+  } catch (error) {
+    return `${snapshot.relative}: ${error instanceof Error ? error.message : String(error)}`;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function sameSet(left: Iterable<string>, right: Iterable<string>): boolean {
+  const a = new Set(left);
+  const b = new Set(right);
+  return a.size === b.size && Array.from(a).every((value) => b.has(value));
+}
+
+function installCommand(packageManager: OnboardingPlan['package_manager']): string {
+  return `${packageManager} install`;
+}
+
+function isStrictlyUnder(directory: string, file: string): boolean {
+  if (directory === '.') return file !== '.';
+  const relative = path.posix.relative(directory, file);
+  return (
+    relative !== '' &&
+    relative !== '..' &&
+    !relative.startsWith('../') &&
+    !path.posix.isAbsolute(relative)
+  );
+}
+
+export async function runApply({
+  cwd,
+  plan,
+  onMessage,
+  onReport,
+  requestApproval,
+  signal,
+  queryFn = (request) => query(request),
+}: {
+  cwd: string;
+  plan: OnboardingPlan;
+  onMessage: (message: SDKMessage) => void;
+  onReport: (report: ApplyReport) => void;
+  requestApproval: ApprovalRequest;
+  signal: AbortSignal;
+  queryFn?: QueryFn;
+}): Promise<ApplyResult> {
+  if (
+    plan.dependency.name !== '@opslane/sdk' ||
+    plan.dependency.version !== OPSLANE_SDK_VERSION
+  ) {
+    return { ok: false, aborted: false, reason: 'invalid_dependency' };
+  }
+  if (!PACKAGE_MANAGERS.has(plan.package_manager)) {
+    return { ok: false, aborted: false, reason: 'invalid_package_manager' };
+  }
+  let entry: FileSnapshot;
+  let manifest: FileSnapshot;
+  try {
+    const appDir = containedRepoRelative(cwd, plan.app_dir) || '.';
+    if (appDir !== plan.app_dir) {
+      return { ok: false, aborted: false, reason: 'invalid_app_dir' };
+    }
+    const detectedPackageManager = packageManagerForRepo(cwd, appDir);
+    if (
+      detectedPackageManager !== null &&
+      detectedPackageManager !== plan.package_manager
+    ) {
+      return { ok: false, aborted: false, reason: 'invalid_package_manager' };
+    }
+    entry = snapshotRegularFile(cwd, plan.edit.file, MAX_ENTRY_BYTES);
+    manifest = snapshotRegularFile(cwd, plan.edit.manifest_file, MAX_MANIFEST_BYTES);
+    if (
+      path.posix.basename(manifest.relative) !== 'package.json' ||
+      !isStrictlyUnder(appDir, entry.relative) ||
+      !isStrictlyUnder(appDir, manifest.relative) ||
+      entry.relative === manifest.relative
+    ) {
+      return { ok: false, aborted: false, reason: 'invalid_manifest' };
+    }
+    JSON.parse(manifest.contents.toString('utf8'));
+  } catch (error) {
+    return {
+      ok: false,
+      aborted: false,
+      reason: `invalid_plan: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  if (hash(entry.contents) !== plan.edit.entry_hash) {
+    return { ok: false, aborted: false, reason: 'stale_plan' };
+  }
+  if (hash(manifest.contents) !== plan.edit.manifest_hash) {
+    return { ok: false, aborted: false, reason: 'stale_manifest' };
+  }
+  if (
+    !new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']).has(
+      path.extname(entry.relative).toLowerCase(),
+    )
+  ) {
+    return { ok: false, aborted: false, reason: 'unsupported_entry_extension' };
+  }
+  if (
+    !anchorIsWholeLine(
+      entry.contents.toString('utf8'),
+      plan.edit.anchor,
+      plan.edit.occurrence,
+    )
+  ) {
+    return { ok: false, aborted: false, reason: 'anchor_moved' };
+  }
+  if (plan.existing_sdk.action === 'migrate') {
+    return { ok: false, aborted: false, reason: 'migrate_unsupported' };
+  }
+
+  const installCwd = plan.app_dir;
+  if (plan.existing_sdk.action === 'no_op') {
+    const verified = verifyAlreadyOnboarded({ root: cwd, plan });
+    if (!verified.ok) {
+      return {
+        ok: false,
+        aborted: false,
+        reason: 'invalid_no_op',
+        failures: verified.failures,
+      };
+    }
+    const report: ApplyReport = {
+      editedFiles: [],
+      summary: 'Opslane was already wired into this application.',
+      installRequired: false,
+      installCwd,
+    };
+    try {
+      onReport(report);
+    } catch (error) {
+      return {
+        ok: false,
+        aborted: false,
+        reason: `report_callback_failed: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+    return {
+      ok: true,
+      aborted: false,
+      subtype: 'already_onboarded',
+      editedFiles: [],
+      installRequired: false,
+      installCwd,
+    };
+  }
+
+  const rollback = (result: ApplyResult): ApplyResult => {
+    const restoreFailures = [restoreSnapshot(entry), restoreSnapshot(manifest)].filter(
+      (failure): failure is string => failure !== undefined,
+    );
+    return restoreFailures.length === 0
+      ? result
+      : {
+          ok: false,
+          aborted: result.aborted,
+          subtype: result.subtype,
+          reason: 'restore_failed',
+          failures: result.failures,
+          restoreFailures,
+        };
+  };
+
+  const state = { finished: false };
+  const tracker = new EditTracker(cwd);
+  let reportCaptures = 0;
+  let capturedReport: FinishApplyReport | undefined;
+  const capture = (report: FinishApplyReport) => {
+    reportCaptures += 1;
+    capturedReport = report;
+  };
+  const hook = onboardPreToolUseHook({
+    root: cwd,
+    state,
+    writablePaths: [entry.relative, manifest.relative],
+  });
+  const canUseTool = createOnboardApproval({
+    requestApproval,
+    allowedTools: ['Read', 'Edit', 'Write', 'mcp__onboard__finish_apply'],
+  });
+  const mcpServers = {
+    onboard: createOnboardServer(
+      createFinishApplyTool(cwd, state, capture, () => !tracker.hasUnsettledEdits()),
+    ),
+  };
+
+  const core = await runAgentCore({
+    prompt: renderApplySpec({ cwd, plan }),
+    options: (abortController) =>
+      applyOptions({ cwd, hook, mcpServers, canUseTool, abortController }),
+    onMessage: (message) => {
+      onMessage(message);
+      tracker.onMessage(message);
+    },
+    signal,
+    queryFn,
+  });
+  if (!core.ok) return rollback(core);
+  if (reportCaptures !== 1 || capturedReport === undefined || !state.finished) {
+    return rollback({ ...core, ok: false, reason: 'no_apply_report' });
+  }
+  if (tracker.hasUnsettledEdits()) {
+    return rollback({ ...core, ok: false, reason: 'unsettled_edits' });
+  }
+  if (tracker.editsAfterFinish().length > 0) {
+    return rollback({ ...core, ok: false, reason: 'edits_after_finish' });
+  }
+
+  const expectedFiles = [entry.relative, manifest.relative];
+  const committedFiles = tracker.committedBeforeFinish();
+  if (
+    !sameSet(capturedReport.editedFiles, committedFiles) ||
+    !sameSet(capturedReport.editedFiles, expectedFiles)
+  ) {
+    return rollback({ ...core, ok: false, reason: 'edit_reconciliation_failed' });
+  }
+
+  const verification = verifyApplied({
+    root: cwd,
+    plan,
+    editedFiles: capturedReport.editedFiles,
+    originals: { entry: entry.contents, manifest: manifest.contents },
+  });
+  if (!verification.ok) {
+    return rollback({
+      ...core,
+      ok: false,
+      reason: 'verification_failed',
+      failures: verification.failures,
+    });
+  }
+
+  const command = installCommand(plan.package_manager);
+  const report: ApplyReport = {
+    ...capturedReport,
+    installRequired: true,
+    installCommand: command,
+    installCwd,
+  };
+  try {
+    onReport(report);
+  } catch (error) {
+    return rollback({
+      ...core,
+      ok: false,
+      reason: `report_callback_failed: ${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+  return {
+    ...core,
+    editedFiles: capturedReport.editedFiles,
+    installRequired: true,
+    installCommand: command,
+    installCwd,
+  };
 }

--- a/cli/src/onboard/events.ts
+++ b/cli/src/onboard/events.ts
@@ -1,5 +1,7 @@
 import path from 'node:path';
 
+import { containedRepoRelative } from './paths.js';
+
 export interface TaskLine {
   id: string;
   label: string;
@@ -69,9 +71,117 @@ export function labelFor(toolName: string, input: Record<string, unknown>): stri
     Bash: `Run ${typeof input.command === 'string' ? input.command : 'check'}`,
     mcp__onboard__ask_user: 'Ask user',
     mcp__onboard__report_plan: 'Report onboarding plan',
+    mcp__onboard__finish_apply: 'Finish applying onboarding plan',
     mcp__onboard__search: 'Search repository',
   };
   return labels[toolName] ?? toolName;
+}
+
+const EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit']);
+const FINISH_APPLY_TOOL = 'mcp__onboard__finish_apply';
+
+interface TrackedEdit {
+  id: string;
+  path?: string;
+  committed: boolean;
+  settled: boolean;
+  commitSeq?: number;
+}
+
+/**
+ * Tracks edit settlement order rather than only tool invocation order. Agent
+ * SDK tool calls may overlap, so an edit invoked before finish can still commit
+ * after the finish tool has settled.
+ */
+export class EditTracker {
+  private seq = 0;
+  private readonly edits = new Map<string, TrackedEdit>();
+  private readonly orderedEdits: TrackedEdit[] = [];
+  private readonly finishToolIds = new Set<string>();
+  private finishSeq?: number;
+
+  constructor(private readonly root: string) {}
+
+  onMessage(message: unknown): void {
+    for (const block of contentBlocks(message)) {
+      const use = asToolUse(block);
+      if (use !== null) {
+        this.seq += 1;
+        if (EDIT_TOOLS.has(use.name)) {
+          const candidate = displayPath(use.input);
+          let normalized: string | undefined;
+          if (candidate !== undefined) {
+            try {
+              normalized = containedRepoRelative(this.root, candidate);
+            } catch {
+              normalized = undefined;
+            }
+          }
+          const edit: TrackedEdit = {
+            id: use.id,
+            path: normalized,
+            committed: false,
+            settled: false,
+          };
+          this.edits.set(use.id, edit);
+          this.orderedEdits.push(edit);
+        } else if (use.name === FINISH_APPLY_TOOL) {
+          this.finishToolIds.add(use.id);
+        }
+        continue;
+      }
+
+      const result = asToolResult(block);
+      if (result === null) continue;
+      this.seq += 1;
+      const edit = this.edits.get(result.tool_use_id);
+      if (edit !== undefined && !edit.settled) {
+        edit.settled = true;
+        if (result.is_error !== true) {
+          edit.committed = true;
+          edit.commitSeq = this.seq;
+        }
+      }
+      if (this.finishToolIds.has(result.tool_use_id) && result.is_error !== true) {
+        this.markFinished(result.tool_use_id);
+      }
+    }
+  }
+
+  markFinished(id: string): void {
+    if (this.finishSeq !== undefined) return;
+    this.finishToolIds.add(id);
+    this.seq += 1;
+    this.finishSeq = this.seq;
+  }
+
+  hasUnsettledEdits(): boolean {
+    return this.orderedEdits.some((edit) => !edit.settled);
+  }
+
+  committedBeforeFinish(): string[] {
+    if (this.finishSeq === undefined) return [];
+    return this.orderedEdits.flatMap((edit) =>
+      edit.committed &&
+      edit.path !== undefined &&
+      edit.commitSeq !== undefined &&
+      edit.commitSeq < this.finishSeq!
+        ? [edit.path]
+        : [],
+    );
+  }
+
+  editsAfterFinish(): string[] {
+    if (this.finishSeq === undefined) return [];
+    return this.orderedEdits.flatMap((edit) =>
+      edit.committed &&
+      edit.path !== undefined &&
+      edit.commitSeq !== undefined &&
+      edit.commitSeq >= this.finishSeq!
+        ? [edit.path]
+        : [],
+    );
+  }
 }
 
 export function reduceTasks(tasks: TaskLine[], message: unknown): TaskLine[] {

--- a/cli/src/onboard/policy.ts
+++ b/cli/src/onboard/policy.ts
@@ -7,6 +7,7 @@ import {
 import { containedRepoRelative, hasSecretSegment } from './paths.js';
 
 const FILE_TOOLS = new Set(['Read', 'Glob', 'Edit', 'Write', 'MultiEdit']);
+const EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit']);
 const MUTATING_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'Bash']);
 const ALLOWED_BASH = /^(npm|pnpm|yarn|bun) run (build|typecheck|lint)$/;
 const PATH_KEYS = new Set(['path', 'file_path', 'pattern']);
@@ -37,10 +38,16 @@ function asRecord(value: unknown): Record<string, unknown> {
 export function onboardPreToolUseHook({
   root,
   state,
+  writablePaths,
 }: {
   root: string;
   state?: { finished: boolean };
+  writablePaths?: Iterable<string>;
 }): HookCallback {
+  const canonicalWritable =
+    writablePaths === undefined
+      ? undefined
+      : new Set(Array.from(writablePaths, (candidate) => containedRepoRelative(root, candidate)));
   return async (input) => {
     const preToolInput = input as PreToolUseHookInput;
     const toolName = preToolInput.tool_name;
@@ -63,6 +70,13 @@ export function onboardPreToolUseHook({
           return deny(`${toolName} path is not contained in the repository`);
         }
         if (hasSecretSegment(relative)) return deny(`${toolName} cannot access secret files`);
+        if (
+          canonicalWritable !== undefined &&
+          EDIT_TOOLS.has(toolName) &&
+          !canonicalWritable.has(relative)
+        ) {
+          return deny(`${toolName} is not allowed to modify ${relative}`);
+        }
       }
     }
 
@@ -84,10 +98,24 @@ export type ApprovalRequest = (
 
 export function createOnboardApproval({
   requestApproval,
+  allowedTools = [
+    'Read',
+    'Edit',
+    'Write',
+    'MultiEdit',
+    'Bash',
+    'mcp__onboard__finish_apply',
+    'mcp__onboard__ask_user',
+  ],
 }: {
   requestApproval: ApprovalRequest;
+  allowedTools?: Iterable<string>;
 }): CanUseTool {
+  const allowed = new Set(allowedTools);
   return async (toolName, input) => {
+    if (!allowed.has(toolName)) {
+      return { behavior: 'deny', message: `Onboarding does not allow tool ${toolName}` };
+    }
     if (!MUTATING_TOOLS.has(toolName)) return { behavior: 'allow', updatedInput: input };
     return (await requestApproval(toolName, input))
       ? { behavior: 'allow', updatedInput: input }

--- a/cli/src/onboard/spec.ts
+++ b/cli/src/onboard/spec.ts
@@ -1,3 +1,5 @@
+import type { OnboardingPlan } from './tools.js';
+
 export function renderDetectSpec({ cwd }: { cwd: string }): string {
   return `# Goal
 
@@ -26,15 +28,66 @@ Call report_plan exactly once and make no further tool calls afterward.
 - Use the repo's own prefix for both Opslane variables. Name them after Opslane, such as
   VITE_OPSLANE_API_KEY or NEXT_PUBLIC_OPSLANE_API_KEY, and never borrow another product's
   name from the repository.
-- Provide exact import_line and init_block code plus an exact anchor, position, and
-  zero-based occurrence for the entry file. Do not compute any hash; the tool records
-  the entry file hash itself.
+- Provide the exact import_line that Apply will place at module top level alongside
+  existing imports. Separately, provide exact init_block code plus an exact anchor,
+  position, and zero-based occurrence that locate the init block only. The anchor must
+  equal the complete non-whitespace content of one line, including its semicolon.
+- Provide manifest_file for the selected app's package.json. Do not provide a dependency
+  version or compute any hash; the host pins the SDK version and records both file hashes.
 - Keep Opslane initialization able to coexist with any existing monitoring SDK, and set
   existing_sdk.action to exactly one of:
   - "none" when the repository has no error or monitoring SDK at all (name: null);
   - "keep" when another SDK is present and Opslane should run alongside it (name: that SDK);
-  - "migrate" when the named SDK should be replaced by Opslane (name: that SDK);
-  - "no_op" only when @opslane/sdk is already installed and nothing should change.
+  - "migrate" when the named SDK should be replaced, including an outdated
+    @opslane/sdk version below 1.2.0 that cannot report SDK identity;
+  - "no_op" only when an identity-capable @opslane/sdk version (at least 1.2.0) is
+    already imported, initialized, and nothing should change.
 - Never report secret values. Report environment-variable names only.
+`;
+}
+
+export function renderApplySpec({
+  cwd,
+  plan,
+}: {
+  cwd: string;
+  plan: OnboardingPlan;
+}): string {
+  return `# Goal
+
+Apply exactly the approved onboarding plan below to ${cwd}. Change nothing else.
+
+# Approved plan
+
+- entry_file: ${plan.edit.file}
+- manifest_file: ${plan.edit.manifest_file}
+- import_line: ${plan.edit.import_line}
+- init_block:
+${plan.edit.init_block}
+- init_anchor: ${plan.edit.anchor}
+- init_position: ${plan.edit.position}
+- init_occurrence_zero_based: ${plan.edit.occurrence}
+- dependency_name: ${plan.dependency.name}
+- dependency_version: ${plan.dependency.version}
+- existing_sdk_action: ${plan.existing_sdk.action}
+- existing_sdk_name: ${plan.existing_sdk.name ?? 'none'}
+
+# Instructions
+
+- Insert init_block ${plan.edit.position} the occurrence numbered ${plan.edit.occurrence}
+  (zero-based) of init_anchor in entry_file. Match the surrounding indentation.
+- Place import_line at module top level alongside the existing imports. Never place it
+  inside a function, class, conditional, or other block.
+- Add exactly ${plan.dependency.name}@${plan.dependency.version} to the dependencies
+  object in manifest_file. Do not edit any other manifest field.
+- Do not touch any file except entry_file and manifest_file.
+- Do not reformat unrelated lines. Do not run installs or any shell command.
+- For existing_sdk_action "none" or "keep", proceed and leave any other SDK untouched.
+- The host handles "no_op" before starting this agent. If one reaches you, make no edits
+  and stop without calling a tool.
+- Migration is unsupported. If existing_sdk_action is "migrate", make no edits and stop;
+  never attempt a partial migration.
+- After both edits have settled, call finish_apply exactly once with the two files edited.
+  Make no edits or other tool calls after finish_apply.
 `;
 }

--- a/cli/src/onboard/tools.ts
+++ b/cli/src/onboard/tools.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { readFileSync, statSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import {
@@ -9,15 +9,21 @@ import {
 import { z } from 'zod';
 
 import { containedRepoRelative, hasSecretSegment } from './paths.js';
+import {
+  OPSLANE_IDENTITY_MIN_VERSION,
+  validatePlannedWiring,
+} from './verify.js';
 
 const PACKAGE_MANAGERS = ['npm', 'pnpm', 'yarn', 'bun'] as const;
+/** First release that includes the required SDK identity and Vite 8 support. */
+export const OPSLANE_SDK_VERSION = `^${OPSLANE_IDENTITY_MIN_VERSION}`;
 /**
  * What Apply should do about an error/monitoring SDK already in the repo.
  *
  *   none    - no error SDK found at all. Apply proceeds normally. (the common case)
  *   keep    - another SDK is present; install Opslane alongside it. `name` is that SDK.
  *   migrate - replace the named SDK with Opslane. `name` is that SDK.
- *   no_op   - @opslane/sdk is ALREADY installed; Apply should change nothing.
+ *   no_op   - identity-capable @opslane/sdk is already wired; Apply changes nothing.
  *
  * `none` exists because without it the model reached for `no_op` on a repo with no
  * SDK (observed live on directus), which would have told Apply "already onboarded"
@@ -27,6 +33,16 @@ const EXISTING_SDK_ACTIONS = ['none', 'keep', 'migrate', 'no_op'] as const;
 const EDIT_POSITIONS = ['before', 'after'] as const;
 const ENV_VARIABLE = /^[A-Z][A-Z0-9_]*$/;
 const OPSLANE_TOKEN = /(?:^|_)OPSLANE(?:_|$)/;
+const MAX_ENTRY_BYTES = 4 * 1024 * 1024;
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+const LOCKFILES: Record<string, (typeof PACKAGE_MANAGERS)[number]> = {
+  'pnpm-lock.yaml': 'pnpm',
+  'package-lock.json': 'npm',
+  'npm-shrinkwrap.json': 'npm',
+  'yarn.lock': 'yarn',
+  'bun.lock': 'bun',
+  'bun.lockb': 'bun',
+};
 
 export interface OnboardingPlan {
   app_dir: string;
@@ -44,7 +60,14 @@ export interface OnboardingPlan {
   edit: {
     file: string;
     entry_hash: string;
+    manifest_file: string;
+    manifest_hash: string;
+    /** Apply places this at module top level alongside existing imports. */
     import_line: string;
+    /**
+     * `anchor`, `position`, and `occurrence` locate this block only. They do
+     * not govern placement of `import_line`.
+     */
     init_block: string;
     anchor: string;
     position: (typeof EDIT_POSITIONS)[number];
@@ -58,7 +81,9 @@ export interface OnboardingPlan {
 }
 
 /**
- * What the MODEL supplies: the full plan minus `edit.entry_hash`.
+ * What the MODEL supplies: the full plan minus host-owned hashes and the SDK
+ * version. The model selects the manifest, while the host contains and hashes
+ * it and pins the dependency version.
  *
  * The Detect agent has only Read/Glob/search — it cannot compute a sha256, so
  * asking it for one made every report_plan call unsatisfiable (it retried until
@@ -66,8 +91,9 @@ export interface OnboardingPlan {
  * from the file it already reads while validating. Exact facts belong to code;
  * judgment belongs to the model.
  */
-export type ReportedPlanInput = Omit<OnboardingPlan, 'edit'> & {
-  edit: Omit<OnboardingPlan['edit'], 'entry_hash'>;
+export type ReportedPlanInput = Omit<OnboardingPlan, 'dependency' | 'edit'> & {
+  dependency: { name: '@opslane/sdk' };
+  edit: Omit<OnboardingPlan['edit'], 'entry_hash' | 'manifest_hash'>;
 };
 
 export type ReportPlanInput =
@@ -128,6 +154,29 @@ function isUnderDirectory(directory: string, file: string): boolean {
   );
 }
 
+export function packageManagerForRepo(
+  root: string,
+  appDir: string,
+): (typeof PACKAGE_MANAGERS)[number] | null {
+  const absoluteRoot = path.resolve(root);
+  let directory = path.resolve(absoluteRoot, appDir === '.' ? '' : appDir);
+  while (directory === absoluteRoot || directory.startsWith(`${absoluteRoot}${path.sep}`)) {
+    const found = new Set(
+      Object.entries(LOCKFILES).flatMap(([file, manager]) =>
+        existsSync(path.join(directory, file)) ? [manager] : [],
+      ),
+    );
+    if (found.size > 1) {
+      throw new Error(`Conflicting package-manager lockfiles in ${path.relative(root, directory) || '.'}`);
+    }
+    const manager = found.values().next().value;
+    if (manager !== undefined) return manager;
+    if (directory === absoluteRoot) break;
+    directory = path.dirname(directory);
+  }
+  return null;
+}
+
 function validateEnvironmentVariable(
   value: unknown,
   envPrefix: string,
@@ -158,12 +207,34 @@ function countOccurrences(contents: string, anchor: string): number {
   return count;
 }
 
+function anchorIsWholeLine(contents: string, anchor: string, occurrence: number): boolean {
+  if (anchor.includes('\n') || anchor.includes('\r')) return false;
+  let offset = 0;
+  let found = -1;
+  for (let index = 0; index <= occurrence; index += 1) {
+    found = contents.indexOf(anchor, offset);
+    if (found === -1) return false;
+    offset = found + anchor.length;
+  }
+  const lineStart = contents.lastIndexOf('\n', found - 1) + 1;
+  const lineEndIndex = contents.indexOf('\n', found + anchor.length);
+  const lineEnd = lineEndIndex === -1 ? contents.length : lineEndIndex;
+  return (
+    /^[\t ]*$/.test(contents.slice(lineStart, found)) &&
+    /^[\t ]*\r?$/.test(contents.slice(found + anchor.length, lineEnd))
+  );
+}
+
 function validatePlan(root: string, value: unknown): OnboardingPlan {
   assertRecord(value, 'plan');
 
   const appDir = canonicalRepoPath(root, value.app_dir, 'app_dir');
   const framework = nonEmptyString(value.framework, 'framework');
   const packageManager = enumValue(value.package_manager, PACKAGE_MANAGERS, 'package manager');
+  const detectedPackageManager = packageManagerForRepo(root, appDir);
+  if (detectedPackageManager !== null && detectedPackageManager !== packageManager) {
+    throw new Error(`package manager must match ${detectedPackageManager} lockfile`);
+  }
   const envPrefix = nonEmptyString(value.env_prefix, 'env_prefix');
   const rationale = nonEmptyString(value.rationale, 'rationale');
 
@@ -172,8 +243,6 @@ function validatePlan(root: string, value: unknown): OnboardingPlan {
   if (dependencyName !== '@opslane/sdk') {
     throw new Error('dependency.name must be @opslane/sdk');
   }
-  const dependencyVersion = nonEmptyString(value.dependency.version, 'dependency.version');
-
   assertRecord(value.env_vars, 'env_vars');
   const apiKey = validateEnvironmentVariable(value.env_vars.api_key, envPrefix, 'env_vars.api_key');
   const endpoint = validateEnvironmentVariable(
@@ -191,7 +260,15 @@ function validatePlan(root: string, value: unknown): OnboardingPlan {
   const editAbsolute = path.join(root, editFile);
   let fileContents: Buffer;
   try {
-    if (!statSync(editAbsolute).isFile()) {
+    const metadata = statSync(editAbsolute);
+    if (
+      lstatSync(editAbsolute).isSymbolicLink() ||
+      !metadata.isFile() ||
+      // A hard link (nlink > 1) can alias a file OUTSIDE the repo that realpath
+      // cannot detect (a hard link has no target path). Refuse it.
+      metadata.nlink > 1 ||
+      metadata.size > MAX_ENTRY_BYTES
+    ) {
       throw new Error('not a regular file');
     }
     fileContents = readFileSync(editAbsolute);
@@ -203,6 +280,29 @@ function validatePlan(root: string, value: unknown): OnboardingPlan {
   // sha256. Apply re-hashes this file and refuses a stale plan.
   const entryHash = createHash('sha256').update(fileContents).digest('hex');
 
+  const manifestFile = canonicalRepoPath(root, value.edit.manifest_file, 'edit.manifest_file');
+  if (!isUnderDirectory(appDir, manifestFile) || path.posix.basename(manifestFile) !== 'package.json') {
+    throw new Error('edit.manifest_file must be a package.json under app_dir');
+  }
+  const manifestAbsolute = path.join(root, manifestFile);
+  let manifestContents: Buffer;
+  try {
+    const metadata = statSync(manifestAbsolute);
+    if (
+      lstatSync(manifestAbsolute).isSymbolicLink() ||
+      !metadata.isFile() ||
+      metadata.nlink > 1 || // hard link may alias an outside file — refuse (see edit.file)
+      metadata.size > MAX_MANIFEST_BYTES
+    ) {
+      throw new Error('not a regular file');
+    }
+    manifestContents = readFileSync(manifestAbsolute);
+    assertRecord(JSON.parse(manifestContents.toString('utf8')), 'edit.manifest_file');
+  } catch {
+    throw new Error('edit.manifest_file must be a valid regular JSON file');
+  }
+  const manifestHash = createHash('sha256').update(manifestContents).digest('hex');
+
   const importLine = nonEmptyString(value.edit.import_line, 'edit.import_line');
   const initBlock = nonEmptyString(value.edit.init_block, 'edit.init_block');
   const anchor = nonEmptyString(value.edit.anchor, 'edit.anchor');
@@ -213,6 +313,19 @@ function validatePlan(root: string, value: unknown): OnboardingPlan {
   }
   if (countOccurrences(fileContents.toString('utf8'), anchor) <= (occurrence as number)) {
     throw new Error('edit.anchor does not occur at edit.occurrence in edit.file');
+  }
+  if (!anchorIsWholeLine(fileContents.toString('utf8'), anchor, occurrence as number)) {
+    throw new Error('edit.anchor must match the complete non-whitespace content of its line');
+  }
+  const wiringFailures = validatePlannedWiring({
+    file: editFile,
+    importLine,
+    initBlock,
+    apiKeyVariable: apiKey,
+    endpointVariable: endpoint,
+  });
+  if (wiringFailures.length > 0) {
+    throw new Error(wiringFailures[0]);
   }
 
   assertRecord(value.existing_sdk, 'existing_sdk');
@@ -240,11 +353,13 @@ function validatePlan(root: string, value: unknown): OnboardingPlan {
     framework,
     package_manager: packageManager,
     env_prefix: envPrefix,
-    dependency: { name: '@opslane/sdk', version: dependencyVersion },
+    dependency: { name: '@opslane/sdk', version: OPSLANE_SDK_VERSION },
     env_vars: { api_key: apiKey, endpoint },
     edit: {
       file: editFile,
       entry_hash: entryHash,
+      manifest_file: manifestFile,
+      manifest_hash: manifestHash,
       import_line: importLine,
       init_block: initBlock,
       anchor,
@@ -290,7 +405,6 @@ export function createReportPlanTool(
     env_prefix: z.string(),
     dependency: z.object({
       name: z.literal('@opslane/sdk'),
-      version: z.string(),
     }),
     env_vars: z.object({
       api_key: z.string(),
@@ -303,6 +417,7 @@ export function createReportPlanTool(
       // model made every report_plan call unsatisfiable (it retried until the
       // turn budget ran out and produced no plan). The host stamps the hash
       // below from the file it already reads. Exact facts belong to code.
+      manifest_file: z.string(),
       import_line: z.string(),
       init_block: z.string(),
       anchor: z.string(),
@@ -353,6 +468,58 @@ export function createReportPlanTool(
       onPlan(plan);
       return {
         content: [{ type: 'text', text: 'Onboarding plan accepted.' }],
+      };
+    },
+  );
+}
+
+export interface FinishApplyReport {
+  editedFiles: string[];
+  summary: string;
+}
+
+export function createFinishApplyTool(
+  root: string,
+  state: { finished: boolean },
+  onReport: (report: FinishApplyReport) => void,
+  canFinish: () => boolean = () => true,
+) {
+  let reported = false;
+  return tool(
+    'finish_apply',
+    'Report the files changed while applying the approved onboarding plan exactly once.',
+    {
+      edited_files: z.array(z.string()).min(1),
+      summary: z.string().min(1),
+    },
+    async ({ edited_files: editedFiles, summary }) => {
+      if (reported || state.finished) {
+        throw new Error('Apply result was already finished');
+      }
+      if (!Array.isArray(editedFiles) || editedFiles.length === 0) {
+        throw new Error('edited_files must contain at least one path');
+      }
+      if (typeof summary !== 'string' || summary.trim().length === 0) {
+        throw new Error('summary must be a non-empty string');
+      }
+      if (!canFinish()) {
+        throw new Error('Cannot finish while an edit is unsettled');
+      }
+      const canonical = editedFiles.map((candidate) => {
+        const relative = containedRepoRelative(root, candidate);
+        if (hasSecretSegment(relative)) {
+          throw new Error('edited_files contains a secret file');
+        }
+        return relative;
+      });
+      if (new Set(canonical).size !== canonical.length) {
+        throw new Error('edited_files must not contain duplicates');
+      }
+      onReport({ editedFiles: canonical, summary });
+      reported = true;
+      state.finished = true;
+      return {
+        content: [{ type: 'text', text: 'Apply result accepted.' }],
       };
     },
   );

--- a/cli/src/onboard/verify.ts
+++ b/cli/src/onboard/verify.ts
@@ -1,0 +1,1026 @@
+import { createHash } from 'node:crypto';
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+} from 'node:fs';
+import path from 'node:path';
+
+import ts from 'typescript';
+
+import { containedRepoRelative } from './paths.js';
+import type { OnboardingPlan } from './tools.js';
+
+const SUPPORTED_ENTRY_EXTENSIONS = new Set([
+  '.cjs',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.ts',
+  '.tsx',
+]);
+const MAX_SOURCE_BYTES = 4 * 1024 * 1024;
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+const MAX_DOTENV_FILES = 64;
+const MAX_DOTENV_FILE_BYTES = 64 * 1024;
+const MAX_DOTENV_TOTAL_BYTES = 512 * 1024;
+const MAX_SCANNED_DIRECTORIES = 10_000;
+const SKIPPED_DIRECTORIES = new Set(['.git', 'node_modules']);
+const TRIVIAL_DOTENV_VALUES = new Set([
+  '',
+  '0',
+  '1',
+  'false',
+  'null',
+  'true',
+  'undefined',
+  'development',
+  'local',
+  'production',
+  'test',
+]);
+export const OPSLANE_IDENTITY_MIN_VERSION = '1.2.0';
+
+export type VerifiableOnboardingPlan = OnboardingPlan & {
+  edit: OnboardingPlan['edit'] & {
+    manifest_file: string;
+    manifest_hash: string;
+  };
+};
+
+export interface VerificationResult {
+  ok: boolean;
+  failures: string[];
+}
+
+export interface VerifyAppliedInput {
+  root: string;
+  plan: VerifiableOnboardingPlan;
+  editedFiles: string[];
+  originals: {
+    entry: Buffer;
+    manifest: Buffer;
+  };
+}
+
+interface ChangedRegion {
+  beforeStart: number;
+  beforeEnd: number;
+  afterStart: number;
+  afterEnd: number;
+  oldText: string;
+  newText: string;
+}
+
+interface DotenvValue {
+  name: string;
+  value: string;
+}
+
+interface EntryMatch {
+  added: string[];
+}
+
+interface SdkBindings {
+  initFunctions: Set<string>;
+  namespaces: Set<string>;
+}
+
+function sha256(value: Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+// True only when the buffer is losslessly valid UTF-8. `toString('utf8')` maps
+// invalid bytes to U+FFFD, so a round-trip that isn't byte-identical means the
+// decode was lossy and a string comparison would not be a faithful byte comparison.
+function isValidUtf8(value: Buffer): boolean {
+  return Buffer.from(value.toString('utf8'), 'utf8').equals(value);
+}
+
+// Drop a single leading UTF-8 BOM so a first-line import still reads as column 0.
+// Apply never adds or removes the BOM, so stripping it from both the original and
+// the current file for structural checks is consistent.
+function stripBom(value: string): string {
+  return value.charCodeAt(0) === 0xfeff ? value.slice(1) : value;
+}
+
+function identityFixedSdkRange(value: string): boolean {
+  const normalized = value.trim();
+  const match = /^(?:\^|~|>=\s*)?v?(\d+)\.(\d+)\.(\d+)$/.exec(
+    normalized,
+  );
+  if (match === null) return false;
+  const [minimumMajor, minimumMinor, minimumPatch] = OPSLANE_IDENTITY_MIN_VERSION.split(
+    '.',
+  ).map(Number) as [number, number, number];
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+  return (
+    major > minimumMajor ||
+    (major === minimumMajor &&
+      (minor > minimumMinor || (minor === minimumMinor && patch >= minimumPatch)))
+  );
+}
+
+function addFailure(failures: string[], message: string): void {
+  if (!failures.includes(message)) failures.push(message);
+}
+
+function normalizeNewlines(value: string): string {
+  return value.replaceAll(/\r\n?|\n/g, '\n');
+}
+
+function lineEnding(value: string): '\r\n' | '\n' {
+  return value.includes('\r\n') ? '\r\n' : '\n';
+}
+
+function countOccurrences(contents: string, needle: string): number[] {
+  const matches: number[] = [];
+  let offset = 0;
+  while (offset <= contents.length - needle.length) {
+    const index = contents.indexOf(needle, offset);
+    if (index === -1) break;
+    matches.push(index);
+    offset = index + needle.length;
+  }
+  return matches;
+}
+
+function commonIndent(lines: string[]): number {
+  const indents = lines
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.match(/^[\t ]*/)?.[0].length ?? 0);
+  return indents.length === 0 ? 0 : Math.min(...indents);
+}
+
+function normalizedBlock(value: string): string[] {
+  const lines = normalizeNewlines(value).replace(/\n+$/g, '').split('\n');
+  const indent = commonIndent(lines);
+  return lines.map((line) => line.slice(Math.min(indent, line.length)));
+}
+
+function indentationBefore(contents: string, offset: number): string | null {
+  const lineStart = Math.max(contents.lastIndexOf('\n', offset - 1) + 1, 0);
+  const prefix = contents.slice(lineStart, offset);
+  return /^[\t ]*$/.test(prefix) ? prefix : null;
+}
+
+function initCandidates(
+  original: string,
+  plan: VerifiableOnboardingPlan,
+): Array<{ value: string; added: string }> {
+  const occurrences = countOccurrences(original, plan.edit.anchor);
+  const anchorStart = occurrences[plan.edit.occurrence];
+  if (anchorStart === undefined) return [];
+
+  const indent = indentationBefore(original, anchorStart);
+  if (indent === null) return [];
+
+  const eol = lineEnding(original);
+  const block = normalizedBlock(plan.edit.init_block).join(`${eol}${indent}`);
+  const anchorEnd = anchorStart + plan.edit.anchor.length;
+  const candidates: Array<{ value: string; added: string }> = [];
+
+  for (const separator of [eol, eol + eol]) {
+    if (plan.edit.position === 'before') {
+      const added = `${block}${separator}${indent}`;
+      candidates.push({
+        value: original.slice(0, anchorStart) + added + original.slice(anchorStart),
+        added,
+      });
+    } else {
+      const added = `${separator}${indent}${block}`;
+      candidates.push({
+        value: original.slice(0, anchorEnd) + added + original.slice(anchorEnd),
+        added,
+      });
+    }
+  }
+  return candidates;
+}
+
+function exactEntryMatch(
+  original: string,
+  current: string,
+  plan: VerifiableOnboardingPlan,
+): EntryMatch | null {
+  const normalizedImport = normalizeNewlines(plan.edit.import_line)
+    .replace(/\n+$/g, '')
+    .replaceAll('\n', lineEnding(original));
+  const importOffsets = countOccurrences(current, normalizedImport);
+  const eol = lineEnding(original);
+
+  for (const initCandidate of initCandidates(original, plan)) {
+    for (const importOffset of importOffsets) {
+      const lineStart = Math.max(current.lastIndexOf('\n', importOffset - 1) + 1, 0);
+      if (lineStart !== importOffset) continue;
+
+      for (const suffix of [eol, eol + eol, '']) {
+        const addedImport = normalizedImport + suffix;
+        if (!current.startsWith(addedImport, importOffset)) continue;
+        const withoutImport =
+          current.slice(0, importOffset) +
+          current.slice(importOffset + addedImport.length);
+        if (withoutImport === initCandidate.value) {
+          return { added: [addedImport, initCandidate.added] };
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+function scriptKind(file: string): ts.ScriptKind {
+  switch (path.extname(file).toLowerCase()) {
+    case '.ts':
+      return ts.ScriptKind.TS;
+    case '.tsx':
+      return ts.ScriptKind.TSX;
+    case '.jsx':
+      return ts.ScriptKind.JSX;
+    default:
+      return ts.ScriptKind.JS;
+  }
+}
+
+function parseSource(
+  file: string,
+  contents: string,
+): { sourceFile: ts.SourceFile; diagnostics: readonly ts.Diagnostic[] } {
+  const sourceFile = ts.createSourceFile(
+    file,
+    contents,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind(file),
+  );
+  const diagnostics =
+    (sourceFile as ts.SourceFile & {
+      parseDiagnostics?: readonly ts.Diagnostic[];
+    }).parseDiagnostics ?? [];
+  return { sourceFile, diagnostics };
+}
+
+function sdkBindings(sourceFile: ts.SourceFile): SdkBindings {
+  const bindings: SdkBindings = {
+    initFunctions: new Set<string>(),
+    namespaces: new Set<string>(),
+  };
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== '@opslane/sdk'
+    ) {
+      continue;
+    }
+
+    const clause = statement.importClause;
+    if (clause?.namedBindings === undefined) continue;
+    // `import type { init } ...` is erased at runtime — it cannot initialize the
+    // SDK, so it must not satisfy verification or the no_op existence check.
+    if (clause.isTypeOnly) continue;
+    if (ts.isNamespaceImport(clause.namedBindings)) {
+      bindings.namespaces.add(clause.namedBindings.name.text);
+      continue;
+    }
+    for (const specifier of clause.namedBindings.elements) {
+      if (specifier.isTypeOnly) continue; // `import { type init }` is also erased
+      const imported = specifier.propertyName?.text ?? specifier.name.text;
+      if (imported === 'init') bindings.initFunctions.add(specifier.name.text);
+      if (imported === 'Opslane' || imported === 'OpslaneSDK') {
+        bindings.namespaces.add(specifier.name.text);
+      }
+    }
+  }
+
+  return bindings;
+}
+
+function hasBoundInitCall(sourceFile: ts.SourceFile, bindings: SdkBindings): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isCallExpression(node)) {
+      const expression = node.expression;
+      if (ts.isIdentifier(expression) && bindings.initFunctions.has(expression.text)) {
+        found = true;
+        return;
+      }
+      if (
+        ts.isPropertyAccessExpression(expression) &&
+        expression.name.text === 'init' &&
+        ts.isIdentifier(expression.expression) &&
+        bindings.namespaces.has(expression.expression.text)
+      ) {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+function boundInitCall(
+  sourceFile: ts.SourceFile,
+  bindings: SdkBindings,
+): ts.CallExpression | null {
+  if (sourceFile.statements.length !== 1) return null;
+  const statement = sourceFile.statements[0];
+  if (statement === undefined || !ts.isExpressionStatement(statement)) return null;
+  const expression = statement.expression;
+  if (!ts.isCallExpression(expression)) return null;
+  if (ts.isIdentifier(expression.expression) && bindings.initFunctions.has(expression.expression.text)) {
+    return expression;
+  }
+  if (
+    ts.isPropertyAccessExpression(expression.expression) &&
+    expression.expression.name.text === 'init' &&
+    ts.isIdentifier(expression.expression.expression) &&
+    bindings.namespaces.has(expression.expression.expression.text)
+  ) {
+    return expression;
+  }
+  return null;
+}
+
+function propertyName(node: ts.PropertyName): string | null {
+  return ts.isIdentifier(node) || ts.isStringLiteralLike(node) ? node.text : null;
+}
+
+function unwrapExpression(expression: ts.Expression): ts.Expression {
+  if (
+    ts.isParenthesizedExpression(expression) ||
+    ts.isAsExpression(expression) ||
+    ts.isTypeAssertionExpression(expression) ||
+    ts.isNonNullExpression(expression)
+  ) {
+    return unwrapExpression(expression.expression);
+  }
+  return expression;
+}
+
+function accessSegments(expression: ts.Expression): string[] | null {
+  const value = unwrapExpression(expression);
+  if (ts.isIdentifier(value)) return [value.text];
+  if (
+    ts.isMetaProperty(value) &&
+    value.keywordToken === ts.SyntaxKind.ImportKeyword &&
+    value.name.text === 'meta'
+  ) {
+    return ['import.meta'];
+  }
+  if (ts.isPropertyAccessExpression(value)) {
+    const base = accessSegments(value.expression);
+    return base === null ? null : [...base, value.name.text];
+  }
+  if (ts.isElementAccessExpression(value)) {
+    const base = accessSegments(value.expression);
+    if (
+      base === null ||
+      value.argumentExpression === undefined ||
+      !ts.isStringLiteralLike(value.argumentExpression)
+    ) {
+      return null;
+    }
+    return [...base, value.argumentExpression.text];
+  }
+  if (
+    ts.isCallExpression(value) &&
+    ts.isIdentifier(value.expression) &&
+    value.expression.text === 'useRuntimeConfig' &&
+    value.arguments.length === 0
+  ) {
+    return ['useRuntimeConfig()'];
+  }
+  return null;
+}
+
+function isSafeVariableAccess(expression: ts.Expression, variable: string): boolean {
+  const segments = accessSegments(expression);
+  if (segments === null || segments.at(-1) !== variable) return false;
+  return (
+    (segments.length === 3 &&
+      segments[0] === 'import.meta' &&
+      segments[1] === 'env') ||
+    (segments.length === 3 && segments[0] === 'process' && segments[1] === 'env') ||
+    (segments.length >= 2 && segments[0] === 'useRuntimeConfig()')
+  );
+}
+
+export function validatePlannedWiring({
+  file,
+  importLine,
+  initBlock,
+  apiKeyVariable,
+  endpointVariable,
+}: {
+  file: string;
+  importLine: string;
+  initBlock: string;
+  apiKeyVariable: string;
+  endpointVariable: string;
+}): string[] {
+  const failures: string[] = [];
+  const plannedImport = parseSource(file, importLine);
+  if (
+    plannedImport.diagnostics.length > 0 ||
+    plannedImport.sourceFile.statements.length !== 1 ||
+    !ts.isImportDeclaration(plannedImport.sourceFile.statements[0])
+  ) {
+    return ['planned import must be one valid import declaration'];
+  }
+  const bindings = sdkBindings(plannedImport.sourceFile);
+  if (bindings.initFunctions.size === 0 && bindings.namespaces.size === 0) {
+    return ['planned import must bind the Opslane initializer'];
+  }
+
+  const plannedInit = parseSource(file, initBlock);
+  if (plannedInit.diagnostics.length > 0) {
+    return ['planned init block has a syntax error'];
+  }
+  const call = boundInitCall(plannedInit.sourceFile, bindings);
+  if (call === null || call.arguments.length !== 1 || !ts.isObjectLiteralExpression(call.arguments[0])) {
+    return ['planned init block must be one direct Opslane init call with one object'];
+  }
+
+  const properties = new Map<string, ts.Expression>();
+  for (const property of call.arguments[0].properties) {
+    if (!ts.isPropertyAssignment(property)) {
+      failures.push('planned init options must use explicit property assignments');
+      continue;
+    }
+    const name = propertyName(property.name);
+    if (name === null || (name !== 'apiKey' && name !== 'endpoint') || properties.has(name)) {
+      failures.push('planned init options may contain only one apiKey and one endpoint');
+      continue;
+    }
+    properties.set(name, property.initializer);
+  }
+  if (properties.size !== 2 || call.arguments[0].properties.length !== 2) {
+    failures.push('planned init options must contain exactly apiKey and endpoint');
+  }
+  const apiKey = properties.get('apiKey');
+  if (apiKey === undefined || !isSafeVariableAccess(apiKey, apiKeyVariable)) {
+    failures.push(`planned apiKey option must directly reference ${apiKeyVariable}`);
+  }
+  const endpoint = properties.get('endpoint');
+  if (endpoint === undefined || !isSafeVariableAccess(endpoint, endpointVariable)) {
+    failures.push(`planned endpoint option must directly reference ${endpointVariable}`);
+  }
+  return [...new Set(failures)];
+}
+
+function hasExactTopLevelImport(
+  sourceFile: ts.SourceFile,
+  expectedImport: string,
+): boolean {
+  const expected = normalizeNewlines(expectedImport).trim();
+  const matchingIndex = sourceFile.statements.findIndex((statement) => {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== '@opslane/sdk'
+    ) {
+      return false;
+    }
+    const location = sourceFile.getLineAndCharacterOfPosition(statement.getStart(sourceFile));
+    return (
+      location.character === 0 &&
+      normalizeNewlines(statement.getText(sourceFile)).trim() === expected
+    );
+  });
+  if (matchingIndex === -1) return false;
+
+  const otherImportIndices = sourceFile.statements.flatMap((statement, index) =>
+    index !== matchingIndex && ts.isImportDeclaration(statement) ? [index] : [],
+  );
+  if (otherImportIndices.length > 0) {
+    const before = sourceFile.statements[matchingIndex - 1];
+    const after = sourceFile.statements[matchingIndex + 1];
+    return (
+      (before !== undefined && ts.isImportDeclaration(before)) ||
+      (after !== undefined && ts.isImportDeclaration(after))
+    );
+  }
+
+  return sourceFile.statements
+    .slice(0, matchingIndex)
+    .every(
+      (statement) =>
+        ts.isExpressionStatement(statement) &&
+        ts.isStringLiteral(statement.expression),
+    );
+}
+
+function verifySourceStructure(
+  file: string,
+  contents: string,
+  plan: VerifiableOnboardingPlan,
+  failures: string[],
+): void {
+  const extension = path.extname(file).toLowerCase();
+  if (!SUPPORTED_ENTRY_EXTENSIONS.has(extension)) {
+    addFailure(failures, `unsupported entry extension: ${extension || '(none)'}`);
+    return;
+  }
+  if (Buffer.byteLength(contents) > MAX_SOURCE_BYTES) {
+    addFailure(failures, 'entry file exceeds verification size limit');
+    return;
+  }
+
+  const parsed = parseSource(file, contents);
+  if (parsed.diagnostics.length > 0) {
+    addFailure(failures, 'entry file has a syntax error');
+    return;
+  }
+  if (!hasExactTopLevelImport(parsed.sourceFile, plan.edit.import_line)) {
+    addFailure(failures, 'planned Opslane import is not in the module top-level import section');
+  }
+
+  for (const failure of validatePlannedWiring({
+    file,
+    importLine: plan.edit.import_line,
+    initBlock: plan.edit.init_block,
+    apiKeyVariable: plan.env_vars.api_key,
+    endpointVariable: plan.env_vars.endpoint,
+  })) {
+    addFailure(failures, failure);
+  }
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function deepEqualJson(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => deepEqualJson(value, right[index]))
+    );
+  }
+  if (!isJsonRecord(left) || !isJsonRecord(right)) return false;
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key, index) =>
+        key === rightKeys[index] && deepEqualJson(left[key], right[key]),
+    )
+  );
+}
+
+function changedRegion(before: string, after: string): ChangedRegion {
+  let prefix = 0;
+  while (
+    prefix < before.length &&
+    prefix < after.length &&
+    before[prefix] === after[prefix]
+  ) {
+    prefix += 1;
+  }
+
+  let suffix = 0;
+  while (
+    suffix < before.length - prefix &&
+    suffix < after.length - prefix &&
+    before[before.length - 1 - suffix] === after[after.length - 1 - suffix]
+  ) {
+    suffix += 1;
+  }
+
+  const beforeEnd = before.length - suffix;
+  const afterEnd = after.length - suffix;
+  return {
+    beforeStart: prefix,
+    beforeEnd,
+    afterStart: prefix,
+    afterEnd,
+    oldText: before.slice(prefix, beforeEnd),
+    newText: after.slice(prefix, afterEnd),
+  };
+}
+
+function jsonPropertyValueRange(
+  contents: string,
+  propertyPath: string[],
+): { start: number; end: number } | null {
+  const sourceFile = ts.parseJsonText('package.json', contents);
+  const statement = sourceFile.statements[0];
+  if (statement === undefined || !ts.isExpressionStatement(statement)) return null;
+  let current: ts.Expression = statement.expression;
+
+  for (const segment of propertyPath) {
+    if (!ts.isObjectLiteralExpression(current)) return null;
+    const property = current.properties.find((candidate) => {
+      if (!ts.isPropertyAssignment(candidate)) return false;
+      const name = candidate.name;
+      return (
+        (ts.isStringLiteralLike(name) || ts.isIdentifier(name)) &&
+        name.text === segment
+      );
+    });
+    if (property === undefined || !ts.isPropertyAssignment(property)) return null;
+    current = property.initializer;
+  }
+
+  return { start: current.getStart(sourceFile), end: current.getEnd() };
+}
+
+function verifyManifest(
+  original: string,
+  current: string,
+  plan: VerifiableOnboardingPlan,
+  failures: string[],
+): string[] {
+  let originalValue: unknown;
+  let currentValue: unknown;
+  try {
+    originalValue = JSON.parse(original) as unknown;
+    currentValue = JSON.parse(current) as unknown;
+  } catch {
+    addFailure(failures, 'manifest is not valid JSON');
+    return [];
+  }
+  if (!isJsonRecord(originalValue) || !isJsonRecord(currentValue)) {
+    addFailure(failures, 'manifest root must be a JSON object');
+    return [];
+  }
+
+  const originalDependencies = originalValue.dependencies;
+  if (
+    originalDependencies !== undefined &&
+    !isJsonRecord(originalDependencies)
+  ) {
+    addFailure(failures, 'original manifest dependencies must be an object');
+    return [];
+  }
+
+  const expected: Record<string, unknown> = {
+    ...originalValue,
+    dependencies: {
+      ...(originalDependencies ?? {}),
+      '@opslane/sdk': plan.dependency.version,
+    },
+  };
+  if (!deepEqualJson(currentValue, expected)) {
+    addFailure(failures, 'manifest has changes other than the pinned Opslane dependency');
+  }
+
+  const region = changedRegion(original, current);
+  const previousVersion = isJsonRecord(originalDependencies)
+    ? originalDependencies['@opslane/sdk']
+    : undefined;
+  if (previousVersion === undefined) {
+    if (region.oldText.length !== 0) {
+      addFailure(failures, 'manifest rewrote existing bytes');
+    }
+  } else if (previousVersion === plan.dependency.version) {
+    if (region.oldText.length !== 0 || region.newText.length !== 0) {
+      addFailure(failures, 'manifest changed despite already having the pinned dependency');
+    }
+  } else {
+    const valueRange = jsonPropertyValueRange(
+      original,
+      ['dependencies', '@opslane/sdk'],
+    );
+    if (
+      valueRange === null ||
+      region.beforeStart < valueRange.start ||
+      region.beforeEnd > valueRange.end
+    ) {
+      addFailure(failures, 'manifest changed bytes outside the Opslane dependency version');
+    }
+  }
+
+  return [region.newText];
+}
+
+function safeRepoFile(
+  root: string,
+  candidate: string,
+  label: string,
+  failures: string[],
+  maxBytes: number,
+): { relative: string; contents: Buffer } | null {
+  let relative: string;
+  try {
+    relative = containedRepoRelative(root, candidate) || '.';
+  } catch {
+    addFailure(failures, `${label} is not contained in the repository`);
+    return null;
+  }
+  if (relative !== candidate) {
+    addFailure(failures, `${label} is not canonical`);
+    return null;
+  }
+
+  const absolute = path.join(realpathSync(root), relative);
+  try {
+    const metadata = lstatSync(absolute);
+    if (metadata.isSymbolicLink() || !metadata.isFile()) {
+      addFailure(failures, `${label} is not a regular file`);
+      return null;
+    }
+    if (metadata.size > maxBytes) {
+      addFailure(failures, `${label} exceeds the verification size limit`);
+      return null;
+    }
+    return { relative, contents: readFileSync(absolute) };
+  } catch {
+    addFailure(failures, `${label} could not be read`);
+    return null;
+  }
+}
+
+function canonicalEditedSet(
+  root: string,
+  editedFiles: string[],
+  failures: string[],
+): Set<string> {
+  const result = new Set<string>();
+  for (const candidate of editedFiles) {
+    try {
+      result.add(containedRepoRelative(root, candidate) || '.');
+    } catch {
+      addFailure(failures, 'reported edited file is not contained in the repository');
+    }
+  }
+  return result;
+}
+
+function sameSet(left: Set<string>, right: Set<string>): boolean {
+  return left.size === right.size && [...left].every((value) => right.has(value));
+}
+
+function parseDotenv(contents: string): DotenvValue[] {
+  const values: DotenvValue[] = [];
+  for (const line of contents.split(/\r?\n/)) {
+    const match =
+      /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/.exec(line);
+    if (match === null) continue;
+    let value = match[2]!.trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (TRIVIAL_DOTENV_VALUES.has(value.toLowerCase())) continue;
+    if (value.length < 8) continue;
+    values.push({ name: match[1]!, value });
+  }
+  return values;
+}
+
+function dotenvValues(root: string, failures: string[]): DotenvValue[] {
+  const realRoot = realpathSync(root);
+  const pending = [realRoot];
+  const values: DotenvValue[] = [];
+  let files = 0;
+  let totalBytes = 0;
+  let directories = 0;
+
+  while (pending.length > 0) {
+    const directory = pending.pop()!;
+    directories += 1;
+    if (directories > MAX_SCANNED_DIRECTORIES) {
+      addFailure(failures, 'dotenv scan exceeded the directory limit');
+      return values;
+    }
+    let entries;
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      addFailure(failures, 'dotenv scan could not read a repository directory');
+      return values;
+    }
+
+    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+      if (entry.isSymbolicLink()) continue;
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!SKIPPED_DIRECTORIES.has(entry.name)) pending.push(absolute);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.toLowerCase().startsWith('.env')) continue;
+
+      files += 1;
+      if (files > MAX_DOTENV_FILES) {
+        addFailure(failures, 'dotenv scan exceeded the file limit');
+        return values;
+      }
+
+      let relative: string;
+      let metadata;
+      try {
+        relative = containedRepoRelative(realRoot, absolute);
+        metadata = lstatSync(absolute);
+      } catch {
+        addFailure(failures, 'dotenv scan encountered an unsafe path');
+        return values;
+      }
+      if (
+        relative.length === 0 ||
+        metadata.isSymbolicLink() ||
+        !metadata.isFile()
+      ) {
+        continue;
+      }
+      if (metadata.size > MAX_DOTENV_FILE_BYTES) {
+        addFailure(failures, `dotenv file exceeds verification size limit: ${relative}`);
+        continue;
+      }
+      totalBytes += metadata.size;
+      if (totalBytes > MAX_DOTENV_TOTAL_BYTES) {
+        addFailure(failures, 'dotenv scan exceeded the total byte limit');
+        return values;
+      }
+      try {
+        values.push(...parseDotenv(readFileSync(absolute, 'utf8')));
+      } catch {
+        addFailure(failures, `dotenv file could not be read: ${relative}`);
+      }
+    }
+  }
+
+  return values;
+}
+
+function verifyNoNewSecrets(
+  root: string,
+  added: string[],
+  failures: string[],
+): void {
+  const additions = added.join('\n');
+  if (additions.length === 0) return;
+  for (const secret of dotenvValues(root, failures)) {
+    if (additions.includes(secret.value)) {
+      addFailure(
+        failures,
+        `newly added content contains the value of dotenv variable ${secret.name}`,
+      );
+    }
+  }
+}
+
+export function verifyApplied({
+  root,
+  plan,
+  editedFiles,
+  originals,
+}: VerifyAppliedInput): VerificationResult {
+  const failures: string[] = [];
+  const expectedFiles = new Set([plan.edit.file, plan.edit.manifest_file]);
+  const actualFiles = canonicalEditedSet(root, editedFiles, failures);
+  if (!sameSet(actualFiles, expectedFiles)) {
+    addFailure(failures, 'edited file set does not match the approved plan');
+  }
+  if (expectedFiles.size !== 2) {
+    addFailure(failures, 'entry and manifest must be distinct files');
+  }
+
+  if (sha256(originals.entry) !== plan.edit.entry_hash) {
+    addFailure(failures, 'entry snapshot does not match the approved plan');
+  }
+  if (sha256(originals.manifest) !== plan.edit.manifest_hash) {
+    addFailure(failures, 'manifest snapshot does not match the approved plan');
+  }
+
+  const entry = safeRepoFile(
+    root,
+    plan.edit.file,
+    'entry file',
+    failures,
+    MAX_SOURCE_BYTES,
+  );
+  const manifest = safeRepoFile(
+    root,
+    plan.edit.manifest_file,
+    'manifest file',
+    failures,
+    MAX_MANIFEST_BYTES,
+  );
+  const added: string[] = [];
+
+  if (entry !== null) {
+    // Guard exact-diff against a lossy UTF-8 decode: an invalid byte decodes to
+    // U+FFFD, so two different byte sequences could compare equal as strings and
+    // hide a change outside the planned insertion. Once a buffer is valid UTF-8,
+    // toString('utf8') round-trips losslessly, so the string diff below IS a byte
+    // diff. Source files are valid UTF-8; refuse anything else.
+    if (!isValidUtf8(originals.entry) || !isValidUtf8(entry.contents)) {
+      addFailure(failures, 'entry file is not valid UTF-8');
+    } else {
+      const original = stripBom(originals.entry.toString('utf8'));
+      const current = stripBom(entry.contents.toString('utf8'));
+      const match = exactEntryMatch(original, current, plan);
+      if (match === null) {
+        addFailure(
+          failures,
+          'entry file differs by more than the planned import and init insertion',
+        );
+      } else {
+        added.push(...match.added);
+      }
+      verifySourceStructure(entry.relative, current, plan, failures);
+    }
+  }
+
+  if (manifest !== null) {
+    if (!isValidUtf8(originals.manifest) || !isValidUtf8(manifest.contents)) {
+      addFailure(failures, 'manifest file is not valid UTF-8');
+    } else {
+      added.push(
+        ...verifyManifest(
+          originals.manifest.toString('utf8'),
+          manifest.contents.toString('utf8'),
+          plan,
+          failures,
+        ),
+      );
+    }
+  }
+
+  verifyNoNewSecrets(root, added, failures);
+  return { ok: failures.length === 0, failures };
+}
+
+export function verifyAlreadyOnboarded({
+  root,
+  plan,
+}: {
+  root: string;
+  plan: VerifiableOnboardingPlan;
+}): VerificationResult {
+  const failures: string[] = [];
+  const entry = safeRepoFile(
+    root,
+    plan.edit.file,
+    'entry file',
+    failures,
+    MAX_SOURCE_BYTES,
+  );
+  const manifest = safeRepoFile(
+    root,
+    plan.edit.manifest_file,
+    'manifest file',
+    failures,
+    MAX_MANIFEST_BYTES,
+  );
+
+  if (manifest !== null) {
+    try {
+      const value = JSON.parse(manifest.contents.toString('utf8')) as unknown;
+      const dependencies = isJsonRecord(value) ? value.dependencies : undefined;
+      if (
+        !isJsonRecord(dependencies) ||
+        typeof dependencies['@opslane/sdk'] !== 'string' ||
+        !identityFixedSdkRange(dependencies['@opslane/sdk'])
+      ) {
+        addFailure(
+          failures,
+          `manifest does not contain an identity-capable Opslane SDK version (>=${OPSLANE_IDENTITY_MIN_VERSION})`,
+        );
+      }
+    } catch {
+      addFailure(failures, 'manifest is not valid JSON');
+    }
+  }
+
+  if (entry !== null) {
+    const extension = path.extname(entry.relative).toLowerCase();
+    if (!SUPPORTED_ENTRY_EXTENSIONS.has(extension)) {
+      addFailure(failures, `unsupported entry extension: ${extension || '(none)'}`);
+    } else {
+      const parsed = parseSource(entry.relative, entry.contents.toString('utf8'));
+      if (parsed.diagnostics.length > 0) {
+        addFailure(failures, 'entry file has a syntax error');
+      } else {
+        const bindings = sdkBindings(parsed.sourceFile);
+        if (
+          bindings.initFunctions.size === 0 &&
+          bindings.namespaces.size === 0
+        ) {
+          addFailure(failures, 'entry file has no top-level Opslane SDK import');
+        } else if (!hasBoundInitCall(parsed.sourceFile, bindings)) {
+          addFailure(failures, 'entry file does not call the imported Opslane initializer');
+        }
+      }
+    }
+  }
+
+  return { ok: failures.length === 0, failures };
+}

--- a/docs/design/2026-07-22-onboard-engineering-design.md
+++ b/docs/design/2026-07-22-onboard-engineering-design.md
@@ -21,7 +21,7 @@ The deeper problem is the manual install itself. In a clean Vite app it costs te
 
 - `opslane onboard` takes a developer from an uninstrumented repo to a confirmed connection (`app_reporting`) in one command.
 - The agent edits code in the repo's own conventions (its env-var prefix, its config location), not ours.
-- Every guardrail is pinned by a test: nothing runs without permission, Bash is allowlisted, no secret reads, no edits after the agent reports done.
+- Every guardrail is pinned by a test: nothing mutates without permission, Apply has no Bash, no secret reads occur, and no edits can land after the agent reports done.
 - Every run leaves a transcript on disk. The prototype's runs didn't, and we felt the gap.
 
 ### Non-goals (milestone A)
@@ -82,24 +82,25 @@ The scope call worth naming: login-first A depends on milestone 0.5 (account pro
                                     │
                             status='ok' + typed OnboardingPlan
                             { app_dir, env_vars, dependency,
-                              edit{ file, entry_hash, anchor,
-                                    position, occurrence,
+                              edit{ file, entry_hash,
+                                    manifest_file, manifest_hash,
+                                    init anchor/position/occurrence,
                                     import_line, init_block },
-                              existing_sdk{ keep|migrate|no_op } }
+                              existing_sdk{ none|keep|migrate|no_op } }
                                     │
                                     ▼
                         ┌──── HUMAN APPROVAL ────┐
                         └────────────┬───────────┘
                                      ▼
            ┌──────────────── APPLY (edits) ─────────────────┐
-           │  re-hash edit.file                             │
-           │      ├── hash MISMATCH ──▶ stop ──▶ re-Detect ─┼──┐
-           │      └── hash OK                               │  │
-           │  find anchor at occurrence                     │  │
-           │      ├── missing / ambiguous ──▶ stop ─────────┼──┤
-           │      └── found ──▶ insert import + init block  │  │
-           │  apply dependency to manifest                  │  │
-           │  finish_onboarding(edited files)               │  │
+           │  contain + re-hash entry and manifest          │
+           │      ├── mismatch/unsafe ──▶ stop ──▶ re-Detect┼──┐
+           │      └── current ──▶ snapshot both files       │  │
+           │  agent edits exactly those two approved paths  │  │
+           │  finish_apply(edited files)                    │  │
+           │  reconcile settlement order + exact verify     │  │
+           │      ├── failure ──▶ restore both snapshots ───┼──┤
+           │      └── pass ──▶ report install required      │  │
            └────────────────────────────────────────────────┘  │
                                      ▲                          │
                                      └──────────────────────────┘
@@ -136,13 +137,17 @@ sequenceDiagram
     end
     CLI->>Srv: POST provision (authenticated, no GitHub yet)
     Srv-->>CLI: api key + endpoint + project ids + session id
-    CLI->>Agent: spawn with spec prompt
-    Agent->>Agent: survey repo (Glob/Grep/Read)
+    CLI->>Agent: Detect prompt (read-only)
+    Agent->>Agent: survey repo (Glob/search/Read)
     Agent->>Dev: ask_user("Which app?")
     Dev-->>Agent: choice
+    Agent->>CLI: report_plan(typed plan)
+    CLI->>CLI: validate + hash entry and manifest
+    CLI->>Agent: Apply prompt (approved plan)
     Agent->>Agent: edit main.ts, package.json
-    Agent->>CLI: finish_onboarding(report)
-    CLI->>CLI: validate report, write .env.local
+    Agent->>CLI: finish_apply(edited files)
+    CLI->>CLI: reconcile, exact-verify, rollback on failure
+    CLI->>CLI: write .env.local (later phase)
     CLI-->>Dev: run pnpm install, then pnpm run dev
     Dev->>App: starts dev server
     App->>Srv: /sessions/init (sdk name+version)
@@ -161,6 +166,8 @@ sequenceDiagram
 ## 5. Component design
 
 ### 5.1 The agent loop
+
+> **Historical prototype context.** The transcript below is the original combined-loop spike. Production splits it into read-only Detect (`report_plan`) and narrow Apply (`finish_apply`). Apply has no Glob, search, or Bash and can write only the two hashed plan files.
 
 `query()` spawns the bundled Claude Code binary as a child process and returns an async generator of messages. The loop runs on its own: the model emits text and tool calls, the harness runs the tools, the results go back to the model, repeat until it stops. We consume the stream; we do not drive the turns. A prototype run against `opslane-smoke` (a throwaway clean Vite + React app kept as the onboarding test target) read like this:
 
@@ -183,13 +190,15 @@ Two mechanics matter. A custom MCP tool's handler is an async function, so while
 
 The prototype's spec was ten imperative lines, and that was the wrong shape. It hardcoded the file (`src/main.tsx`), the env prefix (`VITE_OPSLANE_*`), and the Vite idiom — a codemod narrated to a model. It works on a clean single-app Vite repo and is wrong the moment the repo differs, which is the whole reason to use an agent instead of a codemod. The design's own D3 says follow the repo's convention, never impose one.
 
-So the production spec is a **goal plus constraints plus the SDK contract**, not a step list. The goal: Opslane's `init()` runs once at the app's real entry point, reading key and endpoint from *this repo's* env convention, with `@opslane/sdk` added to dependencies. The constraints: follow the detected prefix and config location; reference env vars by name, never a literal value; migrate an existing SDK rather than duplicate; ask before editing; don't run installs; end with one `finish_onboarding`. The model chooses the file and the wiring by reading the repo. PostHog's wizard is the reference here — it wraps "a deterministic fence around a chaotic process," a stable prompt tailored with the project's specific files.
+Production uses two specs. Detect is a goal-oriented, read-only investigation that chooses the app, entry, env convention, package manifest, and coexistence action, then calls `report_plan`. Host code contains both files, stamps both hashes, and pins the SDK version. Apply receives that approved typed plan: it may only weave the exact import/init/dependency into those two files, must not run installs, refuses migration, and ends with one `finish_apply`. PostHog's wizard remains the reference: a deterministic fence around a model judgment.
 
 A live spike settled it. Against a repo using `VITE_APP_*` with config in `vite.config.ts`, the goal-based spec made the agent read the config, detect the prefix, and choose `VITE_APP_OPSLANE_API_KEY` — matching the repo. The recipe would have written `VITE_OPSLANE_API_KEY`, wrong there. It wrote no literal key, added the dependency, wired `init()` at the entry point, and flagged that it couldn't run the app.
 
 One deterministic half, also from PostHog: the CLI runs a **survey pre-pass** — read `package.json`, the lockfile, the framework config, and `.env*` files to detect framework, entry point, env prefix, config location, and any existing SDK — and injects those findings into the prompt. The model gets a smaller, better-scoped job (wire it, given the map) rather than survey-and-reason-and-edit from a thin prompt. It still verifies and may correct the findings, but starts with a map. Each rule in the rendered prompt is pinned by a test, because the spec is the most-edited file in this system and a dropped line is invisible until an agent misbehaves.
 
 ### 5.3 Custom tools and the structured report
+
+> **Superseded combined-report shape.** The interface below documents the prototype. Production Detect emits `OnboardingPlan`; Apply emits only canonical `edited_files` plus a summary. Install metadata is host-derived after exact verification.
 
 The agent gets the SDK's file tools plus two custom MCP tools. `ask_user` pauses the loop and routes a question to the Ink UI; its resolver defaults to throwing, so a run with no UI attached fails fast instead of hanging. `finish_onboarding` is how the agent hands the CLI a machine-readable result:
 
@@ -211,6 +220,8 @@ The report is model output, so it is validated like input from a stranger: paths
 **When validation or reconciliation fails.** If the report is malformed, references a file the agent never edited, or the reverse (an edit with no report entry), the CLI writes no `.env.local`, does no polling, prints the run-log path and a one-line reason, and exits non-zero (`onboard_failed`). The provisioned session is *not* consumed, so the persisted pending state (R5) lets a plain re-run start a fresh agent against the same session, the same recovery path as a crash. A brand-new user's story is therefore "it stopped and told me to re-run," not a stranded project.
 
 ### 5.4 Tool policy: a gate, not a bypass
+
+> **Production split.** Detect exposes read-only `Read`, `Glob`, and secret-aware search. Apply exposes only `Read`, `Edit`, `Write`, and `finish_apply`; its hook restricts mutations to the exact entry/manifest paths, and Bash is absent. The prototype policy below explains the permission findings that led to the two-layer hook plus fail-closed approval design, but its combined tool list is not the shipping configuration.
 
 The prototype ran `permissionMode: 'bypassPermissions'` because Ink owns the TTY and the subprocess cannot prompt. Reading the actual SDK type definitions (`sdk.d.ts`, v0.3.217) surfaced two problems with carrying that into production. That mode bypasses all permission checks and is grouped with `auto` as an auto-allow mode, so `canUseTool` is never consulted, which would make the guardrails below dead code. And we do not want a bypass. Nothing should run without permission.
 

--- a/docs/plans/2026-07-22-phase-1-engine-core.md
+++ b/docs/plans/2026-07-22-phase-1-engine-core.md
@@ -25,7 +25,7 @@ The split makes each prompt narrow (more reliable), gives a natural human-approv
 **Tech Stack:** TypeScript (ESM, strict), Node 22, `@anthropic-ai/claude-agent-sdk@0.3.217`, `zod@^4.0.0`, Vitest colocated in `__tests__`. All new code in `cli/src/onboard/`.
 **Deferred to the TUI phase:** `ink`, `react`, `@inkjs/ui`, `@types/react`.
 
-**Out of scope for Phase 1:** the Apply stage (edits, `finish_onboarding`, `EditTracker` reconciliation), the Ink TUI, provisioning, the CLI command. Apply is outlined at the end of this doc as the next phase.
+**Out of scope for Phase 1:** the Apply stage (edits, `finish_apply`, exact verification, rollback, and `EditTracker` reconciliation), the Ink TUI, provisioning, the CLI command. Apply is outlined at the end of this doc as the next phase.
 
 ---
 
@@ -79,7 +79,7 @@ interface OnboardingPlan {
   framework: string;
   package_manager: 'npm'|'pnpm'|'yarn'|'bun';
   env_prefix: string;              // e.g. 'VITE_', 'NEXT_PUBLIC_'
-  dependency: { name: '@opslane/sdk'; version: string };
+  dependency: { name: '@opslane/sdk'; version: string }; // HOST-PINNED, never model-supplied
   env_vars: { api_key: string; endpoint: string };  // each starts with env_prefix + carries OPSLANE
   edit: {
     file: string;                  // repo-relative, canonical, exists, under app_dir
@@ -88,13 +88,15 @@ interface OnboardingPlan {
                                    // report_plan unsatisfiable and starved runs of a plan (found in QA).
                                    // The tool stamps it from the file it already reads. Apply re-hashes;
                                    // stale -> stop + re-detect.
-    import_line: string;           // exact code
-    init_block: string;            // exact code
-    anchor: string;                // an exact substring that occurs in `file`
+    manifest_file: string;         // model-selected canonical package.json under app_dir
+    manifest_hash: string;         // HOST-DERIVED; Apply re-hashes before any model call
+    import_line: string;           // exact code; Apply places at module top-level import section
+    init_block: string;            // exact code; the fields below locate this block only
+    anchor: string;                // one complete line's non-whitespace content; init only
     position: 'before'|'after';
     occurrence: number;            // which match of `anchor` (0-based)
   };
-  existing_sdk: { action: 'none'|'keep'|'migrate'|'no_op'; name: string|null };  // none=no SDK found (common), keep=coexist, migrate=replace named SDK, no_op=Opslane already installed
+  existing_sdk: { action: 'none'|'keep'|'migrate'|'no_op'; name: string|null };  // Apply refuses migrate; no_op requires mechanical confirmation
   rationale: string;               // free-text notes — NON-executable, separate from the edit
 }
 ```
@@ -105,13 +107,14 @@ This resolves the keep-vs-migrate ambiguity explicitly (current code says "migra
 - `createAskUserTool(resolver)`: `tool('ask_user', desc, { question: z.string(), options: z.array(z.string()).min(1), multi: z.boolean().default(false) }, handler)`; handler calls this run's `resolver` (throws if `null`).
 - `createReportPlanTool(root, onPlan)` — the Detect stage's single output. State-guarded: **a second call is rejected** (`already reported`, codex P1.2). The handler validates (reject → the model retries, codex P1.3):
   1. every string field non-empty;
-  2. `app_dir` and `edit.file` pass `containedRepoRelative(root, …)` (store the canonical result) **and** are not `isSecretFile`;
-  3. `edit.file` **exists, is a regular file, and is under `app_dir`**;
+  2. `app_dir`, `edit.file`, and `edit.manifest_file` pass `containedRepoRelative(root, …)` (store canonical results) and are not secret paths;
+  3. both edit files exist and are non-symlink regular files under `app_dir`; the manifest is a valid `package.json`;
   4. `package_manager` ∈ the enum; `existing_sdk.action` ∈ the enum;
   5. `env_vars.api_key`/`.endpoint` match `/^[A-Z][A-Z0-9_]*$/`, **start with `env_prefix`**, and contain the bounded `OPSLANE` token (`/(?:^|_)OPSLANE(?:_|$)/`);
-  6. `edit.anchor` occurs in `edit.file` at least `occurrence+1` times, and `edit.entry_hash` equals the sha256 of `edit.file` now (Detect read the file, so it can assert both);
-  7. on success call `onPlan(plan)` **with canonicalized paths**, mark reported, return a confirmation.
-- **No `dev_script` field** (codex P1.6): Apply does not run the app (it only runs allowlisted build/typecheck/lint), so a run command is not needed, and a free command string is an injection vector. If a later phase needs it, model it as `{ manifest_path, script_name }` validated against that manifest's `scripts` and executed via `spawn(pm, ['run', script], { shell:false })` — never a raw string.
+  6. `edit.anchor` occurs in `edit.file` at least `occurrence+1` times;
+  7. host code stamps both file hashes and the reviewed SDK version, ignoring any model-supplied version;
+  8. on success call `onPlan(plan)` with canonicalized paths, mark reported, return a confirmation.
+- **No `dev_script` field** (codex P1.6): Apply does not run the app or any shell command, so a run command is not needed, and a free command string is an injection vector. If a later phase needs it, model it as `{ manifest_path, script_name }` validated against that manifest's `scripts` and executed via `spawn(pm, ['run', script], { shell:false })` — never a raw string.
 - Export `OnboardingPlan` and `createOnboardServer(...tools) = createSdkMcpServer({ name:'onboard', version:'0.0.0', tools })`.
 
 **Test** (real `mkdtemp` app fixture with a real entry file): `ask_user` routes to its resolver / throws with none; `report_plan` accepts a valid `status:'ok'` plan and calls `onPlan` once; a **second** call rejects (`/already/i`); rejects empty fields, a path escape, a secret `edit.file`, an `edit.file` outside `app_dir` or that doesn't exist, a var not starting with `env_prefix`, a borrowed name (`VITE_APP_DEFENDER_API_KEY` → `/opslane/i`), an unknown `package_manager`, a wrong `entry_hash`, and an `anchor` absent from the file. **Discriminant tests (eng-review Issue 1):** `status:'unsupported'` with a non-empty `reason` is accepted **without** any plan fields; `status:'unsupported'` with an empty/missing `reason` rejects; `status:'ok'` without a full plan rejects. Wiring test: `createOnboardServer(createReportPlanTool(...))` registers `report_plan` with an input schema.
@@ -239,10 +242,10 @@ Result of that smoke run (hand-scored), read-only detect over five popular OSS m
 ## Next phase — Apply Stage (outline, not this phase)
 
 Consumes an approved `OnboardingPlan` and makes exactly those edits.
-- **Tools:** `Read`, `Edit`, `Write` (no `Glob`/`search` needed — the plan already located everything); `Bash` only for the allowlisted `run build|typecheck|lint`; `finish_onboarding`.
-- **Apply consumes the typed `OnboardingPlan`, not prose.** It re-hashes `edit.file`; if `edit.entry_hash` no longer matches, it **stops and re-detects** (the repo changed under it). It finds `edit.anchor` at `edit.occurrence`; if the anchor is missing or ambiguous, it stops. It inserts `edit.import_line` + `edit.init_block` `edit.position` the anchor, applies `dependency` to the manifest, and honors `existing_sdk.action` (`keep`/`migrate`/`no_op`). `rationale` is never executed.
-- **Prompt (if a model is used):** `renderApplySpec({ cwd, plan })` — "apply ONLY the operations in this plan, change nothing else," then `finish_onboarding` with the edited files. Because the plan is fully typed, Apply is a strong candidate for a **deterministic codemod** (no model) — evaluated separately.
-- **Policy:** the same `onboardPreToolUseHook` (now gating real `Edit`/`Write`) + `createOnboardApproval` (per-tool approval) + post-`finish` denial; `finish_onboarding` validation (single app, OPSLANE token, containment) and the ordered `EditTracker` reconciliation (reject edits at/after finish).
+- **Tools:** `Read`, `Edit`, `Write`, and `finish_apply`; no `Glob`, search, `MultiEdit`, or Bash.
+- **Apply consumes the typed `OnboardingPlan`, not prose.** It contains/stats/hashes both edit files before querying; checks the init anchor; snapshots both; places `import_line` in the module import section, places `init_block` at its own anchor, and adds the host-pinned dependency to `manifest_file`. `migrate` is refused; `no_op` is returned only after structural confirmation.
+- **Prompt:** `renderApplySpec({ cwd, plan })` says to apply only the approved operations and end with `finish_apply`.
+- **Policy and proof:** the hook allows writes to exactly the two canonical files, approvals fail closed, `EditTracker` reconciles settlement order, and `verifyApplied` proves the exact entry/manifest deltas before the external report is emitted. Every handled failure attempts byte-identical rollback. Success reports that an install is still required and gives a host-derived command.
 
 ---
 
@@ -253,12 +256,12 @@ The committed code (`587bd93`) is the single combined loop. This plan renames/re
 | Current (combined) | Becomes | Note |
 |---|---|---|
 | `renderSpec({cwd})` | `renderDetectSpec({cwd})` | read-only wording; Apply gets its own `renderApplySpec` |
-| `finish_onboarding` + `OnboardingReport` | `report_plan` + `OnboardingPlan` (Detect); `finish_onboarding` returns in the Apply phase | Detect reports a plan, not a completion |
+| `finish_onboarding` + `OnboardingReport` | `report_plan` + `OnboardingPlan` (Detect); `finish_apply` terminates Apply | Detect reports a plan, not a completion |
 | `runOnboardingAgent(...)` | engine core + `runDetect(...)` wrapper; `runApply(...)` later | shared lifecycle (cancellation, tripwire, result mapping, injectable `queryFn`) stays |
 | `engineOptions(...)` | `detectOptions(...)` (read-only) + `applyOptions(...)` later | tool lists differ per stage |
 
-- **Hook signature:** keep `onboardPreToolUseHook({ root, state? })` — `root` required, `state` **optional**. Detect passes no `state` (no edits, no post-finish rule); Apply passes `state` to get post-finish denial. One hook serves both; do not fork it.
-- **Combined-loop tests + `cli/scripts/live-onboard-check.mjs`** target `runOnboardingAgent`/`finish_onboarding`. When Detect lands, either (a) keep them and repoint at `runApply` once Apply exists, or (b) delete the combined-loop path outright. Pick (b) unless we still want an end-to-end combined smoke; the plan assumes the combined loop is **replaced**, not kept in parallel.
+- **Hook signature:** `onboardPreToolUseHook({ root, state?, writablePaths? })`. Detect passes neither optional field; Apply passes state plus the exact two writable files.
+- **Combined-loop tests + the old live check** targeted `runOnboardingAgent`/`finish_onboarding`; they are replaced by the split controller tests and `cli/scripts/apply-check.mjs`, not kept as a parallel path.
 - **Live run:** drive Detect → (approve) → Apply against a throwaway copy of a real app; confirm the SDK is wired at the planned entry with the planned vars, dep added, `.env` untouched.
 
 ---
@@ -275,7 +278,7 @@ The committed code (`587bd93`) is the single combined loop. This plan renames/re
 | `events.ts` — `reduceTasks` | yes | `EditTracker` waits for Apply |
 | milestone 0.5 provisioning endpoint | untouched | committed, live-tested |
 
-Only `spec.ts` genuinely changes shape (one combined prompt → `renderDetectSpec` + a later `renderApplySpec`), plus `finish_onboarding` → `report_plan` for this stage.
+`spec.ts` splits one combined prompt into `renderDetectSpec` and `renderApplySpec`; the combined terminal report becomes `report_plan` for Detect and `finish_apply` for Apply.
 
 ## NOT in scope (considered and deferred)
 

--- a/docs/plans/2026-07-23-phase-1b-apply-stage.md
+++ b/docs/plans/2026-07-23-phase-1b-apply-stage.md
@@ -6,7 +6,7 @@
 
 **Why this is Phase 1b, not Phase 2.** Phase 1 was "engine core." The engine turned out to be two stages, and Apply is the second half of it — not new scope. Phase 2 (deterministic CLI plumbing: poll seam, env writer, `waitForAppReporting`) is independent of both and unchanged. See the pipeline diagram in `docs/design/2026-07-22-onboard-engineering-design.md` §4.
 
-## The two decisions this plan encodes
+## The three decisions this plan encodes
 
 **1. Apply is a narrow agent, not a codemod (user decision, 2026-07-23).** A deterministic codemod is genuinely viable here — Detect emits an exact import, init block, and anchor, and the repo already has transformer machinery in `cli/src/codemods/source.ts` (`lastImportStatement`, `findCreateAppStatement`, …). Codex and this review both recommended the codemod. **The user chose the agent as a standing principle: always use an agent for repo edits.** The honest tradeoff: the agent generalizes to file shapes a codemod's rules don't anticipate and stays consistent with Detect, at the cost of more machinery (approval loop, `EditTracker`, reconciliation, rollback). It is NOT because "code can't place an import" — once Detect has done the judging, placement is mechanical; the directus one-anchor-two-insertions issue is a contract bug (Task 1b.0), not evidence against a codemod. This plan builds the agent because that is the decision, and hardens it against the failure modes the extra machinery introduces.
 
@@ -19,7 +19,7 @@
 
 Apply therefore ends with a deterministic post-verify that the model cannot talk its way past.
 
-**3. Apply is reversible (eng-review Issue 1).** Apply edits exactly two known files. Before the first edit it snapshots both into memory; on **any** failure path — verify fails, reconciliation mismatch, abort, crash, `migrate` refusal reached after an edit — it writes the originals back so the repo ends byte-identical to how it started. A failed onboard costs the user time, never a broken repo. Restore has its own error path: if writing an original back fails, report that explicitly (the one case the user must act on).
+**3. Apply is reversible across handled failures (eng-review Issue 1).** Apply edits exactly two known files. Before the first edit it snapshots both into memory; on every handled failure path after that point — verification, reconciliation, abort, SDK/query failure — it attempts to write both originals back so the two allowed files end byte-identical to how they started. In-memory rollback cannot recover from `SIGKILL`, process death, or machine failure; the implementation makes no crash-recovery claim. Restore has its own `restore_failed` outcome and reports affected paths, never file contents.
 
 ## Contract fix (blocking, do first)
 
@@ -28,7 +28,7 @@ Apply therefore ends with a deterministic post-verify that the model cannot talk
 - `edit.anchor` / `position` / `occurrence` govern **`init_block` only**.
 - `edit.import_line` has **no anchor**. Apply places it at module top level, idiomatically, alongside existing imports.
 
-This is a doc + comment change in `cli/src/onboard/tools.ts` (the `OnboardingPlan` interface) and the Phase 1 plan. No schema field changes: Detect already emits both fields; we are correcting what they mean. Detect's spec should also stop implying one placement covers both.
+This also closes the manifest/version gaps discovered in review. `OnboardingPlan.edit` gains `manifest_file` and host-stamped `manifest_hash`; the model supplies the manifest path but neither hash. The model no longer supplies `dependency.version`: host code pins `@opslane/sdk` to the reviewed range. This is a real schema change across the interface, reported-plan type, Zod schema, Detect prompt, tests, Phase 1 plan, and engineering design.
 
 ### Codex outside-voice fixes folded into this plan (2026-07-23)
 
@@ -51,10 +51,12 @@ The agent path introduces failure modes a codemod wouldn't have. These are addre
 
 ## Task 1b.0: Fix the anchor contract (docs + types)
 
-**Files:** Modify `cli/src/onboard/tools.ts` (interface comments), `cli/src/onboard/spec.ts` (Detect prompt wording), `docs/plans/2026-07-22-phase-1-engine-core.md`.
+**Files:** Modify `cli/src/onboard/tools.ts` (types, validation, host pin, interface comments), `cli/src/onboard/spec.ts` (Detect prompt wording), tests, `docs/plans/2026-07-22-phase-1-engine-core.md`, and `docs/design/2026-07-22-onboard-engineering-design.md`.
 
-- In `OnboardingPlan.edit`, comment that `anchor`/`position`/`occurrence` locate `init_block` only, and that `import_line` is placed by Apply at module top level.
+- In `OnboardingPlan.edit`, comment that `anchor`/`position`/`occurrence` locate `init_block` only, and that `import_line` is placed by Apply at module top level. The anchor must equal one complete line's non-whitespace content (including punctuation), which makes both before/after placement and exact verification unambiguous.
 - In `renderDetectSpec`, change "Provide exact import_line and init_block code plus an exact anchor, position, and zero-based occurrence for the entry file" to make clear the anchor locates the init block, and the import line is a top-level import Apply will place.
+- Require a canonical regular `package.json` under `app_dir`, store it as `edit.manifest_file`, and host-stamp `edit.manifest_hash`.
+- Remove model control of the SDK version and host-pin `dependency.version`.
 - **Test:** `spec.test.ts` asserts the prompt distinguishes the two (`/init block/i` near the anchor language; the import described as top-level).
 
 **Commit** — `fix(cli): anchor locates the init block only, not the import`
@@ -68,8 +70,9 @@ Never built (deferred from Phase 1). Apply needs it to prove no edit landed afte
 **Files:** Modify `cli/src/onboard/events.ts`; test `__tests__/events.test.ts`.
 
 **Implement** `EditTracker(root)`:
-- Ordered log of `{seq, id, kind:'edit'|'finish', path?, committed}`. `onMessage` assigns a monotonic seq per `tool_use`; a matching non-error `tool_result` marks it committed (an errored or denied edit is **never** committed).
-- `markFinished(id)` records the finish seq. `committedBeforeFinish()` → committed edit paths with seq < finish. `editsAfterFinish()` → committed edit paths with seq ≥ finish (what the controller rejects).
+- Track invocation and settlement separately. Every recognized block advances a monotonic event sequence; a matching non-error edit `tool_result` records its **commit sequence** (an errored or denied edit is never committed).
+- The successful `finish_apply` `tool_result` records the finish boundary. `committedBeforeFinish()` returns edits whose commit sequence is before it; `editsAfterFinish()` returns commits at or after it.
+- `hasUnsettledEdits()` lets `finish_apply` reject while any invoked edit lacks a result.
 - Paths normalized through `containedRepoRelative`.
 
 **Test:** an edit then finish then a second edit → `committedBeforeFinish()` is `['src/main.ts']` and `editsAfterFinish()` is `['src/late.ts']`; an **errored** edit result is not committed; two edits to the same file both record.
@@ -84,9 +87,10 @@ Detect ends with `report_plan`; Apply ends with `finish_apply`. Same discipline:
 
 **Files:** Modify `cli/src/onboard/tools.ts`; test `__tests__/tools.test.ts`.
 
-**Implement** `createFinishApplyTool(root, state, onReport)`:
+**Implement** `createFinishApplyTool(root, state, onReport, canFinish)`:
 - Shape: `{ edited_files: z.array(z.string()).min(1), summary: z.string() }`.
-- Handler: reject a second call (`already finished`); every path through `containedRepoRelative` **and** `isSecretFile`/`hasSecretSegment`; on success `onReport({editedFiles, summary})` with canonical paths, then `state.finished = true` so the hook denies everything after.
+- Handler: reject a second call (`already finished`) and reject while `canFinish()` is false; every path through `containedRepoRelative` and the secret policy; reject duplicates; on success capture canonical files, then set `state.finished = true` so the hook denies everything after.
+- `install_required`, the package-manager command, and working directory are not model fields. `runApply` adds them from trusted plan state only after deterministic verification succeeds.
 
 **Test:** valid report accepted once, second rejects `/already/i`; a path escape rejects; a `.env` path rejects; empty `edited_files` rejects; `state.finished` flips only on success.
 
@@ -100,15 +104,16 @@ This is the half code is genuinely better at. It runs **after** the agent, in-pr
 
 **Files:** Create `cli/src/onboard/verify.ts`; test `__tests__/verify.test.ts`.
 
-**Implement** `verifyApplied({ root, plan, editedFiles })` → `{ ok, failures: string[] }`. Checks:
+**Implement** `verifyApplied({ root, plan, editedFiles, originals:{entry,manifest} })` → `{ ok, failures: string[] }`. The before-images are required; hashes alone cannot prove an exact diff. Checks:
 1. **Only expected files changed** — the edited set is exactly `{plan.edit.file, <manifest>}`. Anything else is a failure (catches the agent wandering).
-2. **Dependency present** — `<app_dir>/package.json` `dependencies` contains `@opslane/sdk`.
-3. **Init is actually called** — the entry file contains `plan.env_vars.api_key` and `plan.env_vars.endpoint` **by name**, and an `init(` call.
-4. **Import is at top level** — the `@opslane/sdk` import appears at column 0 (not indented inside a block). This is the directus bug turned into an assertion.
-5. **File still parses** — parse **only `edit.file`** with the TypeScript compiler API (already a dependency via `typescript`); a syntax error is a failure. **Parse the one entry file, never the repo** — a full typecheck would blow the <10min budget and is not this check's job (eng-review perf note).
-6. **No secrets written** — no literal value from any `.env*` appears in either edited file.
+2. **Before-images match the plan** — both supplied snapshots hash to `entry_hash`/`manifest_hash`.
+3. **Exact entry delta** — no deletion, replacement, unrelated addition, or reformat is allowed. The only added blocks are the exact top-level `import_line` in the module import section and `init_block` at the selected anchor, with only surrounding indentation/newline normalization.
+4. **Exact manifest delta** — JSON semantics differ only by `dependencies["@opslane/sdk"] = <host-pinned version>`, and byte changes are confined to that insertion/version region.
+5. **Structural wiring** — TypeScript AST parsing proves the exact Opslane import is top-level, its bound initializer is called, and the planned environment-variable names are syntax nodes rather than comments/strings.
+6. **File still parses** — parse only `edit.file`. Supported extensions are `.{ts,tsx,js,jsx,mjs,cjs}`; anything else is rejected. Because this parser runs in the published CLI, `typescript` moves from dev-only to runtime dependencies.
+7. **No newly written secrets** — scan only bytes added by the exact diff against bounded, regular, non-symlink `.env*` files. Parse `export NAME=value`, quotes, and trivial values; errors name only the variable/path and never reveal a value. Pre-existing matching literals in unchanged bytes do not fail.
 
-**Test** (real `mkdtemp` fixtures): a correctly applied file passes all six; each failure mode fails exactly its own check — an import indented inside a function fails #4; a stray third edited file fails #1; a missing dep fails #2; a deliberately broken file fails #5; a planted secret value fails #6. **Independence (eng-review test gap):** a partially-correct file where the import IS at column 0 but the init block is mis-indented must fail on its own check and not mask, confirming the six checks are independent rather than one pass/fail.
+**Test** (real `mkdtemp` fixtures): a correctly applied pair passes every check. Cover a third reported file, stale before-images, comments/strings that resemble wiring, a block-local or late top-level import, wrong indentation/anchor, syntax failure, unrelated entry or manifest changes, full-manifest reformatting, unsupported extensions, planted secret values, pre-existing matching literals, symlinked dotenv files, and both valid and false `no_op`.
 
 **Commit.**
 
@@ -123,7 +128,7 @@ Narrow prompt. The judgment is already made; Apply executes it and places the im
 **Implement** `renderApplySpec({ cwd, plan })`:
 - **Goal:** apply exactly this approved plan to `cwd`. Change nothing else.
 - **The plan**, rendered as explicit fields (not prose): the entry file, the exact `import_line`, the exact `init_block`, the anchor + position + occurrence for the init block, and the dependency.
-- **Instructions:** insert `init_block` `position` the `occurrence`-th match of `anchor` in `edit.file`, matching the file's existing indentation. Place `import_line` at module **top level** alongside the existing imports — never inside a function or block. Add `dependency` to `<app_dir>/package.json` dependencies. Do not run installs. Do not reformat unrelated lines.
+- **Instructions:** insert `init_block` `position` the `occurrence`-th match of `anchor` in `edit.file`, matching the file's existing indentation. Place `import_line` at module **top level** alongside the existing imports — never inside a function or block. Add the host-pinned dependency to `edit.manifest_file`. Do not run installs. Do not reformat unrelated lines.
 - **existing_sdk:** `none`/`keep` → proceed (coexist; do not touch the other SDK). `no_op` → make no edits and finish immediately. `migrate` → **stop and report that migration is unsupported**; do not attempt it.
 - **Finish:** call `finish_apply` exactly once with the files edited. No edits after.
 
@@ -139,7 +144,7 @@ Narrow prompt. The judgment is already made; Apply executes it and places the im
 
 **Files:** Modify `cli/src/onboard/engine.ts`; existing `__tests__/engine.test.ts` must stay green.
 
-**Implement** `runAgentCore({ prompt, options, mcpServers, onMessage, signal, queryFn })` → `{ ok, aborted, subtype, reason }` holding the shared lifecycle. `runDetect` becomes a thin wrapper that supplies `renderDetectSpec`, `detectOptions`, its MCP tools, and its own report accounting. This is a **pure extraction**: no behavior change, `runDetect`'s tests do not change and stay green. **Commit** before writing `runApply`.
+**Implement** `runAgentCore({ prompt, options, onMessage, signal, queryFn })` where `options` is a factory receiving the internally owned `AbortController`. It returns `{ ok, aborted, subtype, reason }` and owns the shared lifecycle. `runDetect` becomes a thin wrapper that supplies `renderDetectSpec`, `detectOptions`, its MCP tools, and its own report accounting. This is a pure extraction: no behavior change.
 
 ---
 
@@ -152,16 +157,16 @@ Narrow prompt. The judgment is already made; Apply executes it and places the im
 **Implement.**
 - `applyOptions({ cwd, hook, mcpServers, canUseTool, abortController })`: `permissionMode:'default'`; `settingSources:[]`; `strictMcpConfig:true`; `allowedTools:[]` (nothing auto-approved — every edit goes through approval); `tools:['Read','Edit','Write']`; `disallowedTools:['Grep','Glob','Bash','WebFetch','WebSearch']` (the plan located everything; no search needed, and no shell); `hooks:{PreToolUse:[{hooks:[hook]}]}`; `canUseTool`; `abortController`; `maxTurns:30`.
 - `runApply({ cwd, plan, onMessage, onReport, requestApproval, signal, queryFn = query })`:
-  - **Staleness gate, before any model call:** re-hash `plan.edit.file`; if it differs from `plan.edit.entry_hash` → return `{ok:false, reason:'stale_plan'}` and do not query. Also verify `plan.edit.anchor` still occurs at `occurrence` → else `{ok:false, reason:'anchor_moved'}`.
+  - **Containment + staleness gate, before any model call:** re-contain and re-stat both canonical regular files; reject symlinks; re-hash entry and manifest; return `stale_plan`/`stale_manifest` without querying on drift. Also verify the anchor occurrence and supported entry extension.
   - **`migrate` gate:** `plan.existing_sdk.action === 'migrate'` → `{ok:false, reason:'migrate_unsupported'}` without querying.
-  - **`no_op` short-circuit:** → `{ok:true, subtype:'already_onboarded', editedFiles:[]}` with zero edits (eng-review Issue 2). This is a **distinct** outcome from a fresh install so the CLI can say "this repo already has Opslane wired in" instead of reporting work it did not do; without it, downstream (Phase 3) waits for `app_reporting` that a stale pre-existing install may never send, and the user gets a silent hang. Validating the existing key stays Phase 2's job.
-  - **Snapshot before editing (eng-review Issue 1):** read `plan.edit.file` and `<app_dir>/package.json` into memory. Register a restore that writes both originals back; invoke it on every non-success exit below.
-  - `state={finished:false}`; `hook = onboardPreToolUseHook({root:cwd, state})` (state passed, so post-finish denial is live); `canUseTool = createOnboardApproval({requestApproval})`; `mcpServers = { onboard: createOnboardServer(createFinishApplyTool(cwd, state, capture)) }`; an `EditTracker(cwd)` fed from `onMessage`.
+  - **`no_op` short-circuit:** mechanically parse the manifest and entry first. An identity-capable SDK range (minimum 1.2.0) must exist, and a real top-level named/namespace `@opslane/sdk` import must be structurally bound to an initializer call. Only then return `{ok:true, subtype:'already_onboarded', editedFiles:[]}`; otherwise return `invalid_no_op` without querying. Old identity-broken SDK versions are never called already-onboarded. Key validity stays Phase 2's job.
+  - **Snapshot before editing (eng-review Issue 1):** read `plan.edit.file` and `plan.edit.manifest_file` into memory. Register a restore that independently attempts both originals on every non-success exit below.
+  - `state={finished:false}`; `hook = onboardPreToolUseHook({root:cwd, state, writablePaths:[entry,manifest]})`; `canUseTool = createOnboardApproval(...)` with an explicit stage allowlist so unknown tools fail closed; `finish_apply` receives the tracker's unsettled-edit guard; feed the tracker from `onMessage`.
   - **Drive `runAgentCore`** with `renderApplySpec({cwd, plan})` and `applyOptions(...)` (Task 1b.5a) — the shared lifecycle (cancellation, tripwire, `try`/`catch`/`finally`) is not re-implemented here.
-  - **After a clean result:** run `verifyApplied(...)` and reconcile with `EditTracker` — `editsAfterFinish()` must be empty, and the reported `edited_files` must equal `committedBeforeFinish()`. Any mismatch → restore snapshot, `ok:false` with the specific reason.
+  - **After a clean result:** reconcile canonical sets (duplicates in the edit log are allowed; duplicates in the report are not), require no unsettled or late edit, then run `verifyApplied(...)`. Invoke the external `onReport` only after all checks pass, adding trusted install metadata.
   - `ok:true` only when: clean terminal result **and** exactly one report **and** verify passed **and** reconciliation clean. **On any `ok:false`, restore the snapshot first** so the repo is left unchanged.
 
-**Test:** `applyOptions` locks the gate (no `Bash`/`Glob`, `allowedTools` empty, `Edit`/`Write` present); dummy API key set in `beforeAll`; stale hash → `stale_plan` without calling `queryFn`; moved anchor → `anchor_moved` without querying; `migrate` → `migrate_unsupported` without querying; `no_op` → `ok:true, subtype:'already_onboarded'`, zero edits; a clean stub run with a valid report → `ok:true`; a report listing a file the tracker never committed → `ok:false`; an edit after finish → `ok:false`; failed verify → `ok:false` with the failure text. **Rollback (eng-review Issue 1):** after a forced verify failure, assert `plan.edit.file` and the manifest are byte-identical to their pre-run contents (snapshot the fixture bytes, run, compare). **`already_onboarded` is a distinct subtype** from a fresh `ok:true`.
+**Test:** lock the option/tool gates; exercise entry and manifest staleness, moved anchor, migration refusal, supported extensions, proven and false `no_op`, clean success, trusted install metadata, missing/mismatched reports, duplicate same-file edits, unsettled/late edits, query failure, abort, verification failure, and byte-identical rollback. Test `restore_failed` separately by replacing an allowed path with a symlink after snapshot and prove no outside file is written.
 
 **Commit.**
 
@@ -176,20 +181,22 @@ pnpm --filter @opslane/cli exec vitest run src/onboard
 pnpm --filter @opslane/cli test
 ```
 
-**Live gate — the real proof.** Extend `cli/scripts/` with an apply check that runs the **full Detect → Apply loop** against a throwaway copy of a real app:
+**Hermetic controller gate (required in CI).** An injected-query integration test runs the full `runDetect` → host-validated plan → `runApply` handoff against a real temporary filesystem. It proves controller wiring, exact verification, reconciliation, rollback, and trusted install metadata without a model key.
+
+**Live gate (release/pre-merge when credentials and pinned fixtures are available).** `cli/scripts/apply-check.mjs` runs the production **full Detect → Apply loop** against throwaway copies:
 ```bash
 export ANTHROPIC_API_KEY=...
 pnpm --filter @opslane/cli build
-node cli/scripts/apply-check.mjs <app-dir>
+node cli/scripts/apply-check.mjs <app-dir> [app-dir...]
 ```
 It must: copy the app to a temp dir (never the original), neutralize `.env*` with a canary, run Detect, auto-approve, run Apply, then assert:
-- `verifyApplied` passes all six checks;
+- `verifyApplied` passes every deterministic check;
 - the entry file still parses and the `@opslane/sdk` import is at column 0;
 - `git diff`-equivalent shows exactly two files changed;
 - `.env*` untouched and the canary never in the transcript;
 - total elapsed Detect+Apply is within the <10min budget (report it).
 
-Run it against at least `verify-cloud/dashboard` (plain `VITE_`, no existing SDK) and `directus` (Vue, tab-indented, anchor inside `async function init()` — the case that motivated the contract fix).
+The script never mutates the source app. It accepts fixture paths explicitly so it does not depend on an undocumented local directory layout, and reports the resolved source path and elapsed time. Release evidence should pin and record the fixture revisions. The target matrix includes `verify-cloud/dashboard` (plain `VITE_`, no existing SDK) and `directus` (Vue, tab-indented, anchor inside `async function init()` — the case that motivated the contract fix). If the API key or fixtures are absent, record the live gate as unavailable; do not substitute that absence for the hermetic gate or claim a live run occurred.
 
 ---
 
@@ -217,17 +224,15 @@ Run it against at least `verify-cloud/dashboard` (plain `VITE_`, no existing SDK
 |---|---|---|---|---|
 | stale plan | repo changed after approval | yes | pre-flight hash gate | "repo changed, re-detecting" |
 | anchor moved | file edited between stages | yes | pre-flight anchor gate | same |
-| import placed in a block | the directus shape | yes (verify #4) | verify fails the run | "apply failed verification" |
+| import placed in a block or below module setup | the directus shape | yes | AST/import-section verification fails the run | "apply failed verification" |
 | agent edits a third file | wandering | yes (verify #1) | verify + tracker reconcile | failure, not a silent extra edit |
 | edit after finish | late tool result | yes | `editsAfterFinish()` | failure |
 | `migrate` plan | predecessor SDK repo | yes | refused pre-flight | "migration unsupported" |
-| secret written into source | model pastes a value | yes (verify #6) | verify fails | failure |
+| secret written into new source/manifest bytes | model pastes a value | yes | bounded redacted secret verification fails | failure |
 | symlinked manifest | `package.json` → outside repo | yes | containment on `manifest_file` | denied pre-flight |
 | injected `dependency.version` | `npm:attacker@…` in plan | yes | host pins version, ignores model's | attacker string never written |
 | stale lockfile after edit | `pnpm install --frozen-lockfile` fails | n/a | `install_required` in report | told to run install |
-| import lands inside a block | directus shape | yes (verify #3, exact-diff) | verify fails → rollback | failure, repo restored |
-
-**Critical gaps (no test AND no handling AND silent): 0** — after folding the codex fixes. Codex correctly flagged that the *original* draft's claim was false: fuzzy verification (any `init(`) plus no exact-diff meant a wrong-but-plausible edit could pass silently. The exact-string diff (verify #3), rollback (Issue 1), and manifest containment close it.
+The original draft's “0 critical gaps” claim was removed during implementation review. Completion is established by the requirement-by-requirement verification gates below, not by an unaudited table count.
 
 ---
 
@@ -249,22 +254,22 @@ Run it against at least `verify-cloud/dashboard` (plain `VITE_`, no existing SDK
 ## Implementation Tasks
 Synthesized from this review. Each derives from a finding.
 
-- [ ] **T1 (P0, human: ~1h / CC: ~10min)** — tools.ts — Host-pin the SDK version; add contained+hashed `manifest_file` to the plan
+- [x] **T1 (P0, human: ~1h / CC: ~10min)** — tools.ts — Host-pin the SDK version; add contained+hashed `manifest_file` to the plan
   - Surfaced by: codex P0 (supply-chain, manifest containment)
   - Verify: a plan with `version:"npm:x@1"` never writes that string; a symlinked manifest is denied
-- [ ] **T2 (P0, human: ~2h / CC: ~15min)** — verify.ts — Exact-diff verification (only the two known insertions changed)
+- [x] **T2 (P0, human: ~2h / CC: ~15min)** — verify.ts — Exact-diff verification (only the two known insertions changed)
   - Surfaced by: codex P0 (verification too weak)
   - Verify: a file with a stray extra `init()` in a comment fails; a partial-correct file fails its own check
-- [ ] **T3 (P1, human: ~2h / CC: ~15min)** — engine.ts — Rollback snapshot/restore on every failure path; restrict Edit/Write to the two canonical paths at the hook
+- [x] **T3 (P1, human: ~2h / CC: ~15min)** — engine.ts — Rollback snapshot/restore on every failure path; restrict Edit/Write to the two canonical paths at the hook
   - Surfaced by: eng-review Issue 1 + codex P0 (rollback not transactional)
   - Verify: forced verify failure leaves both files byte-identical; a third-file Edit is denied
-- [ ] **T4 (P1, human: ~1.5h / CC: ~15min)** — events.ts — EditTracker orders by commit; reconcile as sets
+- [x] **T4 (P1, human: ~1.5h / CC: ~15min)** — events.ts — EditTracker orders by commit; reconcile as sets
   - Surfaced by: codex P1 (ordering, reconciliation)
   - Verify: two edits to one file reconcile; an unsettled edit blocks finish
-- [ ] **T5 (P1, human: ~2h / CC: ~20min)** — engine.ts — Extract `runAgentCore` via an options factory (not prebuilt options)
+- [x] **T5 (P1, human: ~2h / CC: ~20min)** — engine.ts — Extract `runAgentCore` via an options factory (not prebuilt options)
   - Surfaced by: eng-review Issue 3 + codex P1 (signature)
   - Verify: runDetect tests stay green post-extraction
-- [ ] **T6 (P2, human: ~1h / CC: ~10min)** — verify.ts — Specify secret scan + JS/TS-only parse gate
+- [x] **T6 (P2, human: ~1h / CC: ~10min)** — verify.ts — Specify secret scan + JS/TS-only parse gate
   - Surfaced by: codex P2
   - Verify: failure message names the var not the value; a non-JS entry is rejected, not skipped
 
@@ -274,7 +279,7 @@ Synthesized from this review. Each derives from a finding.
 |--------|---------|-----|------|--------|----------|
 | CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
 | Codex Review | `/codex review` | Independent 2nd opinion | 1 | issues_found | 4 P0 + 6 P1 + 2 P2 |
-| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | issues_open | 4 own findings + codex folded |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | resolved | 4 own findings + codex folded and implemented |
 | Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
 | DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
 
@@ -282,7 +287,7 @@ Synthesized from this review. Each derives from a finding.
 
 **CROSS-MODEL:** one real tension — Apply as a deterministic codemod (codex + this reviewer) vs an agent. **The user chose the agent as a standing principle** ("always use an agent for repo edits"), overriding both models. Logged as a durable decision. The plan's justification was corrected: the earlier "code can't place an import" argument was a false analogy codex debunked (reading is judgment → model; applying a known edit is transformation). The agent is kept for generalization and consistency with Detect, and hardened against the machinery's failure modes.
 
-**VERDICT:** ENG reviewed — plan hardened, NOT yet clean to implement. The agent-hardening fixes (T1–T6) are folded into the tasks but not yet built. The plan is implementation-ready once those tasks are executed. Eng review is logged; re-run `/plan-eng-review` or proceed to implementation per the user's call.
+**VERDICT:** ENG reviewed and implemented. The agent-hardening fixes (T1–T6) are complete, covered by focused CLI tests, and included in the repository-wide verification gate.
 
 **UNRESOLVED DECISIONS:**
 - Lockfile sync: Apply reports `install_required` rather than running the install (folded as the chosen path, consistent with the "no installs" constraint) — flagged here only because it means Apply's output is "manifest edited, install still needed," which Phase 2/3 must honor or the app won't build.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       inquirer:
         specifier: ^12.0.0
         version: 12.11.1(@types/node@26.1.1)
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
       zod:
         specifier: ^4.0.0
         version: 4.4.3
@@ -36,9 +39,6 @@ importers:
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
-      typescript:
-        specifier: ^5.4.0
-        version: 5.9.3
       vitest:
         specifier: ^3.2.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@26.1.1)(jiti@2.7.0)(jsdom@28.1.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)


### PR DESCRIPTION
Stacked on #183 (Detect). Base: \`abhishekray07/onboard-phase-1-engine\` — **not** main.

Completes the onboard engine: given a typed OnboardingPlan from Detect, a narrow agent inserts the \`@opslane/sdk\` import at module top level and \`init()\` at the plan's anchor, adds the dependency to \`package.json\`, then deterministic code verifies the result and rolls back on any failure.

## What's here
- \`runAgentCore\` extracted from \`runDetect\` (shared lifecycle), \`runApply\` reuses it
- Pre-flight gates: stale-hash, moved-anchor, migrate-refused, already-onboarded
- Snapshot before editing; \`EditTracker\` + set reconciliation; \`verifyApplied\` after; rollback on any failure
- \`verify.ts\`: exact-diff verification, top-level-import + init-call structure, JS/TS parse, no-new-secrets scan
- SDK version host-pinned (never model-supplied); hook restricts Edit/Write to the two canonical paths
- \`install_required\` reported (lockfile left for the caller to sync)
- \`cli/scripts/apply-check.mjs\`: live Detect → Apply harness

## QA
- 249 unit tests pass; build clean
- Live Detect → Apply ok on verify-cloud/dashboard (VITE_, npm) and directus (Vue, tabs, anchor inside \`async function init()\`); import at column 0, file parses, dep pinned, exactly 2 files changed

## Codex code review (in a subagent) — 4 P0 + 1 P1, all fixed + regression-tested
- type-only \`import type { init }\` erased at runtime → skipped in binding scan
- lossy UTF-8 compare → reject non-UTF-8 (valid UTF-8 makes the string diff a byte diff)
- hard-linked file aliases an outside inode → reject \`nlink > 1\`
- rollback through a swapped parent symlink → re-verify parent realpath before restore
- leading BOM broke the column-0 import check → strip BOM for structural checks

⚠️ Retarget base to main (or #182's branch) once #183 merges, or the diff will look tangled.