### PR TITLE
Deterministic CLI plumbing for agent-first onboarding

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -130,3 +130,27 @@ It was deliberately left alone by the issue-list polish plan, which is scoped da
 **Context:** Measured during `/qa` on 2026-07-23 against a live build: `/settings` has one 30px select, `/admin` has 30px and 40px selects. These pages were in scope for the chevron padding fix (Task 1 of the issue-list plan) but not for the touch-target fix, which design decision D8 scoped to the issue-list filters only. Pre-existing, not a regression. The cleanest fix is probably migrating them to `SelectField` rather than hand-adding classes.
 
 **Depends on / blocked by:** Nothing.
+
+## Revisit member-level onboarding provisioning in cloud
+
+**What:** `POST /api/v1/onboard/provision` is admin-gated in cloud (`RequireRoleIfCloud("admin")`, `packages/ingestion/handler/routes.go:113`). Decide deliberately whether org members should be able to self-provision.
+
+**Why:** The milestone 0.5 plan (docs/plans/2026-07-22-milestone-0.5-account-provisioning.md, line 24) settled the opposite — "no admin gate, login + org membership only" — to enable bottom-up adoption (any teammate tries Opslane without pinging an admin). Commit e365003 reversed that as a security hardening with no written rationale; the integration test now asserts member→403. If bottom-up adoption becomes the growth motion, this gate silently blocks it.
+
+**Pros:** members can adopt Opslane solo; matches the original product decision. **Cons:** provisioning mints/rotates a production key — member-level access widens that surface; sibling key routes are admin-gated.
+
+**Context:** Found during the 2026-07-24 /plan-eng-review of Phase 2 (onboarding-10x). The CLI now surfaces a typed `NotAuthorizedError` with "ask an org admin" remediation, so the failure is at least honest. Self-hosted OSS is unaffected (`RequireRoleIfCloud` is transparent there). Re-decide with real cloud data on who actually runs `opslane onboard`.
+
+**Depends on / blocked by:** cloud usage data; a product call, not an eng task.
+
+## SDK: recover from a 409 on /sessions/init instead of never reporting
+
+**What:** When the browser SDK holds a stored session identity from a previous project (localStorage on the same origin) and the app is re-onboarded to a NEW project, `POST /api/v1/sessions/init` returns 409 repeatedly and the SDK never reaches `app_reporting`. It should treat 409 as "discard stored identity, start a fresh session."
+
+**Why:** Found live during Phase 2 /qa (2026-07-24): two onboarding runs against the same fixture origin — second run's phone-home 409'd until site storage was cleared manually. Real-world shape: a dev re-onboarding an app to a different org/project, or shared localhost origins across projects.
+
+**Pros:** onboarding "waiting for your app" can't stall on stale browser state. **Cons:** touches the MIT SDK's session lifecycle; needs care not to discard identity on transient 409s.
+
+**Context:** server rejects at `handler/session.go` (project mismatch between API key and stored session); SDK side is the browser package's session-init path. Workaround: clear site storage / incognito window.
+
+**Depends on / blocked by:** nothing; SDK-side change.

--- a/cli/src/__tests__/agent-protocol.test.ts
+++ b/cli/src/__tests__/agent-protocol.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import { pollSessionOnce } from '../agent-protocol.js';
+
+const OPTS = {
+  apiUrl: 'http://localhost:8082',
+  sessionId: '123e4567-e89b-42d3-a456-426614174000',
+  pollToken: 'tok_abc',
+};
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+describe('pollSessionOnce', () => {
+  it('sends the poll token header to the poll endpoint', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, { status: 'pending' }));
+    await pollSessionOnce({ ...OPTS, fetchFn });
+    const [url, init] = fetchFn.mock.calls[0]!;
+    expect(url).toBe(`${OPTS.apiUrl}/api/v1/agent/poll/${OPTS.sessionId}`);
+    expect((init.headers as Record<string, string>)['X-Opslane-Poll-Token']).toBe('tok_abc');
+  });
+
+  it('passes server progress statuses through verbatim with payloads', async () => {
+    for (const status of ['provisioned', 'key_ok', 'app_reporting'] as const) {
+      const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, {
+        status,
+        api_key: 'opk_raw',
+        org_id: 'org1',
+        project_id: 'proj1',
+        repo: 'acme/web',
+      }));
+      const result = await pollSessionOnce({ ...OPTS, fetchFn });
+      expect(result.status).toBe(status);
+      if (result.status === status) {
+        expect(result.apiKey).toBe('opk_raw');
+        expect(result.orgId).toBe('org1');
+        expect(result.projectId).toBe('proj1');
+      }
+    }
+  });
+
+  it.each([
+    [404, { status: 'not_found' }, 'not_found'],
+    [410, { status: 'pending' }, 'expired'],
+    [500, { status: 'pending' }, 'internal_error'],
+    [401, { status: 'completed', api_key: 'k' }, 'internal_error'],
+  ] as const)('maps HTTP %s ahead of body status', async (status, body, expected) => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(status, body));
+    expect((await pollSessionOnce({ ...OPTS, fetchFn })).status).toBe(expected);
+  });
+
+  it('maps 429 retry hints from body and header', async () => {
+    const bodyFetch = vi.fn().mockResolvedValue(
+      jsonResponse(429, { status: 'rate_limited', retry_after: 7 }),
+    );
+    const bodyResult = await pollSessionOnce({ ...OPTS, fetchFn: bodyFetch });
+    expect(bodyResult.status === 'rate_limited' && bodyResult.retryAfterSeconds).toBe(7);
+
+    const headerFetch = vi.fn().mockResolvedValue(
+      jsonResponse(429, { status: 'rate_limited' }, { 'Retry-After': '11' }),
+    );
+    const headerResult = await pollSessionOnce({ ...OPTS, fetchFn: headerFetch });
+    expect(headerResult.status === 'rate_limited' && headerResult.retryAfterSeconds).toBe(11);
+  });
+
+  it('returns unreachable on fetch rejection', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    expect((await pollSessionOnce({ ...OPTS, fetchFn })).status).toBe('unreachable');
+  });
+
+  it('maps malformed JSON to internal_error carrying raw body', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response('<html>oops</html>', { status: 200 }));
+    const result = await pollSessionOnce({ ...OPTS, fetchFn });
+    expect(result.status).toBe('internal_error');
+    if (result.status === 'internal_error') expect(result.message).toContain('oops');
+  });
+
+  it('uses the error dialect message based on HTTP status', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(400, { error: 'invalid session id' }));
+    const result = await pollSessionOnce({ ...OPTS, fetchFn });
+    expect(result.status).toBe('internal_error');
+    if (result.status === 'internal_error') expect(result.message).toBe('invalid session id');
+  });
+
+  it('surfaces unknown server statuses without collapsing them', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, { status: 'wat' }));
+    const result = await pollSessionOnce({ ...OPTS, fetchFn });
+    expect(result.status).toBe('unknown');
+    if (result.status === 'unknown') expect(result.serverStatus).toBe('wat');
+  });
+});

--- a/cli/src/__tests__/auth-rotation.test.ts
+++ b/cli/src/__tests__/auth-rotation.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../fsutil.js', async () => {
+  const actual = await vi.importActual<typeof import('../fsutil.js')>('../fsutil.js');
+  return { ...actual, writeFileAtomic: vi.fn(actual.writeFileAtomic) };
+});
+
+import { writeFileAtomic } from '../fsutil.js';
+import { persistTokensTo, updateTokensAt } from '../auth.js';
+
+const API = 'http://localhost:8082';
+const ORIGIN = 'http://localhost:8082';
+const BURNED = { accessToken: 'old', refreshToken: 'r-burned', expiresAt: Date.now() - 1_000 };
+const ROTATED = { accessToken: 'new', refreshToken: 'r-rotated', expiresAt: Date.now() + 900_000 };
+
+async function tokenPath(): Promise<string> {
+  return join(await mkdtemp(join(tmpdir(), 'opslane-rotation-')), 'credentials.json');
+}
+
+describe('updateTokensAt rotation durability', () => {
+  it('drops the pair it could not persist so the burned token is never replayed', async () => {
+    const path = await tokenPath();
+    await persistTokensTo(path, API, BURNED);
+
+    // The server has already consumed r-burned by the time the write is
+    // attempted, so failing to store r-rotated must not leave r-burned behind.
+    vi.mocked(writeFileAtomic).mockRejectedValueOnce(new Error('ENOSPC'));
+
+    await expect(updateTokensAt(path, API, async () => ROTATED)).rejects.toThrow('ENOSPC');
+
+    const onDisk = JSON.parse(await readFile(path, 'utf8'));
+    expect(onDisk.tokens[ORIGIN]).toBeUndefined();
+    expect(JSON.stringify(onDisk)).not.toContain('r-burned');
+    expect(JSON.stringify(onDisk)).not.toContain('r-rotated');
+  });
+
+  it('leaves the stored pair intact when the write succeeds', async () => {
+    const path = await tokenPath();
+    await persistTokensTo(path, API, BURNED);
+
+    await expect(updateTokensAt(path, API, async () => ROTATED))
+      .resolves.toMatchObject({ refreshToken: 'r-rotated' });
+
+    const onDisk = JSON.parse(await readFile(path, 'utf8'));
+    expect(onDisk.tokens[ORIGIN]).toMatchObject({ refreshToken: 'r-rotated' });
+  });
+});

--- a/cli/src/__tests__/envfile.test.ts
+++ b/cli/src/__tests__/envfile.test.ts
@@ -1,0 +1,73 @@
+import { chmod, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { writeEnvLocal } from '../envfile.js';
+
+async function dir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'opslane-env-'));
+}
+
+async function mode(path: string): Promise<number> {
+  return (await stat(path)).mode & 0o777;
+}
+
+describe('writeEnvLocal', () => {
+  it('creates .env.local with mode 0600 and returns the path', async () => {
+    const d = await dir();
+    const path = await writeEnvLocal(d, { VITE_OPSLANE_API_KEY: 'opk_1' });
+    expect(path).toBe(join(d, '.env.local'));
+    expect(await readFile(path, 'utf8')).toBe('VITE_OPSLANE_API_KEY=opk_1\n');
+    expect(await mode(path)).toBe(0o600);
+  });
+
+  it('appends missing keys without touching existing lines', async () => {
+    const d = await dir();
+    await writeFile(join(d, '.env.local'), 'EXISTING=1\n');
+    await writeEnvLocal(d, { VITE_OPSLANE_ENDPOINT: 'http://x' });
+    expect(await readFile(join(d, '.env.local'), 'utf8'))
+      .toBe('EXISTING=1\nVITE_OPSLANE_ENDPOINT=http://x\n');
+  });
+
+  it('replaces an existing value for the same key', async () => {
+    const d = await dir();
+    await writeFile(join(d, '.env.local'), 'VITE_OPSLANE_API_KEY=old\nOTHER=2\n');
+    await writeEnvLocal(d, { VITE_OPSLANE_API_KEY: 'new' });
+    expect(await readFile(join(d, '.env.local'), 'utf8'))
+      .toBe('VITE_OPSLANE_API_KEY=new\nOTHER=2\n');
+  });
+
+  it('tightens a pre-existing 0644 file to 0600', async () => {
+    const d = await dir();
+    const path = join(d, '.env.local');
+    await writeFile(path, 'A=1\n');
+    await chmod(path, 0o644);
+    await writeEnvLocal(d, { VITE_OPSLANE_API_KEY: 'k' });
+    expect(await mode(path)).toBe(0o600);
+  });
+
+  it('adds .env.local to the dir gitignore exactly once', async () => {
+    const d = await dir();
+    await writeEnvLocal(d, { A_B: '1' });
+    await writeEnvLocal(d, { A_B: '2' });
+    const lines = (await readFile(join(d, '.gitignore'), 'utf8'))
+      .split('\n')
+      .filter((line) => line === '.env.local');
+    expect(lines).toHaveLength(1);
+  });
+
+  it('rejects var names failing the regex', async () => {
+    const d = await dir();
+    await expect(writeEnvLocal(d, { lower_case: 'x' }))
+      .rejects.toThrow(/variable name/);
+    await expect(writeEnvLocal(d, { 'A=B\nINJECTED': 'x' }))
+      .rejects.toThrow(/variable name/);
+  });
+
+  it('rejects values that could inject another dotenv line', async () => {
+    const d = await dir();
+    await expect(writeEnvLocal(d, {
+      VITE_OPSLANE_ENDPOINT: 'http://localhost\nINJECTED=1',
+    })).rejects.toThrow(/line breaks/);
+  });
+});

