### PR TITLE
ci(release): use crane copy to promote images, preserving digest

### DIFF
--- a/.github/workflows/release-platform.yml
+++ b/.github/workflows/release-platform.yml
@@ -117,21 +117,32 @@ jobs:
           done
           echo "cand_tag=$cand_tag" >> "$GITHUB_OUTPUT"
 
+      - name: Install crane
+        run: |
+          mkdir -p "$HOME/.crane-bin"
+          curl -fsSL "https://github.com/google/go-containerregistry/releases/download/v0.20.2/go-containerregistry_Linux_x86_64.tar.gz" \
+            | tar -xz -C "$HOME/.crane-bin" crane
+          echo "$HOME/.crane-bin" >> "$GITHUB_PATH"
+
       # Registry promotion happens BEFORE the immutable git tag: retagging is
       # idempotent and repeatable, while a stranded v* tag can never be
       # removed. The tag is only created once both images are verified.
+      # crane copy preserves the exact manifest bytes (and therefore the
+      # digest); `docker buildx imagetools create` would re-wrap a single-arch
+      # image in a new index, changing the digest and breaking digest pinning.
       - name: Re-tag candidate digests as the version (no rebuild)
         env:
           INGESTION_DIGEST: ${{ steps.digests.outputs.ingestion }}
           WORKER_DIGEST: ${{ steps.digests.outputs.worker }}
         run: |
+          echo "$GH_TOKEN" | crane auth login ghcr.io -u "${{ github.actor }}" --password-stdin
           for image in ingestion worker; do
             digest_var=$(echo "$image" | tr '[:lower:]' '[:upper:]')_DIGEST
             digest=$(eval "echo \$$digest_var")
             src="ghcr.io/$OWNER/opslane-$image@$digest"
             dst="ghcr.io/$OWNER/opslane-$image:$VERSION"
-            docker buildx imagetools create --tag "$dst" "$src"
-            promoted=$(docker buildx imagetools inspect "$dst" --format '{{json .Manifest}}' | jq -r .digest)
+            crane copy "$src" "$dst"
+            promoted=$(crane digest "$dst")
             [ "$promoted" = "$digest" ] || { echo "Digest mismatch after retag: $promoted != $digest"; exit 1; }
             echo "$dst -> $digest (verified)"
           done


### PR DESCRIPTION
## Problem

The platform release workflow cannot promote any release. `release-platform.yml` re-tags the soaked candidate images with `docker buildx imagetools create`, which re-wraps a single-arch image in a **new** OCI index and therefore changes the manifest digest. The workflow then compares the promoted digest to the candidate digest, sees a mismatch, and aborts — before creating the `v*` tag.

## Evidence

The `v26.7.1` release run failed at the re-tag step:

```
run 30099925843 — "Re-tag candidate digests as the version (no rebuild)"
pushing sha256:4b9e49021d8f5189185fc092e66683a373f23bedb5b33d5051c32e5a820a50bf to opslane-ingestion:v26.7.1
Digest mismatch after retag: sha256:4b9e4902... != sha256:6ae27bff...
```

`sha256:6ae27bff...` is the candidate ingestion digest; buildx re-wrapping produced `sha256:4b9e4902...`.

## Fix

Install `crane` and use `crane copy` for the promotion. `crane copy` transfers the exact manifest bytes, so the digest is preserved and the workflow's own guard passes. `crane digest` replaces the buildx inspect for verification.

```diff
-            docker buildx imagetools create --tag "$dst" "$src"
-            promoted=$(docker buildx imagetools inspect "$dst" --format '{{json .Manifest}}' | jq -r .digest)
+            crane copy "$src" "$dst"
+            promoted=$(crane digest "$dst")
```

The digest-mismatch guard and the "tag only after both images verify" ordering are unchanged.

## Provenance

Cherry-picked from `f50f119` (authored 2026-07-17), which was pushed to a feature branch but never merged. `main` has since moved ~234 commits ahead; the change is self-contained to `release-platform.yml` and applied cleanly.

## After merge

Re-run the `v26.7.1` platform release (candidate run `30098835071`), then deploy.