--- a/cli/src/__tests__/fsutil.test.ts
+++ b/cli/src/__tests__/fsutil.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, open, readFile, stat, utimes } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { withFileLock, writeFileAtomic } from '../fsutil.js';
+
+async function target(): Promise<string> {
+  return join(await mkdtemp(join(tmpdir(), 'opslane-fsutil-')), 'credentials.json');
+}
+
+describe('withFileLock', () => {
+  it('reclaims a lock stranded by a run that was interrupted mid-hold', async () => {
+    const path = await target();
+    const lockPath = `${path}.lock`;
+    // A `finally` never runs when a signal kills the process, so the lock the
+    // dead run took is still on disk. Age it past the stale threshold.
+    await (await open(lockPath, 'wx', 0o600)).close();
+    const longAgo = new Date(Date.now() - 5 * 60_000);
+    await utimes(lockPath, longAgo, longAgo);
+
+    const started = Date.now();
+    await withFileLock(path, async () => writeFileAtomic(path, 'ok\n'));
+
+    expect(await readFile(path, 'utf8')).toBe('ok\n');
+    expect(Date.now() - started).toBeLessThan(5_000);
+    await expect(stat(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('serializes concurrent holders rather than reclaiming a live lock', async () => {
+    const path = await target();
+    const order: string[] = [];
+
+    async function hold(label: string): Promise<void> {
+      await withFileLock(path, async () => {
+        order.push(`${label}:enter`);
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        order.push(`${label}:exit`);
+      });
+    }
+
+    await Promise.all([hold('a'), hold('b')]);
+
+    // Never interleaved: each holder exits before the other enters.
+    expect(order).toHaveLength(4);
+    expect(order[1]).toBe(`${order[0]!.split(':')[0]}:exit`);
+    expect(order[3]).toBe(`${order[2]!.split(':')[0]}:exit`);
+  });
+
+  it('releases the lock even when the operation throws', async () => {
+    const path = await target();
+    await expect(withFileLock(path, async () => { throw new Error('boom'); }))
+      .rejects.toThrow('boom');
+    await expect(stat(`${path}.lock`)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/cli/src/__tests__/login.test.ts
+++ b/cli/src/__tests__/login.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, readFile, stat, rm, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -9,6 +9,8 @@ import {
   clearTokensAt,
   type TokenPair,
 } from '../auth.js';
+import { login } from '../login.js';
+import { LoginFailedError } from '../onboard/errors.js';
 
 describe('generatePKCE', () => {
   it('produces a code_verifier between 43 and 128 characters', () => {
@@ -40,6 +42,51 @@ describe('generatePKCE', () => {
     const { codeChallenge } = generatePKCE();
     // SHA256 = 32 bytes = 43 chars in base64url (without padding)
     expect(codeChallenge.length).toBe(43);
+  });
+});
+
+describe('login embedding contract', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    process.exitCode = undefined;
+  });
+
+  it('throws LoginFailedError instead of poisoning process.exitCode', async () => {
+    process.exitCode = undefined;
+    await expect(login({
+      apiUrl: 'http://localhost:8082',
+      clientId: 'test',
+      quiet: true,
+      waitForCallbackFn: vi.fn().mockRejectedValue(new Error('OAuth error: access_denied')),
+    })).rejects.toBeInstanceOf(LoginFailedError);
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('quiet mode emits no output on success and persists to the injected path', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'opslane-login-'));
+    const tokenPath = join(directory, 'credentials.json');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      access_token: 'access',
+      refresh_token: 'refresh',
+      expires_in: 900,
+    }), { status: 200 })));
+
+    await login({
+      apiUrl: 'http://localhost:8082',
+      clientId: 'test',
+      tokenPath,
+      quiet: true,
+      waitForCallbackFn: vi.fn().mockResolvedValue('oauth-code'),
+    });
+
+    expect(log).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+    await expect(loadTokensFrom(tokenPath, 'http://localhost:8082'))
+      .resolves.toMatchObject({ accessToken: 'access' });
+    await rm(directory, { recursive: true, force: true });
   });
 });
 

--- a/cli/src/__tests__/pending.test.ts
+++ b/cli/src/__tests__/pending.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtemp, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { deletePendingSession, loadPendingSession, savePendingSession } from '../pending.js';
+import {
+  deletePendingSession,
+  findPendingByRepo,
+  loadPendingSession,
+  savePendingSession,
+  type PendingSession,
+} from '../pending.js';
 
 const pollId = '123e4567-e89b-42d3-a456-426614174000';
 
@@ -37,5 +43,85 @@ describe('pending session store', () => {
       poll_id: '../evil', poll_token: 'x', api_url: 'https://api.opslane.com',
       repo: 'a/b', created_at: new Date().toISOString(),
     }, directory)).rejects.toThrow('UUID');
+  });
+});
+
+const API = 'http://localhost:8082';
+const ids = [
+  '123e4567-e89b-42d3-a456-426614174001',
+  '123e4567-e89b-42d3-a456-426614174002',
+  '123e4567-e89b-42d3-a456-426614174003',
+];
+
+function onboardSession(
+  id: string,
+  overrides: Partial<PendingSession> = {},
+): PendingSession {
+  return {
+    kind: 'onboard',
+    poll_id: id,
+    poll_token: 'token',
+    api_url: API,
+    repo: 'Acme/Web',
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('findPendingByRepo', () => {
+  let directory: string;
+  beforeEach(async () => { directory = await mkdtemp(join(tmpdir(), 'opslane-find-pending-')); });
+  afterEach(async () => rm(directory, { recursive: true, force: true }));
+
+  it('returns null when nothing matches', async () => {
+    await expect(findPendingByRepo(API, 'acme/web', directory)).resolves.toBeNull();
+  });
+
+  it('matches repo case-insensitively and origin canonically', async () => {
+    await savePendingSession(onboardSession(ids[0]!, {
+      api_url: 'HTTP://LOCALHOST:8082/path',
+    }), directory);
+    await expect(findPendingByRepo(API, 'acme/web', directory))
+      .resolves.toMatchObject({ poll_id: ids[0] });
+  });
+
+  it('does not match another origin', async () => {
+    await savePendingSession(onboardSession(ids[0]!, {
+      api_url: 'http://other:9000',
+    }), directory);
+    await expect(findPendingByRepo(API, 'acme/web', directory)).resolves.toBeNull();
+  });
+
+  it('leaves legacy and setup-kind sessions untouched', async () => {
+    await savePendingSession(onboardSession(ids[0]!, { kind: undefined }), directory);
+    await savePendingSession(onboardSession(ids[1]!, { kind: 'setup' }), directory);
+    await expect(findPendingByRepo(API, 'acme/web', directory)).resolves.toBeNull();
+    await expect(loadPendingSession(ids[0]!, directory)).resolves.not.toBeNull();
+    await expect(loadPendingSession(ids[1]!, directory)).resolves.not.toBeNull();
+  });
+
+  it('returns the newest match and deletes older duplicates', async () => {
+    await savePendingSession(onboardSession(ids[0]!, {
+      created_at: new Date(Date.now() - 60 * 60_000).toISOString(),
+    }), directory);
+    await savePendingSession(onboardSession(ids[1]!), directory);
+    await expect(findPendingByRepo(API, 'acme/web', directory))
+      .resolves.toMatchObject({ poll_id: ids[1] });
+    await expect(loadPendingSession(ids[0]!, directory)).resolves.toBeNull();
+  });
+
+  it('prunes expired matches', async () => {
+    await savePendingSession(onboardSession(ids[0]!, {
+      created_at: new Date(Date.now() - 25 * 60 * 60_000).toISOString(),
+    }), directory);
+    await expect(findPendingByRepo(API, 'acme/web', directory)).resolves.toBeNull();
+    await expect(loadPendingSession(ids[0]!, directory)).resolves.toBeNull();
+  });
+
+  it('skips malformed files while finding a valid match', async () => {
+    await writeFile(join(directory, `${ids[0]}.json`), 'not json');
+    await savePendingSession(onboardSession(ids[1]!), directory);
+    await expect(findPendingByRepo(API, 'acme/web', directory))
+      .resolves.toMatchObject({ poll_id: ids[1] });
   });
 });

--- a/cli/src/agent-protocol.ts
+++ b/cli/src/agent-protocol.ts
@@ -1,0 +1,161 @@
+/**
+ * Shared wire protocol for GET /api/v1/agent/poll/{sessionId}.
+ *
+ * This seam preserves the server's status vocabulary. Callers are responsible
+ * for translating it into their own user-facing states.
+ */
+import { canonicalOrigin } from './origin.js';
+
+export type ServerPollStatus =
+  | 'pending'
+  | 'provisioned'
+  | 'key_ok'
+  | 'app_reporting'
+  | 'completed'
+  | 'failed'
+  | 'not_found'
+  | 'expired'
+  | 'rate_limited'
+  | 'internal_error';
+
+const KNOWN_STATUSES: ReadonlySet<string> = new Set([
+  'pending',
+  'provisioned',
+  'key_ok',
+  'app_reporting',
+  'completed',
+  'failed',
+  'not_found',
+  'expired',
+  'rate_limited',
+  'internal_error',
+]);
+
+export interface PollPayload {
+  apiKey: string | null;
+  orgId: string | null;
+  projectId: string | null;
+  repo: string | null;
+  message: string | null;
+  failureReason: string | null;
+  retryAfterSeconds: number | null;
+}
+
+export type PollResult =
+  | ({ status: ServerPollStatus } & PollPayload)
+  | ({ status: 'unknown'; serverStatus: string } & PollPayload)
+  | { status: 'unreachable'; error: string };
+
+export interface PollSessionOptions {
+  apiUrl: string;
+  sessionId: string;
+  pollToken: string;
+  fetchFn?: typeof fetch;
+  signal?: AbortSignal;
+}
+
+export type JsonBody = Record<string, unknown>;
+
+export async function responseJSON(response: Response): Promise<JsonBody | null> {
+  try {
+    const value: unknown = await response.json();
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? value as JsonBody
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function retryAfterSeconds(response: Response, body: JsonBody): number {
+  const bodyValue = Number(body['retry_after']);
+  if (Number.isFinite(bodyValue) && bodyValue > 0) return bodyValue;
+  const headerValue = Number(response.headers.get('Retry-After'));
+  return Number.isFinite(headerValue) && headerValue > 0 ? headerValue : 60;
+}
+
+function str(body: JsonBody, key: string): string | null {
+  return typeof body[key] === 'string' ? body[key] : null;
+}
+
+function payload(response: Response, body: JsonBody): PollPayload {
+  return {
+    apiKey: str(body, 'api_key'),
+    orgId: str(body, 'org_id'),
+    projectId: str(body, 'project_id'),
+    repo: str(body, 'repo'),
+    message: str(body, 'message'),
+    failureReason: str(body, 'failure_reason'),
+    retryAfterSeconds: retryAfterSeconds(response, body),
+  };
+}
+
+const EMPTY: PollPayload = {
+  apiKey: null,
+  orgId: null,
+  projectId: null,
+  repo: null,
+  message: null,
+  failureReason: null,
+  retryAfterSeconds: null,
+};
+
+function statusFromHTTP(code: number): ServerPollStatus {
+  if (code === 404) return 'not_found';
+  if (code === 410) return 'expired';
+  if (code === 429) return 'rate_limited';
+  return 'internal_error';
+}
+
+export async function pollSessionOnce(options: PollSessionOptions): Promise<PollResult> {
+  const fetchFn = options.fetchFn ?? fetch;
+  let response: Response;
+  try {
+    response = await fetchFn(
+      `${canonicalOrigin(options.apiUrl)}/api/v1/agent/poll/${encodeURIComponent(options.sessionId)}`,
+      {
+        headers: { 'X-Opslane-Poll-Token': options.pollToken },
+        signal: options.signal,
+      },
+    );
+  } catch (error) {
+    return {
+      status: 'unreachable',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const raw = await response.clone().text().catch(() => '');
+  const body = await responseJSON(response);
+  if (!body) {
+    return {
+      status: 'internal_error',
+      ...EMPTY,
+      message: `unparseable server response: ${raw.slice(0, 200)}`,
+    };
+  }
+
+  const serverStatus = str(body, 'status');
+  if (!response.ok) {
+    return {
+      status: statusFromHTTP(response.status),
+      ...payload(response, body),
+      message: str(body, 'message') ?? str(body, 'error')
+        ?? (serverStatus
+          ? `server said ${JSON.stringify(serverStatus)} with HTTP ${response.status}`
+          : `unexpected response (HTTP ${response.status})`),
+    };
+  }
+
+  if (!serverStatus) {
+    return {
+      status: 'internal_error',
+      ...EMPTY,
+      message: str(body, 'error') ?? 'response omitted status',
+    };
+  }
+  if (!KNOWN_STATUSES.has(serverStatus)) {
+    return { status: 'unknown', serverStatus, ...payload(response, body) };
+  }
+  return { status: serverStatus as ServerPollStatus, ...payload(response, body) };
+}

--- a/cli/src/auth.ts
+++ b/cli/src/auth.ts
@@ -100,6 +100,27 @@ export async function loadTokensFrom(
   return tokens;
 }
 
+/**
+ * Serialized read-modify-write over one origin's token pair. The callback sees
+ * expired pairs too, allowing refresh-token rotation to remain atomic.
+ */
+export async function updateTokensAt(
+  filePath: string,
+  apiUrl: string,
+  update: (current: TokenPair | null) => Promise<TokenPair | null>,
+): Promise<TokenPair | null> {
+  return withFileLock(filePath, async () => {
+    const file = await readTokenFile(filePath, false);
+    const origin = canonicalOrigin(apiUrl);
+    const next = await update(file.tokens[origin] ?? null);
+    if (next) {
+      file.tokens[origin] = next;
+      await writeFileAtomic(filePath, `${JSON.stringify(file, null, 2)}\n`);
+    }
+    return next;
+  });
+}
+
 export async function clearTokensAt(filePath: string, apiUrl?: string): Promise<void> {
   if (!apiUrl) {
     await unlink(filePath).catch((error: NodeJS.ErrnoException) => {

--- a/cli/src/auth.ts
+++ b/cli/src/auth.ts
@@ -103,6 +103,10 @@ export async function loadTokensFrom(
 /**
  * Serialized read-modify-write over one origin's token pair. The callback sees
  * expired pairs too, allowing refresh-token rotation to remain atomic.
+ *
+ * The callback must stay fast: it runs under the lock, whose acquisition
+ * timeout is short (see fsutil LOCK_TIMEOUT_MS). Do network work before
+ * calling this and reconcile inside the callback.
  */
 export async function updateTokensAt(
   filePath: string,
@@ -115,7 +119,19 @@ export async function updateTokensAt(
     const next = await update(file.tokens[origin] ?? null);
     if (next) {
       file.tokens[origin] = next;
-      await writeFileAtomic(filePath, `${JSON.stringify(file, null, 2)}\n`);
+      try {
+        await writeFileAtomic(filePath, `${JSON.stringify(file, null, 2)}\n`);
+      } catch (error) {
+        // The server consumes a refresh token the moment it answers, so a pair
+        // we failed to persist leaves a burned token on disk. Replaying it next
+        // run reads as a stolen-token replay and revokes the whole family,
+        // including the user's dashboard session. Drop the entry so the next
+        // run opens a clean login instead.
+        delete file.tokens[origin];
+        await writeFileAtomic(filePath, `${JSON.stringify(file, null, 2)}\n`)
+          .catch(() => undefined);
+        throw error;
+      }
     }
     return next;
   });

--- a/cli/src/envfile.ts
+++ b/cli/src/envfile.ts
@@ -1,0 +1,58 @@
+/**
+ * The single place a provisioned API key touches disk. Names come from the
+ * agent's validated OnboardingPlan (tools.ts validatePlan); values come from
+ * provisioning. Atomic write (fsutil), 0600 always.
+ */
+import { chmod, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { writeFileAtomic } from './fsutil.js';
+
+const ENV_VAR_NAME = /^[A-Z][A-Z0-9_]*$/;
+
+export async function writeEnvLocal(
+  dir: string,
+  vars: Record<string, string>,
+): Promise<string> {
+  for (const name of Object.keys(vars)) {
+    if (!ENV_VAR_NAME.test(name)) {
+      throw new Error(`invalid environment variable name: ${JSON.stringify(name)}`);
+    }
+    if (/[\r\n]/.test(vars[name] ?? '')) {
+      throw new Error(`invalid environment variable value for ${name}: line breaks are not allowed`);
+    }
+  }
+
+  const envPath = join(dir, '.env.local');
+  let current = '';
+  try {
+    current = await readFile(envPath, 'utf8');
+  } catch {
+    // Create the file below.
+  }
+
+  let next = current;
+  for (const [name, value] of Object.entries(vars)) {
+    const line = `${name}=${value}`;
+    const pattern = new RegExp(`^${name}=.*$`, 'm');
+    next = pattern.test(next)
+      ? next.replace(pattern, line)
+      : `${next}${next && !next.endsWith('\n') ? '\n' : ''}${line}\n`;
+  }
+
+  await writeFileAtomic(envPath, next);
+  await chmod(envPath, 0o600);
+
+  const gitignorePath = join(dir, '.gitignore');
+  let gitignore = '';
+  try {
+    gitignore = await readFile(gitignorePath, 'utf8');
+  } catch {
+    // Create the file below.
+  }
+  if (!gitignore.split(/\r?\n/).includes('.env.local')) {
+    gitignore += `${gitignore && !gitignore.endsWith('\n') ? '\n' : ''}.env.local\n`;
+    await writeFile(gitignorePath, gitignore, 'utf8');
+  }
+
+  return envPath;
+}

--- a/cli/src/fsutil.ts
+++ b/cli/src/fsutil.ts
@@ -1,9 +1,15 @@
 import { randomBytes } from 'node:crypto';
-import { open, mkdir, rename, unlink } from 'node:fs/promises';
+import { open, mkdir, rename, stat, unlink } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 const LOCK_RETRY_MS = 20;
-const LOCK_TIMEOUT_MS = 2_000;
+// Long enough to outwait a legitimate holder: token refresh runs under this
+// lock and is itself bounded (see onboard/provision REFRESH_TIMEOUT_MS).
+const LOCK_TIMEOUT_MS = 45_000;
+// A lock older than this belongs to a process that died without releasing it.
+// Kept above the longest legitimate hold and below LOCK_TIMEOUT_MS so a waiter
+// reclaims the lock instead of giving up on it.
+const LOCK_STALE_MS = 30_000;
 
 export async function writeFileAtomic(
   filePath: string,
@@ -24,6 +30,17 @@ export async function writeFileAtomic(
   } catch (error) {
     await unlink(tempPath).catch(() => undefined);
     throw error;
+  }
+}
+
+async function reclaimIfStale(lockPath: string): Promise<void> {
+  try {
+    const { mtimeMs } = await stat(lockPath);
+    if (Date.now() - mtimeMs > LOCK_STALE_MS) {
+      await unlink(lockPath);
+    }
+  } catch {
+    // Already gone, or not ours to reclaim. The retry loop handles both.
   }
 }
 
@@ -49,6 +66,12 @@ export async function withFileLock<T>(
       if (code !== 'EEXIST' || Date.now() >= deadline) {
         throw error;
       }
+      // The release path is a `finally`, which a signal skips, so an
+      // interrupted run can strand the lock and wedge every later write.
+      // Reclaim one that is far older than any legitimate hold. Losing this
+      // race just means another waiter took the lock first, and the retry
+      // below sees it.
+      await reclaimIfStale(lockPath);
       await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_MS));
     }
   }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,6 +12,7 @@ import { status } from './status.js';
 import { listErrors, getError } from './errors.js';
 import { AGENT_STATUSES } from './contract.js';
 import { jsonOutput } from './output.js';
+import chalk from 'chalk';
 
 // Derive the version from package.json so Changesets bumps propagate to
 // `opslane --version` without a hand edit (dist/index.js -> ../package.json).
@@ -36,10 +37,18 @@ program
   .command('login')
   .description('Authenticate with Opslane and connect GitHub')
   .option('--api-url <url>', 'Opslane API URL')
-  .action((opts: { apiUrl?: string }) => login({
-    apiUrl: opts.apiUrl ?? process.env['OPSLANE_API_URL'] ?? 'https://api.opslane.com',
-    clientId: process.env['OPSLANE_CLIENT_ID'] ?? 'opslane-cli',
-  }));
+  .action(async (opts: { apiUrl?: string }) => {
+    try {
+      await login({
+        apiUrl: opts.apiUrl ?? process.env['OPSLANE_API_URL'] ?? 'https://api.opslane.com',
+        clientId: process.env['OPSLANE_CLIENT_ID'] ?? 'opslane-cli',
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(chalk.red(`\nLogin failed: ${message}`));
+      process.exitCode = 1;
+    }
+  });
 
 program
   .command('init')
@@ -130,4 +139,4 @@ errorsCmd
     await getError(id, opts);
   });
 
-program.parse();
+await program.parseAsync(process.argv);

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -1,4 +1,4 @@
-import { chmod, readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
@@ -6,6 +6,7 @@ import { detectFramework, type Framework } from './detect.js';
 import { getCodemod } from './codemods/registry.js';
 import { generateFallbackPatches } from './ai-fallback.js';
 import type { FilePatch } from './codemods/types.js';
+import { writeEnvLocal } from './envfile.js';
 
 /**
  * Format patches as a human-readable diff preview.
@@ -106,25 +107,7 @@ function apiKeyEnvironmentVariable(framework: Framework): string {
 }
 
 async function persistApiKeyEnvironment(cwd: string, framework: Framework, apiKey: string): Promise<void> {
-  const envPath = join(cwd, '.env.local');
-  const variable = apiKeyEnvironmentVariable(framework);
-  let current = '';
-  try { current = await readFile(envPath, 'utf8'); } catch { /* create below */ }
-  const line = `${variable}=${apiKey}`;
-  const pattern = new RegExp(`^${variable}=.*$`, 'm');
-  const next = pattern.test(current)
-    ? current.replace(pattern, line)
-    : `${current}${current && !current.endsWith('\n') ? '\n' : ''}${line}\n`;
-  await writeFile(envPath, next, { encoding: 'utf8', mode: 0o600 });
-  await chmod(envPath, 0o600);
-
-  const gitignorePath = join(cwd, '.gitignore');
-  let gitignore = '';
-  try { gitignore = await readFile(gitignorePath, 'utf8'); } catch { /* create below */ }
-  if (!gitignore.split(/\r?\n/).includes('.env.local')) {
-    gitignore += `${gitignore && !gitignore.endsWith('\n') ? '\n' : ''}.env.local\n`;
-    await writeFile(gitignorePath, gitignore, 'utf8');
-  }
+  await writeEnvLocal(cwd, { [apiKeyEnvironmentVariable(framework)]: apiKey });
 }
 
 /**

--- a/cli/src/login.ts
+++ b/cli/src/login.ts
@@ -2,13 +2,15 @@ import { randomBytes } from 'node:crypto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import chalk from 'chalk';
 import {
+  defaultTokenPath,
   generatePKCE,
-  persistTokens,
+  persistTokensTo,
   type AuthConfig,
   type TokenPair,
 } from './auth.js';
 import { defaultApiUrl } from './config.js';
 import { canonicalOrigin } from './origin.js';
+import { LoginFailedError } from './onboard/errors.js';
 
 function defaultAuthConfig(): AuthConfig {
   return {
@@ -119,9 +121,13 @@ function waitForCallback(port: number, expectedState: string): Promise<string> {
 /**
  * Run the PKCE-based login flow.
  */
-export async function login(
-  config: AuthConfig = defaultAuthConfig(),
-): Promise<void> {
+export interface LoginOptions extends AuthConfig {
+  tokenPath?: string;
+  quiet?: boolean;
+  waitForCallbackFn?: (port: number, expectedState: string) => Promise<string>;
+}
+
+export async function login(config: LoginOptions = defaultAuthConfig()): Promise<void> {
   const apiUrl = canonicalOrigin(config.apiUrl);
   const { codeVerifier, codeChallenge } = generatePKCE();
   const state = randomBytes(16).toString('hex');
@@ -140,15 +146,19 @@ export async function login(
     `&state=${encodeURIComponent(state)}`,
   ].join('');
 
-  console.log(chalk.bold('\nOpslane Login\n'));
-  console.log('Open this URL in your browser to authenticate:\n');
-  console.log(chalk.cyan(authUrl));
-  console.log('\nWaiting for authentication...\n');
+  if (!config.quiet) {
+    console.log(chalk.bold('\nOpslane Login\n'));
+    console.log('Open this URL in your browser to authenticate:\n');
+    console.log(chalk.cyan(authUrl));
+    console.log('\nWaiting for authentication...\n');
+  }
 
   try {
-    const code = await waitForCallback(port, state);
+    const code = await (config.waitForCallbackFn ?? waitForCallback)(port, state);
 
-    console.log(chalk.dim('Exchanging authorization code for tokens...'));
+    if (!config.quiet) {
+      console.log(chalk.dim('Exchanging authorization code for tokens...'));
+    }
 
     const tokens = await exchangeCode(
       apiUrl,
@@ -158,14 +168,15 @@ export async function login(
       redirectUri,
     );
 
-    await persistTokens(apiUrl, tokens);
+    await persistTokensTo(config.tokenPath ?? defaultTokenPath(), apiUrl, tokens);
 
-    console.log(
-      chalk.green('\nLogin successful! Credentials saved to ~/.opslane/credentials.json'),
-    );
+    if (!config.quiet) {
+      console.log(
+        chalk.green('\nLogin successful! Credentials saved to ~/.opslane/credentials.json'),
+      );
+    }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(chalk.red(`\nLogin failed: ${message}`));
-    process.exitCode = 1;
+    throw new LoginFailedError(message);
   }
 }

--- a/cli/src/onboard/__tests__/provision.test.ts
+++ b/cli/src/onboard/__tests__/provision.test.ts
@@ -243,6 +243,27 @@ describe('ensureProvisioned', () => {
     expect(sleepFn).toHaveBeenCalledWith(5_000);
   });
 
+  it('caps a hostile retry_after instead of parking the CLI', async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(response(429, { status: 'rate_limited', retry_after: 86_400 }))
+      .mockResolvedValueOnce(response(201, PROVISIONED));
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    await expect(ensureProvisioned(await base({ fetchFn, sleepFn }))).resolves.toBeDefined();
+    expect(sleepFn).toHaveBeenCalledWith(60_000);
+  });
+
+  it('caps a hostile Retry-After header too', async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: 'rate_limited' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json', 'Retry-After': '999999' },
+      }))
+      .mockResolvedValueOnce(response(201, PROVISIONED));
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    await expect(ensureProvisioned(await base({ fetchFn, sleepFn }))).resolves.toBeDefined();
+    expect(sleepFn).toHaveBeenCalledWith(60_000);
+  });
+
   it('does not retry an ambiguous network failure on POST', async () => {
     const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
     const sleepFn = vi.fn();

--- a/cli/src/onboard/__tests__/provision.test.ts
+++ b/cli/src/onboard/__tests__/provision.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { persistTokensTo } from '../../auth.js';
+import {
+  loadAgentCredentials,
+} from '../../agent-credentials.js';
+import {
+  loadPendingSession,
+  savePendingSession,
+} from '../../pending.js';
+import {
+  ensureLoggedIn,
+  ensureProvisioned,
+  type EnsureProvisionedOptions,
+} from '../provision.js';
+import {
+  ApiUnreachableError,
+  LoginFailedError,
+  NotAuthenticatedError,
+  NotAuthorizedError,
+} from '../errors.js';
+
+const API = 'http://localhost:8082';
+const LIVE = {
+  accessToken: 'live',
+  refreshToken: 'r1',
+  expiresAt: Date.now() + 3_600_000,
+};
+const DEAD = {
+  accessToken: 'dead',
+  refreshToken: 'r2',
+  expiresAt: Date.now() - 1_000,
+};
+const PROVISIONED = {
+  status: 'provisioned',
+  api_key: 'opk_raw',
+  endpoint: API,
+  org_id: 'org1',
+  project_id: 'proj1',
+  repo: 'acme/web',
+  poll_id: '123e4567-e89b-42d3-a456-426614174000',
+  poll_token: 'ptok',
+};
+const OLD_ID = '123e4567-e89b-42d3-a456-426614174001';
+
+function response(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function tokenFile(pair?: typeof LIVE): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'opslane-auth-'));
+  const path = join(directory, 'credentials.json');
+  if (pair) await persistTokensTo(path, API, pair);
+  return path;
+}
+
+async function paths(): Promise<{ pendingDir: string; credentialsPath: string }> {
+  const directory = await mkdtemp(join(tmpdir(), 'opslane-provision-'));
+  return {
+    pendingDir: join(directory, 'pending'),
+    credentialsPath: join(directory, 'agent-credentials.json'),
+  };
+}
+
+async function base(
+  overrides: Partial<EnsureProvisionedOptions> = {},
+): Promise<EnsureProvisionedOptions> {
+  return {
+    apiUrl: API,
+    repo: 'acme/web',
+    token: 'bearer1',
+    ...(await paths()),
+    ...overrides,
+  };
+}
+
+async function seedPending(options: EnsureProvisionedOptions): Promise<void> {
+  await savePendingSession({
+    kind: 'onboard',
+    poll_id: OLD_ID,
+    poll_token: 'old-token',
+    api_url: API,
+    repo: 'acme/web',
+    created_at: new Date().toISOString(),
+  }, options.pendingDir);
+}
+
+describe('ensureLoggedIn', () => {
+  it('returns a live token without refresh or login', async () => {
+    const tokenPath = await tokenFile(LIVE);
+    const loginFn = vi.fn();
+    const fetchFn = vi.fn();
+    await expect(ensureLoggedIn({ apiUrl: API, tokenPath, loginFn, fetchFn }))
+      .resolves.toMatchObject({ accessToken: 'live' });
+    expect(loginFn).not.toHaveBeenCalled();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('refreshes an expired token before opening login', async () => {
+    const tokenPath = await tokenFile(DEAD);
+    const loginFn = vi.fn();
+    const fetchFn = vi.fn().mockResolvedValue(response(200, {
+      access_token: 'fresh',
+      refresh_token: 'r3',
+      expires_in: 900,
+    }));
+    await expect(ensureLoggedIn({ apiUrl: API, tokenPath, loginFn, fetchFn }))
+      .resolves.toMatchObject({ accessToken: 'fresh' });
+    expect(loginFn).not.toHaveBeenCalled();
+    const [url, init] = fetchFn.mock.calls[0]!;
+    expect(url).toBe(`${API}/auth/refresh`);
+    expect(JSON.parse(init.body as string)).toEqual({ refresh_token: 'r2' });
+  });
+
+  it('falls back to login once after refresh rejection', async () => {
+    const tokenPath = await tokenFile(DEAD);
+    const fetchFn = vi.fn().mockResolvedValue(response(401, { error: 'expired' }));
+    const loginFn = vi.fn(async () => persistTokensTo(tokenPath, API, LIVE));
+    await expect(ensureLoggedIn({ apiUrl: API, tokenPath, loginFn, fetchFn }))
+      .resolves.toMatchObject({ accessToken: 'live' });
+    expect(loginFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when login produces no live token', async () => {
+    const tokenPath = await tokenFile();
+    const loginFn = vi.fn(async () => undefined);
+    await expect(ensureLoggedIn({ apiUrl: API, tokenPath, loginFn, fetchFn: vi.fn() }))
+      .rejects.toBeInstanceOf(LoginFailedError);
+    expect(loginFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes concurrent refreshes so the refresh token is consumed once', async () => {
+    const tokenPath = await tokenFile(DEAD);
+    const fetchFn = vi.fn().mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return response(200, {
+        access_token: 'fresh',
+        refresh_token: 'r3',
+        expires_in: 900,
+      });
+    });
+    const loginFn = vi.fn();
+    const [first, second] = await Promise.all([
+      ensureLoggedIn({ apiUrl: API, tokenPath, loginFn, fetchFn }),
+      ensureLoggedIn({ apiUrl: API, tokenPath, loginFn, fetchFn }),
+    ]);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(first.accessToken).toBe('fresh');
+    expect(second.accessToken).toBe('fresh');
+    expect(loginFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('ensureProvisioned', () => {
+  it('POSTs, saves onboard pending state and credentials, and returns the tuple', async () => {
+    const options = await base({
+      fetchFn: vi.fn().mockResolvedValue(response(201, PROVISIONED)),
+    });
+    const result = await ensureProvisioned(options);
+    expect(result).toMatchObject({
+      apiKey: 'opk_raw',
+      endpoint: API,
+      orgId: 'org1',
+      projectId: 'proj1',
+      sessionId: PROVISIONED.poll_id,
+      pollToken: 'ptok',
+    });
+    const fetchFn = options.fetchFn as ReturnType<typeof vi.fn>;
+    const [url, init] = fetchFn.mock.calls[0]!;
+    expect(url).toBe(`${API}/api/v1/onboard/provision`);
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer bearer1');
+    await expect(loadPendingSession(PROVISIONED.poll_id, options.pendingDir))
+      .resolves.toMatchObject({ kind: 'onboard' });
+    await expect(loadAgentCredentials({
+      apiUrl: API,
+      repo: 'acme/web',
+      filePath: options.credentialsPath,
+    })).resolves.toMatchObject({ api_key: 'opk_raw' });
+  });
+
+  it('polls and reuses a live pending session without POSTing', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response(200, {
+      status: 'key_ok',
+      api_key: 'resumed-key',
+      org_id: 'org1',
+      project_id: 'proj1',
+      repo: 'acme/web',
+    }));
+    const options = await base({ fetchFn });
+    await seedPending(options);
+    await expect(ensureProvisioned(options)).resolves.toMatchObject({
+      apiKey: 'resumed-key',
+      sessionId: OLD_ID,
+      pollToken: 'old-token',
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn.mock.calls[0]?.[0]).toContain(`/api/v1/agent/poll/${OLD_ID}`);
+  });
+
+  it.each([
+    ['expired', response(410, { status: 'expired' })],
+    ['completed without a key', response(200, {
+      status: 'completed',
+      org_id: 'org1',
+      project_id: 'proj1',
+    })],
+  ])('replaces a dead pending session: %s', async (_label, probe) => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(probe)
+      .mockResolvedValueOnce(response(201, PROVISIONED));
+    const options = await base({ fetchFn });
+    await seedPending(options);
+    await expect(ensureProvisioned(options)).resolves.toMatchObject({
+      sessionId: PROVISIONED.poll_id,
+    });
+    await expect(loadPendingSession(OLD_ID, options.pendingDir)).resolves.toBeNull();
+    await expect(loadPendingSession(PROVISIONED.poll_id, options.pendingDir))
+      .resolves.toMatchObject({ kind: 'onboard' });
+  });
+
+  it.each([
+    [401, NotAuthenticatedError],
+    [403, NotAuthorizedError],
+  ])('maps HTTP %s to a typed auth error', async (status, ErrorType) => {
+    const options = await base({
+      fetchFn: vi.fn().mockResolvedValue(response(status, { error: 'denied' })),
+    });
+    await expect(ensureProvisioned(options)).rejects.toBeInstanceOf(ErrorType);
+  });
+
+  it('retries only rate-limited requests using retry_after', async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(response(429, { status: 'rate_limited', retry_after: 5 }))
+      .mockResolvedValueOnce(response(201, PROVISIONED));
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    await expect(ensureProvisioned(await base({ fetchFn, sleepFn }))).resolves.toBeDefined();
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(sleepFn).toHaveBeenCalledWith(5_000);
+  });
+
+  it('does not retry an ambiguous network failure on POST', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const sleepFn = vi.fn();
+    await expect(ensureProvisioned(await base({ fetchFn, sleepFn })))
+      .rejects.toBeInstanceOf(ApiUnreachableError);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it('preserves pending state when its resume probe is unreachable', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const options = await base({ fetchFn });
+    await seedPending(options);
+    await expect(ensureProvisioned(options)).rejects.toBeInstanceOf(ApiUnreachableError);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    await expect(loadPendingSession(OLD_ID, options.pendingDir)).resolves.not.toBeNull();
+  });
+
+  it.each([
+    ['rate limited', response(429, { status: 'rate_limited', retry_after: 7 })],
+    ['server error', response(500, { status: 'internal_error', message: 'try later' })],
+    ['still pending', response(200, { status: 'pending' })],
+    ['unknown', response(200, { status: 'future_status' })],
+  ])('preserves pending state instead of rotating when the probe is %s', async (_label, probe) => {
+    const fetchFn = vi.fn().mockResolvedValue(probe);
+    const options = await base({ fetchFn });
+    await seedPending(options);
+    await expect(ensureProvisioned(options)).rejects.toThrow(/safely resume/);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    await expect(loadPendingSession(OLD_ID, options.pendingDir)).resolves.not.toBeNull();
+  });
+
+  it('rejects incomplete success responses without saving credentials', async () => {
+    const options = await base({
+      fetchFn: vi.fn().mockResolvedValue(response(201, {
+        ...PROVISIONED,
+        org_id: undefined,
+      })),
+    });
+    await expect(ensureProvisioned(options)).rejects.toThrow(/omitted required credentials/);
+    await expect(loadAgentCredentials({
+      apiUrl: API,
+      repo: 'acme/web',
+      filePath: options.credentialsPath,
+    })).resolves.toBeNull();
+  });
+});

--- a/cli/src/onboard/__tests__/runlog.test.ts
+++ b/cli/src/onboard/__tests__/runlog.test.ts
@@ -1,0 +1,144 @@
+import { mkdtemp, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { createRunLog } from '../runlog.js';
+
+async function dir() {
+  return mkdtemp(join(tmpdir(), 'opslane-runlog-'));
+}
+
+const MSG = {
+  type: 'tool_use',
+  name: 'Read',
+  input: { file_path: 'src/main.ts' },
+  content: 'const SECRET = "opk_raw_key_123";',
+};
+
+describe('createRunLog', () => {
+  it('metadata mode records ts/type/name/hash/bytes — never content or args', async () => {
+    const d = await dir();
+    const log = await createRunLog({ dir: d, runId: 'r1', mode: 'metadata' });
+    await log.record(MSG);
+    await log.finish({
+      outcome: 'ok',
+      turns: 1,
+      toolCalls: 1,
+      durationMs: 5,
+      totalCostUsd: 0.01,
+    });
+
+    const text = await readFile(log.path, 'utf8');
+    expect(text).not.toContain('opk_raw_key_123');
+    expect(text).not.toContain('src/main.ts');
+    const first = JSON.parse(text.split('\n')[0]!);
+    expect(first).toMatchObject({ type: 'tool_use', name: 'Read' });
+    expect(first.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(first.bytes).toBeGreaterThan(0);
+  });
+
+  it('full mode redacts registered secrets even inside content', async () => {
+    const d = await dir();
+    const log = await createRunLog({
+      dir: d,
+      runId: 'r2',
+      mode: 'full',
+      redact: ['opk_raw_key_123'],
+    });
+    await log.record(MSG);
+
+    const text = await readFile(log.path, 'utf8');
+    expect(text).not.toContain('opk_raw_key_123');
+    expect(text).toContain('[REDACTED]');
+    expect(text).toContain('src/main.ts');
+  });
+
+  it('full mode redacts sensitive fields regardless of value', async () => {
+    const d = await dir();
+    const log = await createRunLog({ dir: d, runId: 'r2b', mode: 'full' });
+    await log.record({
+      poll_token: 'pval1',
+      refresh_token: 'rval1',
+      accessToken: 'aval1',
+      code_verifier: 'vval1',
+    });
+
+    const text = await readFile(log.path, 'utf8');
+    for (const secret of ['pval1', 'rval1', 'aval1', 'vval1']) {
+      expect(text).not.toContain(secret);
+    }
+  });
+
+  it('addSecret registers values discovered after creation', async () => {
+    const d = await dir();
+    const log = await createRunLog({ dir: d, runId: 'r2c', mode: 'full' });
+    log.addSecret('opk_minted_later');
+    await log.record({ content: 'x opk_minted_later y' });
+
+    expect(await readFile(log.path, 'utf8')).not.toContain('opk_minted_later');
+  });
+
+  it('logs before provisioning and records a later session join key', async () => {
+    const d = await dir();
+    const log = await createRunLog({ dir: d, runId: 'r3', mode: 'metadata' });
+    expect(log.path).toContain('onboard-r3');
+    await log.setSessionId('sess-42');
+
+    expect(await readFile(log.path, 'utf8')).toContain('sess-42');
+  });
+
+  it('creates the log with mode 0600', async () => {
+    const d = await dir();
+    const log = await createRunLog({ dir: d, runId: 'r4', mode: 'metadata' });
+    await log.record(MSG);
+
+    expect((await stat(log.path)).mode & 0o777).toBe(0o600);
+  });
+
+  it('keeps the newest N logs and prunes older logs on create', async () => {
+    const d = await dir();
+    for (const id of ['a', 'b', 'c']) {
+      await writeFile(join(d, `onboard-${id}.jsonl`), '{}\n');
+    }
+    await createRunLog({ dir: d, runId: 'new', mode: 'metadata', maxLogs: 3 });
+
+    const names = (await readdir(d)).sort();
+    expect(names).toHaveLength(3);
+    expect(names).toContain('onboard-new.jsonl');
+  });
+
+  it('finish never leaks arbitrary content or registered secrets', async () => {
+    const metadataDir = await dir();
+    const metadata = await createRunLog({
+      dir: metadataDir,
+      runId: 'summary-metadata',
+      mode: 'metadata',
+    });
+    await metadata.finish({
+      outcome: 'ok',
+      content: 'private source text',
+      api_key: 'opk_summary',
+    });
+    const metadataText = await readFile(metadata.path, 'utf8');
+    expect(metadataText).not.toContain('private source text');
+    expect(metadataText).not.toContain('opk_summary');
+
+    const fullDir = await dir();
+    const full = await createRunLog({
+      dir: fullDir,
+      runId: 'summary-full',
+      mode: 'full',
+      redact: ['opk_registered'],
+    });
+    await full.finish({
+      api_key: 'opk_field',
+      message: 'contains opk_registered',
+    });
+    const fullText = await readFile(full.path, 'utf8');
+    expect(fullText).not.toContain('opk_field');
+    expect(fullText).not.toContain('opk_registered');
+    expect(fullText).toContain('[REDACTED]');
+  });
+});

--- a/cli/src/onboard/__tests__/runlog.test.ts
+++ b/cli/src/onboard/__tests__/runlog.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -107,6 +107,29 @@ describe('createRunLog', () => {
     const names = (await readdir(d)).sort();
     expect(names).toHaveLength(3);
     expect(names).toContain('onboard-new.jsonl');
+  });
+
+  it('survives a log entry that readdir lists but stat cannot resolve', async () => {
+    const d = await dir();
+    await writeFile(join(d, 'onboard-a.jsonl'), '{}\n');
+    // A dangling symlink reproduces what a concurrent run pruning the same
+    // directory produces: readdir lists the name, stat rejects with ENOENT.
+    await symlink(join(d, 'gone.jsonl'), join(d, 'onboard-b.jsonl'));
+
+    const log = await createRunLog({ dir: d, runId: 'new', mode: 'metadata', maxLogs: 3 });
+
+    expect(log.path).toContain('onboard-new.jsonl');
+    expect(await readdir(d)).toContain('onboard-new.jsonl');
+  });
+
+  it('full mode redacts a field named key, not just api_key', async () => {
+    const d = await dir();
+    const log = await createRunLog({ dir: d, runId: 'bare-key', mode: 'full' });
+    await log.record({ type: 'x', key: 'opk_bare_123', private_key: 'pem_456' });
+
+    const text = await readFile(log.path, 'utf8');
+    expect(text).not.toContain('opk_bare_123');
+    expect(text).not.toContain('pem_456');
   });
 
   it('finish never leaks arbitrary content or registered secrets', async () => {

--- a/cli/src/onboard/__tests__/wait.test.ts
+++ b/cli/src/onboard/__tests__/wait.test.ts
@@ -82,6 +82,51 @@ describe('waitForAppReporting', () => {
     expect(sleepFn).toHaveBeenCalledWith(1_000);
   });
 
+  it('aborts a stalled poll on its own ceiling so retries still run', async () => {
+    let aborted = 0;
+    // A server that accepts the connection and never answers. Without a
+    // per-request ceiling this single call would consume the whole 15 minute
+    // budget and the unreachable backoff below would never get a turn.
+    const fetchFn = vi.fn((_url: string, init?: RequestInit) => (
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          aborted += 1;
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+        });
+      })
+    ));
+
+    await expect(waitForAppReporting({
+      ...OPTS,
+      timeoutMs: 15 * 60_000,
+      requestTimeoutMs: 20,
+      maxUnreachable: 2,
+      fetchFn: fetchFn as unknown as typeof fetch,
+      sleepFn: vi.fn().mockResolvedValue(undefined),
+    })).rejects.toThrow(/unreachable/i);
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(aborted).toBe(2);
+  });
+
+  it('never lets the per-request ceiling outlive the remaining budget', async () => {
+    let deadlineMs = 0;
+    const fetchFn = vi.fn((_url: string, init?: RequestInit) => {
+      init?.signal?.addEventListener('abort', () => { deadlineMs = Date.now(); });
+      return Promise.resolve(new Response(JSON.stringify({ status: 'app_reporting' })));
+    });
+
+    // A 5ms budget must win over the 30s default ceiling.
+    const started = Date.now();
+    await expect(waitForAppReporting({
+      ...OPTS,
+      timeoutMs: 5,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    })).resolves.toMatchObject({ status: 'app_reporting' });
+    expect(Date.now() - started).toBeLessThan(1_000);
+    expect(deadlineMs).toBe(0);
+  });
+
   it('bounds unreachable retries', async () => {
     const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
     await expect(waitForAppReporting({ ...OPTS, fetchFn, maxUnreachable: 3 }))

--- a/cli/src/onboard/__tests__/wait.test.ts
+++ b/cli/src/onboard/__tests__/wait.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import { waitForAppReporting } from '../wait.js';
+
+const SESSION = '123e4567-e89b-42d3-a456-426614174000';
+const OPTS = {
+  apiUrl: 'http://localhost:8082',
+  sessionId: SESSION,
+  pollToken: 'ptok',
+  timeoutMs: 60_000,
+  sleepFn: vi.fn().mockResolvedValue(undefined),
+};
+
+function seq(...entries: Array<{ status: number; body: unknown }>) {
+  const fetchFn = vi.fn();
+  for (const entry of entries) {
+    fetchFn.mockResolvedValueOnce(new Response(JSON.stringify(entry.body), {
+      status: entry.status,
+    }));
+  }
+  return fetchFn;
+}
+
+describe('waitForAppReporting', () => {
+  it('waits through provisioned and key_ok until app_reporting', async () => {
+    const fetchFn = seq(
+      { status: 200, body: { status: 'provisioned', api_key: 'k' } },
+      { status: 200, body: { status: 'key_ok', api_key: 'k' } },
+      { status: 200, body: { status: 'app_reporting' } },
+    );
+    await expect(waitForAppReporting({ ...OPTS, fetchFn }))
+      .resolves.toMatchObject({ status: 'app_reporting' });
+  });
+
+  it('accepts completed as terminal success', async () => {
+    const fetchFn = seq({ status: 200, body: { status: 'completed' } });
+    await expect(waitForAppReporting({ ...OPTS, fetchFn }))
+      .resolves.toMatchObject({ status: 'completed' });
+  });
+
+  it('rejects a failed session once with its reason', async () => {
+    const fetchFn = seq({
+      status: 200,
+      body: { status: 'failed', failure_reason: 'github_error' },
+    });
+    await expect(waitForAppReporting({ ...OPTS, fetchFn })).rejects.toThrow(/github_error/);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [410, { status: 'expired' }, 'expired'],
+    [404, { status: 'not_found' }, 'not found'],
+  ])('rejects HTTP %s with remediation', async (status, body, message) => {
+    const fetchFn = seq({ status, body });
+    await expect(waitForAppReporting({ ...OPTS, fetchFn })).rejects.toThrow(message);
+  });
+
+  it('honors rate-limit retry_after before polling again', async () => {
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const fetchFn = seq(
+      { status: 429, body: { status: 'rate_limited', retry_after: 9 } },
+      { status: 200, body: { status: 'app_reporting' } },
+    );
+    await expect(waitForAppReporting({ ...OPTS, fetchFn, sleepFn })).resolves.toBeDefined();
+    expect(sleepFn).toHaveBeenCalledWith(9_000);
+  });
+
+  it('caps Retry-After sleep to the remaining timeout', async () => {
+    let current = 0;
+    const nowFn = () => current;
+    const sleepFn = vi.fn(async (ms: number) => { current += ms; });
+    const fetchFn = seq({
+      status: 429,
+      body: { status: 'rate_limited', retry_after: 3_600 },
+    });
+    await expect(waitForAppReporting({
+      ...OPTS,
+      timeoutMs: 1_000,
+      fetchFn,
+      sleepFn,
+      nowFn,
+    })).rejects.toThrow(/timed out/);
+    expect(sleepFn).toHaveBeenCalledWith(1_000);
+  });
+
+  it('bounds unreachable retries', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(waitForAppReporting({ ...OPTS, fetchFn, maxUnreachable: 3 }))
+      .rejects.toThrow(/unreachable/i);
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('times out with the session id in its message', async () => {
+    const nowFn = vi.fn()
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValue(61_000);
+    const fetchFn = seq({ status: 200, body: { status: 'pending' } });
+    await expect(waitForAppReporting({ ...OPTS, fetchFn, nowFn }))
+      .rejects.toThrow(SESSION);
+  });
+});

--- a/cli/src/onboard/errors.ts
+++ b/cli/src/onboard/errors.ts
@@ -1,0 +1,32 @@
+/** Typed failures for the deterministic onboarding plumbing. */
+
+export class LoginFailedError extends Error {
+  constructor(message = 'Login did not complete. Re-run to try again.') {
+    super(message);
+    this.name = 'LoginFailedError';
+  }
+}
+
+export class NotAuthenticatedError extends Error {
+  constructor(message = 'Your session is not valid. Log in again.') {
+    super(message);
+    this.name = 'NotAuthenticatedError';
+  }
+}
+
+/** A 403 from the admin-gated provisioning route cannot be fixed by re-login. */
+export class NotAuthorizedError extends Error {
+  constructor(
+    message = 'Provisioning requires an org admin. Ask an org admin to run onboarding or grant you admin.',
+  ) {
+    super(message);
+    this.name = 'NotAuthorizedError';
+  }
+}
+
+export class ApiUnreachableError extends Error {
+  constructor(apiUrl: string) {
+    super(`Could not reach the Opslane API at ${apiUrl}.`);
+    this.name = 'ApiUnreachableError';
+  }
+}

--- a/cli/src/onboard/provision.ts
+++ b/cli/src/onboard/provision.ts
@@ -35,16 +35,25 @@ export interface EnsureLoggedInOptions {
   fetchFn?: typeof fetch;
 }
 
+/**
+ * Bounded so the credentials lock this runs under is never held on a stalled
+ * connection. Must stay below fsutil's lock timeout.
+ */
+const REFRESH_TIMEOUT_MS = 15_000;
+
 async function refreshTokens(
   apiUrl: string,
   refreshToken: string,
   fetchFn: typeof fetch,
 ): Promise<TokenPair | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS);
   try {
     const response = await fetchFn(`${apiUrl}/auth/refresh`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ refresh_token: refreshToken }),
+      signal: controller.signal,
     });
     if (!response.ok) return null;
     const body: unknown = await response.json();
@@ -62,6 +71,8 @@ async function refreshTokens(
     };
   } catch {
     return null;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -72,11 +83,23 @@ export async function ensureLoggedIn(options: EnsureLoggedInOptions): Promise<To
   const live = await loadTokensFrom(options.tokenPath, apiUrl);
   if (live) return live;
 
-  const refreshed = await updateTokensAt(options.tokenPath, apiUrl, async (current) => {
-    if (current && Date.now() < current.expiresAt) return current;
-    if (!current?.refreshToken) return null;
-    return refreshTokens(apiUrl, current.refreshToken, fetchFn);
-  });
+  // The refresh runs under the credentials lock on purpose: a refresh token is
+  // single-use, so two concurrent CLI runs must not both spend it. The fetch is
+  // bounded (REFRESH_TIMEOUT_MS) so the lock is never held indefinitely, and
+  // fsutil reclaims a lock whose holder died before releasing it.
+  let refreshed: TokenPair | null = null;
+  try {
+    refreshed = await updateTokensAt(options.tokenPath, apiUrl, async (current) => {
+      if (current && Date.now() < current.expiresAt) return current;
+      if (!current?.refreshToken) return null;
+      return refreshTokens(apiUrl, current.refreshToken, fetchFn);
+    });
+  } catch {
+    // Either the lock could not be taken or the rotated pair could not be
+    // persisted. updateTokensAt has already dropped any burned token, so fall
+    // through to an interactive login rather than replaying it.
+    refreshed = null;
+  }
   if (refreshed && Date.now() < refreshed.expiresAt) return refreshed;
 
   await options.loginFn();
@@ -106,6 +129,8 @@ export interface EnsureProvisionedOptions {
 }
 
 const RESUMABLE = new Set(['provisioned', 'key_ok', 'app_reporting', 'completed']);
+
+const MAX_RETRY_AFTER_MS = 60_000;
 
 export async function ensureProvisioned(
   options: EnsureProvisionedOptions,
@@ -189,7 +214,9 @@ export async function ensureProvisioned(
     }
     if (response.status === 429 && attempt < max429Retries) {
       const body = await responseJSON(response.clone()) ?? {};
-      await sleepFn(retryAfterSeconds(response, body) * 1_000);
+      // Retry-After is server-controlled and unbounded; cap it so a bad value
+      // parks the CLI for a minute instead of a day.
+      await sleepFn(Math.min(retryAfterSeconds(response, body) * 1_000, MAX_RETRY_AFTER_MS));
       continue;
     }
     break;

--- a/cli/src/onboard/provision.ts
+++ b/cli/src/onboard/provision.ts
@@ -1,0 +1,248 @@
+import {
+  loadTokensFrom,
+  updateTokensAt,
+  type TokenPair,
+} from '../auth.js';
+import {
+  pollSessionOnce,
+  responseJSON,
+  retryAfterSeconds,
+} from '../agent-protocol.js';
+import {
+  defaultPendingDir,
+  deletePendingSession,
+  findPendingByRepo,
+  savePendingSession,
+  validatePollId,
+  type PendingSession,
+} from '../pending.js';
+import {
+  defaultCredentialsPath,
+  saveAgentCredentials,
+} from '../agent-credentials.js';
+import { canonicalOrigin } from '../origin.js';
+import {
+  ApiUnreachableError,
+  LoginFailedError,
+  NotAuthenticatedError,
+  NotAuthorizedError,
+} from './errors.js';
+
+export interface EnsureLoggedInOptions {
+  apiUrl: string;
+  tokenPath: string;
+  loginFn: () => Promise<void>;
+  fetchFn?: typeof fetch;
+}
+
+async function refreshTokens(
+  apiUrl: string,
+  refreshToken: string,
+  fetchFn: typeof fetch,
+): Promise<TokenPair | null> {
+  try {
+    const response = await fetchFn(`${apiUrl}/auth/refresh`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+    if (!response.ok) return null;
+    const body: unknown = await response.json();
+    if (typeof body !== 'object' || body === null) return null;
+    const record = body as Record<string, unknown>;
+    if (typeof record['access_token'] !== 'string'
+      || typeof record['refresh_token'] !== 'string'
+      || typeof record['expires_in'] !== 'number') {
+      return null;
+    }
+    return {
+      accessToken: record['access_token'],
+      refreshToken: record['refresh_token'],
+      expiresAt: Date.now() + record['expires_in'] * 1_000,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function ensureLoggedIn(options: EnsureLoggedInOptions): Promise<TokenPair> {
+  const apiUrl = canonicalOrigin(options.apiUrl);
+  const fetchFn = options.fetchFn ?? fetch;
+
+  const live = await loadTokensFrom(options.tokenPath, apiUrl);
+  if (live) return live;
+
+  const refreshed = await updateTokensAt(options.tokenPath, apiUrl, async (current) => {
+    if (current && Date.now() < current.expiresAt) return current;
+    if (!current?.refreshToken) return null;
+    return refreshTokens(apiUrl, current.refreshToken, fetchFn);
+  });
+  if (refreshed && Date.now() < refreshed.expiresAt) return refreshed;
+
+  await options.loginFn();
+  const after = await loadTokensFrom(options.tokenPath, apiUrl);
+  if (!after) throw new LoginFailedError();
+  return after;
+}
+
+export interface ProvisionResult {
+  apiKey: string;
+  endpoint: string;
+  orgId: string;
+  projectId: string;
+  sessionId: string;
+  pollToken: string;
+}
+
+export interface EnsureProvisionedOptions {
+  apiUrl: string;
+  repo: string;
+  token: string;
+  fetchFn?: typeof fetch;
+  sleepFn?: (ms: number) => Promise<void>;
+  pendingDir?: string;
+  credentialsPath?: string;
+  max429Retries?: number;
+}
+
+const RESUMABLE = new Set(['provisioned', 'key_ok', 'app_reporting', 'completed']);
+
+export async function ensureProvisioned(
+  options: EnsureProvisionedOptions,
+): Promise<ProvisionResult> {
+  const apiUrl = canonicalOrigin(options.apiUrl);
+  const fetchFn = options.fetchFn ?? fetch;
+  const sleepFn = options.sleepFn
+    ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const pendingDir = options.pendingDir ?? defaultPendingDir();
+  const credentialsPath = options.credentialsPath ?? defaultCredentialsPath();
+
+  const pending = await findPendingByRepo(apiUrl, options.repo, pendingDir);
+  if (pending) {
+    const probe = await pollSessionOnce({
+      apiUrl,
+      sessionId: pending.poll_id,
+      pollToken: pending.poll_token,
+      fetchFn,
+    });
+    if (probe.status === 'unreachable') {
+      throw new ApiUnreachableError(apiUrl);
+    }
+    if (probe.status !== 'unknown'
+      && RESUMABLE.has(probe.status)
+      && probe.apiKey
+      && probe.orgId
+      && probe.projectId) {
+      const result: ProvisionResult = {
+        apiKey: probe.apiKey,
+        endpoint: apiUrl,
+        orgId: probe.orgId,
+        projectId: probe.projectId,
+        sessionId: pending.poll_id,
+        pollToken: pending.poll_token,
+      };
+      await saveAgentCredentials({
+        org_id: result.orgId,
+        project_id: result.projectId,
+        api_key: result.apiKey,
+        repo: options.repo,
+        api_url: apiUrl,
+      }, credentialsPath);
+      return result;
+    }
+    const sessionIsDead = probe.status === 'expired'
+      || probe.status === 'not_found'
+      || probe.status === 'failed'
+      || (probe.status !== 'unknown'
+        && RESUMABLE.has(probe.status)
+        && (!probe.apiKey || !probe.orgId || !probe.projectId));
+    if (!sessionIsDead) {
+      const detail = probe.status === 'rate_limited'
+        ? `rate limited; retry after ${probe.retryAfterSeconds ?? 60} seconds`
+        : probe.status === 'internal_error'
+          ? probe.message ?? 'server error'
+          : probe.status === 'unknown'
+            ? `unrecognized server status ${JSON.stringify(probe.serverStatus)}`
+            : `session is still ${probe.status}`;
+      throw new Error(
+        `could not safely resume onboarding session ${pending.poll_id}: ${detail}`,
+      );
+    }
+
+    await deletePendingSession(pending.poll_id, pendingDir).catch(() => undefined);
+  }
+
+  const max429Retries = options.max429Retries ?? 3;
+  let response: Response;
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      response = await fetchFn(`${apiUrl}/api/v1/onboard/provision`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${options.token}`,
+        },
+        body: JSON.stringify({ repo_url: options.repo }),
+      });
+    } catch {
+      throw new ApiUnreachableError(apiUrl);
+    }
+    if (response.status === 429 && attempt < max429Retries) {
+      const body = await responseJSON(response.clone()) ?? {};
+      await sleepFn(retryAfterSeconds(response, body) * 1_000);
+      continue;
+    }
+    break;
+  }
+
+  if (response.status === 401) throw new NotAuthenticatedError();
+  if (response.status === 403) throw new NotAuthorizedError();
+  const body = await responseJSON(response);
+  if (response.status !== 201 || !body || body['status'] !== 'provisioned') {
+    const detail = body
+      ? (body['error'] ?? body['message'] ?? body['status'])
+      : 'unparseable response';
+    throw new Error(`provisioning failed (HTTP ${response.status}): ${String(detail)}`);
+  }
+
+  const apiKey = body['api_key'];
+  const orgId = body['org_id'];
+  const projectId = body['project_id'];
+  const pollId = body['poll_id'];
+  const pollToken = body['poll_token'];
+  const endpoint = typeof body['endpoint'] === 'string' ? body['endpoint'] : apiUrl;
+  if (typeof apiKey !== 'string'
+    || typeof orgId !== 'string'
+    || typeof projectId !== 'string'
+    || typeof pollId !== 'string'
+    || typeof pollToken !== 'string') {
+    throw new Error('provisioning response omitted required credentials');
+  }
+  validatePollId(pollId);
+
+  const session: PendingSession = {
+    kind: 'onboard',
+    poll_id: pollId,
+    poll_token: pollToken,
+    api_url: apiUrl,
+    repo: options.repo,
+    created_at: new Date().toISOString(),
+  };
+  await savePendingSession(session, pendingDir);
+  await saveAgentCredentials({
+    org_id: orgId,
+    project_id: projectId,
+    api_key: apiKey,
+    repo: options.repo,
+    api_url: apiUrl,
+  }, credentialsPath);
+
+  return {
+    apiKey,
+    endpoint,
+    orgId,
+    projectId,
+    sessionId: pollId,
+    pollToken,
+  };
+}

--- a/cli/src/onboard/runlog.ts
+++ b/cli/src/onboard/runlog.ts
@@ -30,8 +30,10 @@ export interface RunLog {
 
 // Field-name redaction uses substring matching intentionally so it catches
 // poll_token, refresh_token, accessToken, code_verifier, api_key, and similar.
+// `key` is matched bare rather than as api[_-]?key so plain `key` and
+// `private_key` are covered too; over-redacting a debug log is the safe side.
 const SENSITIVE_FIELD =
-  /(authorization|api[_-]?key|token|secret|verifier|password|credential)/i;
+  /(authorization|key|token|secret|verifier|password|credential)/i;
 const METADATA_SUMMARY_FIELDS = new Set([
   'outcome',
   'turns',
@@ -89,12 +91,16 @@ export async function createRunLog(options: RunLogOptions): Promise<RunLog> {
   const existing = (await readdir(options.dir)).filter((name) =>
     /^onboard-.*\.jsonl$/.test(name),
   );
-  const withTimes = await Promise.all(
-    existing.map(async (name) => ({
-      name,
-      mtime: (await stat(join(options.dir, name))).mtimeMs,
-    })),
-  );
+  // A concurrent run may retire a log between the readdir and the stat, so a
+  // vanished file drops out of retention instead of failing the whole run.
+  const withTimes = (await Promise.all(
+    existing.map(async (name) => {
+      const mtime = await stat(join(options.dir, name))
+        .then((stats) => stats.mtimeMs)
+        .catch(() => null);
+      return mtime === null ? null : { name, mtime };
+    }),
+  )).filter((entry): entry is { name: string; mtime: number } => entry !== null);
   withTimes.sort((a, b) => b.mtime - a.mtime);
   for (const { name } of withTimes.slice(Math.max(0, maxLogs - 1))) {
     await unlink(join(options.dir, name)).catch(() => undefined);

--- a/cli/src/onboard/runlog.ts
+++ b/cli/src/onboard/runlog.ts
@@ -1,0 +1,155 @@
+/**
+ * Debuggable trail for onboard runs (design R7). Metadata-only by default —
+ * hashes and byte counts, never content — so the file is safe to attach to a
+ * bug report. Full capture is an explicit opt-in with field redaction.
+ * Keyed by a LOCAL run id so runs that die before provisioning still log;
+ * setSessionId records the server session id as the join key once known.
+ */
+import { createHash } from 'node:crypto';
+import { appendFile, chmod, mkdir, readdir, stat, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export interface RunLogOptions {
+  dir: string;
+  runId: string;
+  mode: 'metadata' | 'full';
+  redact?: string[];
+  maxLogs?: number;
+  maxRecordBytes?: number;
+  nowFn?: () => number;
+}
+
+export interface RunLog {
+  path: string;
+  record(message: unknown): Promise<void>;
+  /** Register a secret value discovered after creation (e.g. the provisioned key). */
+  addSecret(secret: string): void;
+  setSessionId(sessionId: string): Promise<void>;
+  finish(summary: Record<string, unknown>): Promise<void>;
+}
+
+// Field-name redaction uses substring matching intentionally so it catches
+// poll_token, refresh_token, accessToken, code_verifier, api_key, and similar.
+const SENSITIVE_FIELD =
+  /(authorization|api[_-]?key|token|secret|verifier|password|credential)/i;
+const METADATA_SUMMARY_FIELDS = new Set([
+  'outcome',
+  'turns',
+  'toolCalls',
+  'durationMs',
+  'totalCostUsd',
+]);
+
+function redactDeep(value: unknown, secrets: string[]): unknown {
+  if (typeof value === 'string') {
+    let redacted = value;
+    for (const secret of secrets) {
+      if (secret) redacted = redacted.split(secret).join('[REDACTED]');
+    }
+    return redacted;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactDeep(item, secrets));
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const redacted: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      redacted[key] = SENSITIVE_FIELD.test(key)
+        ? '[REDACTED]'
+        : redactDeep(item, secrets);
+    }
+    return redacted;
+  }
+
+  return value;
+}
+
+function metadataSummary(summary: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(summary).filter(([key, value]) =>
+      METADATA_SUMMARY_FIELDS.has(key)
+      && (typeof value === 'string'
+        || typeof value === 'number'
+        || typeof value === 'boolean'),
+    ),
+  );
+}
+
+export async function createRunLog(options: RunLogOptions): Promise<RunLog> {
+  const now = options.nowFn ?? Date.now;
+  const maxLogs = options.maxLogs ?? 20;
+  const maxRecordBytes = options.maxRecordBytes ?? 64 * 1024;
+  const secrets = [...(options.redact ?? [])];
+
+  await mkdir(options.dir, { recursive: true });
+
+  // Keep the newest maxLogs - 1 existing logs, leaving room for this run.
+  const existing = (await readdir(options.dir)).filter((name) =>
+    /^onboard-.*\.jsonl$/.test(name),
+  );
+  const withTimes = await Promise.all(
+    existing.map(async (name) => ({
+      name,
+      mtime: (await stat(join(options.dir, name))).mtimeMs,
+    })),
+  );
+  withTimes.sort((a, b) => b.mtime - a.mtime);
+  for (const { name } of withTimes.slice(Math.max(0, maxLogs - 1))) {
+    await unlink(join(options.dir, name)).catch(() => undefined);
+  }
+
+  // Create the file immediately so even a run that dies before provisioning
+  // leaves a useful artifact and participates in retention.
+  const path = join(options.dir, `onboard-${options.runId}.jsonl`);
+  await appendFile(path, '', { mode: 0o600 });
+  await chmod(path, 0o600);
+
+  async function append(line: Record<string, unknown>): Promise<void> {
+    await appendFile(path, `${JSON.stringify(line)}\n`, { mode: 0o600 });
+  }
+
+  return {
+    path,
+    addSecret(secret: string): void {
+      if (secret) secrets.push(secret);
+    },
+    async record(message: unknown): Promise<void> {
+      const raw = JSON.stringify(message) ?? 'null';
+      const record = message as Record<string, unknown> | null;
+
+      if (options.mode === 'metadata') {
+        await append({
+          ts: now(),
+          type: typeof record?.['type'] === 'string' ? record['type'] : 'unknown',
+          name: typeof record?.['name'] === 'string' ? record['name'] : undefined,
+          hash: createHash('sha256').update(raw).digest('hex'),
+          bytes: Buffer.byteLength(raw),
+        });
+        return;
+      }
+
+      const redacted = redactDeep(message, secrets);
+      let serialized = JSON.stringify(redacted) ?? 'null';
+      if (Buffer.byteLength(serialized) > maxRecordBytes) {
+        serialized = JSON.stringify({
+          truncated: true,
+          bytes: Buffer.byteLength(serialized),
+        });
+      }
+      await append({ ts: now(), full: JSON.parse(serialized) });
+    },
+    async setSessionId(sessionId: string): Promise<void> {
+      await append({ ts: now(), session_id: sessionId });
+    },
+    async finish(summary: Record<string, unknown>): Promise<void> {
+      await append({
+        ts: now(),
+        summary: options.mode === 'metadata'
+          ? metadataSummary(summary)
+          : redactDeep(summary, secrets),
+      });
+    },
+  };
+}

--- a/cli/src/onboard/wait.ts
+++ b/cli/src/onboard/wait.ts
@@ -1,0 +1,88 @@
+import { pollSessionOnce, type PollResult } from '../agent-protocol.js';
+
+export interface WaitOptions {
+  apiUrl: string;
+  sessionId: string;
+  pollToken: string;
+  fetchFn?: typeof fetch;
+  sleepFn?: (ms: number) => Promise<void>;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  maxUnreachable?: number;
+  nowFn?: () => number;
+}
+
+const WAITING = new Set(['pending', 'provisioned', 'key_ok']);
+
+export async function waitForAppReporting(options: WaitOptions): Promise<PollResult> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const sleepFn = options.sleepFn
+    ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const now = options.nowFn ?? Date.now;
+  const interval = options.pollIntervalMs ?? 3_000;
+  const deadline = now() + (options.timeoutMs ?? 15 * 60_000);
+  const maxUnreachable = options.maxUnreachable ?? 20;
+  let unreachable = 0;
+
+  async function pause(ms: number): Promise<void> {
+    const remaining = deadline - now();
+    if (remaining > 0) await sleepFn(Math.min(ms, remaining));
+  }
+
+  while (now() < deadline) {
+    const remaining = deadline - now();
+    if (remaining <= 0) break;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), remaining);
+    const result = await pollSessionOnce({
+      apiUrl: options.apiUrl,
+      sessionId: options.sessionId,
+      pollToken: options.pollToken,
+      fetchFn,
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timeout));
+
+    if (result.status === 'app_reporting' || result.status === 'completed') return result;
+    if (result.status === 'failed') {
+      throw new Error(
+        `onboarding session failed: ${result.failureReason ?? result.message ?? 'unknown'}`,
+      );
+    }
+    if (result.status === 'expired') {
+      throw new Error(
+        `session ${options.sessionId} expired — re-run onboarding to mint a new key`,
+      );
+    }
+    if (result.status === 'not_found') {
+      throw new Error(`session ${options.sessionId} was not found — re-run onboarding`);
+    }
+    if (result.status === 'internal_error' || result.status === 'unknown') {
+      throw new Error(
+        `server error while waiting: ${'message' in result ? result.message ?? 'unknown' : 'unknown'}`,
+      );
+    }
+    if (result.status === 'unreachable') {
+      unreachable += 1;
+      if (unreachable >= maxUnreachable) {
+        throw new Error(
+          `API unreachable after ${unreachable} attempts while waiting for session ${options.sessionId}`,
+        );
+      }
+      await pause(Math.min(interval * unreachable, 30_000));
+      continue;
+    }
+    unreachable = 0;
+    if (result.status === 'rate_limited') {
+      await pause((result.retryAfterSeconds ?? 60) * 1_000);
+      continue;
+    }
+    if (WAITING.has(result.status)) {
+      await pause(interval);
+      continue;
+    }
+  }
+  throw new Error(
+    `timed out waiting for your app to report (session ${options.sessionId}). `
+      + 'Start your app, then re-run onboarding — it will resume this session.',
+  );
+}

--- a/cli/src/onboard/wait.ts
+++ b/cli/src/onboard/wait.ts
@@ -9,10 +9,16 @@ export interface WaitOptions {
   timeoutMs?: number;
   pollIntervalMs?: number;
   maxUnreachable?: number;
+  requestTimeoutMs?: number;
   nowFn?: () => number;
 }
 
 const WAITING = new Set(['pending', 'provisioned', 'key_ok']);
+
+// Per-request ceiling. Without it a connection the server accepts and then
+// never answers would burn the whole wait budget on one poll, so the
+// unreachable backoff below would never get a turn.
+const REQUEST_TIMEOUT_MS = 30_000;
 
 export async function waitForAppReporting(options: WaitOptions): Promise<PollResult> {
   const fetchFn = options.fetchFn ?? fetch;
@@ -22,6 +28,7 @@ export async function waitForAppReporting(options: WaitOptions): Promise<PollRes
   const interval = options.pollIntervalMs ?? 3_000;
   const deadline = now() + (options.timeoutMs ?? 15 * 60_000);
   const maxUnreachable = options.maxUnreachable ?? 20;
+  const requestTimeout = options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS;
   let unreachable = 0;
 
   async function pause(ms: number): Promise<void> {
@@ -33,7 +40,10 @@ export async function waitForAppReporting(options: WaitOptions): Promise<PollRes
     const remaining = deadline - now();
     if (remaining <= 0) break;
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), remaining);
+    const timeout = setTimeout(
+      () => controller.abort(),
+      Math.min(remaining, requestTimeout),
+    );
     const result = await pollSessionOnce({
       apiUrl: options.apiUrl,
       sessionId: options.sessionId,

--- a/cli/src/pending.ts
+++ b/cli/src/pending.ts
@@ -1,10 +1,11 @@
-import { readFile, unlink } from 'node:fs/promises';
+import { readdir, readFile, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { canonicalOrigin } from './origin.js';
 import { writeFileAtomic } from './fsutil.js';
 
 export interface PendingSession {
+  kind?: 'onboard' | 'setup';
   poll_id: string;
   poll_token: string;
   api_url: string;
@@ -14,6 +15,7 @@ export interface PendingSession {
 
 const DEFAULT_PENDING_DIR = join(homedir(), '.opslane', 'pending');
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+export const PENDING_TTL_MS = 24 * 60 * 60 * 1000;
 
 export function validatePollId(pollId: string): void {
   if (!UUID_PATTERN.test(pollId)) {
@@ -29,8 +31,61 @@ function pendingPath(pollId: string, baseDir: string): string {
 function isPendingSession(value: unknown): value is PendingSession {
   if (typeof value !== 'object' || value === null) return false;
   const record = value as Record<string, unknown>;
+  const kind = record['kind'];
+  if (kind !== undefined && kind !== 'onboard' && kind !== 'setup') return false;
   return ['poll_id', 'poll_token', 'api_url', 'repo', 'created_at']
     .every((key) => typeof record[key] === 'string') && UUID_PATTERN.test(record['poll_id'] as string);
+}
+
+export async function findPendingByRepo(
+  apiUrl: string,
+  repo: string,
+  baseDir: string = DEFAULT_PENDING_DIR,
+  ttlMs: number = PENDING_TTL_MS,
+): Promise<PendingSession | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(baseDir);
+  } catch {
+    return null;
+  }
+
+  const origin = canonicalOrigin(apiUrl);
+  const target = repo.toLowerCase();
+  const matches: PendingSession[] = [];
+  for (const name of entries) {
+    if (!name.endsWith('.json')) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await readFile(join(baseDir, name), 'utf8'));
+    } catch {
+      continue;
+    }
+    if (!isPendingSession(parsed) || (parsed.kind ?? 'setup') !== 'onboard') continue;
+
+    let sameTarget = false;
+    try {
+      sameTarget = canonicalOrigin(parsed.api_url) === origin
+        && parsed.repo.toLowerCase() === target;
+    } catch {
+      continue;
+    }
+    if (!sameTarget) continue;
+
+    const age = Date.now() - Date.parse(parsed.created_at);
+    if (!Number.isFinite(age) || age > ttlMs) {
+      await deletePendingSession(parsed.poll_id, baseDir).catch(() => undefined);
+      continue;
+    }
+    matches.push(parsed);
+  }
+
+  matches.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
+  const [newest, ...stale] = matches;
+  for (const session of stale) {
+    await deletePendingSession(session.poll_id, baseDir).catch(() => undefined);
+  }
+  return newest ?? null;
 }
 
 export async function savePendingSession(

--- a/cli/src/setup.ts
+++ b/cli/src/setup.ts
@@ -17,6 +17,12 @@ import {
 } from './pending.js';
 import { defaultTokenPath, loadTokensFrom } from './auth.js';
 import { defaultApiUrl } from './config.js';
+import {
+  pollSessionOnce,
+  responseJSON,
+  retryAfterSeconds,
+  type JsonBody,
+} from './agent-protocol.js';
 
 const POLL_INTERVAL_MS = 3_000;
 const BLOCKING_TIMEOUT_SECONDS = 15 * 60;
@@ -40,8 +46,6 @@ export interface SetupOptions {
   pollIntervalMs?: number;
   sleepFn?: (ms: number) => Promise<void>;
 }
-
-type JsonBody = Record<string, unknown>;
 
 export function normalizeRepoURL(remoteURL: string): string | null {
   if (/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(remoteURL)) return remoteURL;
@@ -69,24 +73,6 @@ function timeoutSeconds(value: number | string | undefined, fallback: number): n
   if (value === undefined) return fallback;
   const parsed = typeof value === 'number' ? value : Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-}
-
-async function responseJSON(response: Response): Promise<JsonBody | null> {
-  try {
-    const value: unknown = await response.json();
-    return typeof value === 'object' && value !== null && !Array.isArray(value)
-      ? value as JsonBody
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-function retryAfterSeconds(response: Response, body: JsonBody): number {
-  const bodyValue = Number(body['retry_after']);
-  if (Number.isFinite(bodyValue) && bodyValue > 0) return bodyValue;
-  const headerValue = Number(response.headers.get('Retry-After'));
-  return Number.isFinite(headerValue) && headerValue > 0 ? headerValue : 60;
 }
 
 function stderrJSON(body: JsonBody): void {
@@ -133,51 +119,47 @@ async function pollLoop(
   let waitingForApp = false;
 
   while (Date.now() < deadline) {
-    let response: Response;
-    try {
-      response = await fetchFn(
-        `${pending.api_url}/api/v1/agent/poll/${encodeURIComponent(pending.poll_id)}`,
-        { headers: { 'X-Opslane-Poll-Token': pending.poll_token } },
-      );
-      reachedServer = true;
-    } catch {
+    const result = await pollSessionOnce({
+      apiUrl: pending.api_url,
+      sessionId: pending.poll_id,
+      pollToken: pending.poll_token,
+      fetchFn,
+    });
+
+    if (result.status === 'unreachable') {
+      const remaining = deadline - Date.now();
+      if (remaining > 0) await sleepFn(Math.min(interval, remaining));
+      continue;
+    }
+    reachedServer = true;
+
+    if (result.status === 'pending') {
       const remaining = deadline - Date.now();
       if (remaining > 0) await sleepFn(Math.min(interval, remaining));
       continue;
     }
 
-    const body = await responseJSON(response);
-    if (!body) {
-      return exitWithStatus('internal_error', { message: 'unparseable server response' }, 1);
-    }
-    const status = body['status'];
-
-    if (status === 'pending') {
-      const remaining = deadline - Date.now();
-      if (remaining > 0) await sleepFn(Math.min(interval, remaining));
-      continue;
-    }
-
-    if (status === 'rate_limited' || response.status === 429) {
+    if (result.status === 'rate_limited') {
       const remaining = deadline - Date.now();
       if (remaining > 0) {
-        await sleepFn(Math.min(retryAfterSeconds(response, body) * 1_000, remaining));
+        await sleepFn(Math.min((result.retryAfterSeconds ?? 60) * 1_000, remaining));
       }
       continue;
     }
 
-    if (status === 'provisioned' || status === 'key_ok' || status === 'app_reporting' || status === 'completed') {
-      const apiKey = typeof body['api_key'] === 'string' ? body['api_key'] : null;
-      if (!apiKey && status !== 'app_reporting') {
+    if (result.status === 'provisioned' || result.status === 'key_ok'
+      || result.status === 'app_reporting' || result.status === 'completed') {
+      const apiKey = result.apiKey;
+      if (!apiKey && result.status !== 'app_reporting') {
         await deletePendingSession(pending.poll_id, pendingDir);
         return exitWithStatus('key_unavailable', {
-          project_id: body['project_id'],
+          project_id: result.projectId ?? undefined,
           remediation: 'run "opslane login" then "opslane setup --relink"',
         }, 1);
       }
-      const orgId = typeof body['org_id'] === 'string' ? body['org_id'] : null;
-      const projectId = typeof body['project_id'] === 'string' ? body['project_id'] : null;
-      const repo = typeof body['repo'] === 'string' ? body['repo'] : pending.repo;
+      const orgId = result.orgId;
+      const projectId = result.projectId;
+      const repo = result.repo ?? pending.repo;
       if (!orgId || !projectId) {
         return exitWithStatus('internal_error', { message: 'provisioned response omitted project credentials' }, 1);
       }
@@ -186,7 +168,7 @@ async function pollLoop(
         if (!saved || saved.project_id !== projectId || saved.org_id !== orgId) {
           await deletePendingSession(pending.poll_id, pendingDir);
           return exitWithStatus('key_unavailable', {
-            project_id: body['project_id'],
+            project_id: result.projectId ?? undefined,
             remediation: 'run "opslane login" then "opslane setup --relink"',
           }, 1);
         }
@@ -207,42 +189,48 @@ async function pollLoop(
         }
       }
 
-      if (status !== 'app_reporting' && status !== 'completed') {
+      if (result.status !== 'app_reporting' && result.status !== 'completed') {
         waitingForApp = true;
         const remaining = deadline - Date.now();
         if (remaining > 0) await sleepFn(Math.min(interval, remaining));
         continue;
       }
       await deletePendingSession(pending.poll_id, pendingDir);
-      jsonOutput({ ...body, status: 'completed' });
+      jsonOutput({
+        status: 'completed',
+        api_key: apiKey ?? undefined,
+        org_id: orgId,
+        project_id: projectId,
+        repo,
+      });
       return;
     }
 
-    if (status === 'failed') {
+    if (result.status === 'failed') {
       await deletePendingSession(pending.poll_id, pendingDir);
       return exitWithStatus('failed', {
-        failure_reason: body['failure_reason'],
-        message: body['message'],
+        failure_reason: result.failureReason ?? undefined,
+        message: result.message ?? undefined,
       }, 1);
     }
 
-    if (status === 'not_found' || response.status === 404) {
+    if (result.status === 'not_found') {
       await deletePendingSession(pending.poll_id, pendingDir);
       return exitWithStatus('not_found', { poll_id: pending.poll_id }, 1);
     }
 
-    if (status === 'expired' || response.status === 410) {
+    if (result.status === 'expired') {
       await deletePendingSession(pending.poll_id, pendingDir);
       return exitWithStatus('expired', { remediation: 're-run setup' }, 1);
     }
 
-    if (status === 'internal_error') {
-      return exitWithStatus('internal_error', { message: body['message'] ?? 'server error' }, 1);
+    if (result.status === 'internal_error') {
+      return exitWithStatus('internal_error', { message: result.message ?? 'server error' }, 1);
     }
 
     return exitWithStatus('internal_error', {
       message: 'unrecognized server status',
-      server_status: status,
+      server_status: result.status === 'unknown' ? result.serverStatus : result.status,
     }, 1);
   }
 

--- a/docs/plans/2026-07-22-onboarding-10x-implementation.md
+++ b/docs/plans/2026-07-22-onboarding-10x-implementation.md
@@ -765,33 +765,76 @@ test runs in CI.
 
 ## Phase 2 — Deterministic CLI plumbing
 
+> **Refreshed 2026-07-24** by `/plan-eng-review` + outside voice against the landed
+> two-stage engine (Detect → Apply, #185/#190) and the landed milestone 0.5 endpoint
+> (#182). The agent's handoff artifact is **`OnboardingPlan`** (`cli/src/onboard/tools.ts:47`)
+> — fields `app_dir`, `env_prefix`, `env_vars.{api_key, endpoint}`, single app, names only,
+> never values. `collectEdit` does not exist: edit reconciliation is the `EditTracker`
+> class (`events.ts:96`), already internal to `runApply`. Var-name/containment validation
+> landed in `validatePlan`/`validateEnvironmentVariable` (`tools.ts:180-258`).
+
 The CLI (not the agent) owns key material and the server poll. Still no TTY, no live model.
 
-**Deliverable:** a reusable typed poll seam that preserves the CLI's documented status
-contract, provisioning that carries the poll token and survives interruption, a shared env
-writer, and `waitForAppReporting` — all unit-tested with injected fetch.
+**Deliverable:** a typed poll seam that speaks the **server's** status vocabulary, a login
+gate with token refresh and typed failures, synchronous account provisioning with
+**poll-first resume**, a shared atomic env writer, `waitForAppReporting`, and a run log
+keyed by a local run id — all unit-tested with injected fetch — plus one small Go task
+closing the duplicate-project gap.
+
+### Task 2.0: Server guard — adopt an existing project for the same repo (Go, TDD)
+
+`OnboardProvision` dedupes only via the idempotency token `"onboard:"+lower(repo)`
+(`packages/ingestion/db/onboard_provision.go:70`). Projects created by the GitHub-App
+setup flow carry **no** token, and the handler never calls `FindProjectByRepoURL` (the
+setup handler does — `agent_setup.go:74`). Result: onboarding a repo that already has a
+setup-flow project mints a **duplicate project** — events split, `setup --relink` picks
+one arbitrarily.
+
+**Files:** modify `packages/ingestion/handler/onboard_provision.go` /
+`db/onboard_provision.go`; extend `handler/onboard_provision_test.go` and the
+integration test.
+
+**Steps:** failing test — an org with an existing setup-flow project for `owner/repo`
+provisions onboard → **same project id**, no new project row, key rotated into it. Then
+implement: repo-level lookup first (reuse `FindProjectByRepoURL` scoped to the org),
+adopt the existing project; fall through to the idempotency-token path otherwise.
+Bundle: fix the misleading window-closed copy at `agent_setup.go:193` ("re-run setup" →
+name relink for configured repos). **Caution:** these DB-backed tests skip silently
+without `DATABASE_URL` — run against the compose Postgres; CI's `check-go-skips` gate is
+the backstop.
 
 ### Task 2.1: Extract a typed poll seam from setup (refactor + TDD)
 
 `cli/src/setup.ts`'s `pollLoop` is private, prints, deletes pending state, and its helpers
 call `process.exit` — it is **not** reusable as-is. Extract the wire protocol; leave setup's
-UX behavior unchanged. **Contract rule:** `cli/src/contract.ts` documents the canonical
-status vocabulary (`not_found`, `expired`, `internal_error`, `api_unreachable`, ...) — the
-seam **preserves every distinct status**; it never collapses them into a generic `failed`.
+UX behavior unchanged. **Contract rule (revised 2026-07-24):** the seam returns the
+**server's** poll vocabulary **verbatim** — `pending | provisioned | key_ok |
+app_reporting | completed | failed | not_found | expired | rate_limited | internal_error`
+(DB domain at `db/queries.go:3277`; `pollLoop` already handles all of these,
+`setup.ts:169`) — plus `'unreachable'` for transport errors. It never collapses statuses.
+Callers translate to CLI-contract statuses themselves (`contract.ts` remains the
+`setup`-command contract; a comment in `agent-protocol.ts` explains why the two lists
+deliberately differ). This is what lets Task 2.4 distinguish `key_ok` from
+`app_reporting` — the aha signal.
 
 **Files:**
 - Create: `cli/src/agent-protocol.ts`
-- Modify: `cli/src/setup.ts` (rewire `pollLoop` on top of the new function)
+- Modify: `cli/src/setup.ts` (rewire `pollLoop` on top of the new function; **move**
+  `responseJSON` and `retryAfterSeconds` (`setup.ts:74,85`) into `agent-protocol.ts` and
+  import them back — one wire parser, not two)
 - Test: `cli/src/__tests__/agent-protocol.test.ts`
 
 **Step 1: Failing test** — `pollSessionOnce({ apiUrl, sessionId, pollToken, fetchFn })`
-returns a discriminated union whose `status` values are exactly the contract's poll
-statuses plus `'unreachable'` for transport errors, with the payload fields the poll
-endpoint returns (key, endpoint, `org_id`, `project_id`, `repo`, message, `retry_after`).
+returns the discriminated union above, with the payload fields the poll endpoint returns
+(`api_key` **optional**, endpoint, `org_id`, `project_id`, `repo`, message, `retry_after`).
 Cases: sends the `X-Opslane-Poll-Token` header (assert on the injected fetch's calls); 404
-→ `not_found` (verbatim, not `failed`); 429 → `rate_limited` with `retryAfter`; fetch
-rejection → `unreachable` (never a throw); malformed JSON → `internal_error` with the raw
-body in the message.
+→ `not_found` (verbatim, not `failed`); 429 → `rate_limited` with `retryAfter` sourced
+from **body AND `Retry-After` header** (both cases); `provisioned`/`key_ok`/`app_reporting`
+pass through **verbatim** with their payloads; fetch rejection → `unreachable` (never a
+throw); malformed JSON → `internal_error` with the raw body in the message; **two wire
+dialects:** valid JSON with `{"error": "..."}` and no `status` field (the server's
+`writeJSONError` shape for 400/401/403) branches on HTTP status and surfaces the `error`
+string — it is not `internal_error`.
 
 **Step 2:** FAIL. **Step 3:** Implement by lifting the fetch/parse core out of `pollLoop`;
 rewire `pollLoop` to call it, keeping its retry/`api_unreachable` remediation behavior
@@ -818,24 +861,45 @@ order (see the design doc's Alternatives).
 
 **Step 0 — login gate, inline in `onboard` (TDD).** There is **no separate `opslane login`
 step for the user** — `onboard` calls this gate itself. `ensureLoggedIn({ apiUrl, tokenPath,
-loginFn })` → returns valid account tokens: if `loadTokensFrom` yields a live token, return
-it; else run `loginFn` (the existing `login()` — prints the URL, awaits the browser
-callback; the same hosted flow handles **signup**, not just login), then re-load. Test with
-an injected `loginFn` and a temp token file: expired/missing token triggers login exactly
-once; a live token skips it. On cloud this is WorkOS; self-hosted is the GitHub login path —
-same CLI code, the server's `AUTH_PROVIDER` decides which identity provider answers
-`/oauth/authorize`. (The standalone `opslane login` command stays for re-auth, but onboarding
-never requires the user to run it first.)
+loginFn, fetchFn })` → returns valid account tokens, in this order:
+1. `loadTokensFrom` yields a live token → use it.
+2. Else, if a `refreshToken` is stored, try the **refresh grant** (the server exposes it;
+   the CLI stores `refreshToken` today but never reads it — `auth.ts:99` just discards
+   expired tokens). One injected-fetch call; on success persist via `persistTokensTo` and
+   use. Without this, "a live token skips login" is a mostly-dead branch and every run
+   opens a browser.
+3. Else run `loginFn` **exactly once** (the hosted flow handles **signup** too), then
+   re-load. Still no live token → typed **`LoginFailedError`** — never auto-retry the
+   browser.
+
+**`login.ts` amendment (in scope for this task):** `login()` currently swallows errors,
+returns `void`, sets `process.exitCode = 1` (`login.ts:166-170`), and persists only to the
+hardcoded credentials file — a wrapper cannot distinguish "login failed" from "logged into
+a different origin," and tests can't redirect the token path. Change `login()` to **throw
+typed errors** on failure and **accept an injectable token path**; the standalone
+`opslane login` command keeps identical behavior by catching at the command layer. Tests
+use the path-taking pair `loadTokensFrom`/`persistTokensTo` (NOT bare `persistTokens`,
+which hardcodes the real `~/.opslane/credentials.json`).
+
+Tests: live token → no login; expired + refresh ok → no browser; refresh rejected →
+`loginFn` once; `loginFn` ran, still dead → `LoginFailedError`, `loginFn` called exactly
+once. On cloud this is WorkOS; self-hosted is the GitHub login path — same CLI code, the
+server's `AUTH_PROVIDER` decides which identity provider answers `/oauth/authorize`.
 
 **Step 0.5 — a by-repo pending lookup (pending.ts + tests).** The design's resume needs to
 find a pending session by repo, but `cli/src/pending.ts` today only loads by the poll-id
-UUID (`loadPendingSession(pollId)`, pending.ts:47) and names files `<pollId>.json`. Add
-`findPendingByRepo(apiUrl, repo, baseDir?)`: scan the pending dir, parse each file, match on
-`canonicalOrigin(api_url)` **and** `repo.toLowerCase()`, ignore entries older than a TTL
-(reuse `created_at`), and if more than one matches return the newest and delete the rest
-(stale cleanup). Test: no match → null; one match → it; multiple → newest kept, older
-deleted; expired → pruned and null; malformed file → skipped, not thrown. This is a
-prerequisite of the resume behavior below.
+UUID (`loadPendingSession(pollId)`, pending.ts:47) and names files `<pollId>.json`.
+**Pending sessions gain a `kind: 'onboard' | 'setup'` discriminator** (a file without
+`kind` is treated as `setup` — backward compatible): the two flows share one dir, and
+without it onboard could "resume" a GitHub-App session that waits forever for an App
+install onboard never triggers — or delete a legitimate in-flight `setup --start` state.
+Add `findPendingByRepo(apiUrl, repo, baseDir?)`: scan the pending dir, parse each file,
+**filter `kind === 'onboard'`**, match on `canonicalOrigin(api_url)` **and**
+`repo.toLowerCase()`, ignore entries older than a TTL (reuse `created_at`), and if more
+than one matches return the newest and delete the rest (same-kind stale cleanup only).
+Test: no match → null; one match → it; multiple → newest kept, older deleted; expired →
+pruned and null; malformed file → skipped, not thrown; **same repo, different origin →
+null**; **setup-kind session for the same repo → null and NOT deleted**.
 
 **Step 1: Failing test** — `ensureProvisioned({ apiUrl, repo, token, fetchFn, sleepFn, now,
 timeoutMs })` → `{ apiKey, endpoint, orgId, projectId, sessionId, pollToken }`. It runs
@@ -844,20 +908,31 @@ timeoutMs })` → `{ apiKey, endpoint, orgId, projectId, sessionId, pollToken }`
 returns the key, endpoint, ids, session id, and poll token in one response — there is no
 second `auth_url` and no browser step here. (The GitHub App browser trip is a separate,
 later milestone.)
-- Fresh repo: POST the account-provisioning endpoint (milestone 0.5) with the bearer token;
-  on `201`, persist `{poll_id, poll_token, api_url, repo, created_at}` via
+- Fresh repo: POST the account-provisioning endpoint (milestone 0.5, landed as
+  `POST /api/v1/onboard/provision`) with the bearer token; on `201`, persist
+  `{kind: 'onboard', poll_id, poll_token, api_url, repo, created_at}` via
   `savePendingSession` and return the key + endpoint + ids + **sessionId + pollToken** (the
   aha poll in Task 2.4 needs the token).
-- **Resume:** call `findPendingByRepo(apiUrl, repo)` first; if a live pending session
-  exists, return its `{sessionId, pollToken}` and skip the POST — a crash or Ctrl-C between
-  provisioning and `app_reporting` must resume the same poll. The server is independently
-  idempotent by `(org_id, repo)`, so a retry after pending-state loss still returns `201` for
-  the same project with a freshly rotated key; the pending path avoids that unnecessary
-  rotation and preserves the in-flight session.
-- Non-2xx: `401/403` → typed `NotAuthenticatedError` (token expired → caller re-runs the
-  login gate); `429` → wait `retry_after`; network error → bounded retries, then a typed
-  error naming the API URL. Provisioning has one success shape: `201 provisioned`; there is
-  no duplicate-project conflict branch.
+- **Resume is poll-first (revised 2026-07-24, outside-voice finding):** call
+  `findPendingByRepo(apiUrl, repo)`; if a live pending session exists, make **one
+  `pollSessionOnce`** with its token. The poll **re-delivers the raw `api_key` on every
+  poll while the session lives** (`agent_setup.go:192-207` — the sealed key is only
+  withheld after `expires_at`), so one poll simultaneously proves server-side liveness,
+  recovers a key that never reached disk, and catches a key another machine rotated.
+  Alive answer (`provisioned`/`key_ok`/`app_reporting`/`completed` with a key where
+  applicable) → reuse the session and the polled key. Anything else (`expired`,
+  `not_found`, key window closed, `unreachable` after bounded retries) → delete the stale
+  pending record and fall through to the fresh POST (the server rotates the key on the
+  same project). **No saved-credentials precondition** — the server's answer, never a
+  stale disk copy, is the source of truth for the key.
+- Non-2xx (both wire dialects — `{"status":...}` and `writeJSONError`'s `{"error":...}`):
+  `401` → typed `NotAuthenticatedError` (caller re-runs the login gate **once**);
+  `403` → typed **`NotAuthorizedError`** — the route is admin-gated in cloud
+  (`RequireRoleIfCloud("admin")`, `routes.go:113`, a deliberate hardening; decision
+  2026-07-24) — remediation: "ask an org admin to run onboarding or grant you admin";
+  **never re-run login for a 403**. `429` → wait `retry_after`; network error → bounded
+  retries, then a typed error naming the API URL. Success is `201 provisioned`; there is
+  no duplicate-project conflict branch (Task 2.0 guarantees adoption instead).
 - Validates `org_id`/`project_id`/`repo` are present (required by `saveAgentCredentials`)
   and saves credentials as setup does.
 
@@ -866,22 +941,29 @@ later milestone.)
 
 ### Task 2.3: Shared env writer driven by the agent's report (refactor + TDD)
 
-`cli/src/init.ts:107` (`persistApiKeyEnvironment`) already writes `.env.local` correctly —
+`cli/src/init.ts:108` (`persistApiKeyEnvironment`) already writes `.env.local` correctly —
 0600 mode, replace-or-append, `.gitignore` entry. Generalize it instead of writing a weaker
-sibling; the app dir and var names come from the agent's **validated** `OnboardingReport`
-(Task 1.2 enforced containment and the var-name regex), never from hardcoded
-`VITE_OPSLANE_*` assumptions — monorepos and custom prefixes are the whole point.
+sibling; the app dir and var **names** come from the agent's **validated** `OnboardingPlan`
+(`tools.ts:47` — `plan.app_dir` + `plan.env_vars.api_key`/`plan.env_vars.endpoint`, one
+app, validated by `validatePlan`/`validateEnvironmentVariable` at `tools.ts:180-258`),
+never from hardcoded `VITE_OPSLANE_*` assumptions — monorepos and custom prefixes are the
+whole point. The **values** come from provisioning (Task 2.2); names and values meet only
+here. (Apply's writable paths exclude `.env*` by policy, so this writer is the sole
+key-to-disk path.)
 
 **Files:**
 - Create: `cli/src/envfile.ts`
 - Modify: `cli/src/init.ts` (rewire `persistApiKeyEnvironment` onto the shared writer)
 - Test: `cli/src/__tests__/envfile.test.ts`
 
-**Step 1: Failing tests** — `writeEnvLocal(dir, vars: Record<string, string>)`: creates
-`.env.local` with mode 0600 when absent; appends missing keys without touching existing
-lines; replaces an existing value for the same key; adds `.env.local` to the dir's
-`.gitignore` (once); rejects var names failing `/^[A-Z][A-Z0-9_]*$/` (defense in depth
-behind Task 1.2); returns the path written. Use `fs.mkdtemp`.
+**Step 1: Failing tests** — `writeEnvLocal(dir, vars: Record<string, string>)`, built on
+**`writeFileAtomic`** (`fsutil.ts:8` — temp file opened 0600, fsync, rename; no torn
+secrets file, and one write idiom instead of two): creates `.env.local` with mode 0600
+when absent; appends missing keys without touching existing lines; replaces an existing
+value for the same key; **tightens a pre-existing 0644 file to 0600 after write**; the
+write is atomic (temp-and-rename observable via the injected dir); adds `.env.local` to
+the dir's `.gitignore` (once); rejects var names failing `/^[A-Z][A-Z0-9_]*$/` (defense in
+depth behind Detect's validation); returns the path written. Use `fs.mkdtemp`.
 
 **Step 2:** FAIL. **Step 3:** Implement by extracting the init.ts logic to accept arbitrary
 vars; rewire init.ts onto it. **Step 4:** new test green AND existing init tests green.
@@ -894,11 +976,16 @@ vars; rewire init.ts onto it. **Step 4:** new test green AND existing init tests
 - Test: `cli/src/onboard/__tests__/wait.test.ts`
 
 **Step 1: Failing test** — `waitForAppReporting({ apiUrl, sessionId, pollToken, fetchFn,
-sleepFn, timeoutMs })` built on `pollSessionOnce`: sequence `key_ok → key_ok →
-app_reporting` resolves; `completed` also resolves; `expired`/`not_found` reject with the
-contract's remediation message; `rate_limited` honors `retryAfter` before the next poll;
-`unreachable` retries with backoff up to a bound; timeout rejects with a message naming the
-session id.
+sleepFn, timeoutMs })` built on `pollSessionOnce`: sequence `provisioned → key_ok →
+app_reporting` resolves (**`provisioned` counts as waiting** — the key was minted
+synchronously, so the first polls return it before the poll-side flip to `key_ok`);
+`completed` also resolves; **`failed` rejects with `failure_reason` (terminal, never
+retried)**; `expired`/`not_found` reject with the contract's remediation message;
+`rate_limited` honors `retryAfter` before the next poll; `unreachable` retries with
+backoff up to a bound; timeout rejects with a message naming the session id; and the
+function **never touches pending state** (same purity rule as `agent-protocol.ts` — the
+Phase 3 controller owns state; on timeout the pending record survives so a re-run
+resumes).
 
 **Step 2:** FAIL. **Step 3:** Implement (~40 lines). **Step 4:** green. **Step 5: Commit.**
 
@@ -914,8 +1001,13 @@ transcript."
 - Create: `cli/src/onboard/runlog.ts`
 - Test: `cli/src/onboard/__tests__/runlog.test.ts`
 
-**Step 1: Failing test** — `createRunLog({ dir, sessionId, mode, redact })` returns
-`{ record(msg), finish(summary), path }`:
+**Step 1: Failing test** — `createRunLog({ dir, runId, mode, redact })` returns
+`{ record(msg), finish(summary), setSessionId(id), path }`. **The log is keyed by a
+locally generated `runId`, not the server session id** (revised 2026-07-24): the session
+id only exists after provisioning succeeds, so a session-keyed log misses exactly the
+flakiest runs — login failures, 403s, provisioning errors — that the log exists to debug.
+`setSessionId` records the server session id as a field once known (the join key for
+server-side lookups):
 - **Default `mode: 'metadata'`:** `record` writes one line per message with `ts`, `type`,
   tool `name`, a content **hash and byte length** — never the content, args, or results.
   `finish` writes `{ outcome, turns, toolCalls, durationMs, totalCostUsd, usage }`. This is
@@ -926,24 +1018,28 @@ transcript."
   one-line warning that the file may contain source and secrets and to review before
   sharing. Full logs get a size cap (truncate oversized tool results) and a retention bound
   (keep the last N, delete older on start).
-- Path `~/.opslane/logs/onboard-<sessionId>.jsonl` (dir injectable), file mode 0600.
+- Path `~/.opslane/logs/onboard-<runId>.jsonl` (dir injectable), file mode 0600.
 - Test: metadata mode writes no message content or tool args; full mode redacts the key even
-  when it appears inside a tool result; retention prunes beyond the cap.
+  when it appears inside a tool result; retention prunes beyond the cap; a run that fails
+  before provisioning still produces a log; `setSessionId` appears as a recorded field.
 
 **Step 2:** FAIL. **Step 3:** Implement. **Step 4:** green. **Step 5: Commit.**
 
-Wiring (Phase 3): every message goes to `reduceTasks`, `collectEdit`, and `runlog.record`;
-on failure the CLI prints the metadata log path (safe to attach). The full-log path is only
-mentioned when the user opted into `--debug-log`, alongside the review-before-sharing
-warning. Optional dev-only trace layer, mirroring `packages/worker/src/tracing.ts`: with
-`LANGFUSE_PUBLIC_KEY`/`SECRET_KEY` set, emit one OTel span per turn and tool call at the
-stream boundary (the subprocess's internal API calls aren't instrumentable from outside).
-No-op without the env vars.
+Wiring (Phase 3, updated for the two-stage engine): the controller invokes `runDetect` →
+approval → `runApply`; edit reconciliation is **internal** to `runApply` (the
+`EditTracker` class — there is no `collectEdit`). The driver layers `reduceTasks` and
+`runlog.record` onto each stage's `onMessage`; on failure the CLI prints the metadata log
+path (safe to attach). The full-log path is only mentioned when the user opted into
+`--debug-log`, alongside the review-before-sharing warning. Optional dev-only trace layer,
+mirroring `packages/worker/src/tracing.ts`: with `LANGFUSE_PUBLIC_KEY`/`SECRET_KEY` set,
+emit one OTel span per turn and tool call at the stream boundary (the subprocess's
+internal API calls aren't instrumentable from outside). No-op without the env vars.
 
 **Phase 2 validation checkpoint:**
 ```bash
 pnpm --filter @opslane/cli build
 pnpm --filter @opslane/cli test
+(cd packages/ingestion && go build ./... && go test ./...)   # Task 2.0 — needs DATABASE_URL for the DB-backed cases
 ```
 All green — including the pre-existing `setup`, `init`, and contract suites over the
 refactored seams — = Phase 2 complete.
@@ -956,7 +1052,27 @@ The two run-and-observe files (`tui.tsx`, `app.tsx`) wrap a live model + a TTY �
 deliberate TDD exception the prototype documented, confined to this phase.
 
 **Deliverable:** `opslane onboard` works end-to-end on a clean Vite repo: survey → ask →
-wire → human runs app → TUI confirms `app_reporting` for this run's session.
+wire → app runs → TUI confirms `app_reporting` for this run's session.
+
+> **Amendment (2026-07-24 eng review, D5b) — in-TUI consented execution.** The
+> print-and-wait hand-off ("now run `<pm> install`, then `<pm> run dev`") is replaced by
+> the TUI running those commands itself, each behind an Enter-to-confirm prompt, so the
+> user never leaves the terminal:
+> - New tested seam `runConsentedCommand` (injected `spawn`): command text is
+>   **lockfile-derived** (R4 — never model text), streamed output, exit-code surfaced.
+>   Skip path on every prompt prints the copy-paste command (old behavior preserved).
+> - The dev server is spawned and **owned by the TUI**: its stdout is parsed for the
+>   real localhost URL (no port guessing), rendered as a clickable link — "Open your
+>   app: http://localhost:5173". On quit, the TUI stops the dev server and prints the
+>   restart command.
+> - `waitForAppReporting` runs alongside; the ✓ flip happens live when the user clicks
+>   the link and the SDK phones home.
+> - Security posture unchanged: deterministic command text (R4) + per-command human
+>   consent (R2). The *agent's* Bash allowlist still denies installs — this is the
+>   TUI's own child process, not a model tool call.
+> - **Playwright/headless auto-open: rejected** — it manufactures `app_reporting`
+>   without the user seeing their app (fakes the aha), adds a heavyweight dependency,
+>   and breaks on auth-walled apps.
 
 ### Task 3.1: Ink view (port; run-and-observe)
 
@@ -1009,17 +1125,19 @@ Only the shell is run-and-observe.
    requestApproval })` (Task 1.5) and pass it as `canUseTool` into `runAgent`. This is the
    one seam: the policy validates and mutates finish-state, and calls the injected
    `requestApproval` for Edit/Write/Bash; in the shell that renders an Ink prompt, in tests
-   it's a spy. Feed `reduceTasks`, `collectEdit(edits, cwd, msg)`, and `runlog.record` from
-   `onMessage`. In a `finally`: reset the resolver/report slots so a failed run never leaks
+   it's a spy. Feed `reduceTasks` and `runlog.record` from each stage's `onMessage` (edit
+   reconciliation is internal to `runApply` via `EditTracker` — there is no `collectEdit`).
+   In a `finally`: reset the resolver/report slots so a failed run never leaks
    state into a same-process retry.
 4. **Validate the outcome — a `result` message is not success.** Require ALL of: SDK result
    reports success; a report was captured; the report's `editedFiles` set **equals** the
    `collectEdit` set (both already canonical repo-relative from Task 1.3, so a normal run
    matches); each `app.devScript` exists in `<dir>/package.json` `scripts`. Otherwise render
    the specific failure, exit 1, **no env writes, no poll**.
-5. **Write env, symlink-safe.** For each `report.apps[i]`, resolve `join(cwd, app.dir)`
-   through `realpath`, reject if outside `cwd`, then `writeEnv(dir, { [app.apiKeyVar]: apiKey,
-   [app.endpointVar]: endpoint })` (Task 2.3 also revalidates the var-name regex).
+5. **Write env, symlink-safe.** The validated `OnboardingPlan` names one app: resolve
+   `join(cwd, plan.app_dir)` through `realpath`, reject if outside `cwd`, then
+   `writeEnvLocal(dir, { [plan.env_vars.api_key]: apiKey, [plan.env_vars.endpoint]:
+   endpoint })` (Task 2.3 also revalidates the var-name regex).
 6. **Hand-off from verified facts only.** Derive the package manager **from the repo's
    lockfile** (`pnpm-lock.yaml`/`package-lock.json`/`yarn.lock`/`bun.lockb`), not from the
    report's `packageManager` field — the enum stops injection but not a wrong value (finding
@@ -1195,14 +1313,24 @@ not "if abuse appears."
 |--------|---------|-----|------|--------|----------|
 | Codex Review | `/codex review` | Independent 2nd opinion | 2 | issues_found → addressed | Round 1: 24; Round 2: 23; engine-license finding overruled by founder decision |
 | Plan review | manual (founder) | Architecture + contract audit | 1 | issues_found → addressed | 9 findings (3 blocking, 4 high, 2 medium); all addressed 2026-07-22 |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR (PLAN) | Phase 2: 16 issues (9 review + 7 outside voice), all folded 2026-07-24 |
+| Outside Voice | Claude subagent (Codex timed out) | Independent plan challenge | 1 | issues_found → addressed | 7 findings; 2 reversed same-day decisions (poll-first resume, login.ts seam) |
 
 **PLAN REVIEW (2026-07-22) — the corrections that mattered:**
 - **Blocking:** added **Phase 0.5** (authenticated account-provisioning endpoint with a full API/DB/test contract) and made Task 2.2 provisioning **synchronous** (no second `auth_url`); **rebuilt the permission architecture** so nothing security-relevant sits in `allowedTools` (Read/Grep were auto-run, so the dotenv and one-finish guards were dead code) — now one composed `createOnboardPolicy` handler with per-run state, an injected approval seam, and secret-aware custom survey tools replacing built-in Read/Grep; added a **by-repo pending lookup** (`findPendingByRepo`) since `pending.ts` only loaded by poll-id UUID.
 - **High:** fixed report/observed-edit **reconciliation** to one canonical repo-relative form with `realpath` symlink containment (normal runs were guaranteed to fail before); resolved the **install contradiction** (agent Bash is checks-only, installs stay the human's job); **run log is metadata-by-default**, full transcript opt-in with redaction/retention/warning; **smoke runs on a truly clean repo** and overlays the tarball `--no-save`.
 - **Medium:** the safety-critical controller is now a **tested core** (`runOnboardCore` with DI) plus a thin Ink shell, with the six required tests; **package manager is derived from the lockfile**, not the model's report field.
 
-**VERDICT:** implementable after these corrections. NOT independently re-reviewed since — the "CODEX CLEARED" claim was removed per the reviewer's note.
+**ENG REVIEW (2026-07-24, Phase 2 scope) — decisions folded into the section above:**
+- **Architecture:** admin gate on `/onboard/provision` **kept** with a typed `NotAuthorizedError` for 403 ("ask an org admin", never re-login); poll seam speaks the **server vocabulary verbatim** (contract.ts stays the setup-command contract); stale pre-split names refreshed (`OnboardingPlan`, `EditTracker`, single-app shape).
+- **Outside voice (all 7 accepted):** new **Task 2.0** — server-side duplicate-project guard (setup-flow projects invisible to the onboard idempotency token) + window-closed copy fix; **resume reversed to poll-first** (the poll re-delivers the key while the session lives — one poll proves liveness, recovers lost keys, catches cross-machine rotation); `login.ts` amended to throw typed errors with an injectable token path; **refresh grant wired** into `ensureLoggedIn`; pending sessions gain a `kind` discriminator; both server wire dialects (`{"status"}` / `{"error"}`) parsed; run log keyed by local run id.
+- **Tests:** 9 gap tests added across the five tasks (403 branch, LoginFailedError, poll-first resume fallback, server-vocab passthrough, atomic write + perm tightening, provisioned-as-waiting, failed-as-terminal, Retry-After header vs body, origin/kind pending mismatches).
+- **Phase 3 amendment (D5b):** in-TUI consented execution — lockfile-derived commands behind Enter-to-confirm, TUI-owned dev server, clickable localhost URL parsed from its stdout; Playwright rejected.
 
-**UNRESOLVED DECISIONS:**
-- Milestone A scope: build Phase 0.5 (account provisioning) up front for the correct login-first order, vs. ship an interim GitHub-App-first A and reorder later. This plan assumes we build 0.5; needs founder confirmation.
-- The corrected plan has not been re-run through an independent review pass; do that before calling it cleared.
+**CODEX:** Codex CLI timed out (5m); the outside voice ran as a Claude subagent — findings verified against source before acceptance.
+
+**CROSS-MODEL:** outside voice overturned two same-day review decisions (D6→poll-first resume, D8→login.ts amendment) with code-verified evidence; both reversals accepted by the founder.
+
+**VERDICT:** ENG CLEARED (Phase 2) — the section is implementation-ready as rewritten; prior plan-review corrections stand. The 2026-07-22 unresolved items are closed: milestone 0.5 was built and landed (#182), and the corrected plan has now been independently re-reviewed (this pass + outside voice).
+
+NO UNRESOLVED DECISIONS

--- a/docs/plans/2026-07-24-phase-2-cli-plumbing.md
+++ b/docs/plans/2026-07-24-phase-2-cli-plumbing.md
@@ -1,0 +1,1775 @@
+# Phase 2 — Deterministic CLI Plumbing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build every non-AI, non-TTY piece of `opslane onboard` — key minting, login gate with refresh, poll seam, env writer, wait-for-app, run log — fully unit-tested with injected fetch, plus one Go task closing the cross-flow duplicate-project gap.
+
+**Architecture:** The CLI (never the agent) owns key material and the server poll. A shared `pollSessionOnce` speaks the server's status vocabulary verbatim; callers translate. Provisioning is synchronous (`POST /api/v1/onboard/provision`, landed) with **poll-first resume**. The env writer is the sole key-to-disk path. Sources of truth: the Phase 2 section of `docs/plans/2026-07-22-onboarding-10x-implementation.md` (refreshed 2026-07-24 by eng review — 16 findings folded) and `docs/design/2026-07-22-onboard-engineering-design.md`.
+
+**Tech Stack:** Node 22 + strict TypeScript (ESM), Vitest (colocated `__tests__`), Go 1.24 + chi/pgx for Task 1. No new dependencies.
+
+**Branch:** `git fetch origin main` first, then create `abhishekray07/onboard-phase-2-plumbing` off **`origin/main`** (975b74d or later — it must contain `cli/src/onboard/engine.ts`, landed by squash-merge #190). Local `main` is stale (c18fc7d) and lacks every Phase 1 prerequisite; do NOT branch from it. Sanity check after branching: `test -f cli/src/onboard/engine.ts && echo ok`.
+
+**Lanes (parallelizable):** Lane A = Task 1 (Go, independent). Lane B = Tasks 2→3→4→5→6 (sequential). Lane C = Tasks 7, 9 (independent of B). Task 8 needs Task 2. Task 10 last.
+
+**Key contracts (memorize before starting):**
+- Server poll statuses (DB domain, `packages/ingestion/db/queries.go:3277`): `pending | provisioned | key_ok | app_reporting | completed | expired | failed`. HTTP mappings: 404→`not_found`, 410→`expired`, 429→`rate_limited`, 500→`internal_error`.
+- Two wire dialects: `agentJSON` emits `{"status": ...}`; `writeJSONError` emits `{"error": "..."}` with **no** status field (400/401/403). Branch on HTTP status for the latter.
+- The poll **re-delivers the raw `api_key` on every poll** while `api_key_sealed` is set and `now < expires_at` (`handler/agent_setup.go:192-207`). This is why resume is poll-first.
+- The agent's handoff is `OnboardingPlan` (`cli/src/onboard/tools.ts:47`): `app_dir`, `env_prefix`, `env_vars.{api_key, endpoint}` — names only, single app.
+- `/onboard/provision` is admin-gated in cloud (`RequireRoleIfCloud("admin")`, `routes.go:113`) — 403 is a distinct, non-retryable error.
+
+---
+
+### Task 1: Go server guard — adopt an existing project for the same repo (+ copy fix)
+
+**Why:** `ProvisionOnboardSession` dedupes only via idempotency token `"onboard:"+lower(repo)`. Projects created by the GitHub-App setup flow have **no** token, so onboarding such a repo mints a duplicate project and splits events. The fix: inside the existing transaction, tag exactly one untagged org-scoped project for this repo, so the existing `INSERT ... ON CONFLICT (org_id, idempotency_token)` upsert converges onto it. Do NOT use `FindProjectByRepoURL` (`db/queries.go:3418`) — it is not org-scoped, and ingestion guardrails require org scoping.
+
+**Files:**
+- Modify: `packages/ingestion/db/onboard_provision.go` (inside `ProvisionOnboardSession`, before the `provisionProjectTx` call at line 64)
+- Modify: `packages/ingestion/handler/agent_setup.go:193` (copy fix)
+- Test: `packages/ingestion/db/onboard_provision_test.go` (extend, reusing its existing org/user/project fixtures)
+
+**Step 1: Write the failing test**
+
+Read `packages/ingestion/db/onboard_provision_test.go` first and reuse its existing setup helpers (org + user creation, `DATABASE_URL` skip guard). Add:
+
+Note: `CreateProjectTx` requires a `pgx.Tx` (`db/queries.go:3166`) — seed the untagged project with plain SQL instead:
+
+```go
+func TestProvisionOnboardSessionAdoptsExistingUntaggedProject(t *testing.T) {
+	// setup: org + user via the file's existing helpers; then create a project
+	// the way the GitHub-App setup flow does — no idempotency token:
+	var existingID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO projects (org_id, name, github_repo) VALUES ($1, 'web', 'Acme/Web') RETURNING id`,
+		orgID).Scan(&existingID); err != nil { t.Fatal(err) }
+
+	result, err := q.ProvisionOnboardSession(ctx, db.OnboardProvisionInput{
+		OrgID: orgID, ProvisionedBy: userID, Repo: "acme/web", // case differs on purpose
+		PollTokenHash: hash, AgentKeyPub: pub, SealKey: sealFn,
+	})
+	if err != nil { t.Fatal(err) }
+
+	if result.ProjectID != existingID {
+		t.Fatalf("adopted project = %s, want existing %s", result.ProjectID, existingID)
+	}
+	// exactly one project for this org+repo — no duplicate row
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM projects WHERE org_id = $1 AND lower(github_repo) = lower($2)`,
+		orgID, "acme/web").Scan(&count); err != nil { t.Fatal(err) }
+	if count != 1 { t.Fatalf("project count = %d, want 1", count) }
+}
+```
+
+Add two more tests:
+1. **Two orgs, same repo** → each keeps its **own** project (no cross-org adoption).
+2. **Dirty coexistence (convergence definition):** the org already has BOTH an
+   onboard-tagged project (token `onboard:acme/web`) AND an untagged GitHub-flow
+   project for the same repo. Provisioning must return the **tagged** project,
+   leave the untagged row untouched, and NOT error — a naive unconditional tag
+   would collide with the partial unique index `(org_id, idempotency_token)`
+   and 500. Assert: `result.ProjectID` = the tagged project's id; untagged row
+   still exists with `idempotency_token IS NULL`.
+
+**Step 2: Run the test — verify it fails**
+
+```bash
+cd packages/ingestion
+DATABASE_URL='postgres://opslane:opslane_dev@localhost:5434/opslane?sslmode=disable' go test ./db -run TestProvisionOnboardSessionAdopts -v
+```
+Expected: FAIL — `adopted project = <new-id>, want existing <id>` (a duplicate was created).
+**CAUTION:** without `DATABASE_URL` these tests `t.Skip` and print ok — that is NOT a pass. Start deps first if needed: `docker compose up -d postgres minio && docker compose run --rm migrate`.
+
+**Step 3: Implement the adopt step**
+
+In `db/onboard_provision.go`, immediately after `defer tx.Rollback(ctx)` and before the `provisionProjectTx` call, insert:
+
+```go
+	// Adopt an existing untagged project for this org+repo (e.g. created by the
+	// GitHub-App setup flow) so onboarding converges on it instead of minting a
+	// duplicate. Tag exactly one row — the oldest — and only when no project in
+	// this org already carries this token: the partial unique index on
+	// (org_id, idempotency_token) forbids two tagged rows, and if a tagged
+	// project already exists it wins (the untagged duplicate is pre-existing
+	// dirty state we tolerate, not worsen).
+	if _, err := tx.Exec(ctx, `
+		UPDATE projects
+		SET idempotency_token = $3
+		WHERE id = (
+			SELECT id FROM projects
+			WHERE org_id = $1
+			  AND lower(github_repo) = lower($2)
+			  AND idempotency_token IS NULL
+			ORDER BY created_at ASC
+			LIMIT 1
+			FOR UPDATE
+		)
+		AND NOT EXISTS (
+			SELECT 1 FROM projects
+			WHERE org_id = $1 AND idempotency_token = $3
+		)`,
+		in.OrgID, repo, "onboard:"+strings.ToLower(repo),
+	); err != nil {
+		return nil, fmt.Errorf("provision onboard session: adopt existing project: %w", err)
+	}
+```
+
+**Step 4: Copy fix.** In `handler/agent_setup.go:193`, change:
+
+```go
+resp["message"] = "key delivery window closed; re-run setup to mint a new key"
+```
+to:
+```go
+resp["message"] = "key delivery window closed; run \"opslane login\" then \"opslane setup --relink\" for an existing project, or re-run provisioning"
+```
+Check `handler/agent_setup_test.go` for an assertion on the old string and update it.
+
+**Step 5: Run tests — verify they pass**
+
+```bash
+DATABASE_URL='postgres://opslane:opslane_dev@localhost:5434/opslane?sslmode=disable' go test ./db ./handler -v 2>&1 | tail -20
+go build ./...
+```
+Expected: PASS (and no unexpected skips in the onboard tests).
+
+**Step 6: Commit**
+
+```bash
+git add packages/ingestion/db/onboard_provision.go packages/ingestion/db/onboard_provision_test.go packages/ingestion/handler/agent_setup.go packages/ingestion/handler/agent_setup_test.go
+git commit -m "fix(ingestion): onboard provisioning adopts an existing project for the same repo"
+```
+
+---
+
+### Task 2: `pollSessionOnce` — the typed poll seam
+
+**Files:**
+- Create: `cli/src/agent-protocol.ts`
+- Modify: `cli/src/setup.ts` (delete its private `responseJSON`/`retryAfterSeconds`, import from the new module; rewire `pollLoop`)
+- Test: `cli/src/__tests__/agent-protocol.test.ts`
+
+**Step 1: Write the failing tests**
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { pollSessionOnce } from '../agent-protocol.js';
+
+const OPTS = {
+  apiUrl: 'http://localhost:8082',
+  sessionId: '123e4567-e89b-42d3-a456-426614174000',
+  pollToken: 'tok_abc',
+};
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    status, headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+describe('pollSessionOnce', () => {
+  it('sends the poll token header to the poll endpoint', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, { status: 'pending' }));
+    await pollSessionOnce({ ...OPTS, fetchFn });
+    const [url, init] = fetchFn.mock.calls[0]!;
+    expect(url).toBe(`http://localhost:8082/api/v1/agent/poll/${OPTS.sessionId}`);
+    expect((init.headers as Record<string, string>)['X-Opslane-Poll-Token']).toBe('tok_abc');
+  });
+
+  it('passes provisioned/key_ok/app_reporting through verbatim with payloads', async () => {
+    for (const status of ['provisioned', 'key_ok', 'app_reporting'] as const) {
+      const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, {
+        status, api_key: 'opk_raw', org_id: 'org1', project_id: 'proj1', repo: 'acme/web',
+      }));
+      const result = await pollSessionOnce({ ...OPTS, fetchFn });
+      expect(result.status).toBe(status);            // never collapsed
+      if (result.status === status) {
+        expect(result.apiKey).toBe('opk_raw');
+        expect(result.orgId).toBe('org1');
+        expect(result.projectId).toBe('proj1');
+      }
+    }
+  });
+
+  it('maps 404 to not_found verbatim, never a generic failed', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(404, { status: 'not_found' }));
+    expect((await pollSessionOnce({ ...OPTS, fetchFn })).status).toBe('not_found');
+  });
+
+  it('maps 429 to rate_limited with retryAfter from the body', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(429, { status: 'rate_limited', retry_after: 7 }));
+    const result = await pollSessionOnce({ ...OPTS, fetchFn });
+    expect(result.status).toBe('rate_limited');
+    if (result.status === 'rate_limited') expect(result.retryAfterSeconds).toBe(7);
+  });
+
+  it('falls back to the Retry-After header when the body has no retry_after', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      jsonResponse(429, { status: 'rate_limited' }, { 'Retry-After': '11' }));
+    const result = await pollSessionOnce({ ...OPTS, fetchFn });
+    if (result.status === 'rate_limited') expect(result.retryAfterSeconds).toBe(11);
+  });
+
+  it('returns unreachable on fetch rejection — never throws', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await pollSessionOnce({ ...OPTS, fetchFn });
+    expect(result.status).toBe('unreachable');
+  });
+
+  it('maps malformed JSON to internal_error carrying the raw body', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response('<html>oops</html>', { status: 200 }));
+    const result = await pollSessionOnce({ ...OPTS, fetchFn });
+    expect(result.status).toBe('internal_error');
+    if (result.status === 'internal_error') expect(result.message).toContain('oops');
+  });
+
+  it('handles the {"error": ...} dialect (valid JSON, no status field) by HTTP status', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(400, { error: 'invalid session id' }));
+    const result = await pollSessionOnce({ ...OPTS, fetchFn });
+    expect(result.status).toBe('internal_error');   // 400 on poll = client bug
+    if (result.status === 'internal_error') expect(result.message).toBe('invalid session id');
+  });
+
+  it('non-2xx HTTP wins over a contradicting body status', async () => {
+    const cases = [
+      { http: 500, body: { status: 'pending' }, want: 'internal_error' },        // never trust "pending" on a 500
+      { http: 401, body: { status: 'completed', api_key: 'k' }, want: 'internal_error' },
+      { http: 410, body: { status: 'pending' }, want: 'expired' },
+      { http: 404, body: { status: 'wat' }, want: 'not_found' },                 // unknown body never shadows a mapped HTTP error
+    ] as const;
+    for (const { http, body, want } of cases) {
+      const fetchFn = vi.fn().mockResolvedValue(jsonResponse(http, body));
+      expect((await pollSessionOnce({ ...OPTS, fetchFn })).status).toBe(want);
+    }
+  });
+
+  it('surfaces an unknown server status as unknown with the raw string', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, { status: 'wat' }));
+    const result = await pollSessionOnce({ ...OPTS, fetchFn });
+    expect(result.status).toBe('unknown');
+    if (result.status === 'unknown') expect(result.serverStatus).toBe('wat');
+  });
+});
+```
+
+**Step 2: Run tests — verify they fail**
+
+```bash
+pnpm --filter @opslane/cli exec vitest run src/__tests__/agent-protocol.test.ts
+```
+Expected: FAIL — `Cannot find module '../agent-protocol.js'`.
+
+**Step 3: Implement `cli/src/agent-protocol.ts`**
+
+```typescript
+/**
+ * Shared wire protocol for GET /api/v1/agent/poll/{sessionId}.
+ *
+ * This module returns the SERVER's status vocabulary verbatim — deliberately
+ * NOT the CLI contract statuses in contract.ts. contract.ts describes what the
+ * `setup` command prints to users; this seam reports what the server said, and
+ * each caller (setup's pollLoop, onboard's waitForAppReporting) translates.
+ * Collapsing here would erase the key_ok vs app_reporting distinction the
+ * onboarding aha depends on.
+ *
+ * Purity rules: no console, no process.exit, no state deletion, never throws.
+ */
+import { canonicalOrigin } from './origin.js';
+
+export type ServerPollStatus =
+  | 'pending' | 'provisioned' | 'key_ok' | 'app_reporting'
+  | 'completed' | 'failed' | 'not_found' | 'expired'
+  | 'rate_limited' | 'internal_error';
+
+const KNOWN_STATUSES: ReadonlySet<string> = new Set([
+  'pending', 'provisioned', 'key_ok', 'app_reporting',
+  'completed', 'failed', 'not_found', 'expired', 'rate_limited', 'internal_error',
+]);
+
+export interface PollPayload {
+  apiKey: string | null;
+  orgId: string | null;
+  projectId: string | null;
+  repo: string | null;
+  message: string | null;
+  failureReason: string | null;
+  retryAfterSeconds: number | null;
+}
+
+export type PollResult =
+  | ({ status: ServerPollStatus } & PollPayload)
+  | ({ status: 'unknown'; serverStatus: string } & PollPayload)
+  | { status: 'unreachable'; error: string };
+
+export interface PollSessionOptions {
+  apiUrl: string;
+  sessionId: string;
+  pollToken: string;
+  fetchFn?: typeof fetch;
+}
+
+type JsonBody = Record<string, unknown>;
+
+export async function responseJSON(response: Response): Promise<JsonBody | null> {
+  try {
+    const value: unknown = await response.json();
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? value as JsonBody
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function retryAfterSeconds(response: Response, body: JsonBody): number {
+  const bodyValue = Number(body['retry_after']);
+  if (Number.isFinite(bodyValue) && bodyValue > 0) return bodyValue;
+  const headerValue = Number(response.headers.get('Retry-After'));
+  return Number.isFinite(headerValue) && headerValue > 0 ? headerValue : 60;
+}
+
+function str(body: JsonBody, key: string): string | null {
+  return typeof body[key] === 'string' ? body[key] as string : null;
+}
+
+function payload(response: Response, body: JsonBody): PollPayload {
+  return {
+    apiKey: str(body, 'api_key'),
+    orgId: str(body, 'org_id'),
+    projectId: str(body, 'project_id'),
+    repo: str(body, 'repo'),
+    message: str(body, 'message'),
+    failureReason: str(body, 'failure_reason'),
+    retryAfterSeconds: retryAfterSeconds(response, body),
+  };
+}
+
+const EMPTY: PollPayload = {
+  apiKey: null, orgId: null, projectId: null, repo: null,
+  message: null, failureReason: null, retryAfterSeconds: null,
+};
+
+function statusFromHTTP(code: number): ServerPollStatus {
+  if (code === 404) return 'not_found';
+  if (code === 410) return 'expired';
+  if (code === 429) return 'rate_limited';
+  return 'internal_error';
+}
+
+export async function pollSessionOnce(options: PollSessionOptions): Promise<PollResult> {
+  const fetchFn = options.fetchFn ?? fetch;
+  let response: Response;
+  try {
+    response = await fetchFn(
+      `${canonicalOrigin(options.apiUrl)}/api/v1/agent/poll/${encodeURIComponent(options.sessionId)}`,
+      { headers: { 'X-Opslane-Poll-Token': options.pollToken } },
+    );
+  } catch (error) {
+    return { status: 'unreachable', error: error instanceof Error ? error.message : String(error) };
+  }
+
+  const raw = await response.clone().text().catch(() => '');
+  const body = await responseJSON(response);
+  if (!body) {
+    return {
+      status: 'internal_error', ...EMPTY,
+      message: `unparseable server response: ${raw.slice(0, 200)}`,
+    };
+  }
+
+  const serverStatus = str(body, 'status');
+
+  // Non-2xx HTTP takes precedence over the body: {"status":"pending"} on a 500
+  // (or "completed" on a 401) must not be trusted — a broken proxy or auth
+  // layer could otherwise put a caller into an infinite wait or a fake success.
+  // This also absorbs the {"error": "..."} dialect (writeJSONError), which
+  // only ever rides on non-2xx responses.
+  if (!response.ok) {
+    return {
+      status: statusFromHTTP(response.status),
+      ...payload(response, body),
+      message: str(body, 'message') ?? str(body, 'error')
+        ?? (serverStatus
+          ? `server said ${JSON.stringify(serverStatus)} with HTTP ${response.status}`
+          : `unexpected response (HTTP ${response.status})`),
+    };
+  }
+
+  if (!serverStatus) {
+    return {
+      status: 'internal_error', ...EMPTY,
+      message: str(body, 'error') ?? 'response omitted status',
+    };
+  }
+  if (!KNOWN_STATUSES.has(serverStatus)) {
+    return { status: 'unknown', serverStatus, ...payload(response, body) };
+  }
+  return { status: serverStatus as ServerPollStatus, ...payload(response, body) };
+}
+```
+
+**Step 4: Run the new tests — verify they pass**
+
+```bash
+pnpm --filter @opslane/cli exec vitest run src/__tests__/agent-protocol.test.ts
+```
+Expected: PASS (all 9).
+
+**Step 5: Rewire `setup.ts` — behavior byte-identical**
+
+1. Delete `responseJSON` (setup.ts:74) and `retryAfterSeconds` (setup.ts:85); add
+   `import { pollSessionOnce, responseJSON, retryAfterSeconds } from './agent-protocol.js';`
+   (the two helpers are still used by `setup()`'s non-poll paths — keep those call sites).
+2. Replace the body of `pollLoop`'s try/catch fetch + status ladder with a switch on `pollSessionOnce`:
+
+```typescript
+async function pollLoop(
+  pending: PendingSession,
+  timeout: number,
+  options: SetupOptions,
+): Promise<void> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const pendingDir = options.pendingDir ?? defaultPendingDir();
+  const credentialsPath = options.credentialsPath ?? defaultCredentialsPath();
+  const sleepFn = options.sleepFn ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const interval = options.pollIntervalMs ?? POLL_INTERVAL_MS;
+  const deadline = Date.now() + timeout * 1_000;
+  let reachedServer = false;
+  let waitingForApp = false;
+
+  while (Date.now() < deadline) {
+    const result = await pollSessionOnce({
+      apiUrl: pending.api_url, sessionId: pending.poll_id,
+      pollToken: pending.poll_token, fetchFn,
+    });
+
+    if (result.status === 'unreachable') {
+      const remaining = deadline - Date.now();
+      if (remaining > 0) await sleepFn(Math.min(interval, remaining));
+      continue;
+    }
+    reachedServer = true;
+
+    if (result.status === 'pending') {
+      const remaining = deadline - Date.now();
+      if (remaining > 0) await sleepFn(Math.min(interval, remaining));
+      continue;
+    }
+    if (result.status === 'rate_limited') {
+      const remaining = deadline - Date.now();
+      if (remaining > 0) {
+        await sleepFn(Math.min((result.retryAfterSeconds ?? 60) * 1_000, remaining));
+      }
+      continue;
+    }
+    if (result.status === 'provisioned' || result.status === 'key_ok'
+      || result.status === 'app_reporting' || result.status === 'completed') {
+      const apiKey = result.apiKey;
+      if (!apiKey && result.status !== 'app_reporting') {
+        await deletePendingSession(pending.poll_id, pendingDir);
+        return exitWithStatus('key_unavailable', {
+          project_id: result.projectId ?? undefined,
+          remediation: 'run "opslane login" then "opslane setup --relink"',
+        }, 1);
+      }
+      const orgId = result.orgId;
+      const projectId = result.projectId;
+      const repo = result.repo ?? pending.repo;
+      if (!orgId || !projectId) {
+        return exitWithStatus('internal_error', { message: 'provisioned response omitted project credentials' }, 1);
+      }
+      if (!apiKey) {
+        const saved = await resolveCredentials({ apiUrl: pending.api_url, repo, filePath: credentialsPath });
+        if (!saved || saved.project_id !== projectId || saved.org_id !== orgId) {
+          await deletePendingSession(pending.poll_id, pendingDir);
+          return exitWithStatus('key_unavailable', {
+            project_id: result.projectId ?? undefined,
+            remediation: 'run "opslane login" then "opslane setup --relink"',
+          }, 1);
+        }
+      }
+      if (apiKey) {
+        try {
+          await saveAgentCredentials({
+            org_id: orgId, project_id: projectId, api_key: apiKey,
+            repo, api_url: pending.api_url,
+          }, credentialsPath);
+        } catch {
+          return exitWithStatus('internal_error', {
+            message: 'could not save provisioned credentials; retry this poll while the key is available',
+          }, 1);
+        }
+      }
+      if (result.status !== 'app_reporting' && result.status !== 'completed') {
+        waitingForApp = true;
+        const remaining = deadline - Date.now();
+        if (remaining > 0) await sleepFn(Math.min(interval, remaining));
+        continue;
+      }
+      await deletePendingSession(pending.poll_id, pendingDir);
+      jsonOutput({
+        status: 'completed', api_key: apiKey ?? undefined,
+        org_id: orgId, project_id: projectId, repo,
+      });
+      return;
+    }
+    if (result.status === 'failed') {
+      await deletePendingSession(pending.poll_id, pendingDir);
+      return exitWithStatus('failed', {
+        failure_reason: result.failureReason ?? undefined,
+        message: result.message ?? undefined,
+      }, 1);
+    }
+    if (result.status === 'not_found') {
+      await deletePendingSession(pending.poll_id, pendingDir);
+      return exitWithStatus('not_found', { poll_id: pending.poll_id }, 1);
+    }
+    if (result.status === 'expired') {
+      await deletePendingSession(pending.poll_id, pendingDir);
+      return exitWithStatus('expired', { remediation: 're-run setup' }, 1);
+    }
+    if (result.status === 'internal_error') {
+      return exitWithStatus('internal_error', { message: result.message ?? 'server error' }, 1);
+    }
+    return exitWithStatus('internal_error', {
+      message: 'unrecognized server status',
+      server_status: result.status === 'unknown' ? result.serverStatus : result.status,
+    }, 1);
+  }
+
+  if (!reachedServer) {
+    return exitWithStatus('api_unreachable', { api_url: pending.api_url }, 1);
+  }
+  jsonOutput({
+    status: 'pending',
+    poll_id: pending.poll_id,
+    message: waitingForApp
+      ? 'Waiting for your app to report. Start it locally, then run setup --poll again.'
+      : 'Authorization is still pending. Run setup --poll again.',
+  });
+}
+```
+
+**IMPORTANT — the regression gate:** the old `pollLoop` emitted `jsonOutput({ ...body, status: 'completed' })` (whole server body). If `cli/src/__tests__/setup.test.ts` or the subprocess suite asserts on extra fields of that output, match the old shape exactly rather than the trimmed object above — the suites are the source of truth. Run them and reconcile.
+
+**Step 6: Run the full CLI suite — the refactor's proof**
+
+```bash
+pnpm --filter @opslane/cli build && pnpm --filter @opslane/cli test
+```
+Expected: PASS — including `setup.test.ts`, `contract-drift.test.ts`, `contract.subprocess.test.ts`.
+
+**Step 7: Commit**
+
+```bash
+git add cli/src/agent-protocol.ts cli/src/setup.ts cli/src/__tests__/agent-protocol.test.ts
+git commit -m "refactor(cli): extract pollSessionOnce speaking the server status vocabulary"
+```
+
+---
+
+### Task 3: `login()` throws typed errors and takes an injectable token path
+
+**Why:** `login()` swallows errors, sets `process.exitCode = 1` (login.ts:166-170), and persists only to the hardcoded credentials file. `ensureLoggedIn` (Task 4) needs a throwing seam and a path-injectable persist.
+
+**Files:**
+- Create: `cli/src/onboard/errors.ts`
+- Modify: `cli/src/login.ts`, `cli/src/index.ts:36-42`
+- Test: `cli/src/__tests__/login.test.ts` (create if absent)
+
+**Step 1: Create the shared error types** (`cli/src/onboard/errors.ts`):
+
+```typescript
+/** Typed failures for the deterministic onboarding plumbing (Phase 2). */
+
+export class LoginFailedError extends Error {
+  constructor(message = 'Login did not complete. Re-run to try again.') {
+    super(message);
+    this.name = 'LoginFailedError';
+  }
+}
+
+export class NotAuthenticatedError extends Error {
+  constructor(message = 'Your session is not valid. Log in again.') {
+    super(message);
+    this.name = 'NotAuthenticatedError';
+  }
+}
+
+/** 403 from the admin-gated provision route — re-logging-in can never fix this. */
+export class NotAuthorizedError extends Error {
+  constructor(message = 'Provisioning requires an org admin. Ask an org admin to run onboarding or grant you admin.') {
+    super(message);
+    this.name = 'NotAuthorizedError';
+  }
+}
+
+export class ApiUnreachableError extends Error {
+  constructor(apiUrl: string) {
+    super(`Could not reach the Opslane API at ${apiUrl}.`);
+    this.name = 'ApiUnreachableError';
+  }
+}
+```
+
+**Step 2: Write the failing test** (`cli/src/__tests__/login.test.ts`) — only the new contract, not the browser flow:
+
+Do NOT test by binding a privileged port — whether port 1 binds varies by
+environment (as root it binds and the test hangs on the 5-minute callback
+timeout). Inject the callback seam instead:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { login } from '../login.js';
+import { LoginFailedError } from '../onboard/errors.js';
+
+describe('login failure contract', () => {
+  it('throws LoginFailedError instead of swallowing when the callback flow fails', async () => {
+    await expect(login({
+      apiUrl: 'http://localhost:8082', clientId: 'test', quiet: true,
+      waitForCallbackFn: vi.fn().mockRejectedValue(new Error('OAuth error: access_denied')),
+    })).rejects.toBeInstanceOf(LoginFailedError);
+    expect(process.exitCode).not.toBe(1);   // no exit-code poisoning
+  });
+
+  it('quiet mode emits zero console output on the success path too', async () => {
+    // waitForCallbackFn resolves a code; fetchFn (inject via global stub or an
+    // exchangeFn seam) returns a token body; spy on console.log/error and
+    // assert neither was called.
+  });
+});
+```
+
+**Step 3: Run — verify it fails** (`login` resolves today instead of rejecting, and `waitForCallbackFn` is not an accepted option):
+
+```bash
+pnpm --filter @opslane/cli exec vitest run src/__tests__/login.test.ts
+```
+Expected: FAIL — promise resolved instead of rejecting.
+
+**Step 4: Modify `login.ts`:**
+
+1. Extend the options: `export interface LoginOptions extends AuthConfig { tokenPath?: string; quiet?: boolean; waitForCallbackFn?: (port: number, expectedState: string) => Promise<string>; }` and change the signature to `login(config: LoginOptions = defaultAuthConfig())`.
+2. Replace the final `catch` block: remove `process.exitCode = 1` and the `console.error`; rethrow as `LoginFailedError` with the underlying message (`import { LoginFailedError } from './onboard/errors.js'`).
+3. Persist via `persistTokensTo(config.tokenPath ?? defaultTokenPath(), apiUrl, tokens)` (import both from `./auth.js`), replacing the bare `persistTokens` call.
+4. Call `(config.waitForCallbackFn ?? waitForCallback)(port, state)`; gate **every** `console.log`/`console.error` in the function behind `if (!config.quiet)` — the intro block, the "Exchanging authorization code" line, AND the success line, so an embedding TUI stays byte-clean.
+5. In `cli/src/index.ts` the login action becomes the catcher (preserves today's UX exactly):
+
+```typescript
+  .action(async (opts: { apiUrl?: string }) => {
+    try {
+      await login({
+        apiUrl: opts.apiUrl ?? process.env['OPSLANE_API_URL'] ?? 'https://api.opslane.com',
+        clientId: process.env['OPSLANE_CLIENT_ID'] ?? 'opslane-cli',
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(chalk.red(`\nLogin failed: ${message}`));
+      process.exitCode = 1;
+    }
+  });
+```
+Check whether `index.ts` already imports `chalk`; add if missing. Also confirm `program.parseAsync` vs `parse` — if the file still uses bare `parse()`, switch to `await program.parseAsync(process.argv)` so the async action's rejection isn't dropped.
+
+**Step 5: Run — verify pass, then full suite:**
+
+```bash
+pnpm --filter @opslane/cli build && pnpm --filter @opslane/cli test
+```
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add cli/src/onboard/errors.ts cli/src/login.ts cli/src/index.ts cli/src/__tests__/login.test.ts
+git commit -m "refactor(cli): login throws typed errors and takes an injectable token path"
+```
+
+---
+
+### Task 4: `ensureLoggedIn` with refresh grant
+
+**Files:**
+- Modify: `cli/src/auth.ts` (add `updateTokensAt` — locked read-modify-write over one origin's pair)
+- Create: `cli/src/onboard/provision.ts` (started here, finished in Task 6)
+- Test: `cli/src/onboard/__tests__/provision.test.ts`
+
+**Why `updateTokensAt`:** two constraints meet here. (a) `loadTokensFrom` returns `null` for expired pairs (auth.ts:99), but the refresh path needs the **expired** pair's `refreshToken`. (b) The refresh grant **rotates** the token server-side and treats a second consumption of the same token as reuse — revoking the user's whole token family (`ConsumeRefreshToken` / `ErrTokenReuse` in `handler/auth_handlers.go`). So the read→refresh→persist sequence must be one atomic unit under the token file's lock, with a re-check inside it. `withFileLock` is not reentrant (nesting `persistTokensTo` inside it would deadlock into the 2s acquire timeout), so add a callback-style primitive to `auth.ts`:
+
+```typescript
+/**
+ * Serialized read-modify-write over one origin's token pair. The callback
+ * receives the stored pair (expired included; null if absent) and returns the
+ * replacement to persist, or null to leave the file unchanged. Holding the
+ * lock across the callback is the point: it makes a refresh-grant rotation
+ * atomic, so two CLI processes can never consume the same refresh token
+ * (the server would treat the loser as token reuse and revoke the family).
+ */
+export async function updateTokensAt(
+  filePath: string,
+  apiUrl: string,
+  update: (current: TokenPair | null) => Promise<TokenPair | null>,
+): Promise<TokenPair | null> {
+  return withFileLock(filePath, async () => {
+    const file = await readTokenFile(filePath, false);
+    const origin = canonicalOrigin(apiUrl);
+    const next = await update(file.tokens[origin] ?? null);
+    if (next) {
+      file.tokens[origin] = next;
+      await writeFileAtomic(filePath, `${JSON.stringify(file, null, 2)}\n`);
+    }
+    return next;
+  });
+}
+```
+
+Known bound: a second process waiting on the lock gives up after `withFileLock`'s 2s acquire deadline and errors visibly — acceptable; a visible error beats a silently revoked token family.
+
+**Step 1: Write the failing tests** (in `provision.test.ts`; use `fs.mkdtemp` + `persistTokensTo` to seed token files):
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { persistTokensTo } from '../../auth.js';
+import { ensureLoggedIn } from '../provision.js';
+import { LoginFailedError } from '../errors.js';
+
+const API = 'http://localhost:8082';
+const LIVE = { accessToken: 'live', refreshToken: 'r1', expiresAt: Date.now() + 3_600_000 };
+const DEAD = { accessToken: 'dead', refreshToken: 'r2', expiresAt: Date.now() - 1_000 };
+
+async function tokenFile(pair?: typeof LIVE) {
+  const dir = await mkdtemp(join(tmpdir(), 'opslane-auth-'));
+  const path = join(dir, 'credentials.json');
+  if (pair) await persistTokensTo(path, API, pair);
+  return path;
+}
+
+describe('ensureLoggedIn', () => {
+  it('a live token skips both refresh and login', async () => {
+    const tokenPath = await tokenFile(LIVE);
+    const loginFn = vi.fn();
+    const fetchFn = vi.fn();
+    const tokens = await ensureLoggedIn({ apiUrl: API, tokenPath, loginFn, fetchFn });
+    expect(tokens.accessToken).toBe('live');
+    expect(loginFn).not.toHaveBeenCalled();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('an expired token tries the refresh grant before any browser', async () => {
+    const tokenPath = await tokenFile(DEAD);
+    const loginFn = vi.fn();
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      access_token: 'fresh', refresh_token: 'r3', expires_in: 900,
+    }), { status: 200 }));
+    const tokens = await ensureLoggedIn({ apiUrl: API, tokenPath, loginFn, fetchFn });
+    expect(tokens.accessToken).toBe('fresh');
+    expect(loginFn).not.toHaveBeenCalled();
+    const [url, init] = fetchFn.mock.calls[0]!;
+    expect(url).toBe(`${API}/auth/refresh`);
+    expect(JSON.parse(init.body as string)).toEqual({ refresh_token: 'r2' });
+  });
+
+  it('refresh rejected → login exactly once, then re-load succeeds', async () => {
+    const tokenPath = await tokenFile(DEAD);
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      error: 'invalid or expired refresh token',
+    }), { status: 401 }));
+    const loginFn = vi.fn(async () => { await persistTokensTo(tokenPath, API, LIVE); });
+    const tokens = await ensureLoggedIn({ apiUrl: API, tokenPath, loginFn, fetchFn });
+    expect(tokens.accessToken).toBe('live');
+    expect(loginFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('login ran but produced no live token → LoginFailedError, login not retried', async () => {
+    const tokenPath = await tokenFile();          // empty
+    const loginFn = vi.fn(async () => {});        // "user closed the tab"
+    await expect(ensureLoggedIn({ apiUrl: API, tokenPath, loginFn, fetchFn: vi.fn() }))
+      .rejects.toBeInstanceOf(LoginFailedError);
+    expect(loginFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('concurrent callers refresh exactly once — the loser reuses the winner\'s tokens', async () => {
+    // Regression for token-family revocation: the refresh grant rotates the
+    // refresh token; a second consumption of the same one revokes the family.
+    const tokenPath = await tokenFile(DEAD);
+    const fetchFn = vi.fn().mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, 50));   // slow refresh, both callers in flight
+      return new Response(JSON.stringify({
+        access_token: 'fresh', refresh_token: 'r3', expires_in: 900,
+      }), { status: 200 });
+    });
+    const loginFn = vi.fn();
+    const [a, b] = await Promise.all([
+      ensureLoggedIn({ apiUrl: API, tokenPath, loginFn, fetchFn }),
+      ensureLoggedIn({ apiUrl: API, tokenPath, loginFn, fetchFn }),
+    ]);
+    expect(fetchFn).toHaveBeenCalledTimes(1);        // one consumption of r2, ever
+    expect(a.accessToken).toBe('fresh');
+    expect(b.accessToken).toBe('fresh');
+    expect(loginFn).not.toHaveBeenCalled();
+  });
+});
+```
+
+**Step 2: Run — verify FAIL** (module not found).
+
+**Step 3: Implement in `cli/src/onboard/provision.ts`:**
+
+```typescript
+import { canonicalOrigin } from '../origin.js';
+import {
+  loadTokensFrom, updateTokensAt, type TokenPair,
+} from '../auth.js';
+import { LoginFailedError } from './errors.js';
+
+export interface EnsureLoggedInOptions {
+  apiUrl: string;
+  tokenPath: string;
+  loginFn: () => Promise<void>;
+  fetchFn?: typeof fetch;
+}
+
+async function refreshTokens(
+  apiUrl: string,
+  refreshToken: string,
+  fetchFn: typeof fetch,
+): Promise<TokenPair | null> {
+  try {
+    const response = await fetchFn(`${apiUrl}/auth/refresh`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+    if (!response.ok) return null;
+    const body: unknown = await response.json();
+    if (typeof body !== 'object' || body === null) return null;
+    const record = body as Record<string, unknown>;
+    if (typeof record['access_token'] !== 'string'
+      || typeof record['refresh_token'] !== 'string'
+      || typeof record['expires_in'] !== 'number') return null;
+    return {
+      accessToken: record['access_token'],
+      refreshToken: record['refresh_token'],
+      expiresAt: Date.now() + record['expires_in'] * 1000,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function ensureLoggedIn(options: EnsureLoggedInOptions): Promise<TokenPair> {
+  const apiUrl = canonicalOrigin(options.apiUrl);
+  const fetchFn = options.fetchFn ?? fetch;
+
+  const live = await loadTokensFrom(options.tokenPath, apiUrl);
+  if (live) return live;
+
+  // Atomic under the token file's lock: re-check (a concurrent winner's
+  // persist satisfies us with no second consumption), then refresh-and-persist
+  // in one unit. See updateTokensAt for why this must not be three steps.
+  const refreshed = await updateTokensAt(options.tokenPath, apiUrl, async (current) => {
+    if (current && Date.now() < current.expiresAt) return current;   // winner already refreshed
+    if (!current?.refreshToken) return null;
+    return refreshTokens(apiUrl, current.refreshToken, fetchFn);
+  });
+  if (refreshed && Date.now() < refreshed.expiresAt) return refreshed;
+
+  await options.loginFn();   // throws LoginFailedError on flow failure (Task 3)
+  const after = await loadTokensFrom(options.tokenPath, apiUrl);
+  if (!after) throw new LoginFailedError();
+  return after;
+}
+```
+
+**Step 4: Run — verify PASS. Step 5: Commit:**
+
+```bash
+git add cli/src/auth.ts cli/src/onboard/provision.ts cli/src/onboard/__tests__/provision.test.ts
+git commit -m "feat(cli): onboard login gate with refresh grant and typed failure"
+```
+
+---
+
+### Task 5: pending sessions gain `kind`; `findPendingByRepo`
+
+**Files:**
+- Modify: `cli/src/pending.ts`
+- Test: `cli/src/__tests__/pending.test.ts` (extend)
+
+**Step 1: Write the failing tests** (extend the existing file, reusing its temp-dir pattern):
+
+```typescript
+// New describe block. UUIDs must be valid v4-ish per UUID_PATTERN.
+import { findPendingByRepo, savePendingSession } from '../pending.js';
+
+const API = 'http://localhost:8082';
+function session(pollId: string, overrides: Partial<PendingSession> = {}): PendingSession {
+  return {
+    kind: 'onboard', poll_id: pollId, poll_token: 't', api_url: API,
+    repo: 'Acme/Web', created_at: new Date().toISOString(), ...overrides,
+  };
+}
+
+describe('findPendingByRepo', () => {
+  it('returns null when nothing matches', async () => { /* empty dir → null */ });
+  it('matches case-insensitively on repo and canonically on origin', async () => {
+    // save session('...1'); expect findPendingByRepo(API, 'acme/web', dir) to return it
+  });
+  it('same repo, different origin → null', async () => {
+    // save with api_url 'http://other:9000'; expect null for API
+  });
+  it('a setup-kind session for the same repo is neither returned nor deleted', async () => {
+    // save session with kind absent (legacy) AND one with kind: 'setup';
+    // expect null, and both files still on disk
+  });
+  it('multiple onboard matches → newest returned, older deleted', async () => {
+    // two sessions, created_at 1h apart; expect newest returned and old file gone
+  });
+  it('entries older than the TTL are pruned and not returned', async () => {
+    // created_at 25h ago (TTL 24h) → null, file deleted
+  });
+  it('malformed files are skipped, not thrown', async () => {
+    // write 'not json' to <uuid>.json → find still works
+  });
+});
+```
+
+Write each body out fully in the test file (they are 3-6 lines each with the helpers above).
+
+**Step 2: Run — verify FAIL** (`findPendingByRepo` not exported).
+
+**Step 3: Implement in `pending.ts`:**
+
+```typescript
+import { readdir, readFile, unlink } from 'node:fs/promises';   // add readdir
+
+export interface PendingSession {
+  kind?: 'onboard' | 'setup';   // absent = setup (pre-discriminator files)
+  poll_id: string;
+  poll_token: string;
+  api_url: string;
+  repo: string;
+  created_at: string;
+}
+
+export const PENDING_TTL_MS = 24 * 60 * 60 * 1000;   // matches server onboardSessionTTL
+
+// In isPendingSession, additionally accept the optional kind:
+//   const kind = record['kind'];
+//   if (kind !== undefined && kind !== 'onboard' && kind !== 'setup') return false;
+
+export async function findPendingByRepo(
+  apiUrl: string,
+  repo: string,
+  baseDir: string = DEFAULT_PENDING_DIR,
+  ttlMs: number = PENDING_TTL_MS,
+): Promise<PendingSession | null> {
+  let entries: string[];
+  try { entries = await readdir(baseDir); } catch { return null; }
+  const origin = canonicalOrigin(apiUrl);
+  const target = repo.toLowerCase();
+  const matches: PendingSession[] = [];
+  for (const name of entries) {
+    if (!name.endsWith('.json')) continue;
+    let parsed: unknown;
+    try { parsed = JSON.parse(await readFile(join(baseDir, name), 'utf8')); } catch { continue; }
+    if (!isPendingSession(parsed)) continue;
+    if ((parsed.kind ?? 'setup') !== 'onboard') continue;
+    let sameTarget = false;
+    try {
+      sameTarget = canonicalOrigin(parsed.api_url) === origin && parsed.repo.toLowerCase() === target;
+    } catch { continue; }
+    if (!sameTarget) continue;
+    const age = Date.now() - Date.parse(parsed.created_at);
+    if (!Number.isFinite(age) || age > ttlMs) {
+      await deletePendingSession(parsed.poll_id, baseDir).catch(() => undefined);
+      continue;
+    }
+    matches.push(parsed);
+  }
+  matches.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
+  const [newest, ...stale] = matches;
+  for (const s of stale) await deletePendingSession(s.poll_id, baseDir).catch(() => undefined);
+  return newest ?? null;
+}
+```
+
+**Step 4: Run pending tests + full suite — PASS** (`setup.ts` needs no change: it never sets `kind`, and absent = setup). **Step 5: Commit:**
+
+```bash
+git add cli/src/pending.ts cli/src/__tests__/pending.test.ts
+git commit -m "feat(cli): pending sessions carry a flow kind; add findPendingByRepo"
+```
+
+---
+
+### Task 6: `ensureProvisioned` — synchronous mint with poll-first resume
+
+**Files:**
+- Modify: `cli/src/onboard/provision.ts` (add to Task 4's file)
+- Test: `cli/src/onboard/__tests__/provision.test.ts` (extend)
+
+**Step 1: Write the failing tests:**
+
+```typescript
+import { ensureProvisioned } from '../provision.js';
+import { NotAuthenticatedError, NotAuthorizedError, ApiUnreachableError } from '../errors.js';
+import { savePendingSession, loadPendingSession } from '../../pending.js';
+import { loadAgentCredentials } from '../../agent-credentials.js';
+
+const PROVISIONED = {
+  status: 'provisioned', api_key: 'opk_raw', endpoint: 'http://localhost:8082',
+  org_id: 'org1', project_id: 'proj1', repo: 'acme/web',
+  poll_id: '123e4567-e89b-42d3-a456-426614174000', poll_token: 'ptok',
+};
+
+describe('ensureProvisioned', () => {
+  it('fresh repo: POSTs with the bearer token, saves pending {kind: onboard} + credentials, returns the tuple', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify(PROVISIONED), { status: 201 }));
+    const result = await ensureProvisioned({ apiUrl: API, repo: 'acme/web', token: 'bearer1', fetchFn, ...tmpPaths() });
+    expect(result).toMatchObject({
+      apiKey: 'opk_raw', endpoint: 'http://localhost:8082', orgId: 'org1',
+      projectId: 'proj1', sessionId: PROVISIONED.poll_id, pollToken: 'ptok',
+    });
+    const [url, init] = fetchFn.mock.calls[0]!;
+    expect(url).toBe(`${API}/api/v1/onboard/provision`);
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer bearer1');
+    const pending = await loadPendingSession(PROVISIONED.poll_id, pendingDir);
+    expect(pending?.kind).toBe('onboard');
+    expect((await loadAgentCredentials({ apiUrl: API, repo: 'acme/web', filePath: credentialsPath }))?.api_key).toBe('opk_raw');
+  });
+
+  it('resume: a live pending session is verified with ONE poll and reused — no POST', async () => {
+    // seed pending {kind:'onboard'}; fetchFn answers the POLL url with key_ok + api_key
+    // expect: no POST call, result.sessionId === pending.poll_id, result.apiKey from the poll
+  });
+
+  it('resume: poll says expired → stale pending deleted, falls through to fresh POST', async () => {
+    // fetchFn: poll url → 410 {status:'expired'}; provision url → 201 PROVISIONED
+    // expect: new sessionId, old pending file gone, new pending file saved
+  });
+
+  it('resume: poll completed WITHOUT api_key (window closed) → fresh POST', async () => { /* same shape */ });
+
+  it('401 → NotAuthenticatedError', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: 'authentication required' }), { status: 401 }));
+    await expect(ensureProvisioned({ ...base, fetchFn })).rejects.toBeInstanceOf(NotAuthenticatedError);
+  });
+
+  it('403 (admin gate, {"error"} dialect) → NotAuthorizedError naming an org admin', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 }));
+    await expect(ensureProvisioned({ ...base, fetchFn })).rejects.toBeInstanceOf(NotAuthorizedError);
+  });
+
+  it('429 waits retry_after then retries', async () => {
+    // first call: 429 {status:'rate_limited', retry_after: 5}; second: 201
+    // injected sleepFn records 5000ms; expect success after 2 fetch calls
+  });
+
+  it('a network error on the POST is NOT retried — one attempt, then ApiUnreachableError', async () => {
+    // Retrying an ambiguous POST is unsafe: a lost response still rotated the
+    // key server-side, so blind retries multiply state mutations.
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    await expect(ensureProvisioned({ ...base, fetchFn, sleepFn })).rejects.toBeInstanceOf(ApiUnreachableError);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it('resume: an unreachable probe throws and PRESERVES the pending session — never falls through to a fresh rotation', async () => {
+    // seed pending {kind:'onboard'}; fetchFn rejects (outage)
+    // expect: ApiUnreachableError, fetchFn called once (no POST), pending file still on disk
+  });
+
+  it('201 missing org_id/project_id → typed error, no credentials saved', async () => { /* body without org_id */ });
+});
+```
+
+Fill in the sketched bodies fully; `tmpPaths()` mints `{pendingDir, credentialsPath}` under `mkdtemp`.
+
+**Step 2: Run — FAIL. Step 3: Implement** (append to `provision.ts`):
+
+```typescript
+import { pollSessionOnce } from '../agent-protocol.js';
+import {
+  findPendingByRepo, savePendingSession, deletePendingSession,
+  validatePollId, defaultPendingDir, type PendingSession,
+} from '../pending.js';
+import { saveAgentCredentials, defaultCredentialsPath } from '../agent-credentials.js';
+import { NotAuthenticatedError, NotAuthorizedError, ApiUnreachableError } from './errors.js';
+import { responseJSON, retryAfterSeconds } from '../agent-protocol.js';
+
+export interface ProvisionResult {
+  apiKey: string;
+  endpoint: string;
+  orgId: string;
+  projectId: string;
+  sessionId: string;
+  pollToken: string;
+}
+
+export interface EnsureProvisionedOptions {
+  apiUrl: string;
+  repo: string;
+  token: string;                       // account bearer token from ensureLoggedIn
+  fetchFn?: typeof fetch;
+  sleepFn?: (ms: number) => Promise<void>;
+  pendingDir?: string;
+  credentialsPath?: string;
+  max429Retries?: number;              // default 3; 429 is the ONLY retried failure
+}
+
+const RESUMABLE = new Set(['provisioned', 'key_ok', 'app_reporting', 'completed']);
+
+export async function ensureProvisioned(options: EnsureProvisionedOptions): Promise<ProvisionResult> {
+  const apiUrl = canonicalOrigin(options.apiUrl);
+  const fetchFn = options.fetchFn ?? fetch;
+  const sleepFn = options.sleepFn ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const pendingDir = options.pendingDir ?? defaultPendingDir();
+  const credentialsPath = options.credentialsPath ?? defaultCredentialsPath();
+
+  // Poll-first resume: the poll re-delivers the raw key while the session lives,
+  // so one poll proves server-side liveness, recovers a key that never reached
+  // disk, and catches a key another machine rotated. A DEAD session falls
+  // through to a fresh POST; an UNREACHABLE probe must NOT — provisioning
+  // rotates the key and expires this session server-side, so falling through
+  // during an outage would destroy a session that is still perfectly alive.
+  const pending = await findPendingByRepo(apiUrl, options.repo, pendingDir);
+  if (pending) {
+    const probe = await pollSessionOnce({
+      apiUrl, sessionId: pending.poll_id, pollToken: pending.poll_token, fetchFn,
+    });
+    if (probe.status === 'unreachable') {
+      throw new ApiUnreachableError(apiUrl);   // pending record preserved; re-run resumes
+    }
+    if (probe.status !== 'unknown'
+      && RESUMABLE.has(probe.status) && probe.apiKey && probe.orgId && probe.projectId) {
+      const result: ProvisionResult = {
+        apiKey: probe.apiKey, endpoint: apiUrl, orgId: probe.orgId,
+        projectId: probe.projectId, sessionId: pending.poll_id, pollToken: pending.poll_token,
+      };
+      await saveAgentCredentials({
+        org_id: result.orgId, project_id: result.projectId, api_key: result.apiKey,
+        repo: options.repo, api_url: apiUrl,
+      }, credentialsPath);
+      return result;
+    }
+    // Dead or key-less session — a fresh POST replaces it.
+    await deletePendingSession(pending.poll_id, pendingDir).catch(() => undefined);
+  }
+
+  // ONE attempt — no automatic retry after an ambiguous network failure. Every
+  // successful POST rotates the key and expires prior sessions server-side, so
+  // a lost RESPONSE means a blind retry mutates server state again (and again).
+  // On failure the user re-runs; resume is poll-first, so a saved session is
+  // recovered rather than re-minted. 429 alone is retried: the limiter rejects
+  // BEFORE provisioning runs, so nothing was mutated.
+  const max429Retries = options.max429Retries ?? 3;
+  let response: Response;
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      response = await fetchFn(`${apiUrl}/api/v1/onboard/provision`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${options.token}` },
+        body: JSON.stringify({ repo_url: options.repo }),
+      });
+    } catch {
+      throw new ApiUnreachableError(apiUrl);
+    }
+    if (response.status === 429 && attempt < max429Retries) {
+      const body = await responseJSON(response.clone()) ?? {};
+      await sleepFn(retryAfterSeconds(response, body) * 1_000);
+      continue;
+    }
+    break;
+  }
+
+  if (response.status === 401) throw new NotAuthenticatedError();
+  if (response.status === 403) throw new NotAuthorizedError();
+  const body = await responseJSON(response);
+  if (response.status !== 201 || !body || body['status'] !== 'provisioned') {
+    const detail = body ? (body['error'] ?? body['message'] ?? body['status']) : 'unparseable response';
+    throw new Error(`provisioning failed (HTTP ${response.status}): ${String(detail)}`);
+  }
+
+  const apiKey = body['api_key'];
+  const orgId = body['org_id'];
+  const projectId = body['project_id'];
+  const pollId = body['poll_id'];
+  const pollToken = body['poll_token'];
+  const endpoint = typeof body['endpoint'] === 'string' ? body['endpoint'] : apiUrl;
+  if (typeof apiKey !== 'string' || typeof orgId !== 'string' || typeof projectId !== 'string'
+    || typeof pollId !== 'string' || typeof pollToken !== 'string') {
+    throw new Error('provisioning response omitted required credentials');
+  }
+  validatePollId(pollId);
+
+  const session: PendingSession = {
+    kind: 'onboard', poll_id: pollId, poll_token: pollToken,
+    api_url: apiUrl, repo: options.repo, created_at: new Date().toISOString(),
+  };
+  await savePendingSession(session, pendingDir);
+  await saveAgentCredentials({
+    org_id: orgId, project_id: projectId, api_key: apiKey,
+    repo: options.repo, api_url: apiUrl,
+  }, credentialsPath);
+
+  return { apiKey, endpoint, orgId, projectId, sessionId: pollId, pollToken };
+}
+```
+
+**Step 4: Run — PASS, then full suite. Step 5: Commit:**
+
+```bash
+git add cli/src/onboard/provision.ts cli/src/onboard/__tests__/provision.test.ts
+git commit -m "feat(cli): ensureProvisioned with poll-first resume and typed auth errors"
+```
+
+---
+
+### Task 7: `writeEnvLocal` — the sole key-to-disk path
+
+**Files:**
+- Create: `cli/src/envfile.ts`
+- Modify: `cli/src/init.ts` (rewire `persistApiKeyEnvironment`, init.ts:108)
+- Test: `cli/src/__tests__/envfile.test.ts`
+
+**Step 1: Write the failing tests:**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, readFile, writeFile, stat, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeEnvLocal } from '../envfile.js';
+
+async function dir() { return mkdtemp(join(tmpdir(), 'opslane-env-')); }
+async function mode(path: string) { return (await stat(path)).mode & 0o777; }
+
+describe('writeEnvLocal', () => {
+  it('creates .env.local with mode 0600 and returns the path', async () => {
+    const d = await dir();
+    const path = await writeEnvLocal(d, { VITE_OPSLANE_API_KEY: 'opk_1' });
+    expect(path).toBe(join(d, '.env.local'));
+    expect(await readFile(path, 'utf8')).toBe('VITE_OPSLANE_API_KEY=opk_1\n');
+    expect(await mode(path)).toBe(0o600);
+  });
+
+  it('appends missing keys without touching existing lines', async () => {
+    const d = await dir();
+    await writeFile(join(d, '.env.local'), 'EXISTING=1\n');
+    await writeEnvLocal(d, { VITE_OPSLANE_ENDPOINT: 'http://x' });
+    expect(await readFile(join(d, '.env.local'), 'utf8'))
+      .toBe('EXISTING=1\nVITE_OPSLANE_ENDPOINT=http://x\n');
+  });
+
+  it('replaces an existing value for the same key', async () => {
+    const d = await dir();
+    await writeFile(join(d, '.env.local'), 'VITE_OPSLANE_API_KEY=old\nOTHER=2\n');
+    await writeEnvLocal(d, { VITE_OPSLANE_API_KEY: 'new' });
+    expect(await readFile(join(d, '.env.local'), 'utf8')).toBe('VITE_OPSLANE_API_KEY=new\nOTHER=2\n');
+  });
+
+  it('tightens a pre-existing 0644 file to 0600', async () => {
+    const d = await dir();
+    const p = join(d, '.env.local');
+    await writeFile(p, 'A=1\n');
+    await chmod(p, 0o644);
+    await writeEnvLocal(d, { VITE_OPSLANE_API_KEY: 'k' });
+    expect(await mode(p)).toBe(0o600);
+  });
+
+  it('adds .env.local to the dir gitignore exactly once', async () => {
+    const d = await dir();
+    await writeEnvLocal(d, { A_B: '1' });
+    await writeEnvLocal(d, { A_B: '2' });
+    const lines = (await readFile(join(d, '.gitignore'), 'utf8')).split('\n').filter((l) => l === '.env.local');
+    expect(lines).toHaveLength(1);
+  });
+
+  it('rejects var names failing the regex', async () => {
+    const d = await dir();
+    await expect(writeEnvLocal(d, { 'lower_case': 'x' })).rejects.toThrow(/variable name/);
+    await expect(writeEnvLocal(d, { 'A=B\nINJECTED': 'x' })).rejects.toThrow(/variable name/);
+  });
+});
+```
+
+**Step 2: Run — FAIL. Step 3: Implement `cli/src/envfile.ts`:**
+
+```typescript
+/**
+ * The single place a provisioned API key touches disk. Names come from the
+ * agent's validated OnboardingPlan (tools.ts validatePlan); values come from
+ * provisioning. Atomic write (fsutil), 0600 always.
+ */
+import { readFile, writeFile, chmod } from 'node:fs/promises';
+import { join } from 'node:path';
+import { writeFileAtomic } from './fsutil.js';
+
+const ENV_VAR_NAME = /^[A-Z][A-Z0-9_]*$/;
+
+export async function writeEnvLocal(dir: string, vars: Record<string, string>): Promise<string> {
+  for (const name of Object.keys(vars)) {
+    if (!ENV_VAR_NAME.test(name)) {
+      throw new Error(`invalid environment variable name: ${JSON.stringify(name)}`);
+    }
+  }
+  const envPath = join(dir, '.env.local');
+  let current = '';
+  try { current = await readFile(envPath, 'utf8'); } catch { /* create below */ }
+  let next = current;
+  for (const [name, value] of Object.entries(vars)) {
+    const line = `${name}=${value}`;
+    const pattern = new RegExp(`^${name}=.*$`, 'm');
+    next = pattern.test(next)
+      ? next.replace(pattern, line)
+      : `${next}${next && !next.endsWith('\n') ? '\n' : ''}${line}\n`;
+  }
+  await writeFileAtomic(envPath, next);   // temp opened 0600 → rename
+  await chmod(envPath, 0o600);            // covers pre-existing looser modes
+
+  const gitignorePath = join(dir, '.gitignore');
+  let gitignore = '';
+  try { gitignore = await readFile(gitignorePath, 'utf8'); } catch { /* create below */ }
+  if (!gitignore.split(/\r?\n/).includes('.env.local')) {
+    gitignore += `${gitignore && !gitignore.endsWith('\n') ? '\n' : ''}.env.local\n`;
+    await writeFile(gitignorePath, gitignore, 'utf8');
+  }
+  return envPath;
+}
+```
+
+**Step 4: Rewire `init.ts`** — replace the body of `persistApiKeyEnvironment` (init.ts:108-128) with:
+
+```typescript
+async function persistApiKeyEnvironment(cwd: string, framework: Framework, apiKey: string): Promise<void> {
+  await writeEnvLocal(cwd, { [apiKeyEnvironmentVariable(framework)]: apiKey });
+}
+```
+(add `import { writeEnvLocal } from './envfile.js';`; remove now-unused fs imports if any).
+
+**Step 5: Run envfile + init tests + full suite — PASS. Step 6: Commit:**
+
+```bash
+git add cli/src/envfile.ts cli/src/init.ts cli/src/__tests__/envfile.test.ts
+git commit -m "refactor(cli): shared atomic env writer; init rewired onto it"
+```
+
+---
+
+### Task 8: `waitForAppReporting`
+
+**Files:**
+- Create: `cli/src/onboard/wait.ts`
+- Test: `cli/src/onboard/__tests__/wait.test.ts`
+
+**Step 1: Write the failing tests** — drive with a queue of poll responses:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { waitForAppReporting } from '../wait.js';
+
+const OPTS = {
+  apiUrl: 'http://localhost:8082',
+  sessionId: '123e4567-e89b-42d3-a456-426614174000',
+  pollToken: 'ptok',
+  timeoutMs: 60_000,
+  sleepFn: vi.fn().mockResolvedValue(undefined),
+};
+function seq(...bodies: Array<{ status: number; body: unknown }>) {
+  const fetchFn = vi.fn();
+  for (const { status, body } of bodies) {
+    fetchFn.mockResolvedValueOnce(new Response(JSON.stringify(body), { status }));
+  }
+  return fetchFn;
+}
+
+describe('waitForAppReporting', () => {
+  it('provisioned → key_ok → app_reporting resolves (provisioned counts as waiting)', async () => {
+    const fetchFn = seq(
+      { status: 200, body: { status: 'provisioned', api_key: 'k' } },
+      { status: 200, body: { status: 'key_ok', api_key: 'k' } },
+      { status: 200, body: { status: 'app_reporting' } },
+    );
+    await expect(waitForAppReporting({ ...OPTS, fetchFn })).resolves.toMatchObject({ status: 'app_reporting' });
+  });
+
+  it('completed resolves', async () => { /* single completed response */ });
+
+  it('failed rejects with the failure_reason and is never retried', async () => {
+    const fetchFn = seq({ status: 200, body: { status: 'failed', failure_reason: 'github_error' } });
+    await expect(waitForAppReporting({ ...OPTS, fetchFn })).rejects.toThrow(/github_error/);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('expired and not_found reject with remediation', async () => { /* 410 / 404 */ });
+
+  it('rate_limited honors retryAfter before the next poll', async () => {
+    // 429 {retry_after: 9} then app_reporting; expect sleepFn called with 9000
+  });
+
+  it('unreachable retries with backoff up to a bound, then rejects', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(waitForAppReporting({ ...OPTS, fetchFn, maxUnreachable: 3 })).rejects.toThrow(/unreachable/i);
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('timeout rejects with a message naming the session id', async () => {
+    // nowFn advancing past timeoutMs; pending-status responses; expect /123e4567/ in message
+  });
+});
+```
+
+**Step 2: Run — FAIL. Step 3: Implement `cli/src/onboard/wait.ts`:**
+
+```typescript
+/**
+ * Poll until the SDK phones home (app_reporting) for this session.
+ * Purity rule: never touches pending state — the controller owns state, and on
+ * timeout the pending record must survive so a re-run resumes the wait.
+ */
+import { pollSessionOnce, type PollResult } from '../agent-protocol.js';
+
+export interface WaitOptions {
+  apiUrl: string;
+  sessionId: string;
+  pollToken: string;
+  fetchFn?: typeof fetch;
+  sleepFn?: (ms: number) => Promise<void>;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  maxUnreachable?: number;
+  nowFn?: () => number;
+}
+
+const WAITING = new Set(['pending', 'provisioned', 'key_ok']);
+
+export async function waitForAppReporting(options: WaitOptions): Promise<PollResult> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const sleepFn = options.sleepFn ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const now = options.nowFn ?? Date.now;
+  const interval = options.pollIntervalMs ?? 3_000;
+  const deadline = now() + (options.timeoutMs ?? 15 * 60_000);
+  const maxUnreachable = options.maxUnreachable ?? 20;
+  let unreachable = 0;
+
+  while (now() < deadline) {
+    const result = await pollSessionOnce({
+      apiUrl: options.apiUrl, sessionId: options.sessionId,
+      pollToken: options.pollToken, fetchFn,
+    });
+
+    if (result.status === 'app_reporting' || result.status === 'completed') return result;
+    if (result.status === 'failed') {
+      throw new Error(`onboarding session failed: ${result.failureReason ?? result.message ?? 'unknown'}`);
+    }
+    if (result.status === 'expired') {
+      throw new Error(`session ${options.sessionId} expired — re-run onboarding to mint a new key`);
+    }
+    if (result.status === 'not_found') {
+      throw new Error(`session ${options.sessionId} was not found — re-run onboarding`);
+    }
+    if (result.status === 'internal_error' || result.status === 'unknown') {
+      throw new Error(`server error while waiting: ${'message' in result ? result.message ?? 'unknown' : 'unknown'}`);
+    }
+    if (result.status === 'unreachable') {
+      unreachable += 1;
+      if (unreachable >= maxUnreachable) {
+        throw new Error(`API unreachable after ${unreachable} attempts while waiting for session ${options.sessionId}`);
+      }
+      await sleepFn(Math.min(interval * unreachable, 30_000));   // linear backoff, capped
+      continue;
+    }
+    unreachable = 0;
+    if (result.status === 'rate_limited') {
+      await sleepFn((result.retryAfterSeconds ?? 60) * 1_000);
+      continue;
+    }
+    if (WAITING.has(result.status)) {
+      await sleepFn(interval);
+      continue;
+    }
+  }
+  throw new Error(`timed out waiting for your app to report (session ${options.sessionId}). ` +
+    'Start your app, then re-run onboarding — it will resume this session.');
+}
+```
+
+**Step 4: Run — PASS. Step 5: Commit:**
+
+```bash
+git add cli/src/onboard/wait.ts cli/src/onboard/__tests__/wait.test.ts
+git commit -m "feat(cli): waitForAppReporting on the shared poll seam"
+```
+
+---
+
+### Task 9: run log — metadata by default, keyed by local run id
+
+**Files:**
+- Create: `cli/src/onboard/runlog.ts`
+- Test: `cli/src/onboard/__tests__/runlog.test.ts`
+
+**Step 1: Write the failing tests:**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRunLog } from '../runlog.js';
+
+async function dir() { return mkdtemp(join(tmpdir(), 'opslane-runlog-')); }
+const MSG = {
+  type: 'tool_use', name: 'Read',
+  input: { file_path: 'src/main.ts' },
+  content: 'const SECRET = "opk_raw_key_123";',
+};
+
+describe('createRunLog', () => {
+  it('metadata mode records ts/type/name/hash/bytes — never content or args', async () => {
+    const d = await dir();
+    const log = await createRunLog({ dir: d, runId: 'r1', mode: 'metadata' });
+    await log.record(MSG);
+    await log.finish({ outcome: 'ok', turns: 1, toolCalls: 1, durationMs: 5, totalCostUsd: 0.01 });
+    const text = await readFile(log.path, 'utf8');
+    expect(text).not.toContain('opk_raw_key_123');
+    expect(text).not.toContain('src/main.ts');
+    const first = JSON.parse(text.split('\n')[0]!);
+    expect(first).toMatchObject({ type: 'tool_use', name: 'Read' });
+    expect(first.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(first.bytes).toBeGreaterThan(0);
+  });
+
+  it('full mode redacts registered secrets even inside content', async () => {
+    const d = await dir();
+    const log = await createRunLog({
+      dir: d, runId: 'r2', mode: 'full', redact: ['opk_raw_key_123'],
+    });
+    await log.record(MSG);
+    const text = await readFile(log.path, 'utf8');
+    expect(text).not.toContain('opk_raw_key_123');
+    expect(text).toContain('[REDACTED]');
+    expect(text).toContain('src/main.ts');   // non-secret content IS kept in full mode
+  });
+
+  it('full mode redacts sensitive FIELDS regardless of value — poll_token, refresh_token, accessToken, code_verifier', async () => {
+    const d = await dir();
+    const log = await createRunLog({ dir: d, runId: 'r2b', mode: 'full' });
+    await log.record({ poll_token: 'pval1', refresh_token: 'rval1', accessToken: 'aval1', code_verifier: 'vval1' });
+    const text = await readFile(log.path, 'utf8');
+    for (const secret of ['pval1', 'rval1', 'aval1', 'vval1']) expect(text).not.toContain(secret);
+  });
+
+  it('addSecret registers values discovered after creation — the provisioned key exists only post-provisioning', async () => {
+    const d = await dir();
+    const log = await createRunLog({ dir: d, runId: 'r2c', mode: 'full' });
+    log.addSecret('opk_minted_later');
+    await log.record({ content: 'x opk_minted_later y' });
+    expect(await readFile(log.path, 'utf8')).not.toContain('opk_minted_later');
+  });
+
+  it('a run that never provisions still logs; setSessionId records the join key later', async () => {
+    const d = await dir();
+    const log = await createRunLog({ dir: d, runId: 'r3', mode: 'metadata' });
+    expect(log.path).toContain('onboard-r3');
+    await log.setSessionId('sess-42');
+    expect(await readFile(log.path, 'utf8')).toContain('sess-42');
+  });
+
+  it('file mode is 0600', async () => {
+    const d = await dir();
+    const log = await createRunLog({ dir: d, runId: 'r4', mode: 'metadata' });
+    await log.record(MSG);
+    expect(((await stat(log.path)).mode & 0o777)).toBe(0o600);
+  });
+
+  it('retention keeps the newest N logs and prunes older on create', async () => {
+    const d = await dir();
+    for (const id of ['a', 'b', 'c']) {
+      await writeFile(join(d, `onboard-${id}.jsonl`), '{}\n');
+    }
+    await createRunLog({ dir: d, runId: 'new', mode: 'metadata', maxLogs: 3 });
+    const names = (await readdir(d)).sort();
+    expect(names).toHaveLength(3);           // 2 survivors + the new file
+    expect(names).toContain('onboard-new.jsonl');
+  });
+});
+```
+
+**Step 2: Run — FAIL. Step 3: Implement `cli/src/onboard/runlog.ts`:**
+
+```typescript
+/**
+ * Debuggable trail for onboard runs (design R7). Metadata-only by default —
+ * hashes and byte counts, never content — so the file is safe to attach to a
+ * bug report. Full capture is an explicit opt-in with field redaction.
+ * Keyed by a LOCAL run id so runs that die before provisioning still log;
+ * setSessionId records the server session id as the join key once known.
+ */
+import { appendFile, chmod, mkdir, readdir, stat, unlink } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+
+export interface RunLogOptions {
+  dir: string;
+  runId: string;
+  mode: 'metadata' | 'full';
+  redact?: string[];        // initial raw secret values to strip in full mode
+  maxLogs?: number;         // retention bound, default 20
+  maxRecordBytes?: number;  // full-mode truncation, default 64 KiB
+  nowFn?: () => number;
+}
+
+export interface RunLog {
+  path: string;
+  record(message: unknown): Promise<void>;
+  /** Register a secret value discovered after creation (e.g. the provisioned key). */
+  addSecret(secret: string): void;
+  setSessionId(sessionId: string): Promise<void>;
+  finish(summary: Record<string, unknown>): Promise<void>;
+}
+
+// Field-name redaction: substring match on purpose — it must catch poll_token,
+// refresh_token, accessToken, code_verifier, api_key, Authorization, etc.
+const SENSITIVE_FIELD = /(authorization|api[_-]?key|token|secret|verifier|password|credential)/i;
+
+function redactDeep(value: unknown, secrets: string[]): unknown {
+  if (typeof value === 'string') {
+    let out = value;
+    for (const secret of secrets) {
+      if (secret) out = out.split(secret).join('[REDACTED]');
+    }
+    return out;
+  }
+  if (Array.isArray(value)) return value.map((v) => redactDeep(v, secrets));
+  if (typeof value === 'object' && value !== null) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = SENSITIVE_FIELD.test(k) ? '[REDACTED]' : redactDeep(v, secrets);
+    }
+    return out;
+  }
+  return value;
+}
+
+export async function createRunLog(options: RunLogOptions): Promise<RunLog> {
+  const now = options.nowFn ?? Date.now;
+  const maxLogs = options.maxLogs ?? 20;
+  const maxRecordBytes = options.maxRecordBytes ?? 64 * 1024;
+  const secrets = [...(options.redact ?? [])];
+  await mkdir(options.dir, { recursive: true });
+
+  // Retention: keep the newest maxLogs-1 existing logs, then this run's file.
+  const existing = (await readdir(options.dir)).filter((n) => /^onboard-.*\.jsonl$/.test(n));
+  const withTimes = await Promise.all(existing.map(async (name) => ({
+    name, mtime: (await stat(join(options.dir, name))).mtimeMs,
+  })));
+  withTimes.sort((a, b) => b.mtime - a.mtime);
+  for (const { name } of withTimes.slice(Math.max(0, maxLogs - 1))) {
+    await unlink(join(options.dir, name)).catch(() => undefined);
+  }
+
+  // Create the file NOW, not on first append — the log's existence is the
+  // point for runs that die before ever recording (and retention counts it).
+  const path = join(options.dir, `onboard-${options.runId}.jsonl`);
+  await appendFile(path, '', { mode: 0o600 });
+  await chmod(path, 0o600);
+  async function append(line: Record<string, unknown>): Promise<void> {
+    await appendFile(path, `${JSON.stringify(line)}\n`, { mode: 0o600 });
+  }
+
+  return {
+    path,
+    addSecret(secret: string): void {
+      if (secret) secrets.push(secret);
+    },
+    async record(message: unknown): Promise<void> {
+      const raw = JSON.stringify(message) ?? 'null';
+      const record = message as Record<string, unknown> | null;
+      if (options.mode === 'metadata') {
+        await append({
+          ts: now(),
+          type: typeof record?.['type'] === 'string' ? record['type'] : 'unknown',
+          name: typeof record?.['name'] === 'string' ? record['name'] : undefined,
+          hash: createHash('sha256').update(raw).digest('hex'),
+          bytes: Buffer.byteLength(raw),
+        });
+        return;
+      }
+      const redacted = redactDeep(message, secrets);
+      let serialized = JSON.stringify(redacted) ?? 'null';
+      if (Buffer.byteLength(serialized) > maxRecordBytes) {
+        serialized = JSON.stringify({ truncated: true, bytes: Buffer.byteLength(serialized) });
+      }
+      await append({ ts: now(), full: JSON.parse(serialized) });
+    },
+    async setSessionId(sessionId: string): Promise<void> {
+      await append({ ts: now(), session_id: sessionId });
+    },
+    async finish(summary: Record<string, unknown>): Promise<void> {
+      await append({ ts: now(), summary });
+    },
+  };
+}
+```
+
+**Step 4: Run — PASS, then full suite. Step 5: Commit:**
+
+```bash
+git add cli/src/onboard/runlog.ts cli/src/onboard/__tests__/runlog.test.ts
+git commit -m "feat(cli): onboard run log — metadata default, local run id, redacted full mode"
+```
+
+---
+
+### Task 10: Phase validation checkpoint
+
+**Step 1: Full verification.** Never pipe `go test` into `tail` on its own — the
+pipeline would return tail's zero status and mask failures. Use `pipefail` + `tee`
+and inspect skips explicitly:
+
+```bash
+pnpm --filter @opslane/cli build
+pnpm --filter @opslane/cli test
+cd packages/ingestion
+go build ./...
+set -o pipefail
+DATABASE_URL='postgres://opslane:opslane_dev@localhost:5434/opslane?sslmode=disable' \
+  go test ./... -v 2>&1 | tee /tmp/phase2-go-test.log
+echo "go test exit: $?"                          # must print 0
+grep -n -- "--- SKIP" /tmp/phase2-go-test.log    # inspect: NO onboard/provision test may appear here
+cd ../..
+docker compose config --quiet
+pnpm -r build && pnpm test
+```
+Expected: every command exits 0; the SKIP list contains no onboard-related test.
+
+**Step 2: Live smoke — REQUIRED, and it must reach `app_reporting`** (the server
+provisioning changed in Task 1; `provisioned`/`key_ok` alone would not prove the
+phone-home path still works end-to-end):
+
+1. Rebuild and start the stack: `docker compose up -d --build postgres minio ingestion` (+ `docker compose run --rm migrate`).
+2. Log in against the local server (`node cli/dist/index.js login --api-url http://localhost:8082`) — or reuse a seeded account per `scripts/seed-e2e.sql`.
+3. Run a throwaway script chaining `ensureLoggedIn → ensureProvisioned` for a test repo; note the printed session id as `$SID`, and write the key with `writeEnvLocal` into `test-fixtures/vue-app`.
+4. Start the fixture app (`pnpm dev` in `test-fixtures/vue-app`) and open it in a browser — the SDK phones home on page load.
+5. Prove it **by this run's session id** (never project-wide; a stale row can fake a pass):
+   ```bash
+   docker compose exec postgres psql -U opslane -c \
+     "select id, status from agent_sessions where id = '$SID'"
+   ```
+   Expected: `app_reporting`. Delete the throwaway script after.
+
+**Step 3: Commit anything outstanding, push, open the PR** (per repo flow: user pushes via `! git push`, then `gh pr create`).
+
+---
+
+## Out of scope for this plan
+
+`opslane onboard` command, Ink TUI, in-TUI consented execution, `runConsentedCommand` — all Phase 3 (see the parent plan's Phase 3 amendment). GitHub App install — later milestone. Member-level cloud provisioning — TODOS.md.

--- a/packages/ingestion/db/onboard_provision.go
+++ b/packages/ingestion/db/onboard_provision.go
@@ -61,6 +61,36 @@ func (q *Queries) ProvisionOnboardSession(ctx context.Context, in OnboardProvisi
 	}
 	defer tx.Rollback(ctx)
 
+	// Adopt an existing untagged project for this org+repo (e.g. created by the
+	// GitHub-App setup flow) so onboarding converges on it instead of minting a
+	// duplicate. Tag exactly one row -- the oldest -- and only when no project
+	// in this org already carries this token. If a tagged project already
+	// exists, it wins and any untagged duplicate remains untouched.
+	if _, err := tx.Exec(ctx, `
+		UPDATE projects
+		SET idempotency_token = $3
+		WHERE id = (
+			SELECT id
+			FROM projects
+			WHERE org_id = $1
+			  AND lower(github_repo) = lower($2)
+			  AND idempotency_token IS NULL
+			ORDER BY created_at ASC
+			LIMIT 1
+			FOR UPDATE
+		)
+		AND NOT EXISTS (
+			SELECT 1
+			FROM projects
+			WHERE org_id = $1 AND idempotency_token = $3
+		)`,
+		in.OrgID,
+		repo,
+		"onboard:"+strings.ToLower(repo),
+	); err != nil {
+		return nil, fmt.Errorf("provision onboard session: adopt existing project: %w", err)
+	}
+
 	provisioning, err := q.provisionProjectTx(
 		ctx,
 		tx,

--- a/packages/ingestion/db/onboard_provision_test.go
+++ b/packages/ingestion/db/onboard_provision_test.go
@@ -195,6 +195,155 @@ func TestProvisionOnboardSession(t *testing.T) {
 	}
 }
 
+func TestProvisionOnboardSessionAdoptsExistingUntaggedProject(t *testing.T) {
+	pool := testPool(t)
+	q := db.New(pool)
+	ctx := context.Background()
+	orgID, userID := seedOnboardOrgOwner(t, pool, "adopt")
+
+	var existingID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO projects (org_id, name, github_repo)
+		VALUES ($1, 'web', 'Acme/Web')
+		RETURNING id`,
+		orgID,
+	).Scan(&existingID); err != nil {
+		t.Fatalf("seed untagged project: %v", err)
+	}
+
+	result, err := q.ProvisionOnboardSession(
+		ctx,
+		onboardInput(orgID, userID, "acme/web", "adopt"),
+	)
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	cleanupOnboardSessions(t, pool, result.SessionID)
+	if result.ProjectID != existingID {
+		t.Fatalf("adopted project = %s, want existing %s", result.ProjectID, existingID)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM projects
+		WHERE org_id = $1 AND lower(github_repo) = lower($2)`,
+		orgID,
+		"acme/web",
+	).Scan(&count); err != nil {
+		t.Fatalf("count matching projects: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("project count = %d, want 1", count)
+	}
+}
+
+func TestProvisionOnboardSessionAdoptsExistingUntaggedProjectWithinOrg(t *testing.T) {
+	pool := testPool(t)
+	q := db.New(pool)
+	ctx := context.Background()
+	firstOrgID, firstUserID := seedOnboardOrgOwner(t, pool, "adopt-first-org")
+	secondOrgID, secondUserID := seedOnboardOrgOwner(t, pool, "adopt-second-org")
+
+	var firstProjectID, secondProjectID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO projects (org_id, name, github_repo)
+		VALUES ($1, 'web', 'acme/web')
+		RETURNING id`,
+		firstOrgID,
+	).Scan(&firstProjectID); err != nil {
+		t.Fatalf("seed first org project: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO projects (org_id, name, github_repo)
+		VALUES ($1, 'web', 'ACME/WEB')
+		RETURNING id`,
+		secondOrgID,
+	).Scan(&secondProjectID); err != nil {
+		t.Fatalf("seed second org project: %v", err)
+	}
+
+	first, err := q.ProvisionOnboardSession(
+		ctx,
+		onboardInput(firstOrgID, firstUserID, "Acme/Web", "adopt-first-org"),
+	)
+	if err != nil {
+		t.Fatalf("provision first org: %v", err)
+	}
+	cleanupOnboardSessions(t, pool, first.SessionID)
+	second, err := q.ProvisionOnboardSession(
+		ctx,
+		onboardInput(secondOrgID, secondUserID, "acme/web", "adopt-second-org"),
+	)
+	if err != nil {
+		t.Fatalf("provision second org: %v", err)
+	}
+	cleanupOnboardSessions(t, pool, second.SessionID)
+
+	if first.ProjectID != firstProjectID {
+		t.Fatalf("first org project = %s, want %s", first.ProjectID, firstProjectID)
+	}
+	if second.ProjectID != secondProjectID {
+		t.Fatalf("second org project = %s, want %s", second.ProjectID, secondProjectID)
+	}
+	if first.ProjectID == second.ProjectID {
+		t.Fatalf("different orgs adopted the same project %s", first.ProjectID)
+	}
+}
+
+func TestProvisionOnboardSessionAdoptsExistingTaggedProjectInDirtyCoexistence(t *testing.T) {
+	pool := testPool(t)
+	q := db.New(pool)
+	ctx := context.Background()
+	orgID, userID := seedOnboardOrgOwner(t, pool, "adopt-dirty")
+
+	var taggedID, untaggedID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO projects (org_id, name, github_repo, idempotency_token)
+		VALUES ($1, 'tagged-web', 'acme/web', 'onboard:acme/web')
+		RETURNING id`,
+		orgID,
+	).Scan(&taggedID); err != nil {
+		t.Fatalf("seed tagged project: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO projects (org_id, name, github_repo)
+		VALUES ($1, 'untagged-web', 'Acme/Web')
+		RETURNING id`,
+		orgID,
+	).Scan(&untaggedID); err != nil {
+		t.Fatalf("seed untagged project: %v", err)
+	}
+
+	result, err := q.ProvisionOnboardSession(
+		ctx,
+		onboardInput(orgID, userID, "acme/web", "adopt-dirty"),
+	)
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	cleanupOnboardSessions(t, pool, result.SessionID)
+	if result.ProjectID != taggedID {
+		t.Fatalf("provisioned project = %s, want tagged %s", result.ProjectID, taggedID)
+	}
+
+	var untaggedStillExists bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM projects
+			WHERE id = $1 AND org_id = $2 AND idempotency_token IS NULL
+		)`,
+		untaggedID,
+		orgID,
+	).Scan(&untaggedStillExists); err != nil {
+		t.Fatalf("read untagged project: %v", err)
+	}
+	if !untaggedStillExists {
+		t.Fatal("pre-existing untagged project was changed")
+	}
+}
+
 func TestProvisionOnboardSessionConcurrent(t *testing.T) {
 	pool := testPool(t)
 	q := db.New(pool)

--- a/packages/ingestion/handler/agent_setup.go
+++ b/packages/ingestion/handler/agent_setup.go
@@ -190,7 +190,7 @@ func (d *Dependencies) AgentPoll(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if session.APIKeySealed == nil || time.Now().After(session.ExpiresAt) {
-			resp["message"] = "key delivery window closed; re-run setup to mint a new key"
+			resp["message"] = "key delivery window closed; run \"opslane login\" then \"opslane setup --relink\" for an existing project, or re-run provisioning"
 		} else {
 			apiKey, openErr := auth.OpenAgentKey(pollToken, session.ID, *session.APIKeySealed)
 			if openErr != nil {


### PR DESCRIPTION
Adds the non-agent half of `opslane onboard`: the deterministic plumbing the agent needs to exist around it. The engine itself (Detect + Apply) landed in #190.

## Why a new branch

#190 was squash-merged, so its content is on main but its commits are not in main's history. A PR from `abhishekray07/onboard-phase-1-engine` would have computed its diff from the pre-squash merge base and shown 11,091 lines, roughly 7k of which already shipped. This branch is cut fresh from main with the identical tree, so the diff is only what is actually new.

## What it adds

- **`agent-protocol.ts`** — one poll seam that preserves the server's status vocabulary instead of each caller reinventing the mapping. `setup.ts` now consumes it rather than hand-rolling the same fetch and parse.
- **`provision.ts`** — login gate with a refresh grant and typed failures, plus account provisioning that probes an existing session before minting a new one, so a re-run resumes instead of duplicating.
- **`pending.ts`** — sessions carry a `kind`, so onboard and setup no longer reach for each other's state. An absent `kind` reads as `setup`, which is what pre-existing files are.
- **`envfile.ts`** — the single place a provisioned key touches disk. Atomic, `0600`, gitignore-aware. `init.ts` drops its duplicate of that logic.
- **`wait.ts`** — waits for the app to report, with bounded unreachable retries.
- **`runlog.ts`** — run-id-keyed trail, metadata-only by default, so a run that dies before provisioning still leaves something worth attaching to a bug report.
- **`onboard_provision.go`** — adopts an existing untagged project for this org and repo rather than minting a duplicate alongside it. Backed by the existing unique partial index on `(org_id, idempotency_token)`.

No `onboard` command is registered yet. This is the substrate; wiring comes next.

## Review fixes (second commit)

`/review` found six issues in the first commit. All are fixed, and each has a regression test that was verified to fail without its fix.

| Where | Problem |
|---|---|
| `provision.ts` | 429 retry slept the raw `Retry-After`, uncapped. A server sending `86400` parks the CLI for a day. Now capped at 60s. |
| `wait.ts` | Per-poll abort used the whole remaining budget, so one stalled connection ate all 15 minutes and the unreachable backoff never ran. Now a 30s per-request ceiling. |
| `auth.ts` | The server consumes a refresh token the moment it answers. If the disk write then failed, the burned token stayed on disk and the next run tripped reuse detection, revoking the whole token family including the dashboard session. Now the entry is dropped on write failure and the next run does a clean login. |
| `fsutil.ts` | The lock is released in a `finally`, which a signal skips, so Ctrl-C mid-refresh stranded `credentials.json.lock` and wedged every later token write. Now reclaimed after 30s, with the refresh fetch bounded at 15s. The refresh deliberately stays under the lock: a refresh token is single-use and concurrent runs must not both spend it. |
| `runlog.ts` | `stat` inside `Promise.all` with no catch, so a file vanishing between `readdir` and `stat` killed the run before it started. |
| `runlog.ts` | Full-mode redaction matched `api_key` but not a bare `key` or `private_key`. |

## Verification

```
pnpm --filter @opslane/cli build   clean
pnpm --filter @opslane/cli test    323 passed (32 files)
pnpm -r build                      clean
pnpm test                          all packages pass
go build ./... && go vet ./...     clean
go test ./db/... ./handler/...     ok
docker compose config --quiet      ok
```

The regression tests were each confirmed to fail against the un-fixed code before being kept.
