### PR TITLE
Onboarding controller and Ink shell: opslane onboard runs end to end

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -29,14 +29,19 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.217",
+    "@inkjs/ui": "2.0.0",
     "chalk": "^5.4.0",
     "commander": "^13.0.0",
+    "ink": "7.1.1",
     "inquirer": "^12.0.0",
+    "react": "19.2.8",
     "typescript": "^5.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
+    "@types/react": "19.2.17",
+    "ink-testing-library": "4.0.0",
     "tsx": "^4.23.1",
     "vitest": "^3.2.0"
   }

--- a/cli/src/__tests__/contract.subprocess.test.ts
+++ b/cli/src/__tests__/contract.subprocess.test.ts
@@ -12,6 +12,15 @@ const pollId = '123e4567-e89b-42d3-a456-426614174000';
 
 interface RunResult { code: number; stdout: string; stderr: string }
 
+/**
+ * Every case here spawns a real compiled CLI. Under `pnpm test` the whole
+ * workspace runs vitest in parallel, so these children compete for CPU with
+ * ~38 other CLI test files plus five other packages. Without a bound, a starved
+ * child stalls the suite and reports as an opaque multi-minute timeout rather
+ * than a diagnosable failure. Kill the process group and say what happened.
+ */
+const CLI_RUN_TIMEOUT_MS = 45_000;
+
 function runCli(args: string[], home: string, cwd: string): Promise<RunResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [cliEntry, ...args], {
@@ -21,12 +30,36 @@ function runCli(args: string[], home: string, cwd: string): Promise<RunResult> {
     });
     let stdout = '';
     let stderr = '';
+    let settled = false;
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+    const timer = setTimeout(() => {
+      finish(() => {
+        child.kill('SIGKILL');
+        reject(new Error(
+          `opslane ${args.join(' ')} did not exit within ${CLI_RUN_TIMEOUT_MS}ms. `
+          + `stdout so far: ${JSON.stringify(stdout.slice(0, 300))}`,
+        ));
+      });
+    }, CLI_RUN_TIMEOUT_MS);
+    timer.unref?.();
     child.stdout.setEncoding('utf8').on('data', (chunk: string) => { stdout += chunk; });
     child.stderr.setEncoding('utf8').on('data', (chunk: string) => { stderr += chunk; });
-    child.on('error', reject);
-    child.on('close', (code) => resolve({ code: code ?? 1, stdout, stderr }));
+    child.on('error', (error) => finish(() => reject(error)));
+    child.on('close', (code) => finish(() => resolve({ code: code ?? 1, stdout, stderr })));
   });
 }
+
+/**
+ * A per-test budget that survives a loaded machine. Vitest's 5s default is for
+ * unit tests; these compile-and-spawn cases need room, and `runCli` above is
+ * what actually catches a genuine hang.
+ */
+const SUBPROCESS_TEST_TIMEOUT_MS = 60_000;
 
 async function listen(server: Server): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -100,7 +133,7 @@ describe('compiled CLI agent contract', () => {
     expect(result.poll.code).toBe(0);
     expect(JSON.parse(result.poll.stdout)).toMatchObject({ status: 'completed', api_key: 'key' });
     expect(result.pollTokenSeen).toBe('subprocess-secret');
-  });
+  }, SUBPROCESS_TEST_TIMEOUT_MS);
 
   it.each([
     [{ status: 'completed', project_id: 'project' }, 200, 'key_unavailable'],
@@ -111,7 +144,7 @@ describe('compiled CLI agent contract', () => {
     const result = await startThenPoll(body, httpStatus);
     expect(result.poll.code).toBe(1);
     expect(JSON.parse(result.poll.stdout)).toMatchObject({ status: expectedStatus });
-  });
+  }, SUBPROCESS_TEST_TIMEOUT_MS);
 
   it('reports conflicting setup modes as one usage_error JSON document', async () => {
     const home = await temp();
@@ -119,14 +152,14 @@ describe('compiled CLI agent contract', () => {
     const result = await runCli(['setup', '--start', '--poll', pollId, '--repo', 'acme/app'], home, cwd);
     expect(result.code).toBe(1);
     expect(JSON.parse(result.stdout)).toMatchObject({ status: 'usage_error' });
-  });
+  }, SUBPROCESS_TEST_TIMEOUT_MS);
 
   it('onboard emits one tty_required JSON document when not a TTY', async () => {
     const result = await runCli(['onboard'], await temp(), await temp());
     expect(result.code).toBe(1);
     expect(JSON.parse(result.stdout)).toMatchObject({ status: 'tty_required' });
     expect(result.stdout).not.toMatch(/\x1b\[/);
-  });
+  }, SUBPROCESS_TEST_TIMEOUT_MS);
 
   it.each([
     ['setup', '--start', '--repo', 'acme/app'],
@@ -141,5 +174,5 @@ describe('compiled CLI agent contract', () => {
     expect(result.code).toBe(1);
     expect(JSON.parse(result.stdout)).toMatchObject({ status: 'usage_error' });
     expect(result.stderr).toBe('');
-  });
+  }, SUBPROCESS_TEST_TIMEOUT_MS);
 });

--- a/cli/src/__tests__/contract.subprocess.test.ts
+++ b/cli/src/__tests__/contract.subprocess.test.ts
@@ -121,6 +121,13 @@ describe('compiled CLI agent contract', () => {
     expect(JSON.parse(result.stdout)).toMatchObject({ status: 'usage_error' });
   });
 
+  it('onboard emits one tty_required JSON document when not a TTY', async () => {
+    const result = await runCli(['onboard'], await temp(), await temp());
+    expect(result.code).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({ status: 'tty_required' });
+    expect(result.stdout).not.toMatch(/\x1b\[/);
+  });
+
   it.each([
     ['setup', '--start', '--repo', 'acme/app'],
     ['snippet', '--api-key', 'test-key'],

--- a/cli/src/__tests__/envfile.test.ts
+++ b/cli/src/__tests__/envfile.test.ts
@@ -1,4 +1,12 @@
-import { chmod, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -54,6 +62,35 @@ describe('writeEnvLocal', () => {
       .split('\n')
       .filter((line) => line === '.env.local');
     expect(lines).toHaveLength(1);
+  });
+
+  it('refuses to write through a symlinked .gitignore', async () => {
+    const d = await dir();
+    const outside = join(await mkdtemp(join(tmpdir(), 'opslane-out-')), 'victim');
+    await writeFile(outside, 'original\n');
+    await symlink(outside, join(d, '.gitignore'));
+
+    await expect(writeEnvLocal(d, { VITE_OPSLANE_API_KEY: 'opk_x' })).rejects.toThrow();
+    expect(await readFile(outside, 'utf8')).toBe('original\n');
+  });
+
+  it('refuses to write through a symlinked .env.local', async () => {
+    const d = await dir();
+    const outside = join(await mkdtemp(join(tmpdir(), 'opslane-out-')), 'victim');
+    await writeFile(outside, 'original\n');
+    await symlink(outside, join(d, '.env.local'));
+
+    await expect(writeEnvLocal(d, { VITE_OPSLANE_API_KEY: 'opk_x' })).rejects.toThrow();
+    expect(await readFile(outside, 'utf8')).toBe('original\n');
+  });
+
+  it('does not leave the key on disk when the gitignore write fails', async () => {
+    const d = await dir();
+    await mkdir(join(d, '.gitignore'));
+
+    await expect(writeEnvLocal(d, { VITE_OPSLANE_API_KEY: 'opk_x' })).rejects.toThrow();
+    await expect(readFile(join(d, '.env.local'), 'utf8'))
+      .rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('rejects var names failing the regex', async () => {

--- a/cli/src/contract.ts
+++ b/cli/src/contract.ts
@@ -54,6 +54,7 @@ export const AGENT_STATUSES = [
   agentStatus("setup", "repo_not_detected", 1, "stdout", "No GitHub owner/repo could be resolved from the arguments or git remote."),
   agentStatus("setup --relink", "project_not_in_active_org", 1, "stdout", "The repo project is not visible in the authenticated active organization."),
   agentStatus("setup --relink", "login_required", 1, "stdout", "A current origin-scoped interactive login is required before relinking."),
+  agentStatus("onboard", "tty_required", 1, "stdout", "The command needs an interactive terminal; run it without piping stdin or stdout."),
   agentStatus("snippet, verify, status, errors", "no_credentials", 1, "stdout", "No credential matches the current API origin and repository."),
   agentStatus("snippet", "internal_error", 1, "stdout", "Framework detection or patch generation failed before a snippet could be emitted."),
   agentStatus("verify", "ok", 0, "stdout", "The API is reachable; has_events says whether the first event arrived."),

--- a/cli/src/envfile.ts
+++ b/cli/src/envfile.ts
@@ -3,11 +3,29 @@
  * agent's validated OnboardingPlan (tools.ts validatePlan); values come from
  * provisioning. Atomic write (fsutil), 0600 always.
  */
-import { chmod, readFile, writeFile } from 'node:fs/promises';
+import { constants, open, type FileHandle } from 'node:fs/promises';
 import { join } from 'node:path';
 import { writeFileAtomic } from './fsutil.js';
 
 const ENV_VAR_NAME = /^[A-Z][A-Z0-9_]*$/;
+
+/** Read a file, refusing to traverse a final-component symlink. Missing is ''. */
+async function readNoFollow(filePath: string): Promise<string> {
+  let handle: FileHandle;
+  try {
+    handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return '';
+    // ELOOP (Linux) / EMLINK (some BSDs) mean the final component is a symlink.
+    throw new Error(`refusing to read ${filePath}: ${code}`);
+  }
+  try {
+    return await handle.readFile('utf8');
+  } finally {
+    await handle.close();
+  }
+}
 
 export async function writeEnvLocal(
   dir: string,
@@ -23,13 +41,18 @@ export async function writeEnvLocal(
   }
 
   const envPath = join(dir, '.env.local');
-  let current = '';
-  try {
-    current = await readFile(envPath, 'utf8');
-  } catch {
-    // Create the file below.
+  const gitignorePath = join(dir, '.gitignore');
+
+  // Ignore the secret first, so a gitignore failure cannot leave it exposed.
+  const gitignore = await readNoFollow(gitignorePath);
+  if (!gitignore.split(/\r?\n/).includes('.env.local')) {
+    await writeFileAtomic(
+      gitignorePath,
+      `${gitignore}${gitignore && !gitignore.endsWith('\n') ? '\n' : ''}.env.local\n`,
+    );
   }
 
+  const current = await readNoFollow(envPath);
   let next = current;
   for (const [name, value] of Object.entries(vars)) {
     const line = `${name}=${value}`;
@@ -40,19 +63,6 @@ export async function writeEnvLocal(
   }
 
   await writeFileAtomic(envPath, next);
-  await chmod(envPath, 0o600);
-
-  const gitignorePath = join(dir, '.gitignore');
-  let gitignore = '';
-  try {
-    gitignore = await readFile(gitignorePath, 'utf8');
-  } catch {
-    // Create the file below.
-  }
-  if (!gitignore.split(/\r?\n/).includes('.env.local')) {
-    gitignore += `${gitignore && !gitignore.endsWith('\n') ? '\n' : ''}.env.local\n`;
-    await writeFile(gitignorePath, gitignore, 'utf8');
-  }
 
   return envPath;
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -87,6 +87,16 @@ program
   });
 
 program
+  .command('onboard')
+  .description('Agent-guided SDK onboarding for the repo in the current directory')
+  .option('--api-url <url>', 'Opslane API URL')
+  .option('--repo <owner/repo>', 'Override auto-detected repository')
+  .action(async (opts: { apiUrl?: string; repo?: string }) => {
+    const { runOnboardCommand } = await import('./onboard/command.js');
+    await runOnboardCommand(opts);
+  });
+
+program
   .command('snippet')
   .description('Get framework-specific SDK init code')
   .option('--framework <name>', 'Override auto-detected framework')

--- a/cli/src/onboard/__tests__/app.test.tsx
+++ b/cli/src/onboard/__tests__/app.test.tsx
@@ -1,0 +1,147 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { cleanup, render } from 'ink-testing-library';
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createOnboardShell, OnboardApp, runOnboardApp } from '../app.js';
+import type { CoreDeps, CoreResult } from '../core.js';
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Ink renders and flushes effects on its own schedule, so a fixed sleep is a
+ * flake waiting to happen. Poll the condition instead.
+ */
+async function waitFor(condition: () => boolean, label: string): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (condition()) return;
+    await delay(5);
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+/**
+ * A frame can be written a tick before the Select's `useInput` effect is live,
+ * so a single keystroke can land on nothing. Repeat until the prompt clears.
+ */
+async function pressEnter(
+  stdin: { write: (data: string) => void },
+  done: () => boolean,
+  label: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (done()) return;
+    stdin.write('\r');
+    await delay(10);
+  }
+  throw new Error(`timed out pressing enter for ${label}`);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+function shellFor(signal = new AbortController().signal): ReturnType<typeof createOnboardShell> {
+  return createOnboardShell({ signal });
+}
+
+describe('onboarding Ink shell', () => {
+  it('resolves an approval to true when accepted', async () => {
+    const shell = shellFor();
+    const { lastFrame, stdin } = render(<OnboardApp shell={shell} />);
+    let resolved: boolean | undefined;
+    void shell.ui.requestApproval('Edit', { file_path: 'src/main.ts' }).then((value) => {
+      resolved = value;
+    });
+    await waitFor(() => /src\/main\.ts/.test(lastFrame() ?? ''), 'the approval prompt');
+    await pressEnter(stdin, () => resolved !== undefined, 'the approval');
+    expect(resolved).toBe(true);
+  });
+
+  it('prefers the SDK-supplied title over a reconstructed sentence', async () => {
+    const shell = shellFor();
+    const { lastFrame } = render(<OnboardApp shell={shell} />);
+    void shell.ui.requestApproval('Edit', { file_path: 'a.ts' }, {
+      title: 'Claude wants to edit a.ts',
+    } as never);
+    await waitFor(
+      () => (lastFrame() ?? '').includes('Claude wants to edit a.ts'),
+      'the SDK-supplied title',
+    );
+    expect(lastFrame()).toContain('Claude wants to edit a.ts');
+  });
+
+  it('queues overlapping approvals instead of dropping one', async () => {
+    const shell = shellFor();
+    const { lastFrame, stdin } = render(<OnboardApp shell={shell} />);
+    const settled: boolean[] = [];
+    const a = shell.ui
+      .requestApproval('Edit', { file_path: 'a.ts' })
+      .then((value) => settled.push(value));
+    const b = shell.ui
+      .requestApproval('Edit', { file_path: 'b.ts' })
+      .then((value) => settled.push(value));
+    await waitFor(() => (lastFrame() ?? '').includes('a.ts'), 'the first approval');
+    await pressEnter(stdin, () => settled.length >= 1, 'the first approval');
+    await waitFor(() => (lastFrame() ?? '').includes('b.ts'), 'the second approval');
+    await pressEnter(stdin, () => settled.length >= 2, 'the second approval');
+    await Promise.all([a, b]);
+    expect(settled).toHaveLength(2);
+  });
+
+  it('settles a queued question with an empty answer, not false', async () => {
+    const controller = new AbortController();
+    const shell = shellFor(controller.signal);
+    render(<OnboardApp shell={shell} />);
+    let answer: string[] | undefined;
+    void shell.ui
+      .askUser({ question: 'Which app?', options: ['web'], multi: false })
+      .then((value) => {
+        answer = value;
+      });
+    await waitFor(() => shell.getPrompt() !== undefined, 'the question to be queued');
+    controller.abort();
+    await waitFor(() => answer !== undefined, 'the question to settle');
+    expect(answer).toEqual([]); // string[], not `false`
+  });
+
+  it('settles every pending prompt when the signal aborts', async () => {
+    const controller = new AbortController();
+    const shell = shellFor(controller.signal);
+    render(<OnboardApp shell={shell} />);
+    let resolved: boolean | undefined;
+    void shell.ui.requestApproval('Edit', { file_path: 'a.ts' }).then((value) => {
+      resolved = value;
+    });
+    await waitFor(() => shell.getPrompt() !== undefined, 'the approval to be queued');
+    controller.abort();
+    await waitFor(() => resolved !== undefined, 'the approval to settle');
+    expect(resolved).toBe(false); // denied, not left hanging
+  });
+
+  it('runOnboardApp builds real deps, logs in through the shell, and returns the core result', async () => {
+    const calls: string[] = [];
+    const result = await runOnboardApp({
+      cwd: '/repo',
+      repo: 'acme/web',
+      apiUrl: 'http://localhost:8082',
+      signal: new AbortController().signal,
+      logDir: mkdtempSync(join(tmpdir(), 'opslane-app-log-')),
+      // test seam: swap the core so we assert the DEPS it received, not the flow
+      runCore: async (d: CoreDeps): Promise<CoreResult> => {
+        calls.push(
+          typeof d.loginFn,
+          typeof d.runLog.record,
+          typeof d.writeEnv,
+          d.tokenPath ? 'tokenPath' : 'none',
+        );
+        return { ok: true, status: 'completed' };
+      },
+    });
+    expect(result).toMatchObject({ ok: true, status: 'completed' });
+    expect(calls).toEqual(['function', 'function', 'function', 'tokenPath']);
+  });
+});

--- a/cli/src/onboard/__tests__/command.test.ts
+++ b/cli/src/onboard/__tests__/command.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentStatus } from '../../contract.js';
+import { installSignalHandlers, requireTty, runOnboardCommand } from '../command.js';
+import type { CoreResult } from '../core.js';
+
+describe('requireTty', () => {
+  it.each([
+    ['stdin not a tty', { stdin: false, stdout: true }],
+    ['stdout not a tty', { stdin: true, stdout: false }],
+    ['neither a tty', { stdin: false, stdout: false }],
+  ])('gates on %s', (_label, tty) => {
+    const exits: Array<[string, number]> = [];
+    requireTty({
+      isStdinTty: tty.stdin,
+      isStdoutTty: tty.stdout,
+      onFail: (status, code) => {
+        exits.push([status, code]);
+      },
+    });
+    expect(exits).toEqual([['tty_required', 1]]);
+  });
+
+  it('passes when both are a tty', () => {
+    const exits: unknown[] = [];
+    requireTty({
+      isStdinTty: true,
+      isStdoutTty: true,
+      onFail: (...args) => {
+        exits.push(args);
+      },
+    });
+    expect(exits).toEqual([]);
+  });
+});
+
+describe('installSignalHandlers', () => {
+  it('aborts the run controller on SIGINT and sets exit code 130', () => {
+    const exits: number[] = [];
+    const controller = new AbortController();
+    const removeHandlers = installSignalHandlers({
+      controller,
+      exitFn: (code) => {
+        exits.push(code);
+      },
+    });
+
+    process.emit('SIGINT');
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(exits).toEqual([130]);
+    removeHandlers();
+  });
+
+  it('maps SIGTERM to 143, not 130', () => {
+    const exits: number[] = [];
+    const removeHandlers = installSignalHandlers({
+      controller: new AbortController(),
+      exitFn: (code) => {
+        exits.push(code);
+      },
+    });
+
+    process.emit('SIGTERM');
+
+    expect(exits).toEqual([143]);
+    removeHandlers();
+  });
+
+  it('removes its handlers so repeated runs do not stack', () => {
+    const before = process.listenerCount('SIGINT');
+    installSignalHandlers({
+      controller: new AbortController(),
+      exitFn: () => undefined,
+    })();
+    expect(process.listenerCount('SIGINT')).toBe(before);
+  });
+});
+
+describe('runOnboardCommand shell wiring', () => {
+  it('passes the resolved repo, api url, and signal into the shell', async () => {
+    const seen: unknown[] = [];
+    await runOnboardCommand(
+      { repo: 'acme/web' },
+      {
+        isStdinTty: true,
+        isStdoutTty: true,
+        loadApp: async () => ({
+          runOnboardApp: async (options: unknown) => {
+            seen.push(options);
+            return { ok: true, status: 'completed' as const };
+          },
+        }),
+      },
+    );
+    expect(seen[0]).toMatchObject({ repo: 'acme/web', apiUrl: expect.any(String) });
+    expect((seen[0] as { signal: AbortSignal }).signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('exits 0 and emits nothing extra on success', async () => {
+    const exits: unknown[] = [];
+    await runOnboardCommand(
+      { repo: 'acme/web' },
+      {
+        isStdinTty: true,
+        isStdoutTty: true,
+        exitWith: (...args) => {
+          exits.push(args);
+        },
+        loadApp: async () => ({
+          runOnboardApp: async () => ({ ok: true, status: 'completed' as const }),
+        }),
+      },
+    );
+    expect(exits).toEqual([]);
+  });
+
+  it('maps unsupported to usage_error and failed to internal_error', async () => {
+    const cases = [
+      ['unsupported', 'usage_error'],
+      ['failed', 'internal_error'],
+    ] as const satisfies ReadonlyArray<readonly [CoreResult['status'], AgentStatus]>;
+    for (const [status, expected] of cases) {
+      const exits: Array<[string, number]> = [];
+      await runOnboardCommand(
+        { repo: 'acme/web' },
+        {
+          isStdinTty: true,
+          isStdoutTty: true,
+          exitWith: (agentStatus, _data, code) => {
+            exits.push([agentStatus, code]);
+          },
+          loadApp: async () => ({
+            runOnboardApp: async () => ({ ok: false, status, message: 'x' }),
+          }),
+        },
+      );
+      expect(exits).toEqual([[expected, 1]]);
+    }
+  });
+
+  it('preserves the 130 exit code a real SIGINT set', async () => {
+    const exits: unknown[] = [];
+    const before = process.exitCode;
+    await runOnboardCommand(
+      { repo: 'acme/web' },
+      {
+        isStdinTty: true,
+        isStdoutTty: true,
+        exitWith: (...args) => {
+          exits.push(args);
+        },
+        loadApp: async () => ({
+          runOnboardApp: async () => {
+            process.emit('SIGINT'); // the handler sets exitCode 130 and aborts
+            return { ok: false, status: 'aborted' as const };
+          },
+        }),
+      },
+    );
+    expect(process.exitCode).toBe(130);
+    expect(exits).toEqual([]); // nothing overwrote it
+    process.exitCode = before;
+  });
+});

--- a/cli/src/onboard/__tests__/core.test.ts
+++ b/cli/src/onboard/__tests__/core.test.ts
@@ -421,9 +421,11 @@ describe('runOnboardCore install', () => {
     expect(runCommand).not.toHaveBeenCalled();
   });
 
-  it('asks for consent and skips the install when declined', async () => {
+  it('asks for consent and skips the install when declined, then still starts the dev server', async () => {
+    const startDevServer = vi.fn<CoreDeps['startDevServer']>(() => fakeServer());
     let consentAsked = false;
     const d = deps({
+      startDevServer,
       // Decline ONLY the install. Task 8 adds a dev-server prompt through the
       // same `confirm`; a blanket false would decline that too.
       confirm: async (prompt) => !prompt.toLowerCase().includes('install'),
@@ -439,6 +441,7 @@ describe('runOnboardCore install', () => {
       status: 'completed',
     });
     expect(consentAsked).toBe(true);
+    expect(startDevServer).toHaveBeenCalledTimes(1);
   });
 
   it('stops on a failed install rather than continuing', async () => {
@@ -451,5 +454,52 @@ describe('runOnboardCore install', () => {
     expect(result).toMatchObject({ ok: false, status: 'failed' });
     expect(result.message).toMatch(/install/i);
     expect(startDevServer).not.toHaveBeenCalled();
+  });
+});
+
+describe('runOnboardCore dev server', () => {
+  it('asks before starting the dev server and stops if declined', async () => {
+    const startDevServer = vi.fn<CoreDeps['startDevServer']>();
+    const d = deps({
+      confirm: async (prompt) => !prompt.includes('dev server'),
+      startDevServer,
+    });
+    const result = await runOnboardCore(d);
+    expect(startDevServer).not.toHaveBeenCalled();
+    expect(result.message).toMatch(/dev server/i);
+  });
+
+  it('emits the URL it parsed', async () => {
+    const events: CoreEvent[] = [];
+    await runOnboardCore(deps({ emit: (event) => events.push(event) }));
+    expect(events.find((event) => event.url)?.url).toBe('http://localhost:5173/');
+  });
+
+  it('fails fast when the dev server dies instead of waiting out the poll', async () => {
+    const waitForAppReporting = vi.fn<CoreDeps['waitForAppReporting']>(
+      () => new Promise(() => undefined), // never settles
+    );
+    const d = deps({
+      startDevServer: () => ({
+        ...fakeServer(),
+        completed: Promise.resolve({ exitCode: 1, signal: null }),
+      }),
+      waitForAppReporting,
+    });
+    const result = await runOnboardCore(d);
+    expect(result).toMatchObject({ ok: false, status: 'failed' });
+    expect(result.message).toMatch(/dev server (exited|stopped)/i);
+  });
+
+  it('stops the dev server when the wait fails', async () => {
+    const server = fakeServer();
+    const d = deps({
+      startDevServer: () => server,
+      waitForAppReporting: async () => {
+        throw new Error('timed out waiting for your app to report');
+      },
+    });
+    await expect(runOnboardCore(d)).resolves.toMatchObject({ ok: false, status: 'failed' });
+    expect(server.stop).toHaveBeenCalled();
   });
 });

--- a/cli/src/onboard/__tests__/core.test.ts
+++ b/cli/src/onboard/__tests__/core.test.ts
@@ -385,3 +385,31 @@ describe('runOnboardCore apply stage', () => {
     );
   });
 });
+
+describe('runOnboardCore env write', () => {
+  it('writes both env vars into the plan app dir', async () => {
+    const writes: Array<[string, Record<string, string>]> = [];
+    await runOnboardCore(
+      deps({
+        writeEnv: async (dir, vars) => {
+          writes.push([dir, vars]);
+          return join(dir, '.env.local');
+        },
+      }),
+    );
+    expect(writes[0]).toEqual([
+      join(root, 'web'),
+      {
+        VITE_OPSLANE_API_KEY: 'opk_test',
+        VITE_OPSLANE_ENDPOINT: 'http://localhost:8082',
+      },
+    ]);
+  });
+
+  it('refuses an app_dir that escapes the repo', async () => {
+    const writeEnv = vi.fn<CoreDeps['writeEnv']>(async () => '/unused/.env.local');
+    const d = deps({ plan: { ...fixturePlan(), app_dir: '../outside' }, writeEnv });
+    await expect(runOnboardCore(d)).resolves.toMatchObject({ ok: false, status: 'failed' });
+    expect(writeEnv).not.toHaveBeenCalled();
+  });
+});

--- a/cli/src/onboard/__tests__/core.test.ts
+++ b/cli/src/onboard/__tests__/core.test.ts
@@ -503,3 +503,48 @@ describe('runOnboardCore dev server', () => {
     expect(server.stop).toHaveBeenCalled();
   });
 });
+
+describe('runOnboardCore task-list bounding', () => {
+  it('bounds retained task state and counts what it dropped', async () => {
+    let last: TaskLine[] = [];
+    await runOnboardCore(
+      deps({
+        // Only the detect stage; the apply stage re-emits an empty list.
+        emit: (event) => {
+          if (event.stage === 'detect' && event.tasks) last = event.tasks;
+        },
+        runDetect: async (options) => {
+          for (let index = 0; index < 200; index += 1) {
+            options.onMessage(toolUse(`t${index}`, 'Read'));
+            options.onMessage(toolResult(`t${index}`));
+          }
+          options.onPlan(fixturePlan());
+          return { ok: true, aborted: false };
+        },
+      }),
+    );
+    expect(last.length).toBeLessThanOrEqual(8);
+    expect(last.filter((task) => task.state === 'run')).toHaveLength(0);
+  });
+
+  it('counts dropped failures separately from dropped successes', async () => {
+    let event: CoreEvent | undefined;
+    await runOnboardCore(
+      deps({
+        emit: (value) => {
+          if (value.stage === 'detect' && value.tasks) event = value;
+        },
+        runDetect: async (options) => {
+          for (let index = 0; index < 30; index += 1) {
+            options.onMessage(toolUse(`t${index}`, 'Read'));
+            options.onMessage(toolResult(`t${index}`, { isError: index % 10 === 0 })); // 3 failures
+          }
+          options.onPlan(fixturePlan());
+          return { ok: true, aborted: false };
+        },
+      }),
+    );
+    expect(event!.droppedFailed).toBe(3);
+    expect(event!.droppedDone).toBe(30 - 3 - event!.tasks!.length);
+  });
+});

--- a/cli/src/onboard/__tests__/core.test.ts
+++ b/cli/src/onboard/__tests__/core.test.ts
@@ -413,3 +413,43 @@ describe('runOnboardCore env write', () => {
     expect(writeEnv).not.toHaveBeenCalled();
   });
 });
+
+describe('runOnboardCore install', () => {
+  it('skips the install when the report says it is not required', async () => {
+    const runCommand = vi.fn<CoreDeps['runCommand']>();
+    await runOnboardCore(deps({ installRequired: false, runCommand }));
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('asks for consent and skips the install when declined', async () => {
+    let consentAsked = false;
+    const d = deps({
+      // Decline ONLY the install. Task 8 adds a dev-server prompt through the
+      // same `confirm`; a blanket false would decline that too.
+      confirm: async (prompt) => !prompt.toLowerCase().includes('install'),
+      runCommand: async (options) => {
+        consentAsked = true;
+        return (await options.consent!())
+          ? { ran: true, ok: true, exitCode: 0, signal: null }
+          : { ran: false, copyPaste: 'pnpm install' };
+      },
+    });
+    await expect(runOnboardCore(d)).resolves.toMatchObject({
+      ok: true,
+      status: 'completed',
+    });
+    expect(consentAsked).toBe(true);
+  });
+
+  it('stops on a failed install rather than continuing', async () => {
+    const startDevServer = vi.fn<CoreDeps['startDevServer']>();
+    const d = deps({
+      runCommand: async () => ({ ran: true, ok: false, exitCode: 1, signal: null }),
+      startDevServer,
+    });
+    const result = await runOnboardCore(d);
+    expect(result).toMatchObject({ ok: false, status: 'failed' });
+    expect(result.message).toMatch(/install/i);
+    expect(startDevServer).not.toHaveBeenCalled();
+  });
+});

--- a/cli/src/onboard/__tests__/core.test.ts
+++ b/cli/src/onboard/__tests__/core.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+
 import { runOnboardCore, type CoreDeps, type CoreEvent } from '../core.js';
 import type { ApplyReport } from '../engine.js';
 import type { DevServerHandle, ProcessCompletion } from '../process.js';
@@ -52,6 +54,18 @@ function fixturePlan(): OnboardingPlan {
     rationale: 'Initialize before mount.',
   };
 }
+
+const toolUse = (id: string, name: string): SDKMessage =>
+  ({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', id, name, input: {} }] },
+  }) as unknown as SDKMessage;
+
+const toolResult = (id: string, { isError = false } = {}): SDKMessage =>
+  ({
+    type: 'user',
+    message: { content: [{ type: 'tool_result', tool_use_id: id, is_error: isError }] },
+  }) as unknown as SDKMessage;
 
 const EDITED = ['web/src/main.ts', 'web/package.json'];
 
@@ -222,5 +236,80 @@ describe('runOnboardCore lifecycle', () => {
       }),
     );
     expect(result.message).not.toMatch(/\bat \w+ \(/);
+  });
+
+  it('drains queued run-log records before finishing', async () => {
+    const order: string[] = [];
+    const runLog: RunLog = {
+      ...fakeRunLog(),
+      record: async () => {
+        await delay(5);
+        order.push('record');
+      },
+      finish: async () => {
+        order.push('finish');
+      },
+    };
+    await runOnboardCore(
+      deps({
+        runLog,
+        runDetect: async (options) => {
+          options.onMessage(toolUse('t1', 'Read'));
+          options.onPlan(fixturePlan());
+          return { ok: true, aborted: false };
+        },
+      }),
+    );
+    expect(order.at(-1)).toBe('finish');
+    expect(order.filter((entry) => entry === 'record').length).toBeGreaterThan(0);
+  });
+});
+
+describe('runOnboardCore detect stage', () => {
+  it('stops with the agent explanation when the repo is unsupported', async () => {
+    const d = deps({
+      runDetect: async () => ({
+        ok: false,
+        aborted: false,
+        reason: 'unsupported',
+        unsupportedReason: 'this repository has no web application',
+      }),
+    });
+    await expect(runOnboardCore(d)).resolves.toMatchObject({
+      ok: false,
+      status: 'unsupported',
+      message: 'this repository has no web application',
+    });
+  });
+
+  it('never writes env or polls when detect fails', async () => {
+    const writeEnv = vi.fn<CoreDeps['writeEnv']>(async () => '/unused/.env.local');
+    const waitForAppReporting = vi.fn<CoreDeps['waitForAppReporting']>();
+    const d = deps({
+      runDetect: async () => ({ ok: false, aborted: false, reason: 'no_plan' }),
+      writeEnv,
+      waitForAppReporting,
+    });
+    await expect(runOnboardCore(d)).resolves.toMatchObject({ ok: false, status: 'failed' });
+    expect(writeEnv).not.toHaveBeenCalled();
+    expect(waitForAppReporting).not.toHaveBeenCalled();
+  });
+
+  it('forwards the human answer back to the agent', async () => {
+    let answer: string[] | undefined;
+    const d = deps({
+      askUser: async ({ options }) => [options[1]!],
+      runDetect: async (options) => {
+        answer = await options.askUser!({
+          question: 'Which app?',
+          options: ['web', 'admin'],
+          multi: false,
+        });
+        options.onPlan(fixturePlan());
+        return { ok: true, aborted: false };
+      },
+    });
+    await runOnboardCore(d);
+    expect(answer).toEqual(['admin']); // the ANSWER, not just that we asked
   });
 });

--- a/cli/src/onboard/__tests__/core.test.ts
+++ b/cli/src/onboard/__tests__/core.test.ts
@@ -1,0 +1,226 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import { runOnboardCore, type CoreDeps, type CoreEvent } from '../core.js';
+import type { ApplyReport } from '../engine.js';
+import type { DevServerHandle, ProcessCompletion } from '../process.js';
+import type { RunLog } from '../runlog.js';
+import { OPSLANE_SDK_VERSION, type OnboardingPlan } from '../tools.js';
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * A real directory on disk: the controller runs plan paths through
+ * `containedRepoRelative`, which resolves them with `realpathSync`.
+ */
+function makeRepo(): string {
+  const repo = mkdtempSync(join(tmpdir(), 'opslane-core-'));
+  mkdirSync(join(repo, 'web', 'src'), { recursive: true });
+  writeFileSync(join(repo, 'web', 'package.json'), '{"scripts":{"dev":"vite"}}\n');
+  writeFileSync(join(repo, 'web', 'pnpm-lock.yaml'), '');
+  writeFileSync(join(repo, 'web', 'src', 'main.ts'), '');
+  return repo;
+}
+
+const root = makeRepo();
+
+function fixturePlan(): OnboardingPlan {
+  return {
+    app_dir: 'web',
+    framework: 'vue-vite',
+    package_manager: 'pnpm',
+    dev_script: 'dev',
+    env_prefix: 'VITE_',
+    dependency: { name: '@opslane/sdk', version: OPSLANE_SDK_VERSION },
+    env_vars: { api_key: 'VITE_OPSLANE_API_KEY', endpoint: 'VITE_OPSLANE_ENDPOINT' },
+    edit: {
+      file: 'web/src/main.ts',
+      entry_hash: createHash('sha256').update('').digest('hex'),
+      manifest_file: 'web/package.json',
+      manifest_hash: createHash('sha256').update('').digest('hex'),
+      import_line: "import { init } from '@opslane/sdk';",
+      init_block: 'init({});',
+      anchor: "createApp(App).mount('#app');",
+      position: 'before',
+      occurrence: 0,
+    },
+    existing_sdk: { action: 'keep', name: null },
+    rationale: 'Initialize before mount.',
+  };
+}
+
+const EDITED = ['web/src/main.ts', 'web/package.json'];
+
+function fixtureReport(installRequired = true): ApplyReport {
+  return {
+    editedFiles: [...EDITED],
+    summary: 'Wired the Opslane SDK into the app entry point.',
+    installRequired,
+    installCwd: 'web',
+  };
+}
+
+function fakeRunLog(): RunLog {
+  return {
+    path: '/dev/null',
+    record: async () => undefined,
+    addSecret: () => undefined,
+    setSessionId: async () => undefined,
+    finish: async () => undefined,
+  };
+}
+
+type FakeServer = DevServerHandle & { stop: ReturnType<typeof vi.fn> };
+
+/** `stop()` settles `completed`, exactly as a real terminated child does. */
+function fakeServer(): FakeServer {
+  let settle: (completion: ProcessCompletion) => void = () => undefined;
+  const completed = new Promise<ProcessCompletion>((resolve) => {
+    settle = resolve;
+  });
+  const stop = vi.fn(() => settle({ exitCode: null, signal: 'SIGTERM' }));
+  return {
+    pid: 1234,
+    url: Promise.resolve('http://localhost:5173/'),
+    completed,
+    stop,
+    restartCommand: 'pnpm run dev',
+  };
+}
+
+interface DepsOverrides extends Partial<CoreDeps> {
+  plan?: OnboardingPlan;
+  installRequired?: boolean;
+}
+
+function deps(overrides: DepsOverrides = {}): CoreDeps {
+  const { plan, installRequired, ...rest } = overrides;
+  const activePlan = plan ?? fixturePlan();
+  return {
+    cwd: root,
+    repo: 'acme/web',
+    apiUrl: 'http://localhost:8082',
+    tokenPath: join(root, 'tokens.json'),
+    signal: new AbortController().signal,
+    loginFn: async () => undefined,
+    ensureLoggedIn: async () => ({
+      accessToken: 'at',
+      refreshToken: 'rt',
+      expiresAt: Date.now() + 3_600_000,
+    }),
+    ensureProvisioned: async () => ({
+      apiKey: 'opk_test',
+      endpoint: 'http://localhost:8082',
+      orgId: 'org-1',
+      projectId: 'proj-1',
+      sessionId: 'sess-1',
+      pollToken: 'poll-1',
+    }),
+    runDetect: async (options) => {
+      options.onPlan(activePlan);
+      return { ok: true, aborted: false };
+    },
+    runApply: async (options) => {
+      options.onReport(fixtureReport(installRequired ?? true));
+      return { ok: true, aborted: false, editedFiles: [...EDITED] };
+    },
+    requestApproval: async () => true,
+    askUser: async ({ options }) => [options[0] ?? ''],
+    confirm: async () => true,
+    writeEnv: async (dir) => join(dir, '.env.local'),
+    runCommand: async () => ({ ran: true, ok: true, exitCode: 0, signal: null }),
+    startDevServer: () => fakeServer(),
+    waitForAppReporting: async () => ({
+      status: 'app_reporting' as const,
+      apiKey: null,
+      orgId: null,
+      projectId: null,
+      repo: null,
+      message: null,
+      failureReason: null,
+      retryAfterSeconds: null,
+    }),
+    runLog: fakeRunLog(),
+    emit: () => undefined,
+    ...rest,
+  };
+}
+
+describe('runOnboardCore lifecycle', () => {
+  it('emits exactly one terminal stage on success', async () => {
+    const events: CoreEvent[] = [];
+    await expect(
+      runOnboardCore(deps({ emit: (event) => events.push(event) })),
+    ).resolves.toMatchObject({ ok: true, status: 'completed' });
+    const terminal = events.filter((event) =>
+      ['done', 'failed', 'unsupported', 'aborted'].includes(event.stage),
+    );
+    expect(terminal).toHaveLength(1);
+    expect(terminal[0]!.stage).toBe('done');
+  });
+
+  it('emits failed as the terminal stage when a step throws', async () => {
+    const events: CoreEvent[] = [];
+    await runOnboardCore(
+      deps({
+        emit: (event) => events.push(event),
+        ensureProvisioned: async () => {
+          throw new Error('boom');
+        },
+      }),
+    );
+    expect(events.at(-1)!.stage).toBe('failed');
+  });
+
+  it('emits aborted, not failed, when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    const events: CoreEvent[] = [];
+    await runOnboardCore(
+      deps({
+        signal: controller.signal,
+        emit: (event) => events.push(event),
+        ensureProvisioned: async () => {
+          controller.abort();
+          throw new Error('cancelled');
+        },
+      }),
+    );
+    expect(events.at(-1)!.stage).toBe('aborted');
+  });
+
+  it('records the session id and registers the api key as a secret', async () => {
+    const setSessionId = vi.fn(async () => undefined);
+    const addSecret = vi.fn();
+    await runOnboardCore(deps({ runLog: { ...fakeRunLog(), setSessionId, addSecret } }));
+    expect(addSecret).toHaveBeenCalledWith('opk_test');
+    expect(setSessionId).toHaveBeenCalledWith('sess-1');
+  });
+
+  it('finishes the run log exactly once, even when a step throws', async () => {
+    const finish = vi.fn(async () => undefined);
+    await runOnboardCore(
+      deps({
+        runLog: { ...fakeRunLog(), finish },
+        ensureProvisioned: async () => {
+          throw new Error('boom');
+        },
+      }),
+    );
+    expect(finish).toHaveBeenCalledTimes(1);
+  });
+
+  it('never leaks a stack trace into the result message', async () => {
+    const result = await runOnboardCore(
+      deps({
+        ensureProvisioned: async () => {
+          throw new Error('ENOENT: no such file');
+        },
+      }),
+    );
+    expect(result.message).not.toMatch(/\bat \w+ \(/);
+  });
+});

--- a/cli/src/onboard/__tests__/core.test.ts
+++ b/cli/src/onboard/__tests__/core.test.ts
@@ -8,6 +8,7 @@ import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 
 import { runOnboardCore, type CoreDeps, type CoreEvent } from '../core.js';
 import type { ApplyReport } from '../engine.js';
+import type { TaskLine } from '../events.js';
 import type { DevServerHandle, ProcessCompletion } from '../process.js';
 import type { RunLog } from '../runlog.js';
 import { OPSLANE_SDK_VERSION, type OnboardingPlan } from '../tools.js';
@@ -311,5 +312,76 @@ describe('runOnboardCore detect stage', () => {
     });
     await runOnboardCore(d);
     expect(answer).toEqual(['admin']); // the ANSWER, not just that we asked
+  });
+});
+
+describe('runOnboardCore apply stage', () => {
+  it('writes no env and never polls when apply fails', async () => {
+    const writeEnv = vi.fn<CoreDeps['writeEnv']>(async () => '/unused/.env.local');
+    const waitForAppReporting = vi.fn<CoreDeps['waitForAppReporting']>();
+    const d = deps({
+      runApply: async () => ({
+        ok: false,
+        aborted: false,
+        reason: 'verification_failed',
+        failures: [
+          'manifest does not contain an identity-capable Opslane SDK version (>=1.2.0)',
+        ],
+      }),
+      writeEnv,
+      waitForAppReporting,
+    });
+    const result = await runOnboardCore(d);
+    expect(result).toMatchObject({ ok: false, status: 'failed' });
+    expect(result.message).toMatch(/identity-capable/);
+    expect(writeEnv).not.toHaveBeenCalled();
+    expect(waitForAppReporting).not.toHaveBeenCalled();
+  });
+
+  it('rejects a report whose editedFiles disagree with the engine', async () => {
+    const d = deps({
+      runApply: async (options) => {
+        options.onReport({
+          editedFiles: ['web/src/main.ts'],
+          summary: 'x',
+          installRequired: true,
+          installCwd: 'web',
+        });
+        return {
+          ok: true,
+          aborted: false,
+          editedFiles: ['web/src/main.ts', 'web/package.json'],
+        };
+      },
+    });
+    const result = await runOnboardCore(d);
+    expect(result).toMatchObject({ ok: false, status: 'failed' });
+    expect(result.message).toMatch(/report.*match|reconcil/i);
+  });
+
+  it('starts the apply task list empty rather than reusing detect tasks', async () => {
+    const seen: TaskLine[][] = [];
+    await runOnboardCore(
+      deps({
+        emit: (event) => {
+          if (event.stage === 'apply' && event.tasks) seen.push(event.tasks);
+        },
+        runDetect: async (options) => {
+          options.onMessage(toolUse('t1', 'Read'));
+          options.onMessage(toolUse('t2', 'Glob'));
+          options.onPlan(fixturePlan());
+          return { ok: true, aborted: false };
+        },
+      }),
+    );
+    expect(seen[0]).toHaveLength(0);
+  });
+
+  it('emits the plan for review before applying', async () => {
+    const events: CoreEvent[] = [];
+    await runOnboardCore(deps({ emit: (event) => events.push(event) }));
+    expect(events.find((event) => event.stage === 'awaiting-approval')?.plan?.app_dir).toBe(
+      'web',
+    );
   });
 });

--- a/cli/src/onboard/__tests__/engine.test.ts
+++ b/cli/src/onboard/__tests__/engine.test.ts
@@ -38,13 +38,15 @@ function fixture(): { root: string; report: ReportPlanInput; plan: OnboardingPla
   const root = mkdtempSync(join(tmpdir(), 'opslane-engine-'));
   mkdirSync(join(root, 'src'));
   const contents = "createApp(App).mount('#app');\n";
-  const manifest = '{\n  "name": "fixture",\n  "dependencies": {}\n}\n';
+  const manifest =
+    '{\n  "name": "fixture",\n  "scripts": { "dev": "vite" },\n  "dependencies": {}\n}\n';
   writeFileSync(join(root, 'src', 'main.ts'), contents);
   writeFileSync(join(root, 'package.json'), manifest);
   const plan: OnboardingPlan = {
     app_dir: '.',
     framework: 'vue-vite',
     package_manager: 'pnpm',
+    dev_script: 'dev',
     env_prefix: 'VITE_',
     dependency: { name: '@opslane/sdk', version: OPSLANE_SDK_VERSION },
     env_vars: {
@@ -131,7 +133,7 @@ function reportQuery(
 function appliedContents(plan: OnboardingPlan): { entry: string; manifest: string } {
   return {
     entry: `${plan.edit.import_line}\n${plan.edit.init_block}\n${plan.edit.anchor}\n`,
-    manifest: `{\n  "name": "fixture",\n  "dependencies": {\n    "@opslane/sdk": "${plan.dependency.version}"\n  }\n}\n`,
+    manifest: `{\n  "name": "fixture",\n  "scripts": { "dev": "vite" },\n  "dependencies": {\n    "@opslane/sdk": "${plan.dependency.version}"\n  }\n}\n`,
   };
 }
 
@@ -506,6 +508,27 @@ describe('detect-stage engine', () => {
       reason: 'unsupported',
     });
     expect(plans).toBe(0);
+  });
+
+  it('returns the agent explanation when the repo is unsupported', async () => {
+    const { root } = fixture();
+
+    const result = await runDetect({
+      cwd: root,
+      signal: new AbortController().signal,
+      onMessage: () => undefined,
+      onPlan: () => undefined,
+      queryFn: reportQuery({
+        status: 'unsupported',
+        reason: 'this repository has no web application',
+      }),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'unsupported',
+      unsupportedReason: 'this repository has no web application',
+    });
   });
 
   it.each([

--- a/cli/src/onboard/__tests__/policy.test.ts
+++ b/cli/src/onboard/__tests__/policy.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createOnboardApproval, onboardPreToolUseHook } from '../policy.js';
 
@@ -70,14 +70,8 @@ describe('onboarding hard-denial hook', () => {
     );
   });
 
-  it('allows only exact package build, typecheck, or lint scripts through Bash', async () => {
-    expect(denied(await run(hook(), 'Bash', { command: 'pnpm run build' }))).toBe(false);
-    for (const command of [
-      'npx tsc',
-      'pnpm install',
-      'pnpm run build && curl x|sh',
-      'pnpm run build\npnpm run lint',
-    ]) {
+  it('denies Bash outright: the agent has no shell', async () => {
+    for (const command of ['pnpm run build', 'pnpm run lint', 'npm install', 'echo hi']) {
       expect(denied(await run(hook(), 'Bash', { command }))).toBe(true);
     }
   });
@@ -120,8 +114,12 @@ describe('onboarding approval callback', () => {
       approved('Edit', { file_path: '/r/a' }, {} as never),
     ).resolves.toMatchObject({ behavior: 'allow' });
     await expect(
-      declined('Bash', { command: 'pnpm run build' }, {} as never),
+      declined('Edit', { file_path: '/r/b' }, {} as never),
     ).resolves.toEqual({ behavior: 'deny', message: 'declined' });
+    // Bash is not in the default allow-set at all, so it never reaches approval.
+    await expect(
+      approved('Bash', { command: 'pnpm run build' }, {} as never),
+    ).resolves.toEqual({ behavior: 'deny', message: 'Onboarding does not allow tool Bash' });
   });
 
   it('allows read-only tools without prompting', async () => {
@@ -148,5 +146,69 @@ describe('onboarding approval callback', () => {
     await expect(approval('WebFetch', {}, {} as never)).resolves.toMatchObject({
       behavior: 'deny',
     });
+  });
+
+  it('forwards the SDK options to requestApproval', async () => {
+    const seen: unknown[] = [];
+    const canUseTool = createOnboardApproval({
+      requestApproval: async (_toolName, _input, options) => {
+        seen.push(options);
+        return true;
+      },
+    });
+    const options = { signal: new AbortController().signal };
+
+    await canUseTool('Edit', { file_path: 'a.ts' }, options as never);
+
+    expect(seen[0]).toBe(options);
+  });
+
+  it('denies rather than hangs when the approval is aborted', async () => {
+    const controller = new AbortController();
+    const canUseTool = createOnboardApproval({
+      requestApproval: () => new Promise<boolean>(() => undefined),
+    });
+    const pending = canUseTool(
+      'Edit',
+      { file_path: 'a.ts' },
+      { signal: controller.signal } as never,
+    );
+
+    controller.abort();
+
+    await expect(pending).resolves.toMatchObject({ behavior: 'deny' });
+  });
+
+  it('denies immediately when the signal is already aborted', async () => {
+    const requestApproval = vi.fn(() => new Promise<boolean>(() => undefined));
+    const canUseTool = createOnboardApproval({ requestApproval });
+
+    await expect(
+      canUseTool(
+        'Edit',
+        { file_path: 'a.ts' },
+        { signal: AbortSignal.abort() } as never,
+      ),
+    ).resolves.toMatchObject({ behavior: 'deny' });
+    expect(requestApproval).not.toHaveBeenCalled();
+  });
+
+  it('removes its abort listener when approval wins the race', async () => {
+    const controller = new AbortController();
+    const add = vi.spyOn(controller.signal, 'addEventListener');
+    const remove = vi.spyOn(controller.signal, 'removeEventListener');
+    const canUseTool = createOnboardApproval({ requestApproval: async () => true });
+
+    for (let index = 0; index < 50; index += 1) {
+      await canUseTool(
+        'Edit',
+        { file_path: 'a.ts' },
+        { signal: controller.signal } as never,
+      );
+    }
+
+    expect(add).toHaveBeenCalledTimes(50);
+    expect(remove).toHaveBeenCalledTimes(50);
+    expect(() => controller.abort()).not.toThrow();
   });
 });

--- a/cli/src/onboard/__tests__/process.test.ts
+++ b/cli/src/onboard/__tests__/process.test.ts
@@ -1,0 +1,471 @@
+import { EventEmitter } from 'node:events';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  devCommand,
+  formatCommand,
+  installCommand,
+  runCommand,
+  startDevServer,
+  startProcess,
+} from '../process.js';
+
+function repoWith(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), 'opslane-process-'));
+  for (const [file, contents] of Object.entries(files)) {
+    const absolute = join(root, file);
+    mkdirSync(dirname(absolute), { recursive: true });
+    writeFileSync(absolute, contents);
+  }
+  return root;
+}
+
+function fakeChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    pid: number;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = 4242;
+  return child;
+}
+
+const npmInstall = { executable: 'npm', args: ['install'] };
+
+describe('command derivation', () => {
+  it.each([
+    ['pnpm-lock.yaml', 'pnpm'],
+    ['package-lock.json', 'npm'],
+    ['yarn.lock', 'yarn'],
+    ['bun.lockb', 'bun'],
+  ])('derives %s -> %s', (lockfile, manager) => {
+    const root = repoWith({ [lockfile]: '', 'package.json': '{}' });
+    expect(installCommand(root, '.')).toEqual({ executable: manager, args: ['install'] });
+  });
+
+  it('builds the dev command from the verified plan script', () => {
+    const root = repoWith({ 'package-lock.json': '', 'package.json': '{}' });
+    expect(devCommand(root, '.', 'dev:staging')).toEqual({
+      executable: 'npm',
+      args: ['run', 'dev:staging'],
+    });
+  });
+
+  it('throws when no lockfile identifies a package manager', () => {
+    expect(() => installCommand(repoWith({ 'package.json': '{}' }), '.')).toThrow(/lockfile/i);
+  });
+});
+
+describe('formatCommand', () => {
+  it('leaves ordinary argv unquoted', () => {
+    expect(formatCommand({ executable: 'npm', args: ['run', 'dev'] })).toBe('npm run dev');
+  });
+
+  it('quotes spaces and shell metacharacters', () => {
+    expect(formatCommand({ executable: 'npm', args: ['run', 'dev staging'] }))
+      .toBe("npm run 'dev staging'");
+    expect(formatCommand({ executable: 'npm', args: ['run', 'dev;echo bad'] }))
+      .toBe("npm run 'dev;echo bad'");
+  });
+
+  it('escapes an embedded single quote', () => {
+    expect(formatCommand({ executable: 'npm', args: ['run', "it's"] }))
+      .toBe("npm run 'it'\\''s'");
+  });
+});
+
+describe('startProcess', () => {
+  it('resolves completion with the close result', async () => {
+    const child = fakeChild();
+    const handle = startProcess({
+      command: npmInstall,
+      cwd: '/repo',
+      spawnFn: () => child as never,
+    });
+    child.emit('close', 0, null);
+    await expect(handle.completed).resolves.toEqual({ exitCode: 0, signal: null });
+  });
+
+  it('finalizes on close rather than exit so output is drained', async () => {
+    const child = fakeChild();
+    const handle = startProcess({
+      command: npmInstall,
+      cwd: '/repo',
+      spawnFn: () => child as never,
+    });
+    child.emit('exit', 0, null);
+    let settled = false;
+    void handle.completed.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    child.emit('close', 0, null);
+    await expect(handle.completed).resolves.toMatchObject({ exitCode: 0 });
+  });
+
+  it('reports signal termination instead of treating it as success', async () => {
+    const child = fakeChild();
+    const handle = startProcess({
+      command: npmInstall,
+      cwd: '/repo',
+      spawnFn: () => child as never,
+    });
+    child.emit('close', null, 'SIGTERM');
+    await expect(handle.completed).resolves.toEqual({ exitCode: null, signal: 'SIGTERM' });
+  });
+
+  it('rejects completion when spawn emits an error', async () => {
+    const child = fakeChild();
+    const handle = startProcess({
+      command: { executable: 'nope', args: [] },
+      cwd: '/repo',
+      spawnFn: () => child as never,
+    });
+    child.emit('error', new Error('ENOENT'));
+    await expect(handle.completed).rejects.toThrow(/ENOENT/);
+  });
+
+  it('spawns with argv, pipes, and shell disabled', () => {
+    const spawnFn = vi.fn((
+      _executable: string,
+      _args: string[],
+      _options: object,
+    ) => fakeChild() as never);
+    startProcess({ command: npmInstall, cwd: '/repo', spawnFn });
+    const [executable, args, options] = spawnFn.mock.calls[0]!;
+    expect(executable).toBe('npm');
+    expect(args).toEqual(['install']);
+    expect(options).toMatchObject({
+      cwd: '/repo',
+      shell: false,
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  });
+
+  it('kills the whole process group on stop, idempotently', () => {
+    const kills: Array<[number, string | undefined]> = [];
+    const handle = startProcess({
+      command: npmInstall,
+      cwd: '/repo',
+      spawnFn: () => fakeChild() as never,
+      killFn: (pid, signal) => {
+        kills.push([pid, signal]);
+      },
+    });
+    handle.stop();
+    handle.stop();
+    handle.stop();
+    expect(kills).toEqual([[-4242, 'SIGTERM']]);
+  });
+
+  it('stops when the injected signal aborts', () => {
+    const kills: number[] = [];
+    const controller = new AbortController();
+    startProcess({
+      command: npmInstall,
+      cwd: '/repo',
+      spawnFn: () => fakeChild() as never,
+      killFn: (pid) => {
+        kills.push(pid);
+      },
+      signal: controller.signal,
+    });
+    controller.abort();
+    expect(kills).toEqual([-4242]);
+  });
+
+  it('never spawns when the signal is already aborted', async () => {
+    const spawnFn = vi.fn(() => fakeChild() as never);
+    const handle = startProcess({
+      command: npmInstall,
+      cwd: '/repo',
+      spawnFn,
+      signal: AbortSignal.abort(),
+    });
+    expect(spawnFn).not.toHaveBeenCalled();
+    await expect(handle.completed).rejects.toThrow(/aborted/i);
+  });
+
+  it('balances its abort listeners', async () => {
+    const controller = new AbortController();
+    const added: unknown[] = [];
+    const removed: unknown[] = [];
+    const realAdd = controller.signal.addEventListener.bind(controller.signal);
+    const realRemove = controller.signal.removeEventListener.bind(controller.signal);
+    vi.spyOn(controller.signal, 'addEventListener').mockImplementation((type, listener, options) => {
+      added.push(listener);
+      realAdd(type, listener, options);
+    });
+    vi.spyOn(controller.signal, 'removeEventListener')
+      .mockImplementation((type, listener, options) => {
+        removed.push(listener);
+        realRemove(type, listener, options);
+      });
+
+    const child = fakeChild();
+    const handle = startProcess({
+      command: npmInstall,
+      cwd: '/repo',
+      spawnFn: () => child as never,
+      signal: controller.signal,
+    });
+    child.emit('close', 0, null);
+    await handle.completed;
+    expect(removed).toEqual(added);
+  });
+});
+
+describe('process output', () => {
+  it('flushes on the interval rather than once per chunk', () => {
+    vi.useFakeTimers();
+    try {
+      const child = fakeChild();
+      const onOutput = vi.fn();
+      startProcess({
+        command: npmInstall,
+        cwd: '/repo',
+        spawnFn: () => child as never,
+        onOutput,
+        flushMs: 100,
+      });
+      for (let index = 0; index < 200; index += 1) {
+        child.stdout.emit('data', Buffer.from(`line ${index}\n`));
+      }
+      expect(onOutput).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(100);
+      expect(onOutput).toHaveBeenCalledTimes(1);
+      for (let index = 0; index < 200; index += 1) {
+        child.stdout.emit('data', Buffer.from(`more ${index}\n`));
+      }
+      vi.advanceTimersByTime(100);
+      expect(onOutput).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('buffers split lines without splicing stdout and stderr', () => {
+    vi.useFakeTimers();
+    try {
+      const child = fakeChild();
+      let last = '';
+      startProcess({
+        command: npmInstall,
+        cwd: '/repo',
+        spawnFn: () => child as never,
+        onOutput: (text) => {
+          last = text;
+        },
+        flushMs: 10,
+      });
+      child.stdout.emit('data', Buffer.from('out-par'));
+      child.stderr.emit('data', Buffer.from('err-line\n'));
+      child.stdout.emit('data', Buffer.from('tial\n'));
+      vi.advanceTimersByTime(10);
+      expect(last).toContain('err-line');
+      expect(last).toContain('out-partial');
+      expect(last).not.toContain('out-parerr-line');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('decodes a multi-byte character split across chunks', () => {
+    vi.useFakeTimers();
+    try {
+      const child = fakeChild();
+      let last = '';
+      startProcess({
+        command: npmInstall,
+        cwd: '/repo',
+        spawnFn: () => child as never,
+        onOutput: (text) => {
+          last = text;
+        },
+        flushMs: 10,
+      });
+      const arrow = Buffer.from('→ done\n', 'utf8');
+      child.stdout.emit('data', arrow.subarray(0, 2));
+      child.stdout.emit('data', arrow.subarray(2));
+      vi.advanceTimersByTime(10);
+      expect(last).toContain('→ done');
+      expect(last).not.toContain('\uFFFD');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps only the last eight sanitized lines', () => {
+    vi.useFakeTimers();
+    try {
+      const child = fakeChild();
+      let last = '';
+      startProcess({
+        command: npmInstall,
+        cwd: '/repo',
+        spawnFn: () => child as never,
+        onOutput: (text) => {
+          last = text;
+        },
+        flushMs: 10,
+      });
+      for (let index = 0; index < 50; index += 1) {
+        child.stdout.emit('data', Buffer.from(`\u001B[31mline ${index}\u001B[0m\n`));
+      }
+      vi.advanceTimersByTime(10);
+      expect(last.split('\n')).toHaveLength(8);
+      expect(last).toContain('line 49');
+      expect(last).not.toContain('line 41');
+      expect(last).not.toContain('\u001B');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('flushes trailing partial lines on close', async () => {
+    const child = fakeChild();
+    let last = '';
+    const handle = startProcess({
+      command: npmInstall,
+      cwd: '/repo',
+      spawnFn: () => child as never,
+      onOutput: (text) => {
+        last = text;
+      },
+      flushMs: 10_000,
+    });
+    child.stdout.emit('data', Buffer.from('no trailing newline'));
+    child.emit('close', 0, null);
+    await handle.completed;
+    expect(last).toContain('no trailing newline');
+    expect(last.split('\n').length).toBeLessThanOrEqual(8);
+  });
+});
+
+describe('process wrappers', () => {
+  it('reports non-zero and signal exits rather than throwing or succeeding', async () => {
+    const failed = fakeChild();
+    const failedResult = runCommand({
+      command: npmInstall,
+      cwd: '/repo',
+      spawnFn: () => failed as never,
+    });
+    failed.emit('close', 1, null);
+    await expect(failedResult).resolves.toEqual({
+      ran: true,
+      ok: false,
+      exitCode: 1,
+      signal: null,
+    });
+
+    const killed = fakeChild();
+    const killedResult = runCommand({
+      command: npmInstall,
+      cwd: '/repo',
+      spawnFn: () => killed as never,
+    });
+    killed.emit('close', null, 'SIGTERM');
+    await expect(killedResult).resolves.toMatchObject({ ok: false, signal: 'SIGTERM' });
+  });
+
+  it('does not spawn without consent and returns a quoted copy-paste command', async () => {
+    const spawnFn = vi.fn();
+    await expect(runCommand({
+      command: { executable: 'npm', args: ['run', 'dev staging'] },
+      cwd: '/repo',
+      consent: async () => false,
+      spawnFn: spawnFn as never,
+    })).resolves.toEqual({ ran: false, copyPaste: "npm run 'dev staging'" });
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it('drains large child output when no renderer is attached', async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2_000);
+    try {
+      await expect(runCommand({
+        command: {
+          executable: process.execPath,
+          args: ['-e', "process.stdout.write(Buffer.alloc(4 * 1024 * 1024, 'x'))"],
+        },
+        cwd: process.cwd(),
+        signal: controller.signal,
+      })).resolves.toMatchObject({ ran: true, ok: true });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }, 5_000);
+
+  it.each([
+    ['  \u001B[32m➜\u001B[0m  Local: http://localhost:5173/\n', 'http://localhost:5173/'],
+    ['  - Local: http://localhost:3000\n', 'http://localhost:3000'],
+  ])('parses a dev server URL from %j', async (banner, expected) => {
+    const child = fakeChild();
+    const handle = startDevServer({
+      command: { executable: 'npm', args: ['run', 'dev'] },
+      cwd: '/repo',
+      spawnFn: () => child as never,
+    });
+    child.stdout.emit('data', Buffer.from(banner));
+    await expect(handle.url).resolves.toBe(expected);
+  });
+
+  it('finds a URL split across chunks and reports the actual port', async () => {
+    const child = fakeChild();
+    const handle = startDevServer({
+      command: { executable: 'npm', args: ['run', 'dev'] },
+      cwd: '/repo',
+      spawnFn: () => child as never,
+    });
+    child.stdout.emit('data', Buffer.from('Port 5173 is in use, trying another one...\n'));
+    child.stdout.emit('data', Buffer.from('  Local: http://localh'));
+    child.stdout.emit('data', Buffer.from('ost:5174/\n'));
+    await expect(handle.url).resolves.toBe('http://localhost:5174/');
+  });
+
+  it('detects URLs even without an output renderer', async () => {
+    const child = fakeChild();
+    const handle = startDevServer({
+      command: { executable: 'npm', args: ['run', 'dev'] },
+      cwd: '/repo',
+      spawnFn: () => child as never,
+    });
+    child.stderr.emit('data', Buffer.from('ready at http://127.0.0.1:8080\n'));
+    await expect(handle.url).resolves.toBe('http://127.0.0.1:8080');
+  });
+
+  it('stops the child when no URL appears before the timeout', async () => {
+    const kills: number[] = [];
+    const child = fakeChild();
+    const handle = startDevServer({
+      command: { executable: 'npm', args: ['run', 'dev'] },
+      cwd: '/repo',
+      spawnFn: () => child as never,
+      killFn: (pid) => {
+        kills.push(pid);
+      },
+      urlTimeoutMs: 10,
+    });
+    await expect(handle.url).rejects.toThrow(/no .*URL/i);
+    expect(kills).toEqual([-4242]);
+  });
+
+  it('rejects URL discovery when the child exits first', async () => {
+    const child = fakeChild();
+    const handle = startDevServer({
+      command: { executable: 'npm', args: ['run', 'dev'] },
+      cwd: '/repo',
+      spawnFn: () => child as never,
+    });
+    child.emit('close', 1, null);
+    await expect(handle.url).rejects.toThrow(/exited/i);
+  });
+});

--- a/cli/src/onboard/__tests__/repo.test.ts
+++ b/cli/src/onboard/__tests__/repo.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRepo } from '../repo.js';
+
+describe('resolveRepo', () => {
+  it('prefers an explicit --repo over git detection', () => {
+    expect(resolveRepo({ repo: 'acme/web', detect: () => 'other/repo' }))
+      .toEqual({ ok: true, repo: 'acme/web' });
+  });
+
+  it('falls back to git detection when no flag is given', () => {
+    expect(resolveRepo({ detect: () => 'acme/web' }))
+      .toEqual({ ok: true, repo: 'acme/web' });
+  });
+
+  it('rejects a malformed --repo instead of sending it to the server', () => {
+    const result = resolveRepo({ repo: 'not a repo', detect: () => null });
+    expect(result).toMatchObject({ ok: false });
+    expect(result.ok === false && result.message).toMatch(/owner\/repo/);
+  });
+
+  it('names the fix when detection fails and no flag was given', () => {
+    const result = resolveRepo({ detect: () => null });
+    expect(result.ok === false && result.message).toMatch(/--repo <owner\/repo>/);
+  });
+});

--- a/cli/src/onboard/__tests__/spec.test.ts
+++ b/cli/src/onboard/__tests__/spec.test.ts
@@ -38,6 +38,8 @@ describe('detect-stage agent specification', () => {
     expect(spec).toMatch(/anchor[\s\S]{0,100}init block|init block[\s\S]{0,100}anchor/i);
     expect(spec).toMatch(/import_line[\s\S]{0,100}module top level/i);
     expect(spec).toContain('manifest_file');
+    expect(spec).toContain('dev_script');
+    expect(spec).toMatch(/exact key[\s\S]{0,120}package\.json "scripts"/i);
     expect(spec).toMatch(/host pins the SDK version/i);
     expect(spec).not.toMatch(/\bedit or write\b/i);
   });
@@ -48,6 +50,7 @@ describe('apply-stage agent specification', () => {
     app_dir: 'web',
     framework: 'vue-vite',
     package_manager: 'pnpm',
+    dev_script: 'dev',
     env_prefix: 'VITE_',
     dependency: { name: '@opslane/sdk', version: '^1.2.0' },
     env_vars: {

--- a/cli/src/onboard/__tests__/tools.test.ts
+++ b/cli/src/onboard/__tests__/tools.test.ts
@@ -50,13 +50,14 @@ describe('report_plan', () => {
     mkdirSync(join(root, 'web', 'src'), { recursive: true });
     entryFile = join(root, 'web', 'src', 'main.ts');
     entryContents = "import App from './App.vue';\ncreateApp(App).mount('#app');\n";
-    manifestContents = '{\n  "name": "web",\n  "dependencies": {}\n}\n';
+    manifestContents = '{\n  "name": "web",\n  "scripts": { "dev": "vite" },\n  "dependencies": {}\n}\n';
     writeFileSync(entryFile, entryContents);
     writeFileSync(join(root, 'web', 'package.json'), manifestContents);
     plan = {
       app_dir: 'web',
       framework: 'vue-vite',
       package_manager: 'pnpm',
+      dev_script: 'dev',
       env_prefix: 'VITE_',
       dependency: { name: '@opslane/sdk' },
       env_vars: {
@@ -110,6 +111,32 @@ describe('report_plan', () => {
       dependency: { name: '@opslane/sdk', version: OPSLANE_SDK_VERSION },
     });
     await expect(call(tool, { status: 'ok', plan })).rejects.toThrow(/already/i);
+  });
+
+  it('keeps dev_script through the schema and reports it', async () => {
+    let captured: OnboardingPlan | undefined;
+    const tool = createReportPlanTool(root, (value) => {
+      captured = value;
+    });
+
+    await call(tool, { status: 'ok', plan });
+
+    expect(captured?.dev_script).toBe('dev');
+  });
+
+  it('rejects a dev_script that the app manifest does not declare', async () => {
+    const tool = createReportPlanTool(root, () => undefined);
+
+    await expect(
+      call(tool, { status: 'ok', plan: { ...plan, dev_script: 'serve' } }),
+    ).rejects.toThrow(/dev_script must be one of: dev/);
+  });
+
+  it('rejects a plan with no dev_script at all', async () => {
+    const tool = createReportPlanTool(root, () => undefined);
+    const { dev_script: _omitted, ...withoutDevScript } = plan;
+
+    await expect(call(tool, { status: 'ok', plan: withoutDevScript })).rejects.toThrow();
   });
 
   it.each([

--- a/cli/src/onboard/__tests__/tui.test.tsx
+++ b/cli/src/onboard/__tests__/tui.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render } from 'ink-testing-library';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Stage } from '../core.js';
+import { Tui } from '../tui.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('onboarding TUI', () => {
+  it('renders the question and resolves on Enter', async () => {
+    const onAnswer = vi.fn();
+    const { lastFrame, stdin } = render(
+      <Tui
+        stage="detect"
+        tasks={[]}
+        onAnswer={onAnswer}
+        question={{ question: 'Which app?', options: ['web', 'admin'], multi: false }}
+      />,
+    );
+    expect(lastFrame()).toContain('Which app?');
+    stdin.write('\r');
+    // Select reports through a React effect, so it lands a tick after the key.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(onAnswer).toHaveBeenCalledWith(['web']);
+  });
+
+  it.each([
+    ['unsupported', 'this repository has no web application', /no web application/],
+    [
+      'failed',
+      'manifest does not contain an identity-capable Opslane SDK version',
+      /identity-capable/,
+    ],
+    ['aborted', undefined, /cancell?ed|stopped/i],
+  ])('renders %s so the user can act', (stage, message, pattern) => {
+    const frame =
+      render(<Tui stage={stage as Stage} tasks={[]} message={message} />).lastFrame() ?? '';
+    expect(frame).toMatch(pattern);
+    expect(frame).not.toMatch(/⠋|⠙|⠹/); // no spinner on a terminal state
+  });
+
+  it('shows the clickable URL while waiting', () => {
+    expect(
+      render(<Tui stage="waiting" tasks={[]} url="http://localhost:5173/" />).lastFrame(),
+    ).toContain('http://localhost:5173/');
+  });
+
+  it('renders dropped successes and failures separately', () => {
+    const tasks = Array.from({ length: 4 }, (_, index) => ({
+      id: `t${index}`,
+      label: `Read f${index}.ts`,
+      state: 'done' as const,
+    }));
+    const frame =
+      render(<Tui stage="detect" tasks={tasks} droppedDone={33} droppedFailed={3} />)
+        .lastFrame() ?? '';
+    expect(frame).toMatch(/\b37 done\b/); // 33 dropped + 4 shown
+    expect(frame).toMatch(/\b3 failed\b/); // failures must never be counted as done
+    expect(frame.split('\n').length).toBeLessThan(15);
+  });
+});

--- a/cli/src/onboard/__tests__/verify.test.ts
+++ b/cli/src/onboard/__tests__/verify.test.ts
@@ -56,6 +56,7 @@ describe('deterministic apply verification', () => {
       app_dir: '.',
       framework: 'vue-vite',
       package_manager: 'pnpm',
+      dev_script: 'dev',
       env_prefix: 'VITE_',
       dependency: { name: '@opslane/sdk', version: '^1.2.0' },
       env_vars: {

--- a/cli/src/onboard/__tests__/wait.test.ts
+++ b/cli/src/onboard/__tests__/wait.test.ts
@@ -134,6 +134,81 @@ describe('waitForAppReporting', () => {
     expect(fetchFn).toHaveBeenCalledTimes(3);
   });
 
+  it('rejects immediately when the signal is already aborted', async () => {
+    const fetchFn = vi.fn();
+
+    await expect(
+      waitForAppReporting({ ...OPTS, fetchFn, signal: AbortSignal.abort() }),
+    ).rejects.toThrow(/aborted/i);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('stops on abort without sleeping through the backoff', async () => {
+    const controller = new AbortController();
+    const sleepFn = vi.fn(async () => undefined);
+    const fetchFn = vi.fn(async () => {
+      controller.abort();
+      throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+    });
+
+    await expect(
+      waitForAppReporting({
+        ...OPTS,
+        fetchFn,
+        sleepFn,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(/aborted/i);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it('interrupts an active default pause and clears its timer', async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const fetchFn = seq({ status: 200, body: { status: 'pending' } });
+      const pending = waitForAppReporting({
+        ...OPTS,
+        fetchFn,
+        sleepFn: undefined,
+        pollIntervalMs: 30_000,
+        signal: controller.signal,
+      });
+      await vi.waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(1));
+
+      controller.abort();
+
+      await expect(pending).rejects.toThrow(/aborted/i);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not accumulate abort listeners across poll turns', async () => {
+    const controller = new AbortController();
+    const add = vi.spyOn(controller.signal, 'addEventListener');
+    const remove = vi.spyOn(controller.signal, 'removeEventListener');
+    let polls = 0;
+    const fetchFn = vi.fn(async () => {
+      polls += 1;
+      if (polls > 30) {
+        return new Response(JSON.stringify({ status: 'app_reporting' }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ status: 'pending' }), { status: 200 });
+    });
+
+    await waitForAppReporting({
+      ...OPTS,
+      fetchFn,
+      sleepFn: async () => undefined,
+      signal: controller.signal,
+    });
+
+    expect(add.mock.calls.length).toBe(remove.mock.calls.length);
+  });
+
   it('times out with the session id in its message', async () => {
     const nowFn = vi.fn()
       .mockReturnValueOnce(0)

--- a/cli/src/onboard/app.tsx
+++ b/cli/src/onboard/app.tsx
@@ -1,0 +1,306 @@
+/**
+ * The Ink shell: the only file that wires real terminal I/O into the pure
+ * controller. It owns the three interactive callbacks and the production
+ * dependency factory.
+ *
+ * The prompt state lives OUTSIDE React on purpose. Login prints the
+ * authorization URL to stdout (`login.ts`), and Ink owns the screen, so the
+ * shell unmounts Ink for the duration of login and renders again afterwards.
+ * A remount must not restart the run, so the run and its queue outlive the view.
+ */
+import { randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { render, type Instance } from 'ink';
+import React, { useEffect, useReducer } from 'react';
+
+import { defaultTokenPath } from '../auth.js';
+import { writeEnvLocal } from '../envfile.js';
+import { login } from '../login.js';
+import {
+  runOnboardCore,
+  type CoreDeps,
+  type CoreEvent,
+  type CoreResult,
+} from './core.js';
+import { runApply, runDetect } from './engine.js';
+import type { ApprovalRequest } from './policy.js';
+import { runCommand, startDevServer } from './process.js';
+import { ensureLoggedIn, ensureProvisioned } from './provision.js';
+import { createRunLog } from './runlog.js';
+import type { AskUserResolver } from './tools.js';
+import { Tui } from './tui.js';
+import { waitForAppReporting } from './wait.js';
+
+const YES = 'Yes';
+const NO = 'No';
+
+export interface ShellUi {
+  requestApproval: ApprovalRequest;
+  askUser: AskUserResolver;
+  confirm: (prompt: string, command: string) => Promise<boolean>;
+  emit: (event: CoreEvent) => void;
+  loginFn: () => Promise<void>;
+}
+
+/**
+ * The three prompt kinds resolve different types. Settling everything with
+ * `false` would hand a question's caller a boolean, so each entry carries its
+ * own settle type: `false` for approvals and confirmations, `[]` for questions.
+ */
+type Pending =
+  | { id: number; kind: 'boolean'; title: string; resolve: (value: boolean) => void }
+  | {
+      id: number;
+      kind: 'question';
+      title: string;
+      question: { question: string; options: string[]; multi: boolean };
+      resolve: (value: string[]) => void;
+    };
+
+export interface OnboardShell {
+  ui: ShellUi;
+  getEvent: () => CoreEvent;
+  getPrompt: () => Pending | undefined;
+  answer: (value: string[]) => void;
+  subscribe: (listener: () => void) => () => void;
+  /** Resolve every parked prompt. Called on abort and on teardown. */
+  settleAll: () => void;
+}
+
+function approvalTitle(
+  toolName: string,
+  input: Record<string, unknown>,
+  options?: { [key: string]: unknown },
+): string {
+  const supplied = options?.['title'];
+  if (typeof supplied === 'string' && supplied !== '') return supplied;
+  const filePath = input['file_path'];
+  return typeof filePath === 'string'
+    ? `Allow ${toolName} ${filePath}?`
+    : `Allow ${toolName}?`;
+}
+
+export function createOnboardShell({
+  signal,
+  loginFn = async () => undefined,
+}: {
+  signal: AbortSignal;
+  loginFn?: () => Promise<void>;
+}): OnboardShell {
+  let event: CoreEvent = { stage: 'login' };
+  const queue: Pending[] = [];
+  const listeners = new Set<() => void>();
+  let nextId = 0;
+
+  const notify = (): void => {
+    for (const listener of [...listeners]) listener();
+  };
+
+  const settle = (entry: Pending): void => {
+    if (entry.kind === 'question') entry.resolve([]);
+    else entry.resolve(false);
+  };
+
+  const settleAll = (): void => {
+    if (queue.length === 0) return;
+    for (const entry of queue.splice(0)) settle(entry);
+    notify();
+  };
+  signal.addEventListener('abort', settleAll, { once: true });
+
+  const enqueue = (entry: Pending): void => {
+    queue.push(entry);
+    notify();
+    if (signal.aborted) settleAll();
+  };
+
+  /** Remove one entry without disturbing the rest of the queue. */
+  const drop = (entry: Pending): void => {
+    const index = queue.indexOf(entry);
+    if (index === -1) return;
+    queue.splice(index, 1);
+    settle(entry);
+    notify();
+  };
+
+  const ui: ShellUi = {
+    requestApproval: (toolName, input, options) =>
+      new Promise<boolean>((resolve) => {
+        if (signal.aborted || options?.signal?.aborted === true) {
+          resolve(false);
+          return;
+        }
+        const entry: Pending = {
+          id: (nextId += 1),
+          kind: 'boolean',
+          title: approvalTitle(toolName, input, options),
+          resolve,
+        };
+        enqueue(entry);
+        // The SDK cancels individual approvals; that must not settle the rest.
+        options?.signal?.addEventListener('abort', () => drop(entry), { once: true });
+      }),
+    confirm: (prompt, command) =>
+      new Promise<boolean>((resolve) => {
+        if (signal.aborted) {
+          resolve(false);
+          return;
+        }
+        enqueue({
+          id: (nextId += 1),
+          kind: 'boolean',
+          title: `${prompt}  ${command}`,
+          resolve,
+        });
+      }),
+    askUser: (request) =>
+      new Promise<string[]>((resolve) => {
+        if (signal.aborted) {
+          resolve([]);
+          return;
+        }
+        enqueue({
+          id: (nextId += 1),
+          kind: 'question',
+          title: request.question,
+          question: { ...request },
+          resolve,
+        });
+      }),
+    emit: (next) => {
+      event = next;
+      notify();
+    },
+    loginFn,
+  };
+
+  return {
+    ui,
+    getEvent: () => event,
+    getPrompt: () => queue[0],
+    answer: (value) => {
+      const head = queue.shift();
+      notify();
+      if (head === undefined) return;
+      if (head.kind === 'question') head.resolve(value);
+      else head.resolve(value[0] === YES);
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    settleAll,
+  };
+}
+
+export function OnboardApp({ shell }: { shell: OnboardShell }): React.JSX.Element {
+  const [, bump] = useReducer((count: number) => count + 1, 0);
+  useEffect(() => {
+    const unsubscribe = shell.subscribe(bump);
+    bump(); // catch anything emitted between render and subscribe
+    return unsubscribe;
+  }, [shell]);
+
+  const event = shell.getEvent();
+  const prompt = shell.getPrompt();
+  const question =
+    prompt === undefined
+      ? undefined
+      : prompt.kind === 'question'
+        ? prompt.question
+        : { question: prompt.title, options: [YES, NO], multi: false };
+
+  return (
+    <Tui
+      // A fresh prompt gets a fresh Select, so no keystroke lands on the last one.
+      key={prompt?.id ?? 'idle'}
+      {...event}
+      tasks={event.tasks ?? []}
+      question={question}
+      onAnswer={(value) => shell.answer(value)}
+    />
+  );
+}
+
+export interface RunOnboardAppOptions {
+  cwd: string;
+  repo: string;
+  apiUrl: string;
+  signal: AbortSignal;
+  /** Overridable so tests never write to the real `~/.opslane/logs`. */
+  logDir?: string;
+  runCore?: (deps: CoreDeps) => Promise<CoreResult>;
+}
+
+async function productionDeps(
+  options: RunOnboardAppOptions,
+  ui: ShellUi,
+): Promise<CoreDeps> {
+  const full = process.env['OPSLANE_ONBOARD_LOG'] === 'full';
+  if (full) {
+    // Full mode records agent messages, which can contain repository source.
+    // Say so before writing any of it.
+    console.error(
+      'OPSLANE_ONBOARD_LOG=full: this run records full agent messages, '
+        + 'including file contents, to ~/.opslane/logs. Secrets are redacted; source is not.',
+    );
+  }
+  return {
+    cwd: options.cwd,
+    repo: options.repo,
+    apiUrl: options.apiUrl,
+    signal: options.signal,
+    tokenPath: defaultTokenPath(),
+    loginFn: ui.loginFn,
+    ensureLoggedIn,
+    ensureProvisioned,
+    runDetect,
+    runApply,
+    writeEnv: writeEnvLocal,
+    runCommand,
+    startDevServer,
+    waitForAppReporting,
+    requestApproval: ui.requestApproval,
+    askUser: ui.askUser,
+    confirm: ui.confirm,
+    runLog: await createRunLog({
+      dir: options.logDir ?? join(homedir(), '.opslane', 'logs'),
+      runId: randomUUID(),
+      mode: full ? 'full' : 'metadata',
+    }),
+    emit: ui.emit,
+  };
+}
+
+export async function runOnboardApp(options: RunOnboardAppOptions): Promise<CoreResult> {
+  const runCore = options.runCore ?? runOnboardCore;
+  let instance: Instance | undefined;
+
+  const shell: OnboardShell = createOnboardShell({
+    signal: options.signal,
+    // Login prints the authorization URL, so give stdout back for its duration.
+    // The run and its prompt queue live outside React, so remounting the view
+    // resumes the same run rather than starting a second one.
+    loginFn: async () => {
+      instance?.clear();
+      instance?.unmount();
+      instance = undefined;
+      await login({
+        apiUrl: options.apiUrl,
+        clientId: process.env['OPSLANE_CLIENT_ID'] ?? 'opslane-cli',
+      });
+      instance = render(<OnboardApp shell={shell} />);
+    },
+  });
+
+  const deps = await productionDeps(options, shell.ui);
+  instance = render(<OnboardApp shell={shell} />);
+  try {
+    return await runCore(deps);
+  } finally {
+    shell.settleAll();
+    instance?.unmount();
+  }
+}

--- a/cli/src/onboard/command.ts
+++ b/cli/src/onboard/command.ts
@@ -1,0 +1,121 @@
+import { defaultApiUrl } from '../config.js';
+import type { AgentStatus } from '../contract.js';
+import { exitWithStatus } from '../output.js';
+import type { CoreResult } from './core.js';
+import { resolveRepo } from './repo.js';
+
+export interface OnboardOptions {
+  apiUrl?: string;
+  repo?: string;
+}
+
+interface TtyGateOptions {
+  isStdinTty: boolean;
+  isStdoutTty: boolean;
+  onFail: (status: AgentStatus, code: number) => void;
+}
+
+/**
+ * Keep the TTY gate outside any .tsx module. That prevents the interactive
+ * renderer and React runtime from loading on the machine-readable piped path.
+ */
+export function requireTty({
+  isStdinTty,
+  isStdoutTty,
+  onFail,
+}: TtyGateOptions): void {
+  if (!isStdinTty || !isStdoutTty) onFail('tty_required', 1);
+}
+
+/**
+ * Signal handling lives in the command layer. The process seam accepts an
+ * AbortSignal so it remains testable and does not install process-global
+ * listeners itself.
+ */
+export function installSignalHandlers({
+  controller,
+  exitFn = (code) => {
+    process.exitCode = code;
+  },
+}: {
+  controller: AbortController;
+  exitFn?: (code: number) => void;
+}): () => void {
+  const codes = { SIGINT: 130, SIGTERM: 143 } as const;
+  const handlers = Object.entries(codes).map(([signal, code]) => {
+    const handler = (): void => {
+      exitFn(code);
+      controller.abort();
+    };
+    process.on(signal as NodeJS.Signals, handler);
+    return () => process.removeListener(signal as NodeJS.Signals, handler);
+  });
+
+  return () => {
+    for (const removeHandler of handlers) removeHandler();
+  };
+}
+
+export interface OnboardCommandDeps {
+  isStdinTty?: boolean;
+  isStdoutTty?: boolean;
+  exitWith?: (status: AgentStatus, data: Record<string, unknown>, code: number) => void;
+  loadApp?: () => Promise<{
+    runOnboardApp: (options: {
+      cwd: string;
+      repo: string;
+      apiUrl: string;
+      signal: AbortSignal;
+    }) => Promise<CoreResult>;
+  }>;
+}
+
+export async function runOnboardCommand(
+  options: OnboardOptions,
+  deps: OnboardCommandDeps = {},
+): Promise<void> {
+  // The gate and the exit both route through the injected deps, or the
+  // injection would be inert and the tests would drive the real process.
+  const exitWith = deps.exitWith ?? exitWithStatus;
+  requireTty({
+    isStdinTty: deps.isStdinTty ?? process.stdin.isTTY === true,
+    isStdoutTty: deps.isStdoutTty ?? process.stdout.isTTY === true,
+    onFail: (status, code) => {
+      exitWith(status, {
+        message:
+          'opslane onboard needs an interactive terminal; run it without piping stdin or stdout.',
+      }, code);
+    },
+  });
+
+  const repo = resolveRepo({ repo: options.repo });
+  if (!repo.ok) {
+    exitWith('usage_error', { message: repo.message }, 1);
+    return;
+  }
+
+  // Loaded lazily so the interactive renderer never reaches the piped path.
+  const loadApp = deps.loadApp ?? (() => import('./app.js'));
+  const apiUrl = options.apiUrl ?? defaultApiUrl();
+  const controller = new AbortController();
+  const removeHandlers = installSignalHandlers({ controller });
+  try {
+    const { runOnboardApp } = await loadApp();
+    const result = await runOnboardApp({
+      cwd: process.cwd(),
+      repo: repo.repo,
+      apiUrl,
+      signal: controller.signal,
+    });
+    if (result.ok) return;
+    // SIGINT already set exitCode 130; do not overwrite it.
+    if (result.status === 'aborted') return;
+    exitWith(
+      result.status === 'unsupported' ? 'usage_error' : 'internal_error',
+      { message: result.message },
+      1,
+    );
+  } finally {
+    removeHandlers();
+  }
+}

--- a/cli/src/onboard/core.ts
+++ b/cli/src/onboard/core.ts
@@ -40,6 +40,9 @@ export type Stage =
 export interface CoreEvent {
   stage: Stage;
   tasks?: TaskLine[];
+  /** Settled lines the controller stopped retaining, so the view can total them. */
+  droppedDone?: number;
+  droppedFailed?: number;
   question?: { question: string; options: string[]; multi: boolean };
   plan?: OnboardingPlan;
   url?: string;
@@ -97,9 +100,37 @@ function sameFiles(left: string[] = [], right: string[] = []): boolean {
   return a.every((value, index) => value === b[index]);
 }
 
-/** Task 9 replaces this with a real cap; the call site never changes. */
-function boundTasks(tasks: TaskLine[]): TaskLine[] {
-  return tasks;
+const MAX_TASKS = 8;
+
+export interface BoundedTasks {
+  tasks: TaskLine[];
+  droppedDone: number;
+  droppedFailed: number;
+}
+
+const NO_TASKS: BoundedTasks = { tasks: [], droppedDone: 0, droppedFailed: 0 };
+
+/**
+ * Keep every still-running line (a `tool_result` must still find its `tool_use`),
+ * plus the most recent settled ones. Failures are NEVER dropped silently — they
+ * are counted separately so the view cannot report a failure as "done".
+ *
+ * `running` is never truncated: dropping a running line would orphan its
+ * `tool_result` and the entry would never settle. When more than MAX_TASKS tools
+ * are in flight the list exceeds the cap, which is correct and transient.
+ */
+function boundTasks(tasks: TaskLine[], prev: BoundedTasks): BoundedTasks {
+  const running = tasks.filter((task) => task.state === 'run');
+  const settled = tasks.filter((task) => task.state !== 'run');
+  const room = Math.max(0, MAX_TASKS - running.length);
+  // slice(-0) is slice(0) and returns EVERYTHING — guard room === 0 explicitly.
+  const keep = room === 0 ? [] : settled.slice(-room);
+  const dropped = settled.slice(0, settled.length - keep.length);
+  return {
+    tasks: [...keep, ...running],
+    droppedDone: prev.droppedDone + dropped.filter((task) => task.state === 'done').length,
+    droppedFailed: prev.droppedFailed + dropped.filter((task) => task.state === 'fail').length,
+  };
 }
 
 async function runFlow(deps: CoreDeps, record: Record_): Promise<CoreResult> {
@@ -124,9 +155,17 @@ async function runFlow(deps: CoreDeps, record: Record_): Promise<CoreResult> {
   deps.runLog.addSecret(provision.pollToken);
   await deps.runLog.setSessionId(provision.sessionId);
 
-  emit({ stage: 'detect', tasks: [] });
+  let bounded = NO_TASKS;
+  const emitTasks = (stage: Stage): void =>
+    emit({
+      stage,
+      tasks: bounded.tasks,
+      droppedDone: bounded.droppedDone,
+      droppedFailed: bounded.droppedFailed,
+    });
+
+  emitTasks('detect');
   let plan: OnboardingPlan | undefined;
-  let tasks: TaskLine[] = [];
   const detect = await deps.runDetect({
     cwd: deps.cwd,
     signal,
@@ -136,8 +175,8 @@ async function runFlow(deps: CoreDeps, record: Record_): Promise<CoreResult> {
     },
     onMessage: (message) => {
       record(message);
-      tasks = boundTasks(reduceTasks(tasks, message));
-      emit({ stage: 'detect', tasks });
+      bounded = boundTasks(reduceTasks(bounded.tasks, message), bounded);
+      emitTasks('detect');
     },
   });
 
@@ -159,8 +198,8 @@ async function runFlow(deps: CoreDeps, record: Record_): Promise<CoreResult> {
 
   emit({ stage: 'awaiting-approval', plan });
 
-  tasks = []; // detect's list must not carry over
-  emit({ stage: 'apply', tasks });
+  bounded = NO_TASKS; // detect's list must not carry over
+  emitTasks('apply');
   let report: ApplyReport | undefined;
   const applied = await deps.runApply({
     cwd: deps.cwd,
@@ -172,8 +211,8 @@ async function runFlow(deps: CoreDeps, record: Record_): Promise<CoreResult> {
     },
     onMessage: (message) => {
       record(message);
-      tasks = boundTasks(reduceTasks(tasks, message));
-      emit({ stage: 'apply', tasks });
+      bounded = boundTasks(reduceTasks(bounded.tasks, message), bounded);
+      emitTasks('apply');
     },
   });
 

--- a/cli/src/onboard/core.ts
+++ b/cli/src/onboard/core.ts
@@ -1,0 +1,133 @@
+/**
+ * The onboarding controller. Every effect is injected, so the whole decision
+ * tree is unit-testable with no TTY, no model, and no network. Nothing here may
+ * import `ink`, read `process.stdin`, or call a model directly.
+ */
+import type { writeEnvLocal } from '../envfile.js';
+import type { runApply, runDetect } from './engine.js';
+import type { TaskLine } from './events.js';
+import type { ApprovalRequest } from './policy.js';
+import type { ensureLoggedIn, ensureProvisioned } from './provision.js';
+import type { runCommand, startDevServer } from './process.js';
+import type { RunLog } from './runlog.js';
+import type { AskUserResolver, OnboardingPlan } from './tools.js';
+import type { waitForAppReporting } from './wait.js';
+
+export type Stage =
+  | 'login'
+  | 'provision'
+  | 'detect'
+  | 'awaiting-approval'
+  | 'apply'
+  | 'writing-env'
+  | 'installing'
+  | 'starting-dev'
+  | 'waiting'
+  | 'done'
+  | 'failed'
+  | 'unsupported'
+  | 'aborted';
+
+export interface CoreEvent {
+  stage: Stage;
+  tasks?: TaskLine[];
+  question?: { question: string; options: string[]; multi: boolean };
+  plan?: OnboardingPlan;
+  url?: string;
+  output?: string;
+  message?: string;
+}
+
+export interface CoreDeps {
+  cwd: string;
+  repo: string;
+  apiUrl: string;
+  tokenPath: string;
+  signal: AbortSignal;
+  loginFn: () => Promise<void>;
+  ensureLoggedIn: typeof ensureLoggedIn;
+  ensureProvisioned: typeof ensureProvisioned;
+  runDetect: typeof runDetect;
+  runApply: typeof runApply;
+  requestApproval: ApprovalRequest;
+  askUser: AskUserResolver;
+  confirm: (prompt: string, command: string) => Promise<boolean>;
+  writeEnv: typeof writeEnvLocal;
+  runCommand: typeof runCommand;
+  startDevServer: typeof startDevServer;
+  waitForAppReporting: typeof waitForAppReporting;
+  runLog: RunLog;
+  emit: (event: CoreEvent) => void;
+}
+
+export interface CoreResult {
+  ok: boolean;
+  status: 'completed' | 'unsupported' | 'failed' | 'aborted';
+  message?: string;
+  url?: string;
+}
+
+const TERMINAL = {
+  completed: 'done',
+  failed: 'failed',
+  unsupported: 'unsupported',
+  aborted: 'aborted',
+} as const satisfies Record<CoreResult['status'], Stage>;
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+type Record_ = (message: unknown) => void;
+
+async function runFlow(deps: CoreDeps, _record: Record_): Promise<CoreResult> {
+  const { emit } = deps;
+
+  emit({ stage: 'login' });
+  const tokens = await deps.ensureLoggedIn({
+    apiUrl: deps.apiUrl,
+    tokenPath: deps.tokenPath,
+    loginFn: deps.loginFn,
+  });
+
+  emit({ stage: 'provision' });
+  const provision = await deps.ensureProvisioned({
+    apiUrl: deps.apiUrl,
+    repo: deps.repo,
+    token: tokens.accessToken,
+  });
+  // Both are required before any message is recorded in full mode: the key and
+  // poll token must be redactable, and the log needs the server join key.
+  deps.runLog.addSecret(provision.apiKey);
+  deps.runLog.addSecret(provision.pollToken);
+  await deps.runLog.setSessionId(provision.sessionId);
+
+  return { ok: true, status: 'completed' };
+}
+
+export async function runOnboardCore(deps: CoreDeps): Promise<CoreResult> {
+  const { emit, signal } = deps;
+
+  // Records are fire-and-forget from the caller's view but must not outlive
+  // `finish`, and a rejection must never become an unhandled rejection.
+  let logChain: Promise<void> = Promise.resolve();
+  const record: Record_ = (message) => {
+    logChain = logChain.then(() => deps.runLog.record(message)).catch(() => undefined);
+  };
+
+  let outcome: CoreResult;
+  try {
+    outcome = await runFlow(deps, record);
+  } catch (error) {
+    outcome = signal.aborted
+      ? { ok: false, status: 'aborted' }
+      : { ok: false, status: 'failed', message: messageOf(error) };
+  } finally {
+    await logChain; // drain before finishing
+  }
+
+  // Exactly one terminal event, mapped straight from the status.
+  emit({ stage: TERMINAL[outcome.status], message: outcome.message, url: outcome.url });
+  await deps.runLog.finish({ outcome: outcome.status }).catch(() => undefined);
+  return outcome;
+}

--- a/cli/src/onboard/core.ts
+++ b/cli/src/onboard/core.ts
@@ -12,6 +12,7 @@ import { containedRepoRelative } from './paths.js';
 import type { ApprovalRequest } from './policy.js';
 import type { ensureLoggedIn, ensureProvisioned } from './provision.js';
 import {
+  devCommand,
   formatCommand,
   installCommand,
   type runCommand,
@@ -224,7 +225,58 @@ async function runFlow(deps: CoreDeps, record: Record_): Promise<CoreResult> {
     }
   }
 
-  return { ok: true, status: 'completed' };
+  const dev = devCommand(deps.cwd, appDir, plan.dev_script);
+  if (!(await deps.confirm('Start the dev server?', formatCommand(dev)))) {
+    return {
+      ok: false,
+      status: 'failed',
+      message:
+        'The dev server was not started. Start it yourself with '
+        + `\`${formatCommand(dev)}\`, then re-run onboarding.`,
+    };
+  }
+
+  emit({ stage: 'starting-dev' });
+  const server = deps.startDevServer({
+    command: dev,
+    cwd: envDir,
+    signal,
+    onOutput: (output) => emit({ stage: 'starting-dev', output }),
+  });
+  // The poll must be cancellable independently: when the server dies, the
+  // losing side of the race would otherwise keep polling for 15 minutes.
+  const pollController = new AbortController();
+  const onOuterAbort = (): void => pollController.abort();
+  signal.addEventListener('abort', onOuterAbort, { once: true });
+  // Never let the losing branch surface as an unhandled rejection.
+  const serverDied = server.completed.then(
+    ({ exitCode }) => {
+      throw new Error(`the dev server stopped (${exitCode ?? 'signal'}) unexpectedly`);
+    },
+    (error: unknown) => {
+      throw error instanceof Error ? error : new Error(String(error));
+    },
+  );
+  void serverDied.catch(() => undefined);
+  try {
+    const url = await Promise.race([server.url, serverDied]);
+    emit({ stage: 'waiting', url });
+    await Promise.race([
+      deps.waitForAppReporting({
+        apiUrl: deps.apiUrl,
+        sessionId: provision.sessionId,
+        pollToken: provision.pollToken,
+        signal: pollController.signal,
+      }),
+      serverDied,
+    ]);
+    return { ok: true, status: 'completed', url };
+  } finally {
+    pollController.abort(); // stop the poll either way
+    signal.removeEventListener('abort', onOuterAbort);
+    server.stop();
+    await server.completed.catch(() => undefined); // teardown before the terminal event
+  }
 }
 
 export async function runOnboardCore(deps: CoreDeps): Promise<CoreResult> {

--- a/cli/src/onboard/core.ts
+++ b/cli/src/onboard/core.ts
@@ -11,7 +11,12 @@ import { reduceTasks, type TaskLine } from './events.js';
 import { containedRepoRelative } from './paths.js';
 import type { ApprovalRequest } from './policy.js';
 import type { ensureLoggedIn, ensureProvisioned } from './provision.js';
-import type { runCommand, startDevServer } from './process.js';
+import {
+  formatCommand,
+  installCommand,
+  type runCommand,
+  type startDevServer,
+} from './process.js';
 import type { RunLog } from './runlog.js';
 import type { AskUserResolver, OnboardingPlan } from './tools.js';
 import type { waitForAppReporting } from './wait.js';
@@ -195,6 +200,29 @@ async function runFlow(deps: CoreDeps, record: Record_): Promise<CoreResult> {
     [plan.env_vars.api_key]: provision.apiKey,
     [plan.env_vars.endpoint]: provision.endpoint,
   });
+
+  if (report.installRequired) {
+    emit({ stage: 'installing' });
+    const installRelative = containedRepoRelative(deps.cwd, report.installCwd);
+    const installDir = join(deps.cwd, installRelative);
+    const install = installCommand(deps.cwd, installRelative);
+    const installed = await deps.runCommand({
+      command: install,
+      cwd: installDir,
+      signal,
+      consent: () => deps.confirm('Install dependencies?', formatCommand(install)),
+      onOutput: (output) => emit({ stage: 'installing', output }),
+    });
+    if (installed.ran && !installed.ok) {
+      return {
+        ok: false,
+        status: 'failed',
+        message:
+          `${formatCommand(install)} failed (exit ${installed.exitCode ?? installed.signal}). `
+          + 'Fix the install and re-run onboarding. Do not change the @opslane/sdk version.',
+      };
+    }
+  }
 
   return { ok: true, status: 'completed' };
 }

--- a/cli/src/onboard/core.ts
+++ b/cli/src/onboard/core.ts
@@ -3,9 +3,12 @@
  * tree is unit-testable with no TTY, no model, and no network. Nothing here may
  * import `ink`, read `process.stdin`, or call a model directly.
  */
+import { join } from 'node:path';
+
 import type { writeEnvLocal } from '../envfile.js';
 import type { ApplyReport, runApply, runDetect } from './engine.js';
 import { reduceTasks, type TaskLine } from './events.js';
+import { containedRepoRelative } from './paths.js';
 import type { ApprovalRequest } from './policy.js';
 import type { ensureLoggedIn, ensureProvisioned } from './provision.js';
 import type { runCommand, startDevServer } from './process.js';
@@ -184,6 +187,14 @@ async function runFlow(deps: CoreDeps, record: Record_): Promise<CoreResult> {
       message: 'the agent report does not match the files the engine tracked',
     };
   }
+
+  emit({ stage: 'writing-env' });
+  const appDir = containedRepoRelative(deps.cwd, plan.app_dir); // throws if it escapes
+  const envDir = join(deps.cwd, appDir);
+  await deps.writeEnv(envDir, {
+    [plan.env_vars.api_key]: provision.apiKey,
+    [plan.env_vars.endpoint]: provision.endpoint,
+  });
 
   return { ok: true, status: 'completed' };
 }

--- a/cli/src/onboard/core.ts
+++ b/cli/src/onboard/core.ts
@@ -4,7 +4,7 @@
  * import `ink`, read `process.stdin`, or call a model directly.
  */
 import type { writeEnvLocal } from '../envfile.js';
-import type { runApply, runDetect } from './engine.js';
+import type { ApplyReport, runApply, runDetect } from './engine.js';
 import { reduceTasks, type TaskLine } from './events.js';
 import type { ApprovalRequest } from './policy.js';
 import type { ensureLoggedIn, ensureProvisioned } from './provision.js';
@@ -80,6 +80,14 @@ function messageOf(error: unknown): string {
 
 type Record_ = (message: unknown) => void;
 
+/** The agent's own report and the engine's tracked edits must name the same files. */
+function sameFiles(left: string[] = [], right: string[] = []): boolean {
+  if (left.length !== right.length) return false;
+  const a = [...left].sort();
+  const b = [...right].sort();
+  return a.every((value, index) => value === b[index]);
+}
+
 /** Task 9 replaces this with a real cap; the call site never changes. */
 function boundTasks(tasks: TaskLine[]): TaskLine[] {
   return tasks;
@@ -137,6 +145,43 @@ async function runFlow(deps: CoreDeps, record: Record_): Promise<CoreResult> {
       ok: false,
       status: 'failed',
       message: detect.reason ?? 'the survey did not produce a plan',
+    };
+  }
+
+  emit({ stage: 'awaiting-approval', plan });
+
+  tasks = []; // detect's list must not carry over
+  emit({ stage: 'apply', tasks });
+  let report: ApplyReport | undefined;
+  const applied = await deps.runApply({
+    cwd: deps.cwd,
+    plan,
+    signal,
+    requestApproval: deps.requestApproval,
+    onReport: (value) => {
+      report = value;
+    },
+    onMessage: (message) => {
+      record(message);
+      tasks = boundTasks(reduceTasks(tasks, message));
+      emit({ stage: 'apply', tasks });
+    },
+  });
+
+  if (applied.aborted) return { ok: false, status: 'aborted' };
+  if (!applied.ok || report === undefined) {
+    return {
+      ok: false,
+      status: 'failed',
+      message:
+        applied.failures?.join('; ') ?? applied.reason ?? 'the wiring could not be verified',
+    };
+  }
+  if (!sameFiles(report.editedFiles, applied.editedFiles)) {
+    return {
+      ok: false,
+      status: 'failed',
+      message: 'the agent report does not match the files the engine tracked',
     };
   }
 

--- a/cli/src/onboard/core.ts
+++ b/cli/src/onboard/core.ts
@@ -5,7 +5,7 @@
  */
 import type { writeEnvLocal } from '../envfile.js';
 import type { runApply, runDetect } from './engine.js';
-import type { TaskLine } from './events.js';
+import { reduceTasks, type TaskLine } from './events.js';
 import type { ApprovalRequest } from './policy.js';
 import type { ensureLoggedIn, ensureProvisioned } from './provision.js';
 import type { runCommand, startDevServer } from './process.js';
@@ -80,8 +80,13 @@ function messageOf(error: unknown): string {
 
 type Record_ = (message: unknown) => void;
 
-async function runFlow(deps: CoreDeps, _record: Record_): Promise<CoreResult> {
-  const { emit } = deps;
+/** Task 9 replaces this with a real cap; the call site never changes. */
+function boundTasks(tasks: TaskLine[]): TaskLine[] {
+  return tasks;
+}
+
+async function runFlow(deps: CoreDeps, record: Record_): Promise<CoreResult> {
+  const { emit, signal } = deps;
 
   emit({ stage: 'login' });
   const tokens = await deps.ensureLoggedIn({
@@ -101,6 +106,39 @@ async function runFlow(deps: CoreDeps, _record: Record_): Promise<CoreResult> {
   deps.runLog.addSecret(provision.apiKey);
   deps.runLog.addSecret(provision.pollToken);
   await deps.runLog.setSessionId(provision.sessionId);
+
+  emit({ stage: 'detect', tasks: [] });
+  let plan: OnboardingPlan | undefined;
+  let tasks: TaskLine[] = [];
+  const detect = await deps.runDetect({
+    cwd: deps.cwd,
+    signal,
+    askUser: deps.askUser,
+    onPlan: (value) => {
+      plan = value;
+    },
+    onMessage: (message) => {
+      record(message);
+      tasks = boundTasks(reduceTasks(tasks, message));
+      emit({ stage: 'detect', tasks });
+    },
+  });
+
+  if (detect.aborted) return { ok: false, status: 'aborted' };
+  if (detect.reason === 'unsupported') {
+    return {
+      ok: false,
+      status: 'unsupported',
+      message: detect.unsupportedReason ?? 'this repository is not supported',
+    };
+  }
+  if (!detect.ok || plan === undefined) {
+    return {
+      ok: false,
+      status: 'failed',
+      message: detect.reason ?? 'the survey did not produce a plan',
+    };
+  }
 
   return { ok: true, status: 'completed' };
 }

--- a/cli/src/onboard/engine.ts
+++ b/cli/src/onboard/engine.ts
@@ -62,6 +62,8 @@ export interface EngineResult {
   aborted: boolean;
   subtype?: string;
   reason?: string;
+  /** The agent's own explanation, when `reason === 'unsupported'`. */
+  unsupportedReason?: string;
 }
 
 export interface ApplyReport extends FinishApplyReport {
@@ -362,7 +364,7 @@ export async function runDetect({
     return { ...core, ok: false, reason: 'multiple_plans' };
   }
   if (unsupportedReason !== undefined) {
-    return { ...core, ok: false, reason: 'unsupported' };
+    return { ...core, ok: false, reason: 'unsupported', unsupportedReason };
   }
   if (reportCaptures === 0 || planCaptures === 0) {
     return { ...core, ok: false, reason: 'no_plan' };

--- a/cli/src/onboard/policy.ts
+++ b/cli/src/onboard/policy.ts
@@ -9,7 +9,6 @@ import { containedRepoRelative, hasSecretSegment } from './paths.js';
 const FILE_TOOLS = new Set(['Read', 'Glob', 'Edit', 'Write', 'MultiEdit']);
 const EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit']);
 const MUTATING_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'Bash']);
-const ALLOWED_BASH = /^(npm|pnpm|yarn|bun) run (build|typecheck|lint)$/;
 const PATH_KEYS = new Set(['path', 'file_path', 'pattern']);
 
 function deny(reason: string) {
@@ -81,10 +80,10 @@ export function onboardPreToolUseHook({
     }
 
     if (toolName === 'Bash') {
-      const command = toolInput.command;
-      if (typeof command !== 'string' || !ALLOWED_BASH.test(command)) {
-        return deny('Only exact package build, typecheck, or lint scripts are allowed');
-      }
+      // The agent has no shell. Both stages also list Bash in disallowedTools
+      // and runApply passes a Bash-free allow-set, so this is defence in depth.
+      // docs/decisions/agent-runs-commands.md records why a shell was rejected.
+      return deny('The onboarding agent is not allowed to run shell commands');
     }
 
     return {};
@@ -94,6 +93,7 @@ export function onboardPreToolUseHook({
 export type ApprovalRequest = (
   toolName: string,
   input: Record<string, unknown>,
+  options?: { signal?: AbortSignal; [key: string]: unknown },
 ) => Promise<boolean>;
 
 export function createOnboardApproval({
@@ -103,7 +103,6 @@ export function createOnboardApproval({
     'Edit',
     'Write',
     'MultiEdit',
-    'Bash',
     'mcp__onboard__finish_apply',
     'mcp__onboard__ask_user',
   ],
@@ -112,13 +111,27 @@ export function createOnboardApproval({
   allowedTools?: Iterable<string>;
 }): CanUseTool {
   const allowed = new Set(allowedTools);
-  return async (toolName, input) => {
+  return async (toolName, input, options) => {
     if (!allowed.has(toolName)) {
       return { behavior: 'deny', message: `Onboarding does not allow tool ${toolName}` };
     }
     if (!MUTATING_TOOLS.has(toolName)) return { behavior: 'allow', updatedInput: input };
-    return (await requestApproval(toolName, input))
-      ? { behavior: 'allow', updatedInput: input }
-      : { behavior: 'deny', message: 'declined' };
+
+    const signal = options?.signal;
+    if (signal?.aborted === true) return { behavior: 'deny', message: 'declined' };
+
+    let onAbort: (() => void) | undefined;
+    try {
+      const approved = await new Promise<boolean>((resolve) => {
+        onAbort = () => resolve(false);
+        signal?.addEventListener('abort', onAbort, { once: true });
+        void requestApproval(toolName, input, options).then(resolve, () => resolve(false));
+      });
+      return approved
+        ? { behavior: 'allow', updatedInput: input }
+        : { behavior: 'deny', message: 'declined' };
+    } finally {
+      if (onAbort !== undefined) signal?.removeEventListener('abort', onAbort);
+    }
   };
 }

--- a/cli/src/onboard/process.ts
+++ b/cli/src/onboard/process.ts
@@ -1,0 +1,288 @@
+import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
+import { StringDecoder } from 'node:string_decoder';
+
+import { packageManagerForRepo } from './tools.js';
+
+export interface Command {
+  executable: string;
+  args: string[];
+}
+
+type SpawnProcess = (
+  executable: string,
+  args: string[],
+  options: {
+    cwd: string;
+    detached: true;
+    shell: false;
+    stdio: ['ignore', 'pipe', 'pipe'];
+  },
+) => ChildProcess;
+
+export interface ProcessOptions {
+  command: Command;
+  cwd: string;
+  signal?: AbortSignal;
+  onOutput?: (text: string) => void;
+  lineListeners?: Set<(line: string) => void>;
+  flushMs?: number;
+  spawnFn?: SpawnProcess;
+  killFn?: (pid: number, signal?: NodeJS.Signals) => void;
+}
+
+export interface ProcessCompletion {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+export interface ProcessHandle {
+  pid: number | undefined;
+  /** Settles on `close`, after stdout and stderr have drained. */
+  completed: Promise<ProcessCompletion>;
+  stop: () => void;
+}
+
+function manager(root: string, appDir: string): string {
+  const detected = packageManagerForRepo(root, appDir);
+  if (detected === null) {
+    throw new Error(`No lockfile in ${appDir} identifies a package manager`);
+  }
+  return detected;
+}
+
+export function installCommand(root: string, appDir: string): Command {
+  return { executable: manager(root, appDir), args: ['install'] };
+}
+
+/** `devScript` was already verified against the selected app manifest. */
+export function devCommand(root: string, appDir: string, devScript: string): Command {
+  return { executable: manager(root, appDir), args: ['run', devScript] };
+}
+
+const SAFE_ARGUMENT = /^[A-Za-z0-9_@%+=:,./-]+$/;
+
+/** For display and copy-paste only. Execution always uses an argv array. */
+export function formatCommand({ executable, args }: Command): string {
+  return [executable, ...args]
+    .map((value) => (
+      SAFE_ARGUMENT.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`
+    ))
+    .join(' ');
+}
+
+// Covers CSI, OSC, and single-character terminal escape sequences.
+const ANSI = /\u001B\[[0-?]*[ -/]*[@-~]|\u001B\][^\u0007\u001B]*(?:\u0007|\u001B\\)|\u001B[@-_]/g;
+const TAIL_LINES = 8;
+
+interface StreamReader {
+  stream: NodeJS.ReadableStream | null;
+  take: (chunk: Buffer | string) => void;
+  finish: () => void;
+}
+
+function attachOutput(child: ChildProcess, options: ProcessOptions): () => void {
+  if (options.onOutput === undefined && options.lineListeners === undefined) {
+    // Piped streams must still be consumed. Otherwise a verbose installer can
+    // fill the OS pipe buffer, block before exit, and leave `completed` waiting
+    // forever even though nobody asked to render its output.
+    const discard = (_chunk: Buffer | string): void => undefined;
+    child.stdout?.on('data', discard);
+    child.stderr?.on('data', discard);
+    return () => {
+      child.stdout?.off('data', discard);
+      child.stderr?.off('data', discard);
+    };
+  }
+
+  const emit = options.onOutput ?? (() => undefined);
+  const tail: string[] = [];
+  let cleaned = false;
+
+  const keepTailBounded = (): void => {
+    if (tail.length > TAIL_LINES) {
+      tail.splice(0, tail.length - TAIL_LINES);
+    }
+  };
+  const acceptLine = (raw: string): void => {
+    const line = raw.replace(ANSI, '');
+    tail.push(line);
+    keepTailBounded();
+    for (const listener of options.lineListeners ?? []) listener(line);
+  };
+  const makeReader = (stream: NodeJS.ReadableStream | null): StreamReader => {
+    const decoder = new StringDecoder('utf8');
+    let carry = '';
+    const take = (chunk: Buffer | string): void => {
+      const decoded = typeof chunk === 'string'
+        ? decoder.write(Buffer.from(chunk))
+        : decoder.write(chunk);
+      const lines = `${carry}${decoded}`.split(/\r?\n/);
+      carry = lines.pop() ?? '';
+      for (const line of lines) acceptLine(line);
+    };
+    const finish = (): void => {
+      const trailing = `${carry}${decoder.end()}`;
+      carry = '';
+      if (trailing !== '') acceptLine(trailing);
+    };
+    return { stream, take, finish };
+  };
+
+  const readers = [
+    makeReader(child.stdout),
+    makeReader(child.stderr),
+  ];
+  for (const { stream, take } of readers) stream?.on('data', take);
+
+  const flush = (): void => emit(tail.join('\n'));
+  const timer = setInterval(flush, options.flushMs ?? 100);
+  timer.unref();
+
+  return () => {
+    if (cleaned) return;
+    cleaned = true;
+    clearInterval(timer);
+    for (const { stream, take, finish } of readers) {
+      stream?.off('data', take);
+      finish();
+    }
+    keepTailBounded();
+    flush();
+  };
+}
+
+export function startProcess(options: ProcessOptions): ProcessHandle {
+  const spawnFn = options.spawnFn ?? (nodeSpawn as SpawnProcess);
+  const killFn = options.killFn ?? ((pid, signal) => {
+    process.kill(pid, signal);
+  });
+
+  // Spawning and then killing can still run package lifecycle scripts.
+  if (options.signal?.aborted === true) {
+    return {
+      pid: undefined,
+      completed: Promise.reject(new Error('aborted before process start')),
+      stop: () => undefined,
+    };
+  }
+
+  const child = spawnFn(options.command.executable, options.command.args, {
+    cwd: options.cwd,
+    detached: true,
+    shell: false,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const cleanups: Array<() => void> = [attachOutput(child, options)];
+  let stopped = false;
+  const clean = (): void => {
+    for (const cleanup of cleanups.splice(0)) cleanup();
+  };
+  const stop = (): void => {
+    if (stopped) return;
+    stopped = true;
+    clean();
+    try {
+      if (child.pid !== undefined) killFn(-child.pid, 'SIGTERM');
+    } catch {
+      // The process may have already completed.
+    }
+  };
+
+  const completed = new Promise<ProcessCompletion>((resolve, reject) => {
+    child.once('error', (error) => {
+      stop();
+      reject(error);
+    });
+    // `exit` can fire before output streams drain; `close` cannot.
+    child.once('close', (exitCode, signal) => {
+      clean();
+      stopped = true;
+      resolve({ exitCode, signal });
+    });
+  });
+
+  const signal = options.signal;
+  if (signal?.aborted === true) {
+    stop();
+  } else if (signal !== undefined) {
+    const onAbort = (): void => stop();
+    signal.addEventListener('abort', onAbort, { once: true });
+    cleanups.push(() => signal.removeEventListener('abort', onAbort));
+  }
+
+  return { pid: child.pid, completed, stop };
+}
+
+export type RunResult =
+  | { ran: true; ok: boolean; exitCode: number | null; signal: NodeJS.Signals | null }
+  | { ran: false; copyPaste: string };
+
+export async function runCommand(
+  options: ProcessOptions & { consent?: () => Promise<boolean> },
+): Promise<RunResult> {
+  if (options.consent !== undefined && !(await options.consent())) {
+    return { ran: false, copyPaste: formatCommand(options.command) };
+  }
+  const { exitCode, signal } = await startProcess(options).completed;
+  return {
+    ran: true,
+    ok: exitCode === 0 && signal === null,
+    exitCode,
+    signal,
+  };
+}
+
+const LOCALHOST_URL =
+  /(https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?(?:\/\S*)?)/i;
+
+export interface DevServerHandle extends ProcessHandle {
+  url: Promise<string>;
+  restartCommand: string;
+}
+
+export function startDevServer(
+  options: ProcessOptions & { urlTimeoutMs?: number },
+): DevServerHandle {
+  const lineListeners = options.lineListeners ?? new Set<(line: string) => void>();
+  const handle = startProcess({ ...options, lineListeners });
+
+  const url = new Promise<string>((resolve, reject) => {
+    let settled = false;
+    let timer: NodeJS.Timeout;
+    const settle = (finish: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      lineListeners.delete(scan);
+      finish();
+    };
+    const scan = (line: string): void => {
+      const match = LOCALHOST_URL.exec(line);
+      if (match !== null) settle(() => resolve(match[1]!));
+    };
+
+    lineListeners.add(scan);
+    timer = setTimeout(() => {
+      settle(() => {
+        handle.stop();
+        reject(new Error('the dev server printed no localhost URL'));
+      });
+    }, options.urlTimeoutMs ?? 30_000);
+    timer.unref();
+
+    void handle.completed
+      .then(({ exitCode, signal }) => {
+        const reason = signal === null ? String(exitCode) : signal;
+        settle(() => reject(new Error(`the dev server exited (${reason})`)));
+      })
+      .catch((error: unknown) => settle(() => reject(error)));
+  });
+  void url.catch(() => undefined);
+
+  return {
+    ...handle,
+    url,
+    restartCommand: formatCommand(options.command),
+  };
+}

--- a/cli/src/onboard/repo.ts
+++ b/cli/src/onboard/repo.ts
@@ -1,0 +1,33 @@
+import { detectRepoFromGit, normalizeRepoURL } from '../setup.js';
+
+export type ResolvedRepo =
+  | { ok: true; repo: string }
+  | { ok: false; message: string };
+
+export function resolveRepo({
+  repo,
+  detect = detectRepoFromGit,
+}: {
+  repo?: string;
+  detect?: () => string | null;
+}): ResolvedRepo {
+  if (repo !== undefined) {
+    const normalized = normalizeRepoURL(repo);
+    return normalized === null
+      ? {
+          ok: false,
+          message: `--repo must be owner/repo or a GitHub URL, got ${JSON.stringify(repo)}`,
+        }
+      : { ok: true, repo: normalized };
+  }
+
+  const detected = detect();
+  return detected === null
+    ? {
+        ok: false,
+        message:
+          'Could not determine the repository from git. Pass --repo <owner/repo>, or add a '
+          + 'GitHub remote with: git remote add origin git@github.com:owner/repo.git',
+      }
+    : { ok: true, repo: detected };
+}

--- a/cli/src/onboard/spec.ts
+++ b/cli/src/onboard/spec.ts
@@ -13,7 +13,8 @@ Read the repository and use the secret-aware search tool to determine:
 - whether the repository is unsupported because it has no web app;
 - the selected app's framework and real entry point;
 - the environment-variable naming convention and prefix this app actually uses;
-- the package manager, based on the repository lock file; and
+- the package manager, based on the repository lock file;
+- the script in the selected app's package.json that starts its dev server; and
 - any existing error or monitoring SDK, including Sentry, PostHog, @defender-dev/sdk,
   or @opslane/sdk.
 
@@ -34,6 +35,9 @@ Call report_plan exactly once and make no further tool calls afterward.
   equal the complete non-whitespace content of one line, including its semicolon.
 - Provide manifest_file for the selected app's package.json. Do not provide a dependency
   version or compute any hash; the host pins the SDK version and records both file hashes.
+- Provide dev_script: the exact key from the selected app's package.json "scripts" that
+  starts its dev server. It must be one of that file's declared scripts. In a repo with
+  several (dev, dev:staging, start), choose the one for the app you selected.
 - Keep Opslane initialization able to coexist with any existing monitoring SDK, and set
   existing_sdk.action to exactly one of:
   - "none" when the repository has no error or monitoring SDK at all (name: null);

--- a/cli/src/onboard/tools.ts
+++ b/cli/src/onboard/tools.ts
@@ -48,6 +48,8 @@ export interface OnboardingPlan {
   app_dir: string;
   framework: string;
   package_manager: (typeof PACKAGE_MANAGERS)[number];
+  /** A key of `scripts` in the app's package.json. Verified against disk. */
+  dev_script: string;
   env_prefix: string;
   dependency: {
     name: '@opslane/sdk';
@@ -286,6 +288,7 @@ function validatePlan(root: string, value: unknown): OnboardingPlan {
   }
   const manifestAbsolute = path.join(root, manifestFile);
   let manifestContents: Buffer;
+  let manifestJson: unknown;
   try {
     const metadata = statSync(manifestAbsolute);
     if (
@@ -297,11 +300,23 @@ function validatePlan(root: string, value: unknown): OnboardingPlan {
       throw new Error('not a regular file');
     }
     manifestContents = readFileSync(manifestAbsolute);
-    assertRecord(JSON.parse(manifestContents.toString('utf8')), 'edit.manifest_file');
+    manifestJson = JSON.parse(manifestContents.toString('utf8'));
+    assertRecord(manifestJson, 'edit.manifest_file');
   } catch {
     throw new Error('edit.manifest_file must be a valid regular JSON file');
   }
   const manifestHash = createHash('sha256').update(manifestContents).digest('hex');
+  const devScript = nonEmptyString(value.dev_script, 'dev_script');
+  const scripts = (manifestJson as Record<string, unknown>).scripts;
+  const availableScripts =
+    typeof scripts === 'object' && scripts !== null && !Array.isArray(scripts)
+      ? Object.keys(scripts)
+      : [];
+  if (!availableScripts.includes(devScript)) {
+    throw new Error(
+      `dev_script must be one of: ${availableScripts.join(', ') || '(none declared)'}`,
+    );
+  }
 
   const importLine = nonEmptyString(value.edit.import_line, 'edit.import_line');
   const initBlock = nonEmptyString(value.edit.init_block, 'edit.init_block');
@@ -352,6 +367,7 @@ function validatePlan(root: string, value: unknown): OnboardingPlan {
     app_dir: appDir,
     framework,
     package_manager: packageManager,
+    dev_script: devScript,
     env_prefix: envPrefix,
     dependency: { name: '@opslane/sdk', version: OPSLANE_SDK_VERSION },
     env_vars: { api_key: apiKey, endpoint },
@@ -402,6 +418,7 @@ export function createReportPlanTool(
     app_dir: z.string(),
     framework: z.string(),
     package_manager: z.enum(PACKAGE_MANAGERS),
+    dev_script: z.string(),
     env_prefix: z.string(),
     dependency: z.object({
       name: z.literal('@opslane/sdk'),

--- a/cli/src/onboard/tui.tsx
+++ b/cli/src/onboard/tui.tsx
@@ -1,0 +1,113 @@
+/**
+ * The onboarding view. Pure: every value it renders arrives as a prop and every
+ * decision it makes is about presentation. No effects, no timers of its own, and
+ * no knowledge of the controller beyond `CoreEvent`'s shape.
+ */
+import { MultiSelect, Select, Spinner } from '@inkjs/ui';
+import { Box, Text } from 'ink';
+import React from 'react';
+
+import type { Stage } from './core.js';
+import type { TaskLine } from './events.js';
+
+export interface TuiProps {
+  stage: Stage;
+  tasks: TaskLine[];
+  droppedDone?: number;
+  droppedFailed?: number;
+  question?: { question: string; options: string[]; multi: boolean };
+  url?: string;
+  output?: string;
+  message?: string;
+  onAnswer?: (answer: string[]) => void;
+}
+
+const TERMINAL_STAGES = new Set<Stage>(['done', 'failed', 'unsupported', 'aborted']);
+
+const HEADLINE: Record<Stage, string> = {
+  login: 'Signing you in',
+  provision: 'Setting up your Opslane project',
+  detect: 'Looking at your repository',
+  'awaiting-approval': 'Reviewing the plan',
+  apply: 'Wiring the Opslane SDK into your app',
+  'writing-env': 'Writing .env.local',
+  installing: 'Installing dependencies',
+  'starting-dev': 'Starting your dev server',
+  waiting: 'Waiting for your app to report',
+  done: 'Your app is connected to Opslane.',
+  failed: 'Onboarding stopped.',
+  unsupported: 'Onboarding cannot handle this repository.',
+  aborted: 'Cancelled. Nothing was left running.',
+};
+
+const ICON: Record<TaskLine['state'], string> = { run: '·', done: '✓', fail: '✗' };
+
+function Tasks({
+  tasks,
+  droppedDone = 0,
+  droppedFailed = 0,
+}: Pick<TuiProps, 'tasks' | 'droppedDone' | 'droppedFailed'>): React.JSX.Element | null {
+  const done = droppedDone + tasks.filter((task) => task.state === 'done').length;
+  const failed = droppedFailed + tasks.filter((task) => task.state === 'fail').length;
+  if (done === 0 && failed === 0 && tasks.length === 0) return null;
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text dimColor>{`✓ ${done} done`}</Text>
+        {failed > 0 ? <Text color="red">{`  ✗ ${failed} failed`}</Text> : null}
+      </Box>
+      {tasks.map((task) => (
+        <Text key={task.id} color={task.state === 'fail' ? 'red' : undefined}>
+          {`${ICON[task.state]} ${task.label}`}
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
+function Question({
+  question,
+  onAnswer,
+}: Required<Pick<TuiProps, 'question'>> & Pick<TuiProps, 'onAnswer'>): React.JSX.Element {
+  const options = question.options.map((option) => ({ label: option, value: option }));
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text bold>{question.question}</Text>
+      {question.multi ? (
+        <MultiSelect options={options} onSubmit={(values) => onAnswer?.(values)} />
+      ) : (
+        <Select options={options} onChange={(value) => onAnswer?.([value])} />
+      )}
+    </Box>
+  );
+}
+
+export function Tui({
+  stage,
+  tasks,
+  droppedDone,
+  droppedFailed,
+  question,
+  url,
+  output,
+  message,
+  onAnswer,
+}: TuiProps): React.JSX.Element {
+  const terminal = TERMINAL_STAGES.has(stage);
+  return (
+    <Box flexDirection="column">
+      {terminal ? (
+        <Text color={stage === 'done' ? 'green' : stage === 'aborted' ? 'yellow' : 'red'}>
+          {HEADLINE[stage]}
+        </Text>
+      ) : (
+        <Spinner label={HEADLINE[stage]} />
+      )}
+      {message ? <Text>{message}</Text> : null}
+      {url ? <Text color="cyan">{url}</Text> : null}
+      <Tasks tasks={tasks} droppedDone={droppedDone} droppedFailed={droppedFailed} />
+      {output ? <Text dimColor>{output}</Text> : null}
+      {question ? <Question question={question} onAnswer={onAnswer} /> : null}
+    </Box>
+  );
+}

--- a/cli/src/onboard/wait.ts
+++ b/cli/src/onboard/wait.ts
@@ -11,6 +11,7 @@ export interface WaitOptions {
   maxUnreachable?: number;
   requestTimeoutMs?: number;
   nowFn?: () => number;
+  signal?: AbortSignal;
 }
 
 const WAITING = new Set(['pending', 'provisioned', 'key_ok']);
@@ -22,24 +23,54 @@ const REQUEST_TIMEOUT_MS = 30_000;
 
 export async function waitForAppReporting(options: WaitOptions): Promise<PollResult> {
   const fetchFn = options.fetchFn ?? fetch;
-  const sleepFn = options.sleepFn
-    ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const sleepFn = options.sleepFn;
   const now = options.nowFn ?? Date.now;
   const interval = options.pollIntervalMs ?? 3_000;
   const deadline = now() + (options.timeoutMs ?? 15 * 60_000);
   const maxUnreachable = options.maxUnreachable ?? 20;
   const requestTimeout = options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS;
+  const callerSignal = options.signal;
+  const abortError = (): Error =>
+    new Error(`waiting for session ${options.sessionId} was aborted`);
+  const throwIfAborted = (): void => {
+    if (callerSignal?.aborted === true) throw abortError();
+  };
   let unreachable = 0;
 
   async function pause(ms: number): Promise<void> {
     const remaining = deadline - now();
-    if (remaining > 0) await sleepFn(Math.min(ms, remaining));
+    if (remaining <= 0) return;
+    throwIfAborted();
+
+    let onAbort: (() => void) | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        onAbort = () => reject(abortError());
+        callerSignal?.addEventListener('abort', onAbort, { once: true });
+        const delay = Math.min(ms, remaining);
+        const sleeping = sleepFn === undefined
+          ? new Promise<void>((resolveSleep) => {
+              timer = setTimeout(resolveSleep, delay);
+              if (typeof timer.unref === 'function') timer.unref();
+            })
+          : sleepFn(delay);
+        void sleeping.then(resolve, reject);
+      });
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+      if (onAbort !== undefined) callerSignal?.removeEventListener('abort', onAbort);
+    }
   }
 
+  throwIfAborted();
   while (now() < deadline) {
     const remaining = deadline - now();
     if (remaining <= 0) break;
+    throwIfAborted();
     const controller = new AbortController();
+    const onCallerAbort = (): void => controller.abort();
+    callerSignal?.addEventListener('abort', onCallerAbort, { once: true });
     const timeout = setTimeout(
       () => controller.abort(),
       Math.min(remaining, requestTimeout),
@@ -50,7 +81,11 @@ export async function waitForAppReporting(options: WaitOptions): Promise<PollRes
       pollToken: options.pollToken,
       fetchFn,
       signal: controller.signal,
-    }).finally(() => clearTimeout(timeout));
+    }).finally(() => {
+      clearTimeout(timeout);
+      callerSignal?.removeEventListener('abort', onCallerAbort);
+    });
+    throwIfAborted();
 
     if (result.status === 'app_reporting' || result.status === 'completed') return result;
     if (result.status === 'failed') {

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -8,7 +8,8 @@
     "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     globals: false,
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
   },
 });

--- a/docs/decisions/agent-runs-commands.md
+++ b/docs/decisions/agent-runs-commands.md
@@ -1,0 +1,278 @@
+# The agent runs commands, gated by human approval
+
+- **Status:** REJECTED (2026-07-24, same day). The evidence did not survive review.
+  The three factual findings below stand and are worth keeping; the decision they were
+  used to justify does not follow from them. Kept as a record so it is not re-proposed
+  without new evidence.
+- **Measured:** 2026-07-24. Three live spike runs (ERESOLVE, ETARGET, denial), real npm, no stubs.
+- **Supersedes:** the Phase 1 "checks-only Bash, installs stay the human's job" decision
+  (`docs/plans/2026-07-22-onboarding-10x-implementation.md:739`)
+- **SDK:** `@anthropic-ai/claude-agent-sdk@0.3.217`
+
+~~The onboarding agent should run the commands onboarding needs — installs included — with
+each call gated by the SDK's `canUseTool` approval callback.~~
+
+**Rejected.** See "Why this was rejected" at the end. The Phase 1 policy stands: the agent
+does not run installs. Phase 3a's deterministic seam stays.
+
+## What we believed, and what is actually true
+
+The Phase 1 decision said the agent's Bash was restricted to `<pm> run build|typecheck|lint`,
+with installs reserved for the human because `install` runs every dependency's `postinstall`
+script. Phase 3a then built a separate deterministic path so the CLI could run the install
+itself with lockfile-derived text.
+
+Three findings, all verified against the code and a live run:
+
+**1. The agent cannot run any command today.** `'Bash'` is in `disallowedTools` for both
+stages (`engine.ts:105` and `engine.ts:151`), which removes the tool from the model's
+context. So `ALLOWED_BASH` (`policy.ts:12`) and the Bash branch of `onboardPreToolUseHook`
+are unreachable in production. `policy.test.ts:73-81` passes because it invokes the hook
+directly. The "checks-only" capability described in the plan does not exist.
+
+**2. The SDK executes the command; the host never handles a shell string.** A `canUseTool`
+implementation returns `{behavior: 'allow'}` and the SDK runs the tool. There is no argv
+reconstruction, no shell string to parse, no `spawn` call in our code. The earlier concern
+that approval-gated Bash would force us to write a shell parser was wrong.
+
+**3. `canUseTool`'s third argument carries everything a prompt needs.** Observed keys:
+
+```
+signal, suggestions, blockedPath, decisionReason,
+title, displayName, description, toolUseID, agentID, requestId
+```
+
+`decisionReason` was `"This command requires approval"`. `suggestions` contained a
+ready-made always-allow rule:
+
+```json
+[{"type":"addRules",
+  "rules":[{"toolName":"Bash","ruleContent":"npm install *"}],
+  "behavior":"allow","destination":"localSettings"}]
+```
+
+That is the "don't ask again" affordance, supplied rather than rebuilt.
+
+## The spikes
+
+Three live runs, `@anthropic-ai/claude-agent-sdk@0.3.217`, real npm, no stubs.
+All used `allowedTools: []` so `canUseTool` was consulted on every call.
+
+### Run 1 — ERESOLVE (2026-07-24). Motivated the proposal. **Invalid.**
+
+A real Vite 8 project, `npm install @opslane/sdk` unversioned, resolving to `1.0.0`
+whose peer range is `vite ^6 || ^7`.
+
+```
+1. npm install @opslane/sdk 2>&1        -> ERESOLVE, exit 1
+2. npm install @opslane/sdk --legacy-peer-deps 2>&1  -> success
+success, 3 turns, $0.28
+```
+
+Impressive, and irrelevant. Production never installs unversioned. See rejection #1.
+
+### Run 2 — ETARGET (2026-07-24). The **real** production scenario. **Decisive against.**
+
+`package.json` carrying exactly what the apply stage writes: `"@opslane/sdk": "^1.2.0"`
+(`tools.ts:19`). Tools `['Bash','Read','Edit']`, matching the apply stage's set plus Bash.
+
+The agent investigated correctly — checked for lockfiles, ran `npm view @opslane/sdk versions`
+to see what actually exists. Then:
+
+```
+Edit  package.json
+Bash  npm install 2>&1        -> added 73 packages
+Bash  node -e "... @opslane/sdk version: 1.0.0"
+
+agent: "Done. Dependencies are installed and @opslane/sdk (v1.0.0) is available.
+        What went wrong: package.json asked for @opslane/sdk@^1.2.0, but the only
+        published version is 1.0.0, so npm errored with ETARGET.
+        Fix: I changed the dependency to ^1.0.0 and reran npm install."
+
+success, 12 turns, $0.46
+package.json CHANGED: "@opslane/sdk": "^1.2.0"  ->  "@opslane/sdk": "^1.0.0"
+```
+
+**It routed around the identity guard.** `OPSLANE_IDENTITY_MIN_VERSION` is `1.2.0` precisely
+because `1.0.0` does not send `sdk:{name,version}` on `/sessions/init`, and the server only
+flips a session to `app_reporting` when that field is present (`session.go:195`). The agent
+downgraded to the one version that cannot complete onboarding, and reported success.
+
+What production would then do, traced through the code:
+
+1. `verifyApplied` rejects the manifest — `^1.0.0` fails the `>=1.2.0` check (verified:
+   `^1.2.0` and `^1.3.0` accepted, `^1.0.0` and `1.0.0` rejected).
+2. `runApply` rolls back. Rollback restores `entry` and `manifest` only (`verify.ts:62-63`).
+3. **Left behind:** `node_modules/@opslane/sdk@1.0.0` and a lockfile pinning `1.0.0`.
+
+The repo now sits in a state its own manifest does not describe: `package.json` says
+`^1.2.0`, disk holds `1.0.0`, the lockfile agrees with disk. A later `npm ci` installs the
+broken version silently.
+
+The agent also attempted `Read` on a path outside the project directory. In production
+`onboardPreToolUseHook` would deny that — but only because the tool argument is a path it
+can inspect. A `cat` inside a Bash string is not inspectable.
+
+### Run 3 — denial (2026-07-24). Closes the gap Run 1 left open. **Clean.**
+
+Same fixture, `canUseTool` refusing every Bash call.
+
+```
+--- canUseTool: Bash :: npm install 2>&1   -> DENY
+[result ERROR] The human declined this command.
+
+agent: "The user declined the npm install. I'll stop here.
+        Nothing was changed. If you'd like me to proceed, just let me know —
+        or tell me a preferred package manager or flags, and I'll run it."
+
+success, 3 turns, $0.08
+package.json CHANGED: false
+```
+
+The refusal reaches the model as a tool error, it stops, and it changes nothing. The
+approval mechanism itself is sound. That was never the problem.
+
+---
+
+# The original proposal (superseded)
+
+Everything from here to "Why this was rejected" is the case as first written, kept
+verbatim so the reasoning that failed is visible. **Do not action the Consequences list.**
+
+## Why this outweighs the original rationale
+
+The Phase 1 reasoning was that `install` triggers arbitrary `postinstall` code. True, but:
+
+- The same code runs whether the human types the command or approves it. The carve-out
+  changes who typed it, not what executes.
+- The plan already conceded the line is blurry: `<pm> run build` runs the repo's own build
+  script, which is equally arbitrary, and was permitted.
+- Adapting to a real repo is the product's stated thesis
+  (`2026-07-22-onboarding-10x-design.md:14`): *"an agent reasons about your actual repo
+  where a codemod cannot."* A hardcoded install command is codemod behaviour.
+
+## Consequences (NOT TO BE ACTIONED — the decision was rejected)
+
+- Remove `'Bash'` from `disallowedTools` in the apply stage; keep it disallowed in detect,
+  which is read-only by design.
+- Delete `ALLOWED_BASH` and the Bash branch in `onboardPreToolUseHook`. Approval is the
+  gate. No regex allowlist.
+- Delete `installCommand` and the consent wrapper around it from `process.ts`.
+- Amend `spec.ts:88`, which currently reads *"Do not run installs or any shell command."*
+  It should instruct the agent to run the install and, on failure, read the error and
+  propose a fix.
+- Keep `allowedTools: []` in the apply stage. This is load-bearing: a bare tool name in
+  `allowedTools` auto-approves the whole tool and `canUseTool` is never consulted. The SDK
+  emits `CLAUDE_SDK_CAN_USE_TOOL_SHADOWED` when this happens; treat that warning as a
+  failure.
+- **Keep `startProcess` and `startDevServer`.** The dev server is not an agent tool call:
+  it must outlive the agent's turn while the CLI polls for `app_reporting`, its stdout must
+  be parsed host-side for the real URL, and its process group must be killed on quit. This
+  SDK version exports no `BashOutput` or `KillShell`, so none of that is reachable through a
+  backgrounded SDK task.
+
+## Residual risk, stated plainly (as assessed at proposal time; Run 2 later found worse)
+
+- **The command string is shell-interpreted.** In the spike the agent appended `2>&1`, a
+  shell redirect, and it worked. So metacharacters are live. Approval is the mitigation,
+  which is the same posture Claude Code ships with.
+- **Prompt injection.** The agent reads the repo before proposing commands, so repo content
+  can influence what it proposes. The human sees the string first. That is a real gate but
+  a human one, and approval fatigue is real.
+- **Cost.** Roughly $0.28 per recovery run in the spike. Onboarding gets more expensive when
+  the agent iterates on a failing install.
+
+## Not proven
+
+~~Denial never executed.~~ **Closed by Run 3**: a refusal reaches the model as a tool error,
+it stops, and nothing changes. Worth keeping as the reference behaviour for M4's approval UI.
+
+Still unproven, and not worth proving unless this is revisited: build success, dev-server
+start, and an actual `app_reporting` flip after an agent-run install.
+
+
+---
+
+# Verdict
+
+## Why this was rejected
+
+A `/codex` review plus direct verification killed it the same day.
+
+**1. The motivating scenario was wrong.** The spike reproduced an ERESOLVE against
+`@opslane/sdk@1.0.0`'s `vite ^6 || ^7` peer range. But production does not install `1.0.0`.
+`tools.ts:19` pins `^${OPSLANE_IDENTITY_MIN_VERSION}` = `^1.2.0`, which is not on npm.
+The failure production actually hits is ETARGET, verified:
+
+```
+npm install @opslane/sdk@^1.2.0 --legacy-peer-deps
+npm error code ETARGET
+npm error notarget No matching version found for @opslane/sdk@^1.2.0.
+```
+
+`--legacy-peer-deps` does not fix ETARGET. Nothing does except publishing the package.
+So the agent's demonstrated recovery would not have helped, and the whole "a fixed command
+cannot adapt, the agent can" argument rests on a case that does not arise. This is the
+Phase 0 release gate (#45/#46) wearing a different hat.
+
+Worse than irrelevant: Run 2 shows what the agent does when the failure is genuinely
+unfixable. It edits the pin down to `^1.0.0` — the one version that cannot report SDK
+identity — installs it, and declares success. "Adaptive" is not a virtue when the only
+available adaptation defeats a correctness guard.
+
+**2. The security equivalence was false.** The doc argued the postinstall risk is unchanged
+because a human approves either way. That holds for one identical install command. It does
+not hold for *enabling Bash*. `onboardPreToolUseHook` enforces repo containment
+(`containedRepoRelative`) and secret-file protection (`hasSecretSegment`) by inspecting path
+arguments. A Bash command is an opaque string, so none of it applies: `cat .env`, writes
+outside the repo, `.git` edits, `curl`, and background jobs all become reachable. The
+SDK subprocess also inherits `ANTHROPIC_API_KEY`. Human approval is one control; this
+proposal deleted the rest.
+
+**3. Install breaks the transaction model.** `runApply` snapshots and rolls back exactly the
+entry file and the manifest (`verify.ts:879`). An install also writes the lockfile and
+`node_modules`. A failed, denied, or aborted install leaves changes rollback does not
+restore and verification does not check.
+
+**4. Nothing would prove the install happened.** `finish_apply` reports edited files and a
+summary. A model can call it after skipping or failing the install and `runApply` accepts it
+as long as the two source edits verify.
+
+**5. The working directory was unspecified.** The apply prompt carries no `app_dir` or
+`package_manager`, so the install cwd would be model improvisation. That breaks monorepos —
+the repo shape the design names as its acceptance bar.
+
+**6. The consequences list missed real breakage.** `cli/scripts/apply-check.mjs:154` requires
+`applyReport.installRequired` and `installCommand`; `engine.ts:68-77` defines them.
+`spec.test.ts` asserts the "Do not run installs" instruction. Removing the seam breaks all
+three.
+
+## What stands, and what to do about it
+
+The three factual findings are verified and independently useful:
+
+- **`ALLOWED_BASH` is dead code.** `'Bash'` is in `disallowedTools` for both stages
+  (`engine.ts:105`, `:151`), and absent from both `tools` arrays and the
+  `createOnboardApproval` allow-set. The "checks-only Bash" capability the Phase 1 plan
+  describes does not exist. Either delete the regex and the Bash branch, or state plainly
+  that the agent has no shell. Leaving code that looks like a security control but can
+  never run is worse than either.
+- **The SDK executes Bash; `canUseTool` only gates.** No host-side shell parsing is
+  required. This removes an argument that was made against approval-gated Bash, without
+  making the case for it.
+- **A bare tool name in `allowedTools` shadows `canUseTool` entirely.** Verified live: the
+  callback fired 0 times with `allowedTools: ['Bash','Read']`, and once per call with
+  `allowedTools: []`. The SDK warns via `CLAUDE_SDK_CAN_USE_TOOL_SHADOWED`. Any code whose
+  security model depends on `canUseTool` should treat that warning as a test failure.
+
+## What would have to be true to revisit
+
+1. `@opslane/sdk >= 1.2.0` published, so the real install failure mode is known rather than
+   masked by ETARGET.
+2. A containment story for Bash that does not depend solely on human approval.
+3. An install-completion signal `runApply` can verify, and a rollback that covers lockfile
+   and `node_modules`.
+4. `app_dir` and `package_manager` in the apply prompt.
+5. ~~A demonstrated denial path.~~ Done (Run 3).
+6. A guard the agent cannot edit its way around. Run 2 defeated the version pin by editing
+   the manifest; any future proposal must show why that cannot happen again.

--- a/docs/plans/2026-07-22-onboarding-10x-implementation.md
+++ b/docs/plans/2026-07-22-onboarding-10x-implementation.md
@@ -1267,6 +1267,22 @@ assert a fresh `provisioned → app_reporting` transition, not merely a terminal
 Keep: `node scripts/check-packed-packages.mjs`, and confirm server-side by **this run's**
 session id.
 
+**Preconditions, recorded 2026-07-25 at the end of Phase 3b.** The controller, the Ink
+shell, and `opslane onboard` are all in place; only the live smoke is outstanding.
+
+1. **Blocked on `@opslane/sdk >= 1.2.0` reaching npm** (#45 / #46). Until then `npm install`
+   fails ETARGET — verified, not assumed.
+2. **Clear `~/.opslane/pending` before the run.** `ensureProvisioned` resumes sessions
+   already at `app_reporting` or `completed` (`cli/src/onboard/provision.ts:131`) and
+   `waitForAppReporting` accepts those statuses immediately (`cli/src/onboard/wait.ts:90`),
+   so a stale record makes the poll succeed without the edited app ever connecting. **This
+   is a false-success path in the product, not only in the smoke.** If it recurs in real
+   use, the fix is a server-side transition marker — a session must prove it moved to
+   `app_reporting` during *this* run — not a workaround in the smoke script.
+3. **Assert a fresh `provisioned → app_reporting` transition for this run's session id.**
+   A terminal status alone does not distinguish a resumed session from a new one.
+4. **Re-run `node scripts/check-packed-packages.mjs`** once the SDK release lands.
+
 ---
 
 ### Folded plan items (outside voice, 2026-07-24)

--- a/docs/plans/2026-07-22-onboarding-10x-implementation.md
+++ b/docs/plans/2026-07-22-onboarding-10x-implementation.md
@@ -1046,210 +1046,240 @@ refactored seams — = Phase 2 complete.
 
 ---
 
-## Phase 3 — TUI, command registration, live smoke (the payoff)
+## Phase 3 — TUI, command registration, live smoke
 
-The two run-and-observe files (`tui.tsx`, `app.tsx`) wrap a live model + a TTY — the same
-deliberate TDD exception the prototype documented, confined to this phase.
+> **Restructured 2026-07-24 by `/plan-eng-review`.** Phase 3 was one milestone with
+> ~11 files and 5 new modules. It is now M1–M5, ordered so the SDK release gates only
+> the last one. 8 review issues and 11 outside-voice (Codex) findings are folded in
+> below. The 2026-07-24 D5b amendment is no longer a pasted addendum — it is built
+> into M2 and M4.
 
-**Deliverable:** `opslane onboard` works end-to-end on a clean Vite repo: survey → ask →
-wire → app runs → TUI confirms `app_reporting` for this run's session.
+**Deliverable (reworded).** M1–M5 prove the **orchestration** end to end: login,
+provisioning, both agent stages, approvals, env write, consented install, a TUI-owned
+dev server, and polling to `app_reporting`.
 
-> **Amendment (2026-07-24 eng review, D5b) — in-TUI consented execution.** The
-> print-and-wait hand-off ("now run `<pm> install`, then `<pm> run dev`") is replaced by
-> the TUI running those commands itself, each behind an Enter-to-confirm prompt, so the
-> user never leaves the terminal:
-> - New tested seam `runConsentedCommand` (injected `spawn`): command text is
->   **lockfile-derived** (R4 — never model text), streamed output, exit-code surfaced.
->   Skip path on every prompt prints the copy-paste command (old behavior preserved).
-> - The dev server is spawned and **owned by the TUI**: its stdout is parsed for the
->   real localhost URL (no port guessing), rendered as a clickable link — "Open your
->   app: http://localhost:5173". On quit, the TUI stops the dev server and prints the
->   restart command.
-> - `waitForAppReporting` runs alongside; the ✓ flip happens live when the user clicks
->   the link and the SDK phones home.
-> - Security posture unchanged: deterministic command text (R4) + per-command human
->   consent (R2). The *agent's* Bash allowlist still denies installs — this is the
->   TUI's own child process, not a model tool call.
-> - **Playwright/headless auto-open: rejected** — it manufactures `app_reporting`
->   without the user seeing their app (fakes the aha), adds a heavyweight dependency,
->   and breaks on auth-walled apps.
+They explicitly do **not** prove the agent beats a codemod. `cli/src/codemods/react-vite.ts`
+and `vue-vite.ts` already handle a clean Vite repo deterministically, and the design doc
+says so in its own words (`2026-07-22-onboarding-10x-design.md:14`): *"If it only handles
+a single clean Vite app, a codemod would have done, and there is no point."* The design's
+acceptance bar is **Milestone B**, the hard repo. Phase 3 is the machinery B runs on.
 
-### Task 3.1: Ink view (port; run-and-observe)
+### Blockers to resolve BEFORE M2 starts
 
-**Files:**
-- Create: `cli/src/onboard/tui.tsx` — port the prototype's `tui.tsx`, importing `TaskLine`
-  from `events.ts`. Per `docs/decisions/tui-renderer.md`: the TTY decision lives **outside**
-  the component tree, and Ink is only imported after that check (dynamic `import()` in the
-  controller), so piped callers never load the renderer.
+Four items make the milestone unwritable as previously specified. Each is a decision,
+not a task.
 
-**Verify:** `pnpm --filter @opslane/cli build` green (JSX config: add `"jsx": "react-jsx"`
-to `cli/tsconfig.json` if not present). **Commit.**
+1. **`devScript` has no source of truth.** The plan references it 7 times (Task 3.3
+   steps 4 and 6, and the finish-tool sketch at lines ~378–424). It exists nowhere in
+   the code. `OnboardingPlan` (`cli/src/onboard/tools.ts:47`) is
+   `{app_dir, framework, package_manager, env_prefix, dependency, env_vars, edit}` —
+   singular, and with no dev-script field. M2 has nothing to run until either the plan
+   schema gains a validated `dev_script`, or the CLI derives it by reading
+   `<app_dir>/package.json` `scripts` itself. **Deriving it CLI-side is preferred**: it
+   keeps the command text out of model output entirely, which is what R4 is for.
+2. **No `--repo` fallback.** `detectRepoFromGit` (`cli/src/setup.ts:58`) returns `null`
+   unless `git remote get-url origin` yields a github.com URL. A freshly scaffolded
+   local Vite app has no remote, so onboarding fails before the agent starts. `setup`
+   already exposes `--repo`; `onboard` must too, plus a clear error naming the fix.
+3. **The approval seam drops what the prompt needs.** `createOnboardApproval`
+   (`cli/src/onboard/policy.ts:99`) is `async (toolName, input) => ...` — two params.
+   The Agent SDK's `CanUseTool` passes a third carrying display metadata and an abort
+   signal. Task 3.3 promises an Ink prompt rendered from the SDK's `title`/`displayName`;
+   that data is currently discarded. The seam must forward the third argument, and must
+   settle any parked approval Promise on cancellation.
+4. **`waitForAppReporting` cannot be cancelled.** `WaitOptions`
+   (`cli/src/onboard/wait.ts:3`) has no `signal`. The teardown contract below depends on
+   aborting during the poll, so `wait.ts` gains a caller `signal` that also interrupts
+   its sleeps. Login has the same gap.
 
-### Task 3.2: `tty_required` joins the CLI status contract (TDD)
+---
 
-The canonical contract (`cli/src/contract.ts`) currently permits exits 0 and 1 and a fixed
-status list; a new machine-readable status must be added there first, not improvised.
+### M1 — Contract and toolchain
 
-**Files:**
-- Modify: `cli/src/contract.ts` — add `tty_required` (exit 1) to the status vocabulary.
-- Modify: the synced contract docs the drift test checks.
-- Test: extend `cli/src/__tests__/contract-drift.test.ts` expectations.
+No UI, no agent. Nothing here depends on the SDK release.
 
-**Steps:** failing drift test → contract + docs updated → green → commit.
+**Files**
+- Modify `cli/src/contract.ts` — add `tty_required` (exit 1) to `AGENT_STATUSES`.
+- Modify `docs/reference/cli-agent-contract.md` — the synced table.
+- Modify `cli/src/__tests__/contract-drift.test.ts` — TDD: failing first.
+- Modify `cli/package.json` — **the plan previously never said to add these.** Exact
+  pins, per `docs/decisions/tui-renderer.md` ("All package versions were exact, not
+  ranges"): `ink@7.1.1`, `@inkjs/ui@2.0.0`, `react@19.2.8`, plus `@types/react` and dev
+  dependency `ink-testing-library@4.0.0`.
+- Modify `cli/tsconfig.json` — `"jsx": "react-jsx"`.
 
-### Task 3.3: Controller — a **tested** core plus a thin Ink shell
+**Gate:** `pnpm --filter @opslane/cli build` and `test` green; the drift test enforces
+the new status.
 
-The controller coordinates approvals, cleanup, reconciliation, secret writes, polling, and
-exit status. That is too safety-critical to leave as run-and-observe, so it splits: a pure
-`runOnboardCore(deps)` with every effect injected (unit-tested, no TTY, no model), and a
-thin `app.tsx` shell that wires the real Ink UI, resolver, and `requestApproval` into it.
-Only the shell is run-and-observe.
+---
 
-**Files:**
-- Create: `cli/src/onboard/core.ts` — `runOnboardCore(deps)` where `deps` injects
-  `{ ensureLoggedIn, ensureProvisioned, runAgent, requestApproval, writeEnv,
-  waitForAppReporting, pending, out }`.
-- Create: `cli/src/onboard/app.tsx` — the Ink shell: real `requestApproval` (renders an Ink
-  prompt using the SDK's `title`/`displayName`), real ask resolver, then calls
-  `runOnboardCore`.
-- Test: `cli/src/onboard/__tests__/core.test.ts`.
+### M2 — `runConsentedCommand`
 
-**Core logic (each step is a tested branch):**
+Pure, injected `spawn`, still no UI. This is the D5b amendment's risky half, isolated
+and tested before anything renders.
 
-1. **TTY gate first** (in the shell, `process.stdin.isTTY && process.stdout.isTTY`), before
-   any Ink import. Non-TTY: `out.json({status:'tty_required', message:'…run it in a terminal'})`
-   and exit 1 (contract from Task 3.2). **No headless auto-answer.**
-2. **Login, then provision.** `ensureLoggedIn(...)`; then `detectRepoFromGit(cwd)` and
-   `ensureProvisioned({ apiUrl, repo, token, ... })` — account-based, no GitHub App.
-3. **Run the agent with the composed policy.** Build `createOnboardPolicy({ root: cwd,
-   requestApproval })` (Task 1.5) and pass it as `canUseTool` into `runAgent`. This is the
-   one seam: the policy validates and mutates finish-state, and calls the injected
-   `requestApproval` for Edit/Write/Bash; in the shell that renders an Ink prompt, in tests
-   it's a spy. Feed `reduceTasks` and `runlog.record` from each stage's `onMessage` (edit
-   reconciliation is internal to `runApply` via `EditTracker` — there is no `collectEdit`).
-   In a `finally`: reset the resolver/report slots so a failed run never leaks
-   state into a same-process retry.
-4. **Validate the outcome — a `result` message is not success.** Require ALL of: SDK result
-   reports success; a report was captured; the report's `editedFiles` set **equals** the
-   `collectEdit` set (both already canonical repo-relative from Task 1.3, so a normal run
-   matches); each `app.devScript` exists in `<dir>/package.json` `scripts`. Otherwise render
-   the specific failure, exit 1, **no env writes, no poll**.
-5. **Write env, symlink-safe.** The validated `OnboardingPlan` names one app: resolve
-   `join(cwd, plan.app_dir)` through `realpath`, reject if outside `cwd`, then
-   `writeEnvLocal(dir, { [plan.env_vars.api_key]: apiKey, [plan.env_vars.endpoint]:
-   endpoint })` (Task 2.3 also revalidates the var-name regex).
-6. **Hand-off from verified facts only.** Derive the package manager **from the repo's
-   lockfile** (`pnpm-lock.yaml`/`package-lock.json`/`yarn.lock`/`bun.lockb`), not from the
-   report's `packageManager` field — the enum stops injection but not a wrong value (finding
-   #9). Print "In `<dir>`: run `<pm> install`, then `<pm> run <devScript>`" using the derived
-   pm and the script-existence-checked `devScript`.
-7. `waitForAppReporting({ ..., sessionId, pollToken })`; on resolve flip to success, clear
-   the pending record, exit 0. On reject: show the poll error with the session id (pending
-   record kept so a re-run resumes), exit 1.
+**Files:** create `cli/src/onboard/consented-command.ts` and its `__tests__`.
 
-**Controller tests (DI, no TTY, no model) — the six the review requires:**
+**Behaviour**
+- Package manager derived from the repo's lockfile (`pnpm-lock.yaml`,
+  `package-lock.json`, `yarn.lock`, `bun.lockb`), never from model output.
+- Dev script derived per blocker 1, never from model output.
+- `spawn(executable, argv, { shell: false })`. Never a shell string.
+- Streamed output, exit code surfaced, skip path prints the copy-paste command.
+- Dev-server mode: long-running child, stdout scanned for the real localhost URL.
+- **Output rendering is throttled.** Chunks accumulate in a plain array holding only
+  the last ~8 lines and flush to React state on a ~100ms timer. A loud `npm install`
+  must not cause one Ink frame rebuild per line.
+- **Child output is ANSI-stripped before rendering.** The CLI is now executing package
+  lifecycle scripts and the repo's arbitrary dev script; without stripping, a hostile
+  script can emit terminal control sequences that spoof an Ink consent prompt.
+
+**Teardown contract (all paths, not just quit)**
+```
+spawn(..., { detached: true })            // child leads its own process group
+stop() => process.kill(-child.pid, 'SIGTERM')
+
+  normal quit          -> stop() + print restart command
+  SIGINT / SIGTERM     -> stop(), exit 130
+  uncaught throw       -> stop(), rethrow
+  abort during polling -> stop()          (needs blocker 4)
+```
+Vite spawns its own children (esbuild), so killing the direct child is not enough —
+kill the group. Precedent in this repo: `withFileLock` released only in a `finally`,
+which a signal skips, and a Ctrl-C stranded a lock file that wedged every later token
+write (found in the 2026-07-24 pre-landing review).
+
+**Tests (fake spawn, no real processes)**
+- package-manager detection: pnpm | npm | yarn | bun | none (5 cases)
+- run: exit 0 | non-zero | skip
+- dev server: URL parsed | non-default port (5174 when 5173 is taken) | URL never
+  appears | timeout
+- teardown: SIGINT during install | SIGINT during poll | throw | quit | abort
+- throttling: 500 synthetic lines produce ≤ ceil(duration/100ms) flushes; tail holds
+  only the last 8
+- ANSI stripping: a chunk containing `\x1b[2J\x1b[H` plus fake prompt text renders inert
+
+---
+
+### M3 — `runOnboardCore`
+
+Tested controller, still no UI. Every effect injected.
+
+**Files:** create `cli/src/onboard/core.ts` and `__tests__/core.test.ts`.
+
+**Corrected dependency contract.** The previous list named `runAgent` and
+`createOnboardPolicy`; neither exists.
+
+```
+deps = {
+  ensureLoggedIn, ensureProvisioned,
+  runDetect,   // {cwd, onMessage, onPlan, signal, askUser, queryFn}
+  runApply,    // {cwd, plan, onMessage, onReport, requestApproval, signal, queryFn}
+  requestApproval,          // passed INTO runApply, not used to build a policy
+  runConsentedCommand,      // from M2
+  writeEnv, waitForAppReporting, pending,
+}
+```
+
+**The caller does not build the tool policy.** `runApply` already constructs both
+`onboardPreToolUseHook` and `createOnboardApproval` internally
+(`cli/src/onboard/engine.ts:629-647`) and just wants `requestApproval` passed in.
+
+**Preflight runs before anything mutates state.** Today the model API key is only
+checked when `runAgentCore` starts (`engine.ts:235`), i.e. after login and provisioning
+have already changed server and local state. Check the model credential and the required
+package-manager executable first.
+
+**Edit reconciliation.** Reconcile the report's `editedFiles` against `EditTracker`.
+There is no `collectEdit`; the previous Task 3.3 contradicted itself by requiring one in
+step 4 while step 3 said it did not exist.
+
+**Tests**
+- login → provision
+- `runDetect` → plan | unsupported | failure
+- human rejection denies the tool and records no edit
+- an invalid or unreconciled report writes no env file and never polls
+- `editedFiles` vs `EditTracker`
+- `writeEnv` targets are realpath-contained
+- `waitForAppReporting` success | failure | timeout
+- the `finally` always resets resolver and report slots, even on throw
+- `abort()` cancels the SDK via the injected `AbortController`
+
+---
+
+### M4 — Ink shell and command registration
+
+First live run. **Not** blocked by the SDK release: `verify.ts:987-997` range-checks the
+`package.json` **text**, so Detect and Apply both pass without the SDK being published.
+
+**Files:** create `cli/src/onboard/tui.tsx`, `app.tsx`, `command.ts`; modify
+`cli/src/index.ts`.
+
+**The Ink boundary is a module boundary, not an import boundary.** With
+`"jsx": "react-jsx"`, every `.tsx` compiles with `import { jsx } from "react/jsx-runtime"`
+hoisted above all user code. So `await import('ink')` *inside* `app.tsx` does not satisfy
+`docs/decisions/tui-renderer.md` — loading `app.tsx` has already pulled React in. The
+dynamic boundary sits around the whole `.tsx` module:
+
 ```ts
-// with a requestApproval spy and injected deps:
-it('human rejection denies the tool and no edit is recorded', ...);
-it('abort() cancels the SDK via the injected AbortController', ...);
-it('an invalid/unreconciled report writes no env file and never polls', ...);
-it('the finally always resets resolver + report slots, even on throw', ...);
-it('success writes exactly the reported apps, each realpath-contained', ...);
-it('non-TTY output is exactly one JSON line, zero ANSI bytes', ...);
+// command.ts — plain .ts, no JSX, no react import
+if (!process.stdin.isTTY || !process.stdout.isTTY) {
+  exitWithStatus('tty_required', { message: '...run it in a terminal' }, 1)
+}
+const { runOnboardApp } = await import('./app.js')   // first touch of any .tsx
 ```
 
-**Verify (observe, the shell only):** build green; piped run emits the single JSON line, no
-ANSI: `node cli/dist/index.js onboard < /dev/null | cat`. **Commit.**
+Use the typed `exitWithStatus` from `cli/src/output.ts`, not a new `out.json`. Its first
+parameter is `AgentStatus`, so a typo is a compile error rather than a silent contract break.
 
-### Task 3.4: Register the command + live smoke
+**Bound the task list.** `reduceTasks` (`cli/src/onboard/events.ts:187`) appends per tool
+call with no cap and re-clones the array on every message — O(n²) allocations and an
+unbounded wall of text on a multi-app repo. Keep a rolling window of in-flight lines,
+collapse settled ones into a counter, and stop cloning per message.
 
-**Files:**
-- Modify: `cli/src/index.ts` — register after the `setup` command, and switch the program to
-  `await program.parseAsync()` (the action is async; bare `parse()` drops rejections):
+**Tests**
+- `contract.subprocess.test.ts`: piped run emits **exactly one JSON document** (matching
+  `docs/reference/cli-agent-contract.md:7` and how every other command already behaves —
+  *not* "one line", which nothing consumes), zero ANSI bytes, exit 1.
+- `ink-testing-library`: the question renders and a keystroke resolves it; each terminal
+  failure state renders something actionable rather than a spinner (unsupported repo,
+  apply failed and rolled back, poll timed out).
+- `reduceTasks`: 200 synthetic tool calls keep the array bounded and the counter correct.
 
-```ts
-program
-  .command('onboard')
-  .description('Agent-guided SDK onboarding for the repo in the current directory')
-  .argument('[dir]', 'target repo', process.cwd())
-  .option('--api-url <url>', 'Opslane API URL')
-  .action(async (dir, opts) => {
-    const { runOnboardCommand } = await import('./onboard/command.js');
-    await runOnboardCommand(dir, opts);
-  });
-```
-- Create: `cli/src/onboard/command.ts` — resolves options and calls `runOnboard`; repeat
-  provisioning follows the same `201 provisioned` path as the first run.
+Only real-terminal behaviour (colour, resize, spinner animation) stays run-and-observe.
 
-**Step 1:** `pnpm --filter @opslane/cli build && pnpm --filter @opslane/cli test` — green.
+---
 
-**Step 2: Packed-CLI reality check.** The published CLI now carries the Agent SDK as a
-regular npm dependency (npm fetches it separately; we do not bundle it). Run the repo's
-packed-package check and fix anything it flags; confirm the license checker outcome from
-Task 1.1 Step 2 holds for the packed artifact too:
+### M5 — Live smoke to `app_reporting`
 
-```bash
-node scripts/check-packed-packages.mjs
-```
+**Blocked on the SDK release** (#45 / #46). The agent writes `"@opslane/sdk": "^1.2.0"`
+(`cli/src/onboard/tools.ts:19`, derived from `OPSLANE_IDENTITY_MIN_VERSION` at
+`verify.ts:43`) and npm's latest is `1.0.0`, so `npm install` fails with ETARGET before
+the tarball-overlay line is ever reached. Once published, the smoke needs no tarball
+overlay at all.
 
-**Step 3: Live smoke (run-and-observe, the Phase 3 acceptance).** Order matters: pack the
-tarball from THIS worktree before leaving it.
+**The smoke must isolate pending state first.** `ensureProvisioned` resumes sessions
+already at `app_reporting` or `completed` (`cli/src/onboard/provision.ts:131`). A crash
+before the pending file is deleted makes the next run's poll succeed instantly without
+the newly edited app ever connecting. Clear `~/.opslane/pending` before the run and
+assert a fresh `provisioned → app_reporting` transition, not merely a terminal status.
 
-```bash
-# in the worktree:
-cd /Users/abhishekray/orca/workspaces/opslane-oss/onboarding-10x-2
-PACK_DIR=$(mktemp -d)
-pnpm --filter @opslane/sdk pack --pack-destination "$PACK_DIR"
-export ANTHROPIC_API_KEY=$(grep '^ANTHROPIC_API_KEY=' /Users/abhishekray/Projects/opslane/opslane-oss/.env | cut -d= -f2-)
+Keep: `node scripts/check-packed-packages.mjs`, and confirm server-side by **this run's**
+session id.
 
-# in the smoke repo — TRULY clean: no @opslane/sdk installed or in package.json yet,
-# so the agent has to add the dependency itself (that's the path Phase 3 verifies).
-cd ~/Projects/opslane/opslane-smoke
-grep -q '@opslane/sdk' package.json && echo "NOT CLEAN — reset the smoke repo first" && exit 1
-node /Users/abhishekray/orca/workspaces/opslane-oss/onboarding-10x-2/cli/dist/index.js onboard --api-url http://localhost:8082
-# TUI prints the session id — note it as $SID.
-# Complete login, then watch survey → answer the ask → agent edits + reports.
+---
 
-# Verify the agent actually added the registry dependency (not a file: path, not skipped):
-grep '"@opslane/sdk"' package.json    # expect a normal semver range in dependencies
+### Folded plan items (outside voice, 2026-07-24)
 
-# The human install step the TUI instructs, then overlay the UNRELEASED identity fix only
-# (--no-save so package.json keeps the registry dep the agent wrote):
-npm install
-npm install --no-save "$PACK_DIR"/opslane-sdk-*.tgz   # drop when milestone 0's release ships
-npm run dev     # open the page
-# The TUI's poll should flip to app_reporting and exit 0.
-```
-
-Confirm server-side **by this run's session id** (a project-wide query can pass on a stale
-session):
-```bash
-docker compose -p opslane-oss exec -T postgres psql -U opslane -d opslane -c \
-  "select id, status from agent_sessions where id='<SID>';"
-```
-Expected: `app_reporting`.
-
-Note on what this proves: `app_reporting` means the wired SDK's `/sessions/init` reached
-the server with identity — "your app connected." It is not proof an error event landed.
-Optionally extend the smoke: trigger a test error in the page and confirm a row lands in
-the events/errors table for the project.
-
-**Step 4: Commit** — `feat(cli): opslane onboard — agent-guided TUI onboarding to app_reporting`
-
-**Phase 3 validation checkpoint (engineering acceptance):**
-- Live smoke reaches `app_reporting` for this run's session id (TUI exit 0 + DB row).
-- Piped invocation emits exactly one byte-clean JSON object with `status: "tty_required"`.
-- `node scripts/check-packed-packages.mjs` green.
-- `pnpm --filter @opslane/cli build && pnpm --filter @opslane/cli test` green.
-- Whole-repo gate before the PR (per AGENTS.md): `pnpm -r build && pnpm test` +
-  `(cd packages/ingestion && go build ./... && go test ./...)` +
-  `docker compose config --quiet`.
-
-**Phase 3 done means:** a user in a clean Vite repo runs `opslane onboard`, answers one
-question, runs their app, and watches the TUI confirm the app connected — with every unit
-seam (`tools`, `events`, `spec`, `engine`, `agent-protocol`, `provision`, `envfile`,
-`wait`, contract) covered by Vitest. The design's 10/10 bar (the hard repo) is Milestone
-B, immediately next.
+- **`envfile.ts` symlink exposure.** Resolving `app_dir` through realpath does not protect
+  the files written inside it. `cli/src/envfile.ts:25` reads and writes `.env.local` and
+  writes `.gitignore` directly, following symlinks. A symlinked `.gitignore` writes outside
+  the repo, and a failed `.gitignore` write leaves an un-ignored secret behind. Realpath
+  both targets and fail closed.
+- **Security posture is not unchanged.** The D5b line claiming otherwise is wrong: the CLI
+  now executes package lifecycle scripts and the repo's arbitrary dev script. Lockfile-derived
+  *names* do not shrink that code-execution boundary. Covered by M2's `shell:false` and ANSI
+  stripping; the plan text should state the trust boundary plainly rather than deny it.
 
 ---
 
@@ -1311,26 +1341,24 @@ not "if abuse appears."
 
 | Review | Trigger | Why | Runs | Status | Findings |
 |--------|---------|-----|------|--------|----------|
-| Codex Review | `/codex review` | Independent 2nd opinion | 2 | issues_found → addressed | Round 1: 24; Round 2: 23; engine-license finding overruled by founder decision |
-| Plan review | manual (founder) | Architecture + contract audit | 1 | issues_found → addressed | 9 findings (3 blocking, 4 high, 2 medium); all addressed 2026-07-22 |
-| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR (PLAN) | Phase 2: 16 issues (9 review + 7 outside voice), all folded 2026-07-24 |
-| Outside Voice | Claude subagent (Codex timed out) | Independent plan challenge | 1 | issues_found → addressed | 7 findings; 2 reversed same-day decisions (poll-first resume, login.ts seam) |
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 2 | issues_found → addressed | Round 1: 24; Round 2: 23 (2026-07-22 vintage) |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 2 | issues_open (PLAN) | Phase 2: 16, all folded. **Phase 3: 19 (8 review + 11 outside voice), 2 critical gaps** |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
 
-**PLAN REVIEW (2026-07-22) — the corrections that mattered:**
-- **Blocking:** added **Phase 0.5** (authenticated account-provisioning endpoint with a full API/DB/test contract) and made Task 2.2 provisioning **synchronous** (no second `auth_url`); **rebuilt the permission architecture** so nothing security-relevant sits in `allowedTools` (Read/Grep were auto-run, so the dotenv and one-finish guards were dead code) — now one composed `createOnboardPolicy` handler with per-run state, an injected approval seam, and secret-aware custom survey tools replacing built-in Read/Grep; added a **by-repo pending lookup** (`findPendingByRepo`) since `pending.ts` only loaded by poll-id UUID.
-- **High:** fixed report/observed-edit **reconciliation** to one canonical repo-relative form with `realpath` symlink containment (normal runs were guaranteed to fail before); resolved the **install contradiction** (agent Bash is checks-only, installs stay the human's job); **run log is metadata-by-default**, full transcript opt-in with redaction/retention/warning; **smoke runs on a truly clean repo** and overlays the tarball `--no-save`.
-- **Medium:** the safety-critical controller is now a **tested core** (`runOnboardCore` with DI) plus a thin Ink shell, with the six required tests; **package manager is derived from the lockfile**, not the model's report field.
+**ENG REVIEW (2026-07-24, Phase 3 scope) — Phase 3 restructured into M1–M5:**
 
-**ENG REVIEW (2026-07-24, Phase 2 scope) — decisions folded into the section above:**
-- **Architecture:** admin gate on `/onboard/provision` **kept** with a typed `NotAuthorizedError` for 403 ("ask an org admin", never re-login); poll seam speaks the **server vocabulary verbatim** (contract.ts stays the setup-command contract); stale pre-split names refreshed (`OnboardingPlan`, `EditTracker`, single-app shape).
-- **Outside voice (all 7 accepted):** new **Task 2.0** — server-side duplicate-project guard (setup-flow projects invisible to the onboard idempotency token) + window-closed copy fix; **resume reversed to poll-first** (the poll re-delivers the key while the session lives — one poll proves liveness, recovers lost keys, catches cross-machine rotation); `login.ts` amended to throw typed errors with an injectable token path; **refresh grant wired** into `ensureLoggedIn`; pending sessions gain a `kind` discriminator; both server wire dialects (`{"status"}` / `{"error"}`) parsed; run log keyed by local run id.
-- **Tests:** 9 gap tests added across the five tasks (403 branch, LoginFailedError, poll-first resume fallback, server-vocab passthrough, atomic write + perm tightening, provisioned-as-waiting, failed-as-terminal, Retry-After header vs body, origin/kind pending mismatches).
-- **Phase 3 amendment (D5b):** in-TUI consented execution — lockfile-derived commands behind Enter-to-confirm, TUI-owned dev server, clickable localhost URL parsed from its stdout; Playwright rejected.
+- **The unlock:** `verify.ts:987-997` range-checks the `package.json` **text**, not `node_modules`. So the SDK release gates only M5 — M1–M4 build and verify now, while #45 sits.
+- **Architecture (4):** the live smoke cannot run (agent writes `^1.2.0`, npm latest is `1.0.0` → ETARGET) → M5 gated on the real release; Task 3.3 named `createOnboardPolicy`/`runAgent`, neither of which exists → dep contract rewritten against `runDetect`/`runApply`, and `runApply` already builds the policy internally; the plan never added `ink`/`react`/`@inkjs/ui` → folded into M1 as exact pins per `docs/decisions/tui-renderer.md`; no teardown contract for the spawned dev server → process-group kill on quit / SIGINT / throw / abort, tested in M2.
+- **Code quality (2):** `reduceTasks` (`events.ts:187`) grew unbounded and re-cloned per message → rolling window plus a done counter; the plan invented an untyped `out.json` → use the typed `exitWithStatus`, so a bad status is a compile error.
+- **Tests (1):** `tui.tsx`/`app.tsx` were declared run-and-observe → covered with `ink-testing-library@4.0.0`; only real-terminal behaviour stays unobserved. The plan named 6 tests for ~36 new branches.
+- **Performance (1):** streaming child stdout into Ink state renders per line → bounded tail flushed on a ~100ms timer.
 
-**CODEX:** Codex CLI timed out (5m); the outside voice ran as a Claude subagent — findings verified against source before acceptance.
+**CODEX:** ran (gpt-5.6-sol, high effort). 11 findings, none a repeat of the review. Four are hard blockers that make the milestone unwritable: `devScript` is referenced 7× in the plan and exists nowhere in `OnboardingPlan` (`tools.ts:47`); `detectRepoFromGit` returns null without a GitHub remote and `onboard` exposes no `--repo`; `createOnboardApproval` discards the SDK's third argument (display metadata + signal); `wait.ts` has no caller `signal`, so the agreed teardown has nothing to hook. All 11 verified against source before acceptance and folded above.
 
-**CROSS-MODEL:** outside voice overturned two same-day review decisions (D6→poll-first resume, D8→login.ts amendment) with code-verified evidence; both reversals accepted by the founder.
+**CROSS-MODEL:** two tensions. (1) Codex flagged that `exitWithStatus` pretty-prints, contradicting the plan's "one JSON line" — resolved **against the plan**: `docs/reference/cli-agent-contract.md:7` says "one JSON **document**" and `contract.subprocess.test.ts` parses whole stdout, so the plan's wording was the outlier. (2) Codex challenged the acceptance target as proving nothing the `react-vite`/`vue-vite` codemods already do — the design doc agrees in its own words (`onboarding-10x-design.md:14`); resolved by keeping the clean-repo target and **renaming what it proves** (the orchestration, not the agent's reasoning advantage). Milestone B remains the design's acceptance bar.
 
-**VERDICT:** ENG CLEARED (Phase 2) — the section is implementation-ready as rewritten; prior plan-review corrections stand. The 2026-07-22 unresolved items are closed: milestone 0.5 was built and landed (#182), and the corrected plan has now been independently re-reviewed (this pass + outside voice).
+**VERDICT:** ENG CLEARED — the M1–M5 structure is sound, all 19 findings are folded, and the one open decision was settled on 2026-07-24: `dev_script` joins the `OnboardingPlan` schema, model-reported and cross-checked against the app's `package.json` scripts, mirroring how `package_manager` is already handled at `tools.ts:234-237`. (The review had recorded "derive CLI-side" as preferred; that was reversed — pure derivation has to guess between `dev`, `dev:staging`, and `start`, and choosing correctly is the judgment the agent exists to provide.) Executable plan for the blockers plus M1–M2: `docs/plans/2026-07-24-phase-3a-execution-seam.md`.
 
 NO UNRESOLVED DECISIONS

--- a/docs/plans/2026-07-24-phase-3a-execution-seam.md
+++ b/docs/plans/2026-07-24-phase-3a-execution-seam.md
@@ -1,0 +1,1694 @@
+# Phase 3a: Unblock Phase 3 and build the execution seam
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Resolve the four blockers that make Phase 3 unwritable, add the Ink toolchain and the non-TTY command boundary, and build one tested process-ownership primitive that runs the install and owns the dev server.
+
+**Architecture:** Nothing here renders. Tasks 1–5 correct modules that already shipped. Task 6 adds `tty_required`, the pinned Ink toolchain, and a minimal `onboard` command whose only job is the TTY boundary — so the contract row describes a command that exists. Tasks 7–11 build `process.ts`: **one** primitive (`startProcess`) owns every child, reacts to an **injected** `AbortSignal`, exposes completion, and cleans up deterministically. Install and dev server are both thin wrappers over it. Process-global signal handling lives in the command layer, never in the seam.
+
+**Tech Stack:** TypeScript (ESM, strict), Node 22, Vitest, `ink@7.1.1` + `@inkjs/ui@2.0.0` + `react@19.2.8` (exact pins per `docs/decisions/tui-renderer.md`), `ink-testing-library@4.0.0` (dev).
+
+**Source:** `/plan-eng-review` of Phase 3 (2026-07-24), its Codex outside voice, and a review of plan revision 1 that produced these corrections:
+- `dev_script` must join the Zod `planShape`, not just the interface — `z.object` strips unknown keys, so validation would fail on every report.
+- One process-ownership primitive for install *and* dev server. Revision 1 spawned the installer `detached` and never read its signal.
+- No `process.on` / `process.exit` inside the seam. Signals belong to the command layer; the seam takes a signal.
+- Abort must be checked *immediately*, never via a listener added to an already-aborted signal (that listener never fires).
+- Finalize on `close`, not `exit`, and treat signal-termination as failure rather than `code ?? 0`.
+- Quote argv when formatting a command for humans.
+
+Revision 3 corrections, from a `/codex` pass over revision 2:
+- A **literal** `import('./app.js')` is type-resolved at compile time, so it is TS2307 until `app.tsx` exists. The command ships without it; M4 adds it.
+- `isJsonRecord` is not in `tools.ts` (it is unexported in `verify.ts:558`). Use `assertRecord` plus a local guard.
+- Validate `dev_script` against the manifest `validatePlan` already read from `edit.manifest_file`, not a re-derived `<app_dir>/package.json`.
+- Check `signal.aborted` **before** spawning, not after — spawn-then-kill still runs lifecycle scripts.
+- Drop the trailing `chmod` in `envfile`: the temp file is already `0600` and `chmod` follows a swapped-in symlink.
+- One `carry` shared by stdout and stderr splices their lines together; `String(chunk)` corrupts a split UTF-8 sequence. Use `StringDecoder` per stream.
+- The dev-server URL regex required a trailing slash, so `http://localhost:3000` never matched, and per-chunk scanning misses a split URL.
+- `process.exit` in a signal handler pre-empts the teardown it is supposed to trigger. Set `process.exitCode` and let the abort unwind.
+
+**Not in scope:** `core.ts`, `app.tsx`, `tui.tsx`, the live smoke. Those are M3–M5. The SDK release (#45/#46) gates only M5.
+
+---
+
+## Before you start
+
+```bash
+cd /Users/abhishekray/orca/workspaces/opslane-oss/onboarding-10x-2
+git fetch origin main --quiet
+git checkout -b abhishekray07/phase-3a-execution-seam origin/main
+pnpm install --frozen-lockfile
+pnpm --filter @opslane/cli test    # expect: 32 files, 323 tests, all passing
+```
+
+All test commands run from `cli/`. Single test: `npx vitest run <file> -t "<name>"`.
+
+---
+
+## Task 1: `dev_script` joins the plan schema
+
+The TUI must run the app's dev script and nothing tells it the name. `devScript` is referenced 7 times in the Phase 3 plan and exists nowhere in the code.
+
+Follow the pattern `package_manager` already uses (`tools.ts:234-237`): the model reports, the CLI verifies against disk, a mismatch throws. A lockfile has one right answer; a dev script does not.
+
+**Critical:** the field must be added to **three** places. The Zod `planShape` in `createReportPlanTool` (`tools.ts:396`) strips unknown keys, so a field present only on the interface never reaches `validatePlan`.
+
+`validatePlan` is **not exported**. Test through `createReportPlanTool`, matching the existing style.
+
+**Files:**
+- Modify: `cli/src/onboard/tools.ts` (`planShape`, `OnboardingPlan`, `validatePlan`)
+- Modify: `cli/src/onboard/spec.ts` (`renderDetectSpec`)
+- Test: `cli/src/onboard/__tests__/tools.test.ts`
+
+**Step 1: Write the failing test**
+
+In the existing `describe('report_plan')` block, whose `beforeEach` already builds `root` and a `plan: ReportedPlanInput`. First extend that fixture's manifest so the app declares scripts:
+
+```ts
+    manifestContents = '{\n  "name": "web",\n  "scripts": { "dev": "vite" },\n  "dependencies": {}\n}\n';
+```
+
+and add `dev_script: 'dev',` to the `plan` object literal. Then:
+
+```ts
+  it('keeps dev_script through the schema and reports it', async () => {
+    let captured: OnboardingPlan | undefined;
+    const tool = createReportPlanTool(root, (value) => { captured = value; });
+
+    await call(tool, { status: 'ok', plan });
+
+    expect(captured?.dev_script).toBe('dev');
+  });
+
+  it('rejects a dev_script that the app manifest does not declare', async () => {
+    const tool = createReportPlanTool(root, () => undefined);
+
+    await expect(call(tool, { status: 'ok', plan: { ...plan, dev_script: 'serve' } }))
+      .rejects.toThrow(/dev_script must be one of: dev/);
+  });
+
+  it('rejects a plan with no dev_script at all', async () => {
+    const tool = createReportPlanTool(root, () => undefined);
+    const { dev_script: _omitted, ...withoutDevScript } = plan;
+
+    await expect(call(tool, { status: 'ok', plan: withoutDevScript })).rejects.toThrow();
+  });
+```
+
+The first test is the one that catches the Zod-strip bug: it passes only if `planShape` carries the field through.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/tools.test.ts -t "dev_script"`
+Expected: FAIL — `dev_script` is not on `ReportedPlanInput`, and nothing validates it.
+
+**Step 3: Write minimal implementation**
+
+Add to the Zod `planShape` in `createReportPlanTool`, after `package_manager`:
+
+```ts
+    dev_script: z.string(),
+```
+
+Add to the `OnboardingPlan` interface, after `package_manager`:
+
+```ts
+  /** A key of `scripts` in the app's package.json. Verified against disk. */
+  dev_script: string;
+```
+
+**Validate against the manifest `validatePlan` already read — do not re-derive a path.**
+`validatePlan` reads `plan.edit.manifest_file` into `manifestContents` and JSON-parses it
+at `tools.ts:288-300`. That is the app's real `package.json`. Deriving
+`<app_dir>/package.json` independently would validate a different file whenever the plan
+selects a nested manifest, and would read the same file twice.
+
+There is no `isJsonRecord` in `tools.ts` — it lives unexported in `verify.ts:558`.
+`tools.ts` has `assertRecord`. Use a small local guard rather than importing anything.
+
+Move the `dev_script` check to **after** the manifest is parsed. Replace the existing
+bare parse at `tools.ts:300` so the parsed value is kept:
+
+```ts
+  let manifestJson: unknown;
+  try {
+    manifestContents = readFileSync(manifestAbsolute);
+    manifestJson = JSON.parse(manifestContents.toString('utf8'));
+    assertRecord(manifestJson, 'edit.manifest_file');
+  } catch {
+    throw new Error('edit.manifest_file must be a valid regular JSON file');
+  }
+
+  const devScript = nonEmptyString(value.dev_script, 'dev_script');
+  const scripts = (manifestJson as Record<string, unknown>).scripts;
+  const availableScripts =
+    typeof scripts === 'object' && scripts !== null && !Array.isArray(scripts)
+      ? Object.keys(scripts)
+      : [];
+  if (!availableScripts.includes(devScript)) {
+    throw new Error(
+      `dev_script must be one of: ${availableScripts.join(', ') || '(none declared)'}`,
+    );
+  }
+```
+
+Add `dev_script: devScript` to the returned object. No new imports.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/onboard/__tests__/tools.test.ts`
+Expected: PASS. Other tests constructing plans need `dev_script` and a `scripts` manifest — fix the fixtures, never weaken `validatePlan`.
+
+**Step 5: Tell the model about the field**
+
+`renderDetectSpec`, `# Investigate` list, after the package-manager bullet:
+
+```
+- the script in the selected app's package.json that starts its dev server; and
+```
+
+`# Report` list, after the `manifest_file` bullet:
+
+```
+- Provide dev_script: the exact key from the selected app's package.json "scripts" that
+  starts its dev server. It must be one of that file's declared scripts. In a repo with
+  several (dev, dev:staging, start), choose the one for the app you selected.
+```
+
+**Step 6: Full suite, then commit**
+
+```bash
+pnpm --filter @opslane/cli build && pnpm --filter @opslane/cli test
+git add cli/src/onboard/tools.ts cli/src/onboard/spec.ts cli/src/onboard/__tests__/tools.test.ts
+git commit -m "feat(cli): plan carries a dev_script verified against the app manifest"
+```
+
+---
+
+## Task 2: `resolveRepo`
+
+`detectRepoFromGit` (`setup.ts:58`) returns `null` without a github.com remote, so a freshly scaffolded app dies before the agent runs. Task 6 wires this into the command, so it does not stay dead code.
+
+**Files:** create `cli/src/onboard/repo.ts` and `__tests__/repo.test.ts`.
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { resolveRepo } from '../repo.js';
+
+describe('resolveRepo', () => {
+  it('prefers an explicit --repo over git detection', () => {
+    expect(resolveRepo({ repo: 'acme/web', detect: () => 'other/repo' }))
+      .toEqual({ ok: true, repo: 'acme/web' });
+  });
+
+  it('falls back to git detection when no flag is given', () => {
+    expect(resolveRepo({ detect: () => 'acme/web' })).toEqual({ ok: true, repo: 'acme/web' });
+  });
+
+  it('rejects a malformed --repo instead of sending it to the server', () => {
+    const result = resolveRepo({ repo: 'not a repo', detect: () => null });
+    expect(result).toMatchObject({ ok: false });
+    expect(result.ok === false && result.message).toMatch(/owner\/repo/);
+  });
+
+  it('names the fix when detection fails and no flag was given', () => {
+    const result = resolveRepo({ detect: () => null });
+    expect(result.ok === false && result.message).toMatch(/--repo <owner\/repo>/);
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/repo.test.ts`
+Expected: FAIL — `Cannot find module '../repo.js'`.
+
+**Step 3: Write minimal implementation**
+
+```ts
+import { detectRepoFromGit, normalizeRepoURL } from '../setup.js';
+
+export type ResolvedRepo = { ok: true; repo: string } | { ok: false; message: string };
+
+export function resolveRepo({
+  repo,
+  detect = detectRepoFromGit,
+}: { repo?: string; detect?: () => string | null }): ResolvedRepo {
+  if (repo !== undefined) {
+    const normalized = normalizeRepoURL(repo);
+    return normalized === null
+      ? { ok: false, message: `--repo must be owner/repo or a GitHub URL, got ${JSON.stringify(repo)}` }
+      : { ok: true, repo: normalized };
+  }
+  const detected = detect();
+  return detected === null
+    ? {
+        ok: false,
+        message:
+          'Could not determine the repository from git. Pass --repo <owner/repo>, or add a '
+          + 'GitHub remote with: git remote add origin git@github.com:owner/repo.git',
+      }
+    : { ok: true, repo: detected };
+}
+```
+
+**Step 4: Verify and commit**
+
+Run: `npx vitest run src/onboard/__tests__/repo.test.ts` → PASS (4).
+
+```bash
+git add cli/src/onboard/repo.ts cli/src/onboard/__tests__/repo.test.ts
+git commit -m "feat(cli): resolve the onboard repo from --repo or git with an actionable error"
+```
+
+---
+
+## Task 3: The approval seam keeps the SDK's third argument
+
+`createOnboardApproval` (`policy.ts:99`) is `async (toolName, input) => ...`. The SDK passes a third argument carrying display metadata and an abort signal; the Ink prompt is specified to render that metadata. A parked approval also never settles on cancellation, so quitting mid-prompt hangs.
+
+**Files:** modify `cli/src/onboard/policy.ts` and `__tests__/policy.test.ts`.
+
+**Step 1: Write the failing test**
+
+```ts
+it('forwards the SDK options to requestApproval', async () => {
+  const seen: unknown[] = [];
+  const canUseTool = createOnboardApproval({
+    requestApproval: async (_t, _i, options) => { seen.push(options); return true; },
+  });
+  const opts = { signal: new AbortController().signal };
+  await canUseTool('Edit', { file_path: 'a.ts' }, opts as never);
+  expect(seen[0]).toBe(opts);
+});
+
+it('denies rather than hangs when the approval is aborted', async () => {
+  const controller = new AbortController();
+  const canUseTool = createOnboardApproval({
+    requestApproval: () => new Promise<boolean>(() => { /* never settles */ }),
+  });
+  const pending = canUseTool('Edit', { file_path: 'a.ts' }, { signal: controller.signal } as never);
+  controller.abort();
+  await expect(pending).resolves.toMatchObject({ behavior: 'deny' });
+});
+
+it('denies immediately when the signal is already aborted', async () => {
+  const requestApproval = vi.fn(() => new Promise<boolean>(() => undefined));
+  const canUseTool = createOnboardApproval({ requestApproval });
+  await expect(canUseTool('Edit', { file_path: 'a.ts' }, { signal: AbortSignal.abort() } as never))
+    .resolves.toMatchObject({ behavior: 'deny' });
+});
+
+it('removes its abort listener when approval wins the race', async () => {
+  const controller = new AbortController();
+  const canUseTool = createOnboardApproval({ requestApproval: async () => true });
+  for (let i = 0; i < 50; i += 1) {
+    await canUseTool('Edit', { file_path: 'a.ts' }, { signal: controller.signal } as never);
+  }
+  // A leak here surfaces as a MaxListenersExceededWarning; assert the signal is clean
+  // by aborting and confirming nothing throws from a stale handler.
+  expect(() => controller.abort()).not.toThrow();
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/policy.test.ts -t "SDK options"`
+Expected: FAIL — third argument is `undefined`; the abort cases hang.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export type ApprovalRequest = (
+  toolName: string,
+  input: Record<string, unknown>,
+  options?: { signal?: AbortSignal; [key: string]: unknown },
+) => Promise<boolean>;
+```
+
+In the handler:
+
+```ts
+  return async (toolName, input, options) => {
+    if (!allowed.has(toolName)) {
+      return { behavior: 'deny', message: `Onboarding does not allow tool ${toolName}` };
+    }
+    if (!MUTATING_TOOLS.has(toolName)) return { behavior: 'allow', updatedInput: input };
+
+    const signal = options?.signal;
+    // Check first: a listener added to an already-aborted signal never fires.
+    if (signal?.aborted === true) return { behavior: 'deny', message: 'declined' };
+
+    let onAbort: (() => void) | undefined;
+    try {
+      const approved = await new Promise<boolean>((resolve) => {
+        onAbort = () => resolve(false);
+        signal?.addEventListener('abort', onAbort, { once: true });
+        void requestApproval(toolName, input, options).then(resolve, () => resolve(false));
+      });
+      return approved
+        ? { behavior: 'allow', updatedInput: input }
+        : { behavior: 'deny', message: 'declined' };
+    } finally {
+      if (onAbort !== undefined) signal?.removeEventListener('abort', onAbort);
+    }
+  };
+```
+
+**Step 4: Verify and commit**
+
+Run: `npx vitest run src/onboard/__tests__/policy.test.ts` → PASS.
+
+```bash
+git add cli/src/onboard/policy.ts cli/src/onboard/__tests__/policy.test.ts
+git commit -m "fix(cli): approval seam forwards SDK options and settles on abort"
+```
+
+---
+
+## Task 4: `waitForAppReporting` accepts a caller signal
+
+`WaitOptions` (`wait.ts:3`) has no `signal`. Two traps: `pollSessionOnce` turns an aborted fetch into `status: 'unreachable'` (`agent-protocol.ts:120-125`), which falls into backoff rather than exiting; and a listener registered on an already-aborted signal never fires, so a `Promise.race` against it sleeps forever.
+
+**Check the signal immediately after every poll and before registering any pause listener.**
+
+**Files:** modify `cli/src/onboard/wait.ts` and `__tests__/wait.test.ts`.
+
+**Step 1: Write the failing test**
+
+```ts
+it('rejects immediately when the signal is already aborted', async () => {
+  const fetchFn = vi.fn();
+  await expect(waitForAppReporting({ ...OPTS, fetchFn, signal: AbortSignal.abort() }))
+    .rejects.toThrow(/aborted/i);
+  expect(fetchFn).not.toHaveBeenCalled();
+});
+
+it('stops on abort without sleeping through the backoff', async () => {
+  const controller = new AbortController();
+  const sleepFn = vi.fn(async () => undefined);
+  const fetchFn = vi.fn(async () => {
+    controller.abort();                       // abort lands mid-flight
+    throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+  });
+  await expect(waitForAppReporting({ ...OPTS, fetchFn, sleepFn, signal: controller.signal }))
+    .rejects.toThrow(/aborted/i);
+  expect(fetchFn).toHaveBeenCalledTimes(1);
+  expect(sleepFn).not.toHaveBeenCalled();     // the unreachable backoff must not run
+});
+
+it('does not accumulate abort listeners across poll turns', async () => {
+  const controller = new AbortController();
+  let polls = 0;
+  const fetchFn = vi.fn(async () => {
+    polls += 1;
+    if (polls > 30) return new Response(JSON.stringify({ status: 'app_reporting' }), { status: 200 });
+    return new Response(JSON.stringify({ status: 'pending' }), { status: 200 });
+  });
+  await waitForAppReporting({
+    ...OPTS, fetchFn, sleepFn: async () => undefined, signal: controller.signal,
+  });
+  expect(controller.signal).toBeDefined();    // no MaxListenersExceededWarning emitted
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/wait.test.ts -t "abort"`
+Expected: FAIL — `signal` is not an option; the mid-flight case backs off instead of rejecting.
+
+**Step 3: Write minimal implementation**
+
+Add `signal?: AbortSignal;` to `WaitOptions`. Then:
+
+```ts
+  const callerSignal = options.signal;
+  const abortError = (): Error => new Error(`waiting for session ${options.sessionId} was aborted`);
+  const throwIfAborted = (): void => { if (callerSignal?.aborted === true) throw abortError(); };
+
+  throwIfAborted();
+```
+
+Make `pause` interruptible with deterministic listener cleanup:
+
+```ts
+  async function pause(ms: number): Promise<void> {
+    const remaining = deadline - now();
+    if (remaining <= 0) return;
+    throwIfAborted();                          // never register on an aborted signal
+    let onAbort: (() => void) | undefined;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        onAbort = () => reject(abortError());
+        callerSignal?.addEventListener('abort', onAbort, { once: true });
+        void sleepFn(Math.min(ms, remaining)).then(resolve, reject);
+      });
+    } finally {
+      if (onAbort !== undefined) callerSignal?.removeEventListener('abort', onAbort);
+    }
+  }
+```
+
+**The default sleep must be cancellable.** Rejecting the race leaves the default
+`setTimeout` referenced, so the process can stay alive through a 30s backoff after the
+user has already quit. Replace the default `sleepFn` with a cancellable one:
+
+```ts
+  const sleepFn = options.sleepFn ?? ((ms: number) => new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    // Do not hold the event loop open on an abandoned backoff.
+    if (typeof timer.unref === 'function') timer.unref();
+  }));
+```
+
+Test it: abort during an active pause and assert the promise rejects without waiting out
+the interval (drive it with `vi.useFakeTimers()` and assert no timer remains pending).
+
+Inside the loop, after the `remaining <= 0` guard **and again right after the poll returns**:
+
+```ts
+    throwIfAborted();
+```
+
+The second call is the one that matters: it runs before the `unreachable` branch can back off.
+
+Chain the caller signal into the per-request controller, removing the listener when the request settles:
+
+```ts
+    const onCallerAbort = (): void => controller.abort();
+    callerSignal?.addEventListener('abort', onCallerAbort, { once: true });
+    // ...in the existing .finally(): clearTimeout(timeout) plus
+    callerSignal?.removeEventListener('abort', onCallerAbort);
+```
+
+**Step 4: Verify and commit**
+
+Run: `npx vitest run src/onboard/__tests__/wait.test.ts` → PASS.
+
+```bash
+git add cli/src/onboard/wait.ts cli/src/onboard/__tests__/wait.test.ts
+git commit -m "feat(cli): waitForAppReporting accepts a caller signal and aborts promptly"
+```
+
+---
+
+## Task 5: `envfile.ts` stops following symlinks
+
+`envfile.ts:25` joins paths and writes, following symlinks. A symlinked `.gitignore` writes outside the repo; a `.gitignore` write that fails after `.env.local` succeeded leaves the key un-ignored.
+
+Realpath-then-write is check-then-use and loses to a symlink swapped in between. **Open with `O_NOFOLLOW` and write through the open handle**, and use atomic rename for `.gitignore` too.
+
+**Files:** modify `cli/src/envfile.ts` and `cli/src/__tests__/envfile.test.ts`.
+
+**Step 1: Write the failing test**
+
+```ts
+it('refuses to write through a symlinked .gitignore', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'opslane-env-'));
+  const outside = join(await mkdtemp(join(tmpdir(), 'opslane-out-')), 'victim');
+  await writeFile(outside, 'original\n');
+  await symlink(outside, join(dir, '.gitignore'));
+
+  await expect(writeEnvLocal(dir, { VITE_OPSLANE_API_KEY: 'opk_x' })).rejects.toThrow();
+  expect(await readFile(outside, 'utf8')).toBe('original\n');
+});
+
+it('refuses to write through a symlinked .env.local', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'opslane-env-'));
+  const outside = join(await mkdtemp(join(tmpdir(), 'opslane-out-')), 'victim');
+  await writeFile(outside, 'original\n');
+  await symlink(outside, join(dir, '.env.local'));
+
+  await expect(writeEnvLocal(dir, { VITE_OPSLANE_API_KEY: 'opk_x' })).rejects.toThrow();
+  expect(await readFile(outside, 'utf8')).toBe('original\n');
+});
+
+it('does not leave the key on disk when the gitignore write fails', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'opslane-env-'));
+  await mkdir(join(dir, '.gitignore'));       // a directory: the write must fail
+
+  await expect(writeEnvLocal(dir, { VITE_OPSLANE_API_KEY: 'opk_x' })).rejects.toThrow();
+  await expect(readFile(join(dir, '.env.local'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/__tests__/envfile.test.ts -t "symlink"`
+Expected: FAIL — writes follow the links and clobber `victim`.
+
+**Step 3: Write minimal implementation**
+
+```ts
+import { constants, open } from 'node:fs/promises';
+
+/** Read a file, refusing to traverse a final-component symlink. Missing is ''. */
+async function readNoFollow(filePath: string): Promise<string> {
+  let handle;
+  try {
+    handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return '';
+    // ELOOP (Linux) / EMLINK (some BSDs) mean the final component is a symlink.
+    throw new Error(`refusing to read ${filePath}: ${code}`);
+  }
+  try { return await handle.readFile('utf8'); } finally { await handle.close(); }
+}
+```
+
+Order matters: resolve and write `.gitignore` **before** the key, so a gitignore failure aborts before any secret reaches disk. Use `writeFileAtomic` for both — rename replaces the name, never traversing an existing link.
+
+```ts
+  const envPath = join(dir, '.env.local');
+  const gitignorePath = join(dir, '.gitignore');
+
+  // gitignore FIRST: if this throws, no key has been written.
+  const gitignore = await readNoFollow(gitignorePath);
+  if (!gitignore.split(/\r?\n/).includes('.env.local')) {
+    await writeFileAtomic(
+      gitignorePath,
+      `${gitignore}${gitignore && !gitignore.endsWith('\n') ? '\n' : ''}.env.local\n`,
+    );
+  }
+
+  const current = await readNoFollow(envPath);
+  // ...existing merge logic against `current`...
+  await writeFileAtomic(envPath, next);
+```
+
+**Delete the trailing `chmod(envPath, 0o600)`.** It is redundant and it reintroduces the
+race the rest of this task removes: `writeFileAtomic` already creates its temp file with
+`open(tempPath, 'wx', 0o600)` (`fsutil.ts:15`) and `rename` preserves that mode, while
+`chmod` is a path operation that follows whatever symlink is at `envPath` at that instant.
+If a mode change is ever needed, do it on the open handle before the rename, inside
+`writeFileAtomic`.
+
+**Step 4: Verify and commit**
+
+Run: `npx vitest run src/__tests__/envfile.test.ts` → PASS.
+
+```bash
+git add cli/src/envfile.ts cli/src/__tests__/envfile.test.ts
+git commit -m "fix(cli): envfile refuses symlinked targets and ignores before writing the key"
+```
+
+---
+
+## Task 6: `tty_required`, the Ink toolchain, and the command boundary
+
+The contract row and the command land together. Adding the status alone would advertise a command that does not exist, and `resolveRepo` would stay dead code.
+
+**Files:**
+- Modify: `cli/src/contract.ts`, `docs/reference/cli-agent-contract.md`, `cli/package.json`, `cli/tsconfig.json`, `cli/src/index.ts`
+- Create: `cli/src/onboard/command.ts`
+- Test: `cli/src/__tests__/contract.subprocess.test.ts`
+
+**Step 1: Add the doc row and watch the drift test fail**
+
+Inside the `AGENT_STATUS_CONTRACT` markers, after the last `setup` row:
+
+```
+| `onboard` | `tty_required` | 1 | `stdout` | The command needs an interactive terminal; run it without piping stdin or stdout. |
+```
+
+Also update the document's opening line, and **scope the one-JSON-document invariant**.
+`onboard` under a TTY renders Ink, so adding it to the covered list without qualification
+would contradict the invariant three lines below it:
+
+```
+This deterministic reference is sourced from `cli/src/contract.ts` and the setup protocol in `cli/src/setup.ts`. It covers the agent-facing `setup`, `snippet`, `verify`, and `status` commands, and `onboard` when invoked non-interactively.
+```
+
+And amend the first invariant bullet:
+
+```
+- Each covered command writes exactly one JSON document to stdout per invocation. It never mixes prose, progress, or a second JSON document into stdout. `onboard` is covered only on its non-TTY path, which emits `tty_required` and exits 1; under a TTY it is an interactive human command and, like `login` and `init`, is exempt.
+```
+
+Run: `npx vitest run src/__tests__/contract-drift.test.ts` → FAIL (table has a row `AGENT_STATUSES` lacks).
+
+**Step 2: Add the contract entry**
+
+One line, in `AGENT_STATUSES` (`scripts/check-docs-drift.mjs` parses these without a build):
+
+```ts
+  agentStatus("onboard", "tty_required", 1, "stdout", "The command needs an interactive terminal; run it without piping stdin or stdout."),
+```
+
+Run: `npx vitest run src/__tests__/contract-drift.test.ts` → PASS.
+
+**Step 3: Write the failing subprocess test**
+
+In `cli/src/__tests__/contract.subprocess.test.ts`:
+
+```ts
+  it('onboard emits one tty_required JSON document when not a TTY', async () => {
+    const result = await runCli(['onboard'], await temp(), await temp());
+    expect(result.code).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({ status: 'tty_required' });
+    expect(result.stdout).not.toMatch(/\x1b\[/);      // zero ANSI bytes
+  });
+```
+
+Note the assertion is one JSON **document**, matching `cli-agent-contract.md` and every other command — not one line. `jsonOutput` pretty-prints and that is the shipped contract.
+
+**This subprocess test cannot separate the two gates.** `runCli` pipes stdin *and* stdout,
+so it passes even if the implementation only checks one of them. Add a unit test that
+drives the gate directly with injected TTY state, so each condition is proved on its own:
+
+```ts
+// command.test.ts
+it.each([
+  ['stdin not a tty',  { stdin: false, stdout: true  }],
+  ['stdout not a tty', { stdin: true,  stdout: false }],
+  ['neither a tty',    { stdin: false, stdout: false }],
+])('gates on %s', (_label, tty) => {
+  const exits: Array<[string, number]> = [];
+  requireTty({ isStdinTty: tty.stdin, isStdoutTty: tty.stdout,
+    onFail: (status, code) => { exits.push([status, code]); } });
+  expect(exits).toEqual([['tty_required', 1]]);
+});
+
+it('passes when both are a tty', () => {
+  const exits: unknown[] = [];
+  requireTty({ isStdinTty: true, isStdoutTty: true,
+    onFail: (...a) => { exits.push(a); } });
+  expect(exits).toEqual([]);
+});
+```
+
+Extract the check into a `requireTty({ isStdinTty, isStdoutTty, onFail })` helper in
+`command.ts` so it is reachable without a PTY.
+
+Run: `npx vitest run src/__tests__/contract.subprocess.test.ts -t "onboard"` → FAIL (unknown command).
+
+**Step 4: Add the toolchain**
+
+Exact pins, no ranges (`docs/decisions/tui-renderer.md`: "All package versions were exact, not ranges"). This repo has no `save-exact`, so pin `@types/react` explicitly too:
+
+```bash
+cd cli
+pnpm add ink@7.1.1 @inkjs/ui@2.0.0 react@19.2.8
+pnpm add -D ink-testing-library@4.0.0
+pnpm add -D @types/react@$(npm view @types/react version)
+```
+
+Verify **both** dependency sections carry bare versions:
+```bash
+node -p "JSON.stringify({d:require('./package.json').dependencies,dev:require('./package.json').devDependencies},null,1)"
+```
+Expected: no `^` or `~` on `ink`, `@inkjs/ui`, `react`, `@types/react`, `ink-testing-library`.
+
+Add to `cli/tsconfig.json` `compilerOptions`: `"jsx": "react-jsx",`
+
+**Step 5: Write the minimal command**
+
+`cli/src/onboard/command.ts` — plain `.ts`, no JSX, so no `react/jsx-runtime` import reaches the piped path:
+
+```ts
+import { exitWithStatus } from '../output.js';
+import { resolveRepo } from './repo.js';
+
+export interface OnboardOptions { apiUrl?: string; repo?: string }
+
+/**
+ * The TTY gate lives here, outside any .tsx. With jsx:react-jsx every .tsx
+ * compiles with react/jsx-runtime hoisted above user code, so deferring only
+ * the `ink` import would still load React on the piped path. The dynamic
+ * boundary has to wrap the whole shell module.
+ */
+export async function runOnboardCommand(options: OnboardOptions): Promise<void> {
+  if (process.stdin.isTTY !== true || process.stdout.isTTY !== true) {
+    exitWithStatus('tty_required', {
+      message: 'opslane onboard needs an interactive terminal; run it without piping stdin or stdout.',
+    }, 1);
+  }
+
+  const repo = resolveRepo({ repo: options.repo });
+  if (!repo.ok) exitWithStatus('usage_error', { message: repo.message }, 1);
+
+  // M4 replaces this with: await (await import('./app.js')).runOnboardApp({...})
+  exitWithStatus('internal_error', { message: 'the onboarding UI is not built yet' }, 1);
+}
+```
+
+**Do not write the `import('./app.js')` line in this phase.** TypeScript resolves a
+*literal* dynamic-import specifier at compile time, so `import('./app.js')` is a TS2307
+error until `app.tsx` exists — and a runtime `try/catch` cannot suppress a compile error.
+The command ships with the TTY gate and repo resolution working, and M4 adds the import
+in the same commit that creates the module.
+
+That keeps this phase's contract row honest: `tty_required` is reachable and tested today.
+
+Register in `cli/src/index.ts`, after `setup`:
+
+```ts
+program
+  .command('onboard')
+  .description('Agent-guided SDK onboarding for the repo in the current directory')
+  .option('--api-url <url>', 'Opslane API URL')
+  .option('--repo <owner/repo>', 'Override auto-detected repository')
+  .action(async (opts: { apiUrl?: string; repo?: string }) => {
+    const { runOnboardCommand } = await import('./onboard/command.js');
+    await runOnboardCommand(opts);
+  });
+```
+
+**Step 6: Verify and commit**
+
+```bash
+pnpm --filter @opslane/cli build && pnpm --filter @opslane/cli test
+git add cli/src/contract.ts docs/reference/cli-agent-contract.md cli/package.json cli/tsconfig.json cli/src/index.ts cli/src/onboard/command.ts cli/src/__tests__/contract.subprocess.test.ts pnpm-lock.yaml
+git commit -m "feat(cli): onboard command boundary, tty_required status, and the pinned Ink toolchain"
+```
+
+---
+
+## Task 7: Command derivation and shell-safe formatting
+
+> **Revision note, 2026-07-24.** A proposal to move installs into the agent (gated by
+> `canUseTool`) was written up and then **rejected** the same day —
+> `docs/decisions/agent-runs-commands.md` has the full reasoning. Task 7 is unchanged:
+> `installCommand` stays, the deterministic seam stays, the agent does not run installs.
+>
+> One real defect that review surfaced and that this plan does NOT yet address:
+> `ALLOWED_BASH` (`policy.ts:12`) and the Bash branch of `onboardPreToolUseHook` are
+> **unreachable** — `'Bash'` is in `disallowedTools` for both stages (`engine.ts:105`,
+> `:151`) and absent from both `tools` arrays. The tests pass by calling the hook directly.
+> Code that looks like a security control but can never execute is worse than either
+> enabling or deleting it. Decide which in M3; do not leave it as-is.
+
+**Files:** create `cli/src/onboard/process.ts` and `__tests__/process.test.ts`.
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { devCommand, formatCommand, installCommand } from '../process.js';
+
+describe('command derivation', () => {
+  it.each([
+    ['pnpm-lock.yaml', 'pnpm'], ['package-lock.json', 'npm'],
+    ['yarn.lock', 'yarn'], ['bun.lockb', 'bun'],
+  ])('derives %s -> %s', (lockfile, manager) => {
+    const root = repoWith({ [lockfile]: '', 'package.json': '{}' });
+    expect(installCommand(root, '.')).toEqual({ executable: manager, args: ['install'] });
+    expect(devCommand(root, '.', 'dev')).toEqual({ executable: manager, args: ['run', 'dev'] });
+  });
+
+  it('builds the dev command from the plan dev_script', () => {
+    const root = repoWith({ 'package-lock.json': '', 'package.json': '{}' });
+    expect(devCommand(root, '.', 'dev:staging'))
+      .toEqual({ executable: 'npm', args: ['run', 'dev:staging'] });
+  });
+
+  it('throws when no lockfile identifies a package manager', () => {
+    expect(() => installCommand(repoWith({ 'package.json': '{}' }), '.')).toThrow(/lockfile/i);
+  });
+});
+
+describe('formatCommand', () => {
+  it('leaves ordinary argv unquoted', () => {
+    expect(formatCommand({ executable: 'npm', args: ['run', 'dev'] })).toBe('npm run dev');
+  });
+
+  it('quotes a script name containing a space', () => {
+    expect(formatCommand({ executable: 'npm', args: ['run', 'dev staging'] }))
+      .toBe("npm run 'dev staging'");
+  });
+
+  it('quotes shell metacharacters so copy-paste cannot run a second command', () => {
+    expect(formatCommand({ executable: 'npm', args: ['run', 'dev;echo bad'] }))
+      .toBe("npm run 'dev;echo bad'");
+  });
+
+  it('escapes an embedded single quote', () => {
+    expect(formatCommand({ executable: 'npm', args: ['run', "it's"] }))
+      .toBe("npm run 'it'\\''s'");
+  });
+});
+```
+
+Define `repoWith` at the top of this new test file (a `mkdtempSync` plus `writeFileSync` loop) — the existing `tools.test.ts` does not export one.
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/process.test.ts`
+Expected: FAIL — `Cannot find module '../process.js'`.
+
+**Step 3: Write minimal implementation**
+
+```ts
+import { packageManagerForRepo } from './tools.js';
+
+export interface Command { executable: string; args: string[] }
+
+function manager(root: string, appDir: string): string {
+  const detected = packageManagerForRepo(root, appDir);
+  if (detected === null) throw new Error(`No lockfile in ${appDir} identifies a package manager`);
+  return detected;
+}
+
+export function installCommand(root: string, appDir: string): Command {
+  return { executable: manager(root, appDir), args: ['install'] };
+}
+
+/** `devScript` comes from the plan, already verified against the app manifest (Task 1). */
+export function devCommand(root: string, appDir: string, devScript: string): Command {
+  return { executable: manager(root, appDir), args: ['run', devScript] };
+}
+
+const SAFE = /^[A-Za-z0-9_@%+=:,./-]+$/;
+
+/** For display and copy-paste only. Execution always uses argv, never this string. */
+export function formatCommand({ executable, args }: Command): string {
+  return [executable, ...args]
+    .map((value) => (SAFE.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`))
+    .join(' ');
+}
+```
+
+**Step 4: Verify and commit**
+
+Run: `npx vitest run src/onboard/__tests__/process.test.ts` → PASS (9).
+
+```bash
+git add cli/src/onboard/process.ts cli/src/onboard/__tests__/process.test.ts
+git commit -m "feat(cli): derive install and dev commands, format them shell-safely"
+```
+
+---
+
+## Task 8: `startProcess` — one ownership primitive
+
+Install and dev server share this. It owns the child, reacts to an **injected** signal, exposes completion, and cleans up deterministically. It installs **no** `process.on` handlers and never calls `process.exit` — those belong to the command layer (Task 11), which is what makes this testable without killing Vitest.
+
+**Files:** modify `process.ts` and its test.
+
+**Step 1: Write the failing test**
+
+```ts
+function fakeChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter; stderr: EventEmitter; pid: number;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = 4242;
+  return child;
+}
+
+it('resolves completion with the exit code', async () => {
+  const child = fakeChild();
+  const handle = startProcess({
+    command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+    spawnFn: () => child as never,
+  });
+  child.emit('close', 0, null);
+  await expect(handle.completed).resolves.toEqual({ exitCode: 0, signal: null });
+});
+
+it('finalizes on close, not exit, so output is drained', async () => {
+  const child = fakeChild();
+  const handle = startProcess({
+    command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+    spawnFn: () => child as never,
+  });
+  child.emit('exit', 0, null);
+  let settled = false;
+  void handle.completed.then(() => { settled = true; });
+  await Promise.resolve();
+  expect(settled).toBe(false);
+  child.emit('close', 0, null);
+  await expect(handle.completed).resolves.toMatchObject({ exitCode: 0 });
+});
+
+it('reports signal termination rather than calling it success', async () => {
+  const child = fakeChild();
+  const handle = startProcess({
+    command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+    spawnFn: () => child as never,
+  });
+  child.emit('close', null, 'SIGTERM');
+  await expect(handle.completed).resolves.toEqual({ exitCode: null, signal: 'SIGTERM' });
+});
+
+it('rejects completion when spawn errors', async () => {
+  const child = fakeChild();
+  const handle = startProcess({
+    command: { executable: 'nope', args: [] }, cwd: '/repo', spawnFn: () => child as never,
+  });
+  child.emit('error', new Error('ENOENT'));
+  await expect(handle.completed).rejects.toThrow(/ENOENT/);
+});
+
+it('spawns with argv and shell:false', () => {
+  const spawnFn = vi.fn(() => fakeChild() as never);
+  startProcess({ command: { executable: 'npm', args: ['install'] }, cwd: '/repo', spawnFn });
+  const [exe, args, opts] = spawnFn.mock.calls[0]!;
+  expect(exe).toBe('npm');
+  expect(args).toEqual(['install']);
+  expect(opts).toMatchObject({ shell: false, detached: true, cwd: '/repo' });
+});
+
+it('kills the whole process group on stop, idempotently', () => {
+  const kills: Array<[number, string | undefined]> = [];
+  const handle = startProcess({
+    command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+    spawnFn: () => fakeChild() as never,
+    killFn: (pid, signal) => { kills.push([pid, signal]); },
+  });
+  handle.stop(); handle.stop(); handle.stop();
+  expect(kills).toEqual([[-4242, 'SIGTERM']]);       // negative pid = the group
+});
+
+it('stops when the injected signal aborts', () => {
+  const kills: number[] = [];
+  const controller = new AbortController();
+  startProcess({
+    command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+    spawnFn: () => fakeChild() as never,
+    killFn: (pid) => { kills.push(pid); },
+    signal: controller.signal,
+  });
+  controller.abort();
+  expect(kills).toEqual([-4242]);
+});
+
+it('never spawns when the signal is already aborted', async () => {
+  const spawnFn = vi.fn(() => fakeChild() as never);
+  const handle = startProcess({
+    command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+    spawnFn, signal: AbortSignal.abort(),
+  });
+  expect(spawnFn).not.toHaveBeenCalled();     // not "spawned then killed"
+  await expect(handle.completed).rejects.toThrow(/aborted/i);
+});
+
+it('balances its abort listeners', () => {
+  const controller = new AbortController();
+  const added: unknown[] = [];
+  const removed: unknown[] = [];
+  const realAdd = controller.signal.addEventListener.bind(controller.signal);
+  const realRemove = controller.signal.removeEventListener.bind(controller.signal);
+  vi.spyOn(controller.signal, 'addEventListener')
+    .mockImplementation((t, l, o) => { added.push(l); realAdd(t, l as never, o); });
+  vi.spyOn(controller.signal, 'removeEventListener')
+    .mockImplementation((t, l, o) => { removed.push(l); realRemove(t, l as never, o); });
+
+  const child = fakeChild();
+  startProcess({
+    command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+    spawnFn: () => child as never, signal: controller.signal,
+  });
+  child.emit('close', 0, null);
+  expect(removed).toEqual(added);             // every listener added was removed
+});
+```
+
+Those two are the ones revision 2 would have failed: it spawned first and checked
+`aborted` after, and its leak test only asserted a signal object was defined.
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/process.test.ts -t "startProcess"`
+Expected: FAIL — `startProcess` is not exported.
+
+**Step 3: Write minimal implementation**
+
+```ts
+import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
+
+export interface ProcessOptions {
+  command: Command;
+  cwd: string;
+  signal?: AbortSignal;
+  onOutput?: (text: string) => void;
+  /**
+   * Called once per decoded, ANSI-stripped, complete line. startDevServer uses
+   * this for URL detection so it never scans raw chunks. A mutable Set works:
+   * the scanner removes itself once the URL is found or the timeout fires.
+   */
+  lineListeners?: Set<(line: string) => void>;
+  flushMs?: number;
+  spawnFn?: (executable: string, args: string[], options: object) => ChildProcess;
+  killFn?: (pid: number, signal?: NodeJS.Signals) => void;
+}
+
+export interface ProcessHandle {
+  pid: number | undefined;
+  /** Settles on `close`, so stdout and stderr have drained. */
+  completed: Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>;
+  stop: () => void;
+}
+
+export function startProcess(options: ProcessOptions): ProcessHandle {
+  const spawnFn = options.spawnFn ?? nodeSpawn;
+  const killFn = options.killFn ?? ((pid, signal) => { process.kill(pid, signal); });
+
+  // Check BEFORE spawning. Spawning and then killing still runs the package's
+  // lifecycle scripts for however long it takes the signal to land.
+  if (options.signal?.aborted === true) {
+    return {
+      pid: undefined,
+      completed: Promise.reject(new Error('aborted before start')),
+      stop: () => undefined,
+    };
+  }
+
+  // detached makes the child a group leader, so killing -pid also takes the
+  // grandchildren a dev server spawns (Vite -> esbuild).
+  const child = spawnFn(options.command.executable, options.command.args, {
+    cwd: options.cwd, shell: false, detached: true,
+  });
+
+  const cleanups: Array<() => void> = [];
+  let stopped = false;
+  const stop = (): void => {
+    if (stopped) return;
+    stopped = true;
+    for (const cleanup of cleanups.splice(0)) cleanup();
+    try { if (child.pid !== undefined) killFn(-child.pid, 'SIGTERM'); } catch { /* already gone */ }
+  };
+
+  cleanups.push(attachOutput(child, options));
+
+  const completed = new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>(
+    (resolve, reject) => {
+      child.once('error', (error) => { stop(); reject(error); });
+      // `close` not `exit`: exit can fire before the streams are drained.
+      child.once('close', (code, signal) => {
+        for (const cleanup of cleanups.splice(0)) cleanup();
+        stopped = true;                       // nothing left to kill
+        resolve({ exitCode: code, signal });
+      });
+    },
+  );
+
+  const signal = options.signal;
+  if (signal?.aborted === true) {
+    stop();                                   // check first; a late listener never fires
+  } else if (signal !== undefined) {
+    const onAbort = (): void => stop();
+    signal.addEventListener('abort', onAbort, { once: true });
+    cleanups.push(() => signal.removeEventListener('abort', onAbort));
+  }
+
+  return { pid: child.pid, completed, stop };
+}
+```
+
+`attachOutput` is Task 9. For now return a no-op cleanup and pipe chunks straight through; Task 9 replaces the body and its tests prove the change.
+
+**Step 4: Verify and commit**
+
+Run: `npx vitest run src/onboard/__tests__/process.test.ts` → PASS (17).
+
+```bash
+git add cli/src/onboard/process.ts cli/src/onboard/__tests__/process.test.ts
+git commit -m "feat(cli): one process-ownership primitive with injected abort and group teardown"
+```
+
+---
+
+## Task 9: Line-buffered, throttled, sanitised output
+
+A cold `npm install` prints hundreds of lines; one Ink frame rebuild per line makes the noisiest moment the jankiest. Child output is also untrusted — the CLI now runs package lifecycle scripts and the repo's dev script — so control sequences must be stripped before anything renders them.
+
+Two correctness points revision 1 got wrong: chunk boundaries are not line boundaries (buffer the partial line), and a fake child that emits everything in one microtask proves nothing about throttling (use fake timers and keep it alive).
+
+**Files:** modify `process.ts` and its test.
+
+**Step 1: Write the failing test**
+
+```ts
+it('flushes on the interval, not once per chunk', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = fakeChild();
+    const onOutput = vi.fn();
+    startProcess({
+      command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+      spawnFn: () => child as never, onOutput, flushMs: 100,
+    });
+    for (let i = 0; i < 200; i += 1) child.stdout.emit('data', Buffer.from(`line ${i}\n`));
+    expect(onOutput).not.toHaveBeenCalled();          // nothing before the first tick
+    vi.advanceTimersByTime(100);
+    expect(onOutput).toHaveBeenCalledTimes(1);
+    for (let i = 0; i < 200; i += 1) child.stdout.emit('data', Buffer.from(`more ${i}\n`));
+    vi.advanceTimersByTime(100);
+    expect(onOutput).toHaveBeenCalledTimes(2);         // 400 lines, 2 flushes
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+it('buffers a line split across two chunks', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = fakeChild();
+    let last = '';
+    startProcess({
+      command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+      spawnFn: () => child as never, onOutput: (t) => { last = t; }, flushMs: 10,
+    });
+    child.stdout.emit('data', Buffer.from('added 42 pac'));
+    child.stdout.emit('data', Buffer.from('kages\n'));
+    vi.advanceTimersByTime(10);
+    expect(last).toContain('added 42 packages');
+    expect(last).not.toContain('added 42 pac\nkages');
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+it('does not splice stdout and stderr into one another', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = fakeChild();
+    let last = '';
+    startProcess({
+      command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+      spawnFn: () => child as never, onOutput: (t) => { last = t; }, flushMs: 10,
+    });
+    child.stdout.emit('data', Buffer.from('out-par'));
+    child.stderr.emit('data', Buffer.from('err-line\n'));
+    child.stdout.emit('data', Buffer.from('tial\n'));
+    vi.advanceTimersByTime(10);
+    expect(last).toContain('err-line');
+    expect(last).toContain('out-partial');
+    expect(last).not.toContain('out-parerr-line');
+  } finally { vi.useRealTimers(); }
+});
+
+it('decodes a multi-byte character split across chunks', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = fakeChild();
+    let last = '';
+    startProcess({
+      command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+      spawnFn: () => child as never, onOutput: (t) => { last = t; }, flushMs: 10,
+    });
+    const arrow = Buffer.from('\u2192 done\n', 'utf8');   // -> is 3 bytes
+    child.stdout.emit('data', arrow.subarray(0, 2));
+    child.stdout.emit('data', arrow.subarray(2));
+    vi.advanceTimersByTime(10);
+    expect(last).toContain('\u2192 done');
+    expect(last).not.toContain('\ufffd');
+  } finally { vi.useRealTimers(); }
+});
+
+it('keeps only the last 8 lines', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = fakeChild();
+    let last = '';
+    startProcess({
+      command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+      spawnFn: () => child as never, onOutput: (t) => { last = t; }, flushMs: 10,
+    });
+    for (let i = 0; i < 50; i += 1) child.stdout.emit('data', Buffer.from(`line ${i}\n`));
+    vi.advanceTimersByTime(10);
+    expect(last.split('\n')).toHaveLength(8);
+    expect(last).toContain('line 49');
+    expect(last).not.toContain('line 41');
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+it('strips terminal control sequences so a script cannot spoof a prompt', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = fakeChild();
+    let last = '';
+    startProcess({
+      command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+      spawnFn: () => child as never, onOutput: (t) => { last = t; }, flushMs: 10,
+    });
+    child.stdout.emit('data', Buffer.from('[2J[H[31mRun npm install? [Y/n][0m\n'));
+    vi.advanceTimersByTime(10);
+    expect(last).not.toContain('');
+    expect(last).toContain('Run npm install? [Y/n]');
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+it('flushes the trailing partial line on close', async () => {
+  const child = fakeChild();
+  let last = '';
+  const handle = startProcess({
+    command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+    spawnFn: () => child as never, onOutput: (t) => { last = t; }, flushMs: 10_000,
+  });
+  child.stdout.emit('data', Buffer.from('no trailing newline'));
+  child.emit('close', 0, null);
+  await handle.completed;
+  expect(last).toContain('no trailing newline');
+  expect(last.split('\n').length).toBeLessThanOrEqual(8);   // carry must not make it 9
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/process.test.ts -t "flushes on the interval"`
+Expected: FAIL — the stub flushes per chunk, splits mid-line, and leaves escapes intact.
+
+**Step 3: Write minimal implementation**
+
+```ts
+// Covers CSI, OSC and single-character escapes.
+const ANSI = /\[[0-9;?]*[ -/]*[@-~]|\][^]*(?:|\\)|[@-Z\\-_]/g;
+const TAIL_LINES = 8;
+
+import { StringDecoder } from 'node:string_decoder';
+
+function attachOutput(child: ChildProcess, options: ProcessOptions): () => void {
+  const onOutput = options.onOutput;
+  // Attach when EITHER a renderer or a line listener needs the stream. Bailing
+  // on `onOutput === undefined` alone would silently disable URL detection for
+  // a dev server started without an output sink.
+  if (onOutput === undefined && options.lineListeners === undefined) return () => undefined;
+  const emit = onOutput ?? (() => undefined);
+
+  const tail: string[] = [];
+  const trim = (): void => {
+    if (tail.length > TAIL_LINES) tail.splice(0, tail.length - TAIL_LINES);
+  };
+
+  /**
+   * Per-stream state. stdout and stderr interleave, so a single shared carry
+   * splices half a stderr line onto half a stdout line. StringDecoder holds
+   * back a multi-byte UTF-8 sequence split across a chunk boundary, which
+   * String(chunk) would decode as replacement characters.
+   */
+  const reader = (): ((chunk: Buffer | string) => void) => {
+    const decoder = new StringDecoder('utf8');
+    let carry = '';
+    return (chunk) => {
+      const lines = (carry + decoder.write(Buffer.from(chunk as Buffer))).split(/\r?\n/);
+      carry = lines.pop() ?? '';
+      for (const raw of lines) {
+        const line = raw.replace(ANSI, '');
+        tail.push(line);
+        // startDevServer subscribes here so it scans complete, decoded lines.
+        for (const listener of options.lineListeners ?? []) listener(line);
+      }
+      trim();
+    };
+  };
+  const readers: Array<{ stream: NodeJS.ReadableStream | null; take: (c: Buffer) => void }> = [
+    { stream: child.stdout, take: reader() as (c: Buffer) => void },
+    { stream: child.stderr, take: reader() as (c: Buffer) => void },
+  ];
+  for (const { stream, take } of readers) stream?.on('data', take);
+
+  const flush = (): void => emit(tail.join('\n'));
+  const timer = setInterval(flush, options.flushMs ?? 100);
+
+  return () => {
+    clearInterval(timer);
+    for (const { stream, take } of readers) stream?.off('data', take);
+    trim();                       // the trailing partial line must not make it 9
+    flush();
+  };
+}
+```
+
+The final `trim()` matters: revision 2 pushed the carry after the last trim, so the tail
+could reach nine lines on close.
+
+**Step 4: Verify and commit**
+
+Run: `npx vitest run src/onboard/__tests__/process.test.ts` → PASS (22).
+
+```bash
+git add cli/src/onboard/process.ts cli/src/onboard/__tests__/process.test.ts
+git commit -m "feat(cli): line-buffered, throttled, ANSI-stripped child output"
+```
+
+---
+
+## Task 10: `runCommand` and `startDevServer` on top of the primitive
+
+Both are thin wrappers. Neither touches `process.on` or `process.exit`.
+
+**Files:** modify `process.ts` and its test.
+
+**Step 1: Write the failing test**
+
+```ts
+it('reports a non-zero exit rather than throwing', async () => {
+  const child = fakeChild();
+  const promise = runCommand({
+    command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+    spawnFn: () => child as never,
+  });
+  child.emit('close', 1, null);
+  await expect(promise).resolves.toEqual({ ran: true, ok: false, exitCode: 1, signal: null });
+});
+
+it('treats signal termination as failure, not success', async () => {
+  const child = fakeChild();
+  const promise = runCommand({
+    command: { executable: 'npm', args: ['install'] }, cwd: '/repo',
+    spawnFn: () => child as never,
+  });
+  child.emit('close', null, 'SIGTERM');
+  await expect(promise).resolves.toMatchObject({ ok: false, signal: 'SIGTERM' });
+});
+
+it('does not spawn when consent is declined, and returns a quoted copy-paste', async () => {
+  const spawnFn = vi.fn();
+  await expect(runCommand({
+    command: { executable: 'npm', args: ['run', 'dev staging'] }, cwd: '/repo',
+    consent: async () => false, spawnFn: spawnFn as never,
+  })).resolves.toEqual({ ran: false, copyPaste: "npm run 'dev staging'" });
+  expect(spawnFn).not.toHaveBeenCalled();
+});
+
+it('parses the dev server URL from stdout', async () => {
+  const child = fakeChild();
+  const handle = startDevServer({
+    command: { executable: 'npm', args: ['run', 'dev'] }, cwd: '/repo',
+    spawnFn: () => child as never,
+  });
+  child.stdout.emit('data', Buffer.from('  [32m➜[0m  Local:   http://localhost:5173/\n'));
+  await expect(handle.url).resolves.toBe('http://localhost:5173/');
+});
+
+it('matches a URL with no trailing slash (Next, CRA)', async () => {
+  const child = fakeChild();
+  const handle = startDevServer({
+    command: { executable: 'npm', args: ['run', 'dev'] }, cwd: '/repo',
+    spawnFn: () => child as never,
+  });
+  child.stdout.emit('data', Buffer.from('  - Local:        http://localhost:3000\n'));
+  await expect(handle.url).resolves.toBe('http://localhost:3000');
+});
+
+it('finds a URL split across two chunks', async () => {
+  const child = fakeChild();
+  const handle = startDevServer({
+    command: { executable: 'npm', args: ['run', 'dev'] }, cwd: '/repo',
+    spawnFn: () => child as never,
+  });
+  child.stdout.emit('data', Buffer.from('  Local:   http://localh'));
+  child.stdout.emit('data', Buffer.from('ost:5173/\n'));
+  await expect(handle.url).resolves.toBe('http://localhost:5173/');
+});
+
+it('reports the real port when the default was taken', async () => {
+  const child = fakeChild();
+  const handle = startDevServer({
+    command: { executable: 'npm', args: ['run', 'dev'] }, cwd: '/repo',
+    spawnFn: () => child as never,
+  });
+  child.stdout.emit('data', Buffer.from('Port 5173 is in use, trying another one...\n'));
+  child.stdout.emit('data', Buffer.from('  ➜  Local:   http://localhost:5174/\n'));
+  await expect(handle.url).resolves.toBe('http://localhost:5174/');
+});
+
+it('stops the child when no URL appears before the timeout', async () => {
+  const kills: number[] = [];
+  const child = fakeChild();
+  const handle = startDevServer({
+    command: { executable: 'npm', args: ['run', 'dev'] }, cwd: '/repo',
+    spawnFn: () => child as never, killFn: (pid) => { kills.push(pid); }, urlTimeoutMs: 10,
+  });
+  await expect(handle.url).rejects.toThrow(/no .*URL/i);
+  expect(kills).toEqual([-4242]);          // a hung dev server must not be left running
+});
+
+it('rejects the URL when the child exits first', async () => {
+  const child = fakeChild();
+  const handle = startDevServer({
+    command: { executable: 'npm', args: ['run', 'dev'] }, cwd: '/repo',
+    spawnFn: () => child as never,
+  });
+  child.emit('close', 1, null);
+  await expect(handle.url).rejects.toThrow(/exited/i);
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/process.test.ts -t "dev server"`
+Expected: FAIL — neither wrapper is exported.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export type RunResult =
+  | { ran: true; ok: boolean; exitCode: number | null; signal: NodeJS.Signals | null }
+  | { ran: false; copyPaste: string };
+
+export async function runCommand(
+  options: ProcessOptions & { consent?: () => Promise<boolean> },
+): Promise<RunResult> {
+  if (options.consent !== undefined && !(await options.consent())) {
+    return { ran: false, copyPaste: formatCommand(options.command) };
+  }
+  const { exitCode, signal } = await startProcess(options).completed;
+  // A signal-terminated child has exitCode null; calling that success hides a kill.
+  return { ran: true, ok: exitCode === 0 && signal === null, exitCode, signal };
+}
+
+// The path is OPTIONAL. Vite prints a trailing slash; Next and CRA do not, and
+// revision 2's regex silently missed `http://localhost:3000`.
+const LOCALHOST_URL = /(https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?(?:\/\S*)?)/i;
+
+export interface DevServerHandle extends ProcessHandle {
+  url: Promise<string>;
+  restartCommand: string;
+}
+
+export function startDevServer(
+  options: ProcessOptions & { urlTimeoutMs?: number },
+): DevServerHandle {
+  const lineListeners = options.lineListeners ?? new Set<(line: string) => void>();
+  const handle = startProcess({ ...options, lineListeners });
+
+  // Scan DECODED, LINE-BUFFERED text, not raw chunks. A URL split across a
+  // chunk boundary is invisible to a per-chunk scan, and that is exactly what
+  // happens when a dev server flushes its banner in pieces. Give attachOutput
+  // an onLine hook and subscribe to that instead of re-reading the streams.
+  const url = new Promise<string>((resolve, reject) => {
+    const timer = setTimeout(
+      () => settle(() => { handle.stop(); reject(new Error('the dev server printed no localhost URL')); }),
+      options.urlTimeoutMs ?? 30_000,
+    );
+    const settle = (finish: () => void): void => {
+      clearTimeout(timer);
+      lineListeners.delete(scan);
+      finish();
+    };
+    const scan = (line: string): void => {
+      const match = LOCALHOST_URL.exec(line);
+      if (match !== null) settle(() => resolve(match[1]!));
+    };
+    lineListeners.add(scan);
+    void handle.completed
+      .then(({ exitCode }) => settle(() => reject(new Error(`the dev server exited (${exitCode})`))))
+      .catch((error: unknown) => settle(() => reject(error)));
+  });
+  void url.catch(() => undefined);          // no unhandled rejection if nobody awaits
+
+  return { ...handle, url, restartCommand: formatCommand(options.command) };
+}
+```
+
+**Step 4: Verify and commit**
+
+Run: `npx vitest run src/onboard/__tests__/process.test.ts` → PASS (29).
+
+```bash
+git add cli/src/onboard/process.ts cli/src/onboard/__tests__/process.test.ts
+git commit -m "feat(cli): consented run and TUI-owned dev server over the process primitive"
+```
+
+---
+
+## Task 11: Signals belong to the command layer
+
+`startProcess` reacts to a signal; it never installs one. The command owns the `AbortController`, translates `SIGINT`/`SIGTERM` into an abort, and exits. Keeping this out of the seam is what lets Task 8's tests run without killing Vitest.
+
+**Files:** modify `cli/src/onboard/command.ts`; test `cli/src/onboard/__tests__/command.test.ts`.
+
+**Step 1: Write the failing test**
+
+```ts
+it('aborts the run controller on SIGINT and sets exit code 130', () => {
+  const exits: number[] = [];
+  const controller = new AbortController();
+  const off = installSignalHandlers({
+    controller, exitFn: (code) => { exits.push(code); },
+  });
+  process.emit('SIGINT');
+  expect(controller.signal.aborted).toBe(true);
+  expect(exits).toEqual([130]);
+  off();
+  // The handler must NOT have exited the process; teardown runs after abort.
+});
+
+it('maps SIGTERM to 143, not 130', () => {
+  const exits: number[] = [];
+  const off = installSignalHandlers({
+    controller: new AbortController(), exitFn: (code) => { exits.push(code); },
+  });
+  process.emit('SIGTERM');
+  expect(exits).toEqual([143]);
+  off();
+});
+
+it('removes its handlers so repeated runs do not stack', () => {
+  const before = process.listenerCount('SIGINT');
+  installSignalHandlers({ controller: new AbortController(), exitFn: () => undefined })();
+  expect(process.listenerCount('SIGINT')).toBe(before);
+});
+```
+
+`exitFn` is injected precisely so the test never calls the real `process.exit`.
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/command.test.ts`
+Expected: FAIL — `installSignalHandlers` is not exported.
+
+**Step 3: Write minimal implementation**
+
+```ts
+/**
+ * Signal handling lives here, not in process.ts. The seam takes an AbortSignal
+ * so it stays testable; this is the one place allowed to touch process globals.
+ */
+export function installSignalHandlers({
+  controller,
+  exitFn = (code) => { process.exitCode = code; },
+}: {
+  controller: AbortController;
+  exitFn?: (code: number) => void;
+}): () => void {
+  const codes = { SIGINT: 130, SIGTERM: 143 } as const;
+  const handlers = Object.entries(codes).map(([signal, code]) => {
+    // Set exitCode and abort; do NOT call process.exit here. A synchronous
+    // exit kills the process before startProcess's teardown and the command's
+    // `finally` have run, which is how orphaned dev servers happen — the exact
+    // failure this whole task exists to prevent.
+    const handler = (): void => { exitFn(code); controller.abort(); };
+    process.on(signal as NodeJS.Signals, handler);
+    return () => process.removeListener(signal as NodeJS.Signals, handler);
+  });
+  return () => { for (const off of handlers) off(); };
+}
+```
+
+**Wire the signal through, explicitly.** The controller is useless unless its signal
+reaches the seam. In `runOnboardCommand`:
+
+```ts
+  const controller = new AbortController();
+  const removeHandlers = installSignalHandlers({ controller });
+  try {
+    // M4: await runOnboardApp({ ...options, repo: repo.repo, signal: controller.signal })
+    // Every startProcess / waitForAppReporting call downstream takes this signal.
+  } finally {
+    removeHandlers();
+  }
+```
+
+Node exits on its own once the abort has torn down the children and the event loop
+drains, using the `process.exitCode` already set. If a hung child ever prevents that,
+add a bounded `setTimeout(() => process.exit(code), 5_000).unref()` as a last resort —
+but only after the teardown has been given its chance.
+
+**Step 4: Verify and commit**
+
+Run: `npx vitest run src/onboard/__tests__/command.test.ts` → PASS (3).
+
+```bash
+git add cli/src/onboard/command.ts cli/src/onboard/__tests__/command.test.ts
+git commit -m "feat(cli): command layer owns signal handling and aborts the run controller"
+```
+
+---
+
+## Task 12: Full gate and PR
+
+**Step 1: Whole-repo gate** (per `AGENTS.md`)
+
+```bash
+cd /Users/abhishekray/orca/workspaces/opslane-oss/onboarding-10x-2
+pnpm install --frozen-lockfile
+pnpm -r build
+pnpm test
+(cd packages/ingestion && go build ./... && go test ./...)
+docker compose config --quiet
+```
+
+`pnpm test` excludes `@opslane/test-e2e` by design; nothing here touches it.
+
+**Step 2: Prove every new test is real**
+
+For Tasks 1, 3, 4, 5, 8, 9, 10, and 11, revert the implementation hunk, confirm the new tests fail, restore. A test that passes against unfixed code is not a regression test. Pay particular attention to:
+- Task 1's "keeps dev_script through the schema" — must fail with `planShape` unchanged.
+- Task 8's "stops immediately when the signal is already aborted" — must fail if the `aborted` pre-check is replaced by a listener.
+- Task 9's throttle test — must fail if the interval is replaced by a per-chunk flush.
+
+**Step 3: Confirm nothing leaks a process**
+
+```bash
+pnpm --filter @opslane/cli test
+pgrep -f 'npm run dev' || echo "no orphans"
+```
+
+**Step 4: Open the PR**
+
+`git push` is blocked by a local hook. Ask the user to run:
+`! git push -u origin abhishekray07/phase-3a-execution-seam`
+then create the PR with `gh pr create --base main`.
+
+---
+
+## What already exists (do not rebuild)
+
+| Need | Already shipped |
+|---|---|
+| Package-manager detection from lockfiles | `packageManagerForRepo` — `tools.ts:157` |
+| Model-reports-CLI-verifies pattern | `validatePlan` — `tools.ts:234-237` |
+| Repo string normalisation | `normalizeRepoURL` / `detectRepoFromGit` — `setup.ts:52-70` |
+| Typed terminal status output | `exitWithStatus` — `output.ts` |
+| Atomic 0600 writes, file locking | `writeFileAtomic` / `withFileLock` — `fsutil.ts` |
+| Compiled-CLI subprocess test harness | `contract.subprocess.test.ts` |
+| Task-list state from SDK messages | `reduceTasks` / `TaskLine` — `events.ts:187` |
+| Both agent stages | `runDetect` / `runApply` — `engine.ts:302,484` |
+| Login, provisioning, env write, polling, run log | Phase 2 (#192) |
+
+## NOT in scope
+
+| Deferred | Why |
+|---|---|
+| `core.ts`, `app.tsx`, `tui.tsx` | M3–M4; they consume this seam, so they need its real shape first |
+| Live smoke to `app_reporting` | M5; blocked on `@opslane/sdk` >= 1.2.0 (#45/#46) |
+| Bounding `reduceTasks` | M4, where the renderer that suffers from it exists |
+| `ink-testing-library` view coverage | M4, when there is a view to test |
+| Preflight ordering (model key before mutation) | M3, where the controller sequences login and provisioning |
+| Smoke pending-state isolation | M5, part of the smoke procedure |
+| Hard-repo acceptance | Milestone B, the design's actual bar |
+| Reconciling `engine.ts`'s install-command fields | See the note below — decide in M3, not here |
+
+## Known duplication to resolve in M3
+
+`engine.ts:67` and `:690` still expose an install command as a **string** plus a relative
+`installCwd`, from when the report carried the hand-off text. `process.ts` now derives
+structured argv and re-detects the package manager independently. Two seams computing the
+same thing will drift.
+
+Do not fix it in this plan: nothing here consumes the engine's version, and changing the
+report shape touches the apply-stage tests. Decide in M3, when `core.ts` has to pick one:
+either the report returns the structured command plus the real lockfile directory, or
+those fields are removed and the command is derived once, downstream, from the plan.

--- a/docs/plans/2026-07-25-phase-3b-controller-and-tui.md
+++ b/docs/plans/2026-07-25-phase-3b-controller-and-tui.md
@@ -1,0 +1,1364 @@
+# Phase 3b: the onboarding controller and its Ink shell
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `opslane onboard` work end to end in a terminal: survey the repo, ask one question, wire the SDK, run the install and dev server behind consent, and confirm the app reported.
+
+**Architecture:** A pure `runOnboardCore(deps)` holds every decision with all effects injected, so it is unit-testable with no TTY, no model, and no network. Task 3 builds the whole flow skeleton — including the terminal try/catch/finally — so every later task adds a branch inside a shape that already works. `app.tsx` is the only run-and-observe file: it wires real Ink into the core. `tui.tsx` is a pure view. `command.ts` already owns the TTY gate, repo resolution, and signals.
+
+**Tech Stack:** TypeScript (ESM, strict), Node 22, Vitest, `ink@7.1.1` + `@inkjs/ui@2.0.0` + `react@19.2.8` + `ink-testing-library@4.0.0` (installed and pinned in Phase 3a).
+
+**Builds on:** Phase 3a (`process.ts`, `command.ts`, `repo.ts`, `dev_script`, abort-safe seams). Phases 1/1b (`runDetect`/`runApply`). Phase 2 (`ensureLoggedIn`, `ensureProvisioned`, `writeEnvLocal`, `waitForAppReporting`, `createRunLog`).
+
+**Revision 2** — rewritten after a `/codex` pass on revision 1 found 30 defects. The ones that reshaped it:
+- `runDetect` returns `{ok:false, reason:'unsupported'}` and **discards** the agent's explanation (`engine.ts:364`). Revision 1 branched on a `subtype` that does not exist. Task 1 now surfaces the reason first.
+- `createOnboardApproval`'s **default** allow-set does include `Bash`; the engine overrides it with a Bash-free list (`engine.ts:636`). Revision 1 had this backwards.
+- `ApplyReport.installRequired` is `false` on the already-onboarded path (`engine.ts:580`). Revision 1 always installed.
+- Revision 1's Task 2 test required Tasks 3-6, and Tasks 5-6 needed Task 7's error handling. Ordering is now dependency-correct.
+- `startDevServer` takes no consent option, so "both commands behind consent" was false.
+
+**Not in scope:** the live smoke (M5), blocked on `@opslane/sdk >= 1.2.0` reaching npm (#45/#46). Milestone B. Giving the agent a shell — rejected, see `docs/decisions/agent-runs-commands.md`.
+
+---
+
+## Before you start
+
+```bash
+cd /Users/abhishekray/orca/workspaces/opslane-oss/onboarding-10x-2
+git fetch origin main --quiet
+git checkout -b abhishekray07/phase-3b-controller-tui
+pnpm install --frozen-lockfile
+pnpm --filter @opslane/cli test    # expect 381 passing
+```
+
+All test commands run from `cli/`. Single test: `npx vitest run <file> -t "<name>"`.
+
+---
+
+## Task 1: Surface the unsupported reason
+
+When the agent decides a repo has no web app it calls `report_plan` with a concrete reason. `runDetect` captures it into `unsupportedReason` and then throws it away, returning only `{ok:false, reason:'unsupported'}` (`engine.ts:364`). The controller has nothing to show the user beyond the word "unsupported".
+
+**Files:**
+- Modify: `cli/src/onboard/engine.ts` (`EngineResult`, the unsupported return)
+- Test: `cli/src/onboard/__tests__/engine.test.ts`
+
+**Step 1: Write the failing test**
+
+In the detect-stage describe block:
+
+```ts
+  it('returns the agent explanation when the repo is unsupported', async () => {
+    const result = await runDetect({
+      cwd: root, signal: new AbortController().signal,
+      onMessage: () => undefined, onPlan: () => undefined,
+      queryFn: unsupportedQuery('this repository has no web application'),
+    });
+    expect(result).toMatchObject({
+      ok: false, reason: 'unsupported',
+      unsupportedReason: 'this repository has no web application',
+    });
+  });
+```
+
+Use whatever fake `queryFn` helper the neighbouring detect tests already use to drive `report_plan` with `status: 'unsupported'`.
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/engine.test.ts -t "unsupported"`
+Expected: FAIL — `unsupportedReason` is undefined.
+
+**Step 3: Write minimal implementation**
+
+Add to `EngineResult`:
+
+```ts
+export interface EngineResult {
+  ok: boolean;
+  aborted: boolean;
+  subtype?: string;
+  reason?: string;
+  /** The agent's own explanation, when `reason === 'unsupported'`. */
+  unsupportedReason?: string;
+}
+```
+
+And carry it through:
+
+```ts
+  if (unsupportedReason !== undefined) {
+    return { ...core, ok: false, reason: 'unsupported', unsupportedReason };
+  }
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/onboard/__tests__/engine.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add cli/src/onboard/engine.ts cli/src/onboard/__tests__/engine.test.ts
+git commit -m "feat(cli): detect result carries the agent's unsupported reason"
+```
+
+---
+
+## Task 2: Deny Bash outright
+
+`ALLOWED_BASH` (`policy.ts:12`) and the `Bash` branch of `onboardPreToolUseHook` cannot execute: `'Bash'` is in `disallowedTools` for both stages (`engine.ts:105`, `:151`). `policy.test.ts` passes by calling the hook directly.
+
+**Precise state, since revision 1 got it wrong:** `createOnboardApproval`'s *default* `allowedTools` includes `'Bash'` (`policy.ts:107`), but `runApply` overrides it with `['Read','Edit','Write','mcp__onboard__finish_apply']` (`engine.ts:636`). So the default is stale, not live. Removing `'Bash'` from it changes the denial message for any direct caller of the default — which is why the existing test at `policy.test.ts:123` must be updated too.
+
+Giving the agent a shell was considered and rejected (`docs/decisions/agent-runs-commands.md`), so delete rather than wire.
+
+**Step 1: Write the failing test**
+
+Replace the "allows only exact package build, typecheck, or lint scripts through Bash" case:
+
+```ts
+  it('denies Bash outright: the agent has no shell', async () => {
+    for (const command of ['pnpm run build', 'pnpm run lint', 'npm install', 'echo hi']) {
+      expect(denied(await run(hook(), 'Bash', { command }))).toBe(true);
+    }
+  });
+```
+
+Then find the existing assertion at `policy.test.ts:123` that expects a `declined` denial for Bash through `createOnboardApproval`'s default, and update it to expect `does not allow tool Bash`.
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/policy.test.ts -t "no shell"`
+Expected: FAIL — `pnpm run build` is currently permitted.
+
+**Step 3: Write minimal implementation**
+
+Delete `ALLOWED_BASH`. Replace the Bash branch:
+
+```ts
+    if (toolName === 'Bash') {
+      // The agent has no shell. Both stages also list Bash in disallowedTools
+      // and runApply passes a Bash-free allow-set, so this is defence in depth.
+      // docs/decisions/agent-runs-commands.md records why a shell was rejected.
+      return deny('The onboarding agent is not allowed to run shell commands');
+    }
+```
+
+Remove `'Bash'` from `createOnboardApproval`'s default `allowedTools`.
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/onboard/__tests__/policy.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git commit -am "fix(cli): deny Bash outright instead of an unreachable allowlist"
+```
+
+---
+
+## Task 3: `runOnboardCore` skeleton — contract, terminal handling, run-log discipline
+
+Build the **whole shape** now, with one stub step, so no later task depends on error handling that does not exist yet.
+
+**Files:**
+- Create: `cli/src/onboard/core.ts`
+- Test: `cli/src/onboard/__tests__/core.test.ts`
+
+**The contract.** Every effect injected. Nothing imports `ink`, touches a TTY, or calls a model.
+
+```ts
+export type Stage =
+  | 'login' | 'provision' | 'detect' | 'awaiting-approval' | 'apply'
+  | 'writing-env' | 'installing' | 'starting-dev' | 'waiting'
+  | 'done' | 'failed' | 'unsupported' | 'aborted';
+
+export interface CoreEvent {
+  stage: Stage;
+  tasks?: TaskLine[];
+  question?: { question: string; options: string[]; multi: boolean };
+  plan?: OnboardingPlan;
+  url?: string;
+  output?: string;
+  message?: string;
+}
+
+export interface CoreDeps {
+  cwd: string;
+  repo: string;
+  apiUrl: string;
+  tokenPath: string;
+  signal: AbortSignal;
+  loginFn: () => Promise<void>;
+  ensureLoggedIn: typeof import('./provision.js').ensureLoggedIn;
+  ensureProvisioned: typeof import('./provision.js').ensureProvisioned;
+  runDetect: typeof import('./engine.js').runDetect;
+  runApply: typeof import('./engine.js').runApply;
+  requestApproval: ApprovalRequest;
+  askUser: AskUserResolver;
+  confirm: (prompt: string, command: string) => Promise<boolean>;
+  writeEnv: typeof import('../envfile.js').writeEnvLocal;
+  runCommand: typeof import('./process.js').runCommand;
+  startDevServer: typeof import('./process.js').startDevServer;
+  waitForAppReporting: typeof import('./wait.js').waitForAppReporting;
+  runLog: RunLog;
+  emit: (event: CoreEvent) => void;
+}
+
+export interface CoreResult {
+  ok: boolean;
+  status: 'completed' | 'unsupported' | 'failed' | 'aborted';
+  message?: string;
+  url?: string;
+}
+```
+
+**Step 1: Write the failing test**
+
+```ts
+it('emits exactly one terminal stage on success', async () => {
+  const events: CoreEvent[] = [];
+  await expect(runOnboardCore(deps({ emit: (e) => events.push(e) })))
+    .resolves.toMatchObject({ ok: true, status: 'completed' });
+  const terminal = events.filter((e) =>
+    ['done', 'failed', 'unsupported', 'aborted'].includes(e.stage));
+  expect(terminal).toHaveLength(1);
+  expect(terminal[0]!.stage).toBe('done');
+});
+
+it('emits failed as the terminal stage when a step throws', async () => {
+  const events: CoreEvent[] = [];
+  await runOnboardCore(deps({ emit: (e) => events.push(e),
+    ensureProvisioned: async () => { throw new Error('boom') } }));
+  expect(events.at(-1)!.stage).toBe('failed');
+});
+
+it('emits aborted, not failed, when the signal is already aborted', async () => {
+  const controller = new AbortController();
+  const events: CoreEvent[] = [];
+  await runOnboardCore(deps({
+    signal: controller.signal, emit: (e) => events.push(e),
+    ensureProvisioned: async () => { controller.abort(); throw new Error('cancelled'); },
+  }));
+  expect(events.at(-1)!.stage).toBe('aborted');
+});
+
+it('records the session id and registers the api key as a secret', async () => {
+  const setSessionId = vi.fn(async () => undefined);
+  const addSecret = vi.fn();
+  await runOnboardCore(deps({ runLog: { ...fakeRunLog(), setSessionId, addSecret } }));
+  expect(addSecret).toHaveBeenCalledWith('opk_test');
+  expect(setSessionId).toHaveBeenCalledWith('sess-1');
+});
+
+it('finishes the run log exactly once, even when a step throws', async () => {
+  const finish = vi.fn(async () => undefined);
+  await runOnboardCore(deps({
+    runLog: { ...fakeRunLog(), finish },
+    ensureProvisioned: async () => { throw new Error('boom'); },
+  }));
+  expect(finish).toHaveBeenCalledTimes(1);
+});
+
+it('drains queued run-log records before finishing', async () => {
+  const order: string[] = [];
+  const runLog = {
+    ...fakeRunLog(),
+    record: async () => { await delay(5); order.push('record'); },
+    finish: async () => { order.push('finish'); },
+  };
+  await runOnboardCore(deps({ runLog }));
+  expect(order.at(-1)).toBe('finish');
+  expect(order.filter((o) => o === 'record').length).toBeGreaterThan(0);
+});
+
+it('never leaks a stack trace into the result message', async () => {
+  const result = await runOnboardCore(deps({
+    ensureProvisioned: async () => { throw new Error('ENOENT: no such file'); },
+  }));
+  expect(result.message).not.toMatch(/\bat \w+ \(/);
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts`
+Expected: FAIL — `Cannot find module '../core.js'`.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export async function runOnboardCore(deps: CoreDeps): Promise<CoreResult> {
+  const { emit, signal } = deps;
+
+  // Records are fire-and-forget from the caller's view but must not outlive
+  // `finish`, and a rejection must never become an unhandled rejection.
+  let logChain: Promise<void> = Promise.resolve();
+  const record = (message: unknown): void => {
+    logChain = logChain.then(() => deps.runLog.record(message)).catch(() => undefined);
+  };
+
+  let outcome: CoreResult;
+  try {
+    outcome = await runFlow(deps, record);
+  } catch (error) {
+    outcome = signal.aborted
+      ? { ok: false, status: 'aborted' }
+      : { ok: false, status: 'failed', message: messageOf(error) };
+  } finally {
+    await logChain;                                   // drain before finishing
+  }
+
+  // Exactly one terminal event, mapped straight from the status.
+  const TERMINAL = { completed: 'done', failed: 'failed', unsupported: 'unsupported', aborted: 'aborted' } as const;
+  emit({ stage: TERMINAL[outcome.status], message: outcome.message, url: outcome.url });
+  await deps.runLog.finish({ outcome: outcome.status }).catch(() => undefined);
+  return outcome;
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+```
+
+`runFlow` for now:
+
+```ts
+  emit({ stage: 'login' });
+  const tokens = await deps.ensureLoggedIn({
+    apiUrl: deps.apiUrl, tokenPath: deps.tokenPath, loginFn: deps.loginFn,
+  });
+
+  emit({ stage: 'provision' });
+  const provision = await deps.ensureProvisioned({
+    apiUrl: deps.apiUrl, repo: deps.repo, token: tokens.accessToken,
+  });
+  // Both are required before any message is recorded in full mode: the key and
+  // poll token must be redactable, and the log needs the server join key.
+  deps.runLog.addSecret(provision.apiKey);
+  deps.runLog.addSecret(provision.pollToken);
+  await deps.runLog.setSessionId(provision.sessionId);
+
+  return { ok: true, status: 'completed' };   // Tasks 4-8 replace this tail
+```
+
+**No terminal event is emitted inside `runFlow`** — that is the wrapper's job. Login stays
+*inside* core so it is covered by the same error handling and the same abort; Task 11 gives
+the shell a `loginFn` that unmounts Ink first so the authorization URL prints to a clean
+stdout.
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts`
+Expected: PASS (5 tests).
+
+**Step 5: Commit**
+
+```bash
+git add cli/src/onboard/core.ts cli/src/onboard/__tests__/core.test.ts
+git commit -m "feat(cli): onboarding controller skeleton with one terminal event and drained logs"
+```
+
+---
+
+## Task 4: Detect — plan, unsupported, failure, and the question
+
+**Step 1: Write the failing test**
+
+```ts
+it('stops with the agent explanation when the repo is unsupported', async () => {
+  const d = deps({
+    runDetect: async () => ({ ok: false, aborted: false, reason: 'unsupported',
+      unsupportedReason: 'this repository has no web application' }),
+  });
+  await expect(runOnboardCore(d)).resolves.toMatchObject({
+    ok: false, status: 'unsupported',
+    message: 'this repository has no web application',
+  });
+});
+
+it('never writes env or polls when detect fails', async () => {
+  const writeEnv = vi.fn();
+  const waitForAppReporting = vi.fn();
+  const d = deps({
+    runDetect: async () => ({ ok: false, aborted: false, reason: 'no_plan' }),
+    writeEnv, waitForAppReporting,
+  });
+  await expect(runOnboardCore(d)).resolves.toMatchObject({ ok: false, status: 'failed' });
+  expect(writeEnv).not.toHaveBeenCalled();
+  expect(waitForAppReporting).not.toHaveBeenCalled();
+});
+
+it('forwards the human answer back to the agent', async () => {
+  let answer: string[] | undefined;
+  const d = deps({
+    askUser: async ({ options }) => [options[1]!],
+    runDetect: async (o) => {
+      answer = await o.askUser!({ question: 'Which app?', options: ['web', 'admin'], multi: false });
+      o.onPlan(fixturePlan());
+      return { ok: true, aborted: false };
+    },
+  });
+  await runOnboardCore(d);
+  expect(answer).toEqual(['admin']);       // the ANSWER, not just that we asked
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts -t "detect"`
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+Inside `runFlow`:
+
+```ts
+    emit({ stage: 'detect', tasks: [] });
+    let plan: OnboardingPlan | undefined;
+    let tasks: TaskLine[] = [];
+    const detect = await deps.runDetect({
+      cwd: deps.cwd, signal, askUser: deps.askUser,
+      onPlan: (value) => { plan = value; },
+      onMessage: (message) => {
+        record(message);
+        tasks = boundTasks(reduceTasks(tasks, message));   // Task 9 supplies boundTasks
+        emit({ stage: 'detect', tasks });
+      },
+    });
+
+    if (detect.aborted) return { ok: false, status: 'aborted' };
+    if (detect.reason === 'unsupported') {
+      return { ok: false, status: 'unsupported',
+        message: detect.unsupportedReason ?? 'this repository is not supported' };
+    }
+    if (!detect.ok || plan === undefined) {
+      return { ok: false, status: 'failed',
+        message: detect.reason ?? 'the survey did not produce a plan' };
+    }
+```
+
+Until Task 9 lands, `boundTasks` is the identity function; define it locally so the call site never changes.
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git commit -am "feat(cli): controller handles unsupported repos and forwards agent questions"
+```
+
+---
+
+## Task 5: Approve, apply, reconcile
+
+`runApply` returns `editedFiles`; the captured `ApplyReport` also lists them. They must agree. A `result` message alone is not success.
+
+**Step 1: Write the failing test**
+
+```ts
+it('writes no env and never polls when apply fails', async () => {
+  const writeEnv = vi.fn();
+  const waitForAppReporting = vi.fn();
+  const d = deps({
+    runApply: async () => ({ ok: false, aborted: false, reason: 'verification_failed',
+      failures: ['manifest does not contain an identity-capable Opslane SDK version (>=1.2.0)'] }),
+    writeEnv, waitForAppReporting,
+  });
+  const result = await runOnboardCore(d);
+  expect(result).toMatchObject({ ok: false, status: 'failed' });
+  expect(result.message).toMatch(/identity-capable/);
+  expect(writeEnv).not.toHaveBeenCalled();
+  expect(waitForAppReporting).not.toHaveBeenCalled();
+});
+
+it('rejects a report whose editedFiles disagree with the engine', async () => {
+  const d = deps({
+    runApply: async (o) => {
+      o.onReport({ editedFiles: ['src/main.ts'], summary: 'x', installRequired: true, installCwd: 'web' });
+      return { ok: true, aborted: false, editedFiles: ['src/main.ts', 'package.json'] };
+    },
+  });
+  const result = await runOnboardCore(d);
+  expect(result).toMatchObject({ ok: false, status: 'failed' });
+  expect(result.message).toMatch(/report.*match|reconcil/i);
+});
+
+it('starts the apply task list empty rather than reusing detect tasks', async () => {
+  const seen: TaskLine[][] = [];
+  await runOnboardCore(deps({
+    emit: (e) => { if (e.stage === 'apply' && e.tasks) seen.push(e.tasks); },
+    runDetect: async (o) => {
+      o.onMessage(toolUse('t1', 'Read')); o.onMessage(toolUse('t2', 'Glob'));
+      o.onPlan(fixturePlan());
+      return { ok: true, aborted: false };
+    },
+  }));
+  expect(seen[0]).toHaveLength(0);
+});
+
+it('emits the plan for review before applying', async () => {
+  const events: CoreEvent[] = [];
+  await runOnboardCore(deps({ emit: (e) => events.push(e) }));
+  expect(events.find((e) => e.stage === 'awaiting-approval')?.plan?.app_dir).toBe('web');
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts -t "apply"`
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+```ts
+    emit({ stage: 'awaiting-approval', plan });
+
+    tasks = [];                                  // detect's list must not carry over
+    emit({ stage: 'apply', tasks });
+    let report: ApplyReport | undefined;
+    const applied = await deps.runApply({
+      cwd: deps.cwd, plan, signal,
+      requestApproval: deps.requestApproval,
+      onReport: (value) => { report = value; },
+      onMessage: (message) => {
+        record(message);
+        tasks = boundTasks(reduceTasks(tasks, message));
+        emit({ stage: 'apply', tasks });
+      },
+    });
+
+    if (applied.aborted) return { ok: false, status: 'aborted' };
+    if (!applied.ok || report === undefined) {
+      return { ok: false, status: 'failed',
+        message: applied.failures?.join('; ') ?? applied.reason ?? 'the wiring could not be verified' };
+    }
+    const sameFiles = (a: string[] = [], b: string[] = []) =>
+      a.length === b.length && [...a].sort().every((v, i) => v === [...b].sort()[i]);
+    if (!sameFiles(report.editedFiles, applied.editedFiles)) {
+      return { ok: false, status: 'failed',
+        message: 'the agent report does not match the files the engine tracked' };
+    }
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git commit -am "feat(cli): controller reconciles the apply report before writing secrets"
+```
+
+---
+
+## Task 6: Env write, symlink-contained
+
+**Step 1: Write the failing test**
+
+```ts
+it('writes both env vars into the plan app dir', async () => {
+  const writes: Array<[string, Record<string, string>]> = [];
+  await runOnboardCore(deps({ writeEnv: async (dir, vars) => { writes.push([dir, vars]); return `${dir}/.env.local`; } }));
+  expect(writes[0]).toEqual(['/repo/web', {
+    VITE_OPSLANE_API_KEY: 'opk_test',
+    VITE_OPSLANE_ENDPOINT: 'http://localhost:8082',
+  }]);
+});
+
+it('refuses an app_dir that escapes the repo', async () => {
+  const writeEnv = vi.fn();
+  const d = deps({ plan: { ...fixturePlan(), app_dir: '../outside' }, writeEnv });
+  await expect(runOnboardCore(d)).resolves.toMatchObject({ ok: false, status: 'failed' });
+  expect(writeEnv).not.toHaveBeenCalled();
+});
+```
+
+The second test passes because Task 3's wrapper already catches — `containedRepoRelative` throws.
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts -t "env"`
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+```ts
+    emit({ stage: 'writing-env' });
+    const appDir = containedRepoRelative(deps.cwd, plan.app_dir);   // throws if it escapes
+    const envDir = join(deps.cwd, appDir);
+    await deps.writeEnv(envDir, {
+      [plan.env_vars.api_key]: provision.apiKey,
+      [plan.env_vars.endpoint]: provision.endpoint,
+    });
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git commit -am "feat(cli): controller writes env vars inside the contained app dir"
+```
+
+---
+
+## Task 7: Install — driven by the report, behind consent
+
+`ApplyReport.installRequired` is `false` when the repo was already wired (`engine.ts:580`). Respect it. `installCwd` comes from the report too; do not re-derive it.
+
+A failed install must stop the flow. A live spike showed an agent given this job "fixed" an ETARGET by downgrading the SDK pin to a version that cannot report identity (`docs/decisions/agent-runs-commands.md`, Run 2). The controller reports and stops.
+
+**Step 1: Write the failing test**
+
+```ts
+it('skips the install when the report says it is not required', async () => {
+  const runCommand = vi.fn();
+  await runOnboardCore(deps({ installRequired: false, runCommand }));
+  expect(runCommand).not.toHaveBeenCalled();
+});
+
+it('asks for consent and skips the install when declined, then still starts the dev server', async () => {
+  const startDevServer = vi.fn(() => fakeServer());
+  let consentAsked = false;
+  const d = deps({
+    // Decline ONLY the install. Task 8 adds a dev-server prompt through the same
+    // `confirm`; a blanket false would decline that too and this assertion would break.
+    confirm: async (prompt) => !prompt.toLowerCase().includes('install'),
+    runCommand: async (o) => {
+      consentAsked = true;
+      return (await o.consent!()) ? { ran: true, ok: true, exitCode: 0, signal: null }
+                                  : { ran: false, copyPaste: 'pnpm install' };
+    },
+    startDevServer,
+  });
+  await expect(runOnboardCore(d)).resolves.toMatchObject({ ok: true, status: 'completed' });
+  expect(consentAsked).toBe(true);
+  expect(startDevServer).toHaveBeenCalledTimes(1);
+});
+
+it('stops on a failed install rather than continuing', async () => {
+  const startDevServer = vi.fn();
+  const d = deps({
+    runCommand: async () => ({ ran: true, ok: false, exitCode: 1, signal: null }),
+    startDevServer,
+  });
+  const result = await runOnboardCore(d);
+  expect(result).toMatchObject({ ok: false, status: 'failed' });
+  expect(result.message).toMatch(/install/i);
+  expect(startDevServer).not.toHaveBeenCalled();
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts -t "install"`
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+```ts
+    if (report.installRequired) {
+      emit({ stage: 'installing' });
+      const installDir = join(deps.cwd, containedRepoRelative(deps.cwd, report.installCwd));
+      const install = installCommand(deps.cwd, containedRepoRelative(deps.cwd, report.installCwd));
+      const installed = await deps.runCommand({
+        command: install, cwd: installDir, signal,
+        consent: () => deps.confirm('Install dependencies?', formatCommand(install)),
+        onOutput: (output) => emit({ stage: 'installing', output }),
+      });
+      if (installed.ran && !installed.ok) {
+        return { ok: false, status: 'failed',
+          message: `${formatCommand(install)} failed (exit ${installed.exitCode ?? installed.signal}). `
+            + 'Fix the install and re-run onboarding. Do not change the @opslane/sdk version.' };
+      }
+    }
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git commit -am "feat(cli): install driven by the apply report, behind consent"
+```
+
+---
+
+## Task 8: Dev server — consent, race, teardown
+
+`startDevServer` has no consent option, so the controller asks before calling it. And once running, the wait must race the server's own death: if Vite exits, sitting in a 15-minute poll is wrong.
+
+**Step 1: Write the failing test**
+
+```ts
+it('asks before starting the dev server and stops if declined', async () => {
+  const startDevServer = vi.fn();
+  const d = deps({ confirm: async (prompt) => !prompt.includes('dev server'), startDevServer });
+  const result = await runOnboardCore(d);
+  expect(startDevServer).not.toHaveBeenCalled();
+  expect(result.message).toMatch(/dev server/i);
+});
+
+it('emits the URL it parsed', async () => {
+  const events: CoreEvent[] = [];
+  await runOnboardCore(deps({ emit: (e) => events.push(e) }));
+  expect(events.find((e) => e.url)?.url).toBe('http://localhost:5173/');
+});
+
+it('fails fast when the dev server dies instead of waiting out the poll', async () => {
+  const waitForAppReporting = vi.fn(() => new Promise(() => undefined));   // never settles
+  const d = deps({
+    startDevServer: () => ({ ...fakeServer(), completed: Promise.resolve({ exitCode: 1, signal: null }) }),
+    waitForAppReporting,
+  });
+  const result = await runOnboardCore(d);
+  expect(result).toMatchObject({ ok: false, status: 'failed' });
+  expect(result.message).toMatch(/dev server (exited|stopped)/i);
+});
+
+it('stops the dev server when the wait fails', async () => {
+  const stop = vi.fn();
+  const d = deps({
+    startDevServer: () => ({ ...fakeServer(), stop }),
+    waitForAppReporting: async () => { throw new Error('timed out waiting for your app to report'); },
+  });
+  await expect(runOnboardCore(d)).resolves.toMatchObject({ ok: false, status: 'failed' });
+  expect(stop).toHaveBeenCalled();
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts -t "dev server"`
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+```ts
+    const dev = devCommand(deps.cwd, appDir, plan.dev_script);
+    if (!(await deps.confirm('Start the dev server?', formatCommand(dev)))) {
+      return { ok: false, status: 'failed',
+        message: `Start it yourself with \`${formatCommand(dev)}\`, then re-run onboarding.` };
+    }
+
+    emit({ stage: 'starting-dev' });
+    const server = deps.startDevServer({
+      command: dev, cwd: envDir, signal,
+      onOutput: (output) => emit({ stage: 'starting-dev', output }),
+    });
+    // The poll must be cancellable independently: when the server dies, the
+    // losing side of the race would otherwise keep polling for 15 minutes.
+    const pollController = new AbortController();
+    const onOuterAbort = (): void => pollController.abort();
+    signal.addEventListener('abort', onOuterAbort, { once: true });
+    // Never let the losing branch surface as an unhandled rejection.
+    const serverDied = server.completed.then(
+      ({ exitCode }) => { throw new Error(`the dev server stopped (${exitCode ?? 'signal'}) unexpectedly`); },
+      (error: unknown) => { throw error instanceof Error ? error : new Error(String(error)); },
+    );
+    void serverDied.catch(() => undefined);
+    try {
+      const url = await Promise.race([server.url, serverDied]);
+      emit({ stage: 'waiting', url });
+      await Promise.race([
+        deps.waitForAppReporting({
+          apiUrl: deps.apiUrl, sessionId: provision.sessionId,
+          pollToken: provision.pollToken, signal: pollController.signal,
+        }),
+        serverDied,
+      ]);
+      return { ok: true, status: 'completed', url };
+    } finally {
+      pollController.abort();                       // stop the poll either way
+      signal.removeEventListener('abort', onOuterAbort);
+      server.stop();
+      await server.completed.catch(() => undefined);  // teardown before the terminal event
+    }
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git commit -am "feat(cli): dev server behind consent, raced against its own exit"
+```
+
+---
+
+## Task 9: Bound the task list in the controller
+
+Bounding only the view leaves `reduceTasks` retaining every entry and re-cloning the array per message — O(n²) allocations on a real repo survey.
+
+**Files:** modify `cli/src/onboard/core.ts`; test in `core.test.ts`.
+
+**Step 1: Write the failing test**
+
+```ts
+it('bounds retained task state and counts what it dropped', async () => {
+  let last: TaskLine[] = [];
+  await runOnboardCore(deps({
+    emit: (e) => { if (e.tasks) last = e.tasks; },
+    runDetect: async (o) => {
+      for (let i = 0; i < 200; i += 1) {
+        o.onMessage(toolUse(`t${i}`, 'Read'));
+        o.onMessage(toolResult(`t${i}`));
+      }
+      o.onPlan(fixturePlan());
+      return { ok: true, aborted: false };
+    },
+  }));
+  expect(last.length).toBeLessThanOrEqual(8);
+  expect(last.filter((t) => t.state === 'run')).toHaveLength(0);
+});
+
+it('counts dropped failures separately from dropped successes', async () => {
+  let event: CoreEvent | undefined;
+  await runOnboardCore(deps({
+    emit: (e) => { if (e.tasks) event = e; },
+    runDetect: async (o) => {
+      for (let i = 0; i < 30; i += 1) {
+        o.onMessage(toolUse(`t${i}`, 'Read'));
+        o.onMessage(toolResult(`t${i}`, { isError: i % 10 === 0 }));   // 3 failures
+      }
+      o.onPlan(fixturePlan());
+      return { ok: true, aborted: false };
+    },
+  }));
+  expect(event!.droppedFailed).toBe(3);
+  expect(event!.droppedDone).toBe(30 - 3 - event!.tasks!.length);
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts -t "bounds retained"`
+Expected: FAIL — 200 entries retained.
+
+**Step 3: Write minimal implementation**
+
+Replace the identity `boundTasks` from Task 4:
+
+```ts
+const MAX_TASKS = 8;
+
+export interface BoundedTasks {
+  tasks: TaskLine[];
+  droppedDone: number;
+  droppedFailed: number;
+}
+
+/**
+ * Keep every still-running line (a `tool_result` must still find its `tool_use`),
+ * plus the most recent settled ones. Failures are NEVER dropped silently — they
+ * are counted separately so the view cannot report a failure as "done".
+ */
+function boundTasks(tasks: TaskLine[], prev: BoundedTasks): BoundedTasks {
+  const running = tasks.filter((t) => t.state === 'run');
+  const settled = tasks.filter((t) => t.state !== 'run');
+  const room = Math.max(0, MAX_TASKS - running.length);
+  // slice(-0) is slice(0) and returns EVERYTHING — guard room === 0 explicitly.
+  const keep = room === 0 ? [] : settled.slice(-room);
+  const dropped = settled.slice(0, settled.length - keep.length);
+  return {
+    tasks: [...keep, ...running],
+    droppedDone: prev.droppedDone + dropped.filter((t) => t.state === 'done').length,
+    droppedFailed: prev.droppedFailed + dropped.filter((t) => t.state === 'fail').length,
+  };
+}
+```
+
+Note `running` is never truncated: dropping a running line would orphan its
+`tool_result` and the entry would never settle. When more than `MAX_TASKS` tools are
+in flight the list exceeds the cap, which is correct and transient.
+
+Carry `droppedDone` / `droppedFailed` in the emitted event so the view renders
+`✓ N done` and, separately, `✗ M failed`.
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/onboard/__tests__/core.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git commit -am "feat(cli): bound retained task state, not just the rendered list"
+```
+
+---
+
+## Task 10: `tui.tsx` — the pure view
+
+**Files:** create `cli/src/onboard/tui.tsx` and `__tests__/tui.test.tsx`.
+
+**Step 1: Write the failing test**
+
+```tsx
+it('renders the question and resolves on Enter', () => {
+  const onAnswer = vi.fn();
+  const { lastFrame, stdin } = render(
+    <Tui stage="detect" tasks={[]} onAnswer={onAnswer}
+      question={{ question: 'Which app?', options: ['web', 'admin'], multi: false }} />);
+  expect(lastFrame()).toContain('Which app?');
+  stdin.write('\r');
+  expect(onAnswer).toHaveBeenCalledWith(['web']);
+});
+
+it.each([
+  ['unsupported', 'this repository has no web application', /no web application/],
+  ['failed', 'manifest does not contain an identity-capable Opslane SDK version', /identity-capable/],
+  ['aborted', undefined, /cancell?ed|stopped/i],
+])('renders %s so the user can act', (stage, message, pattern) => {
+  const frame = render(<Tui stage={stage as Stage} tasks={[]} message={message} />).lastFrame() ?? '';
+  expect(frame).toMatch(pattern);
+  expect(frame).not.toMatch(/⠋|⠙|⠹/);              // no spinner on a terminal state
+});
+
+it('shows the clickable URL while waiting', () => {
+  expect(render(<Tui stage="waiting" tasks={[]} url="http://localhost:5173/" />).lastFrame())
+    .toContain('http://localhost:5173/');
+});
+
+it('renders dropped successes and failures separately', () => {
+  const tasks = Array.from({ length: 4 }, (_, i) => ({ id: `t${i}`, label: `Read f${i}.ts`, state: 'done' as const }));
+  const frame = render(<Tui stage="detect" tasks={tasks} droppedDone={33} droppedFailed={3} />).lastFrame() ?? '';
+  expect(frame).toMatch(/\b37 done\b/);            // 33 dropped + 4 shown
+  expect(frame).toMatch(/\b3 failed\b/);           // failures must never be counted as done
+  expect(frame.split('\n').length).toBeLessThan(15);
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/tui.test.tsx`
+Expected: FAIL — module missing.
+
+**Step 3: Write minimal implementation**
+
+A `Box` column. `Select`/`MultiSelect` from `@inkjs/ui` when `question` is set. Above the live lines: `✓ {droppedDone + shownDone} done` and, only when non-zero, `✗ {droppedFailed + shownFailed} failed`. Terminal stages render `message` with no spinner; `aborted` renders "Cancelled. Nothing was left running."
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/onboard/__tests__/tui.test.tsx`
+Expected: PASS (6 tests).
+
+**Step 5: Commit**
+
+```bash
+git add cli/src/onboard/tui.tsx cli/src/onboard/__tests__/tui.test.tsx
+git commit -m "feat(cli): onboarding TUI view with actionable terminal states"
+```
+
+---
+
+## Task 11: `app.tsx` — the Ink shell and the production dependency factory
+
+Two jobs: supply the three interactive callbacks, and build the real `CoreDeps`. Revision 1 specified neither concretely.
+
+**Approvals may overlap.** `runApply` tool calls can interleave, so a single parked resolver loses one. Queue them.
+
+**The queue holds three prompt kinds with different resolve types.** `requestApproval` and `confirm` resolve `boolean`; `askUser` resolves `string[]` (`tools.ts:109`). A queue that settles everything with `false` is a type error. Tag each entry and settle per kind: `false` for approvals and confirmations, `[]` for questions.
+
+Settle on: the outer `signal`, the per-approval `options.signal` the SDK supplies, and unmount.
+
+**Login prints to stdout** (`login.ts:130`) — the authorization URL is the one thing the user must see, and Ink owns the screen. Do **not** move login outside core: that would duplicate the `ensureLoggedIn` call, put it outside core's error handling and abort, and leave an un-abortable OAuth wait (login accepts no signal, `login.ts:66`).
+
+Instead the shell supplies a `loginFn` that **unmounts Ink, runs login, then re-renders**:
+
+```ts
+const loginFn = async (): Promise<void> => {
+  instance.clear();
+  instance.unmount();            // give stdout back
+  await login({ apiUrl, clientId: process.env['OPSLANE_CLIENT_ID'] ?? 'opslane-cli' });
+  instance = render(<OnboardApp {...props} />);   // resume
+};
+```
+
+Login therefore still happens inside `runOnboardCore` (Task 3), covered by the same
+try/catch and the same terminal mapping.
+
+**Files:** create `cli/src/onboard/app.tsx` and `__tests__/app.test.tsx`.
+
+**Step 1: Write the failing test**
+
+```tsx
+it('resolves an approval to true when accepted', async () => {
+  let resolved: boolean | undefined;
+  const { lastFrame, stdin } = render(<OnboardApp {...props({
+    runCore: async (d) => {
+      resolved = await d.requestApproval('Edit', { file_path: 'src/main.ts' });
+      return { ok: true, status: 'completed' };
+    },
+  })} />);
+  await delay(10);
+  expect(lastFrame()).toMatch(/src\/main\.ts/);
+  stdin.write('\r');
+  await delay(10);
+  expect(resolved).toBe(true);
+});
+
+it('prefers the SDK-supplied title over a reconstructed sentence', async () => {
+  const { lastFrame } = render(<OnboardApp {...props({
+    runCore: async (d) => {
+      void d.requestApproval('Edit', { file_path: 'a.ts' },
+        { title: 'Claude wants to edit a.ts' } as never);
+      return new Promise(() => undefined);
+    },
+  })} />);
+  await delay(10);
+  expect(lastFrame()).toContain('Claude wants to edit a.ts');
+});
+
+it('queues overlapping approvals instead of dropping one', async () => {
+  const settled: boolean[] = [];
+  const { stdin } = render(<OnboardApp {...props({
+    runCore: async (d) => {
+      const a = d.requestApproval('Edit', { file_path: 'a.ts' }).then((v) => settled.push(v));
+      const b = d.requestApproval('Edit', { file_path: 'b.ts' }).then((v) => settled.push(v));
+      await Promise.all([a, b]);
+      return { ok: true, status: 'completed' };
+    },
+  })} />);
+  await delay(10); stdin.write('\r');
+  await delay(10); stdin.write('\r');
+  await delay(10);
+  expect(settled).toHaveLength(2);
+});
+
+it('settles a queued question with an empty answer, not false', async () => {
+  const controller = new AbortController();
+  let answer: string[] | undefined;
+  render(<OnboardApp {...props({
+    signal: controller.signal,
+    runCore: async (d) => {
+      answer = await d.askUser({ question: 'Which app?', options: ['web'], multi: false });
+      return { ok: false, status: 'aborted' };
+    },
+  })} />);
+  await delay(10);
+  controller.abort();
+  await delay(10);
+  expect(answer).toEqual([]);          // string[], not `false`
+});
+
+it('runOnboardApp builds real deps, logs in through the shell, and returns the core result', async () => {
+  const calls: string[] = [];
+  const result = await runOnboardApp({
+    cwd: '/repo', repo: 'acme/web', apiUrl: 'http://localhost:8082',
+    signal: new AbortController().signal,
+    // test seam: swap the core so we assert the DEPS it received, not the flow
+    runCore: async (d) => {
+      calls.push(typeof d.loginFn, typeof d.runLog.record, typeof d.writeEnv, d.tokenPath ? 'tokenPath' : 'none');
+      return { ok: true, status: 'completed' };
+    },
+  } as never);
+  expect(result).toMatchObject({ ok: true, status: 'completed' });
+  expect(calls[0]).toEqual(['function', 'function', 'function', 'tokenPath'].join(''));
+});
+
+it('settles every pending prompt when the signal aborts', async () => {
+  const controller = new AbortController();
+  let resolved: boolean | undefined;
+  render(<OnboardApp {...props({
+    signal: controller.signal,
+    runCore: async (d) => {
+      resolved = await d.requestApproval('Edit', { file_path: 'a.ts' });
+      return { ok: false, status: 'aborted' };
+    },
+  })} />);
+  await delay(10);
+  controller.abort();
+  await delay(10);
+  expect(resolved).toBe(false);          // denied, not left hanging
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/app.test.tsx`
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+`app.tsx` exports:
+
+```ts
+export async function runOnboardApp(o: {
+  cwd: string; repo: string; apiUrl: string; signal: AbortSignal;
+}): Promise<CoreResult>
+```
+
+It (1) runs `ensureLoggedIn` before any render, (2) builds the production deps, (3) renders `<OnboardApp>` and resolves when core settles.
+
+The production factory — every field of `CoreDeps` with a real implementation:
+
+```ts
+interface ShellUi {
+  requestApproval: ApprovalRequest;
+  askUser: AskUserResolver;
+  confirm: (prompt: string, command: string) => Promise<boolean>;
+  emit: (event: CoreEvent) => void;
+  loginFn: () => Promise<void>;
+}
+
+// async: createRunLog returns a Promise. Revision 2 had `await` in a sync function.
+async function productionDeps(
+  o: { cwd: string; repo: string; apiUrl: string; signal: AbortSignal },
+  ui: ShellUi,
+): Promise<CoreDeps> {
+  const full = process.env['OPSLANE_ONBOARD_LOG'] === 'full';
+  if (full) {
+    // Full mode records agent messages, which can contain repository source.
+    // Say so before writing any of it.
+    console.error('OPSLANE_ONBOARD_LOG=full: this run records full agent messages, '
+      + 'including file contents, to ~/.opslane/logs. Secrets are redacted; source is not.');
+  }
+  return {
+    ...o,
+    tokenPath: defaultTokenPath(),
+    loginFn: ui.loginFn,
+    ensureLoggedIn, ensureProvisioned, runDetect, runApply,
+    writeEnv: writeEnvLocal, runCommand, startDevServer, waitForAppReporting,
+    requestApproval: ui.requestApproval,
+    askUser: ui.askUser,
+    confirm: ui.confirm,
+    runLog: await createRunLog({
+      dir: join(homedir(), '.opslane', 'logs'),
+      runId: randomUUID(),
+      mode: full ? 'full' : 'metadata',
+    }),
+    emit: ui.emit,
+  };
+}
+```
+
+A prompt queue: `pending: Array<{prompt, resolve}>`, render only `pending[0]`, shift on answer. On `signal.abort` and on unmount, resolve every entry `false`.
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/onboard/__tests__/app.test.tsx`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add cli/src/onboard/app.tsx cli/src/onboard/__tests__/app.test.tsx
+git commit -m "feat(cli): Ink shell with a queued approval prompt and production deps"
+```
+
+---
+
+## Task 12: Wire the command
+
+`command.ts` today ends with an **unconditional** `exitWithStatus('internal_error', ...)` after the `finally`. Replace the whole placeholder path, not just the comment, or every successful run still fails.
+
+**Step 1: Write the failing test**
+
+```ts
+it('passes the resolved repo, api url, and signal into the shell', async () => {
+  const seen: unknown[] = [];
+  await runOnboardCommand({ repo: 'acme/web' }, {
+    isStdinTty: true, isStdoutTty: true,
+    loadApp: async () => ({ runOnboardApp: async (o: unknown) => { seen.push(o); return { ok: true, status: 'completed' }; } }),
+  });
+  expect(seen[0]).toMatchObject({ repo: 'acme/web', apiUrl: expect.any(String) });
+  expect((seen[0] as { signal: AbortSignal }).signal).toBeInstanceOf(AbortSignal);
+});
+
+it('exits 0 and emits nothing extra on success', async () => {
+  const exits: unknown[] = [];
+  await runOnboardCommand({ repo: 'acme/web' }, {
+    isStdinTty: true, isStdoutTty: true,
+    exitWith: (...a) => { exits.push(a); },
+    loadApp: async () => ({ runOnboardApp: async () => ({ ok: true, status: 'completed' }) }),
+  });
+  expect(exits).toEqual([]);
+});
+
+it('maps unsupported to usage_error and failed to internal_error', async () => {
+  const cases = [
+    ['unsupported', 'usage_error'],
+    ['failed', 'internal_error'],
+  ] as const satisfies ReadonlyArray<readonly [CoreResult['status'], AgentStatus]>;
+  for (const [status, expected] of cases) {
+    const exits: Array<[string, number]> = [];
+    await runOnboardCommand({ repo: 'acme/web' }, {
+      isStdinTty: true, isStdoutTty: true,
+      exitWith: (s, _d, c) => { exits.push([s, c]); },
+      loadApp: async () => ({ runOnboardApp: async () => ({ ok: false, status, message: 'x' }) }),
+    });
+    expect(exits).toEqual([[expected, 1]]);
+  }
+});
+
+it('preserves the 130 exit code a real SIGINT set', async () => {
+  const exits: unknown[] = [];
+  const before = process.exitCode;
+  await runOnboardCommand({ repo: 'acme/web' }, {
+    isStdinTty: true, isStdoutTty: true,
+    exitWith: (...a) => { exits.push(a); },
+    loadApp: async () => ({
+      runOnboardApp: async () => {
+        process.emit('SIGINT');                 // the handler sets exitCode 130 and aborts
+        return { ok: false, status: 'aborted' as const };
+      },
+    }),
+  });
+  expect(process.exitCode).toBe(130);
+  expect(exits).toEqual([]);                    // nothing overwrote it
+  process.exitCode = before;
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/onboard/__tests__/command.test.ts -t "shell"`
+Expected: FAIL — `runOnboardCommand` takes one argument.
+
+**Step 3: Write minimal implementation**
+
+Add a typed second parameter with production defaults:
+
+```ts
+export interface OnboardCommandDeps {
+  isStdinTty?: boolean;
+  isStdoutTty?: boolean;
+  exitWith?: (status: AgentStatus, data: Record<string, unknown>, code: number) => void;
+  loadApp?: () => Promise<{ runOnboardApp: (o: {
+    cwd: string; repo: string; apiUrl: string; signal: AbortSignal;
+  }) => Promise<CoreResult> }>;
+}
+```
+
+**Route the TTY gate and the exit through the injected deps too.** Revision 2 left
+`requireTty` reading the real `process.stdin/stdout` and calling the real `exitWithStatus`,
+which makes the injected `isStdinTty` / `exitWith` inert:
+
+```ts
+  const exitWith = deps.exitWith ?? exitWithStatus;
+  requireTty({
+    isStdinTty: deps.isStdinTty ?? process.stdin.isTTY === true,
+    isStdoutTty: deps.isStdoutTty ?? process.stdout.isTTY === true,
+    onFail: (status, code) => exitWith(status, { message: '...' }, code),
+  });
+```
+
+Then replace everything after `resolveRepo` — including the trailing unconditional exit:
+
+```ts
+  const apiUrl = options.apiUrl ?? defaultApiUrl();
+  const controller = new AbortController();
+  const removeHandlers = installSignalHandlers({ controller });
+  try {
+    const { runOnboardApp } = await loadApp();
+    const result = await runOnboardApp({ cwd: process.cwd(), repo: repo.repo, apiUrl, signal: controller.signal });
+    if (result.ok) return;
+    // SIGINT already set exitCode 130; do not overwrite it.
+    if (result.status === 'aborted') return;
+    exitWith(result.status === 'unsupported' ? 'usage_error' : 'internal_error',
+      { message: result.message }, 1);
+  } finally {
+    removeHandlers();
+  }
+```
+
+**Step 4: Verify the piped path is unchanged**
+
+```bash
+pnpm --filter @opslane/cli build
+node dist/index.js onboard < /dev/null
+```
+Expected: one JSON document, `tty_required`, exit 1, zero ANSI. The shell must not load.
+
+**Step 5: Commit**
+
+```bash
+git commit -am "feat(cli): opslane onboard runs the interactive flow"
+```
+
+---
+
+## Task 13: Record what M5 needs
+
+Do this **before** the gate so it lands in the same PR. Append to `docs/plans/2026-07-22-onboarding-10x-implementation.md` under M5:
+
+- Blocked on `@opslane/sdk >= 1.2.0` on npm (#45/#46). Until then `npm install` fails ETARGET, verified.
+- **Clear `~/.opslane/pending` first.** `ensureProvisioned` resumes sessions already at `app_reporting` or `completed` (`provision.ts:131`) and `waitForAppReporting` accepts those immediately (`wait.ts`), so a stale record makes the poll succeed without the edited app ever connecting. This is a false-success path in the product, not only in the smoke — if it recurs in real use, the fix is a server-side transition marker, not a smoke-script workaround.
+- Assert a fresh `provisioned → app_reporting` transition for **this run's** session id.
+- Re-run `node scripts/check-packed-packages.mjs`.
+
+**Commit:** `git commit -am "docs: record M5 preconditions and the stale-session false-success path"`
+
+---
+
+## Task 14: Full gate and PR
+
+```bash
+cd /Users/abhishekray/orca/workspaces/opslane-oss/onboarding-10x-2
+pnpm install --frozen-lockfile
+pnpm -r build
+pnpm test
+(cd packages/ingestion && go build ./... && go test ./...)
+docker compose config --quiet
+```
+
+**Prove the new tests are real.** For Tasks 1, 5, 7, 8, 9, and 11, revert the implementation hunk, confirm the new tests fail, restore.
+
+**Bounded live checks only.** Do **not** run an unstubbed `opslane onboard` under a PTY: it would log in, provision a real project, call the model, edit files, and install packages. Two safe checks:
+
+```bash
+# piped path, real binary
+node cli/dist/index.js onboard < /dev/null | python3 -c "import sys,json;print(json.load(sys.stdin)['status'])"
+# expect: tty_required
+
+# TTY gate passes and stops at repo resolution, no network, no model
+cd /tmp && mkdir -p onboard-gate && cd onboard-gate && git init -q
+script -q /dev/null node <repo>/cli/dist/index.js onboard | tr -d '\r' | head -5
+# expect: usage_error naming --repo
+```
+
+Then confirm nothing leaked: `pgrep -f vite || echo "no orphans"` and `lsof -ti :5173 || echo "port free"`.
+
+**Open the PR.** `git push` is blocked by a local hook — ask the user to run
+`! git push -u origin abhishekray07/phase-3b-controller-tui`, then `gh pr create --base main`.
+
+---
+
+## What already exists (do not rebuild)
+
+| Need | Shipped in |
+|---|---|
+| TTY gate, repo resolution, signal handlers | `command.ts` (Phase 3a) |
+| Install / dev-server commands, group teardown, output throttling | `process.ts` (Phase 3a, proven live) |
+| Both agent stages | `runDetect` / `runApply` — `engine.ts` |
+| Task-list state from SDK messages | `reduceTasks` / `TaskLine` — `events.ts` |
+| Login, provisioning, env write, polling, run log | Phase 2 |
+| Path containment | `containedRepoRelative` — `paths.ts` |
+
+## NOT in scope
+
+| Deferred | Why |
+|---|---|
+| Live smoke to `app_reporting` | M5; blocked on the SDK release |
+| Hard-repo acceptance | Milestone B, the design's real bar |
+| Giving the agent a shell | Considered and rejected — `docs/decisions/agent-runs-commands.md` |
+| Reconciling `engine.ts`'s install fields with `process.ts` | Task 7 consumes the report's fields; collapse the duplication once M5 shows which shape survives |

--- a/docs/reference/cli-agent-contract.md
+++ b/docs/reference/cli-agent-contract.md
@@ -1,10 +1,10 @@
 # CLI agent contract
 
-This deterministic reference is sourced from `cli/src/contract.ts` and the setup protocol in `cli/src/setup.ts`. It covers the agent-facing `setup`, `snippet`, `verify`, and `status` commands.
+This deterministic reference is sourced from `cli/src/contract.ts` and the setup protocol in `cli/src/setup.ts`. It covers the agent-facing `setup`, `snippet`, `verify`, and `status` commands, and `onboard` when invoked non-interactively.
 
 ## Output and persistence invariants
 
-- Each covered command writes exactly one JSON document to stdout per invocation. It never mixes prose, progress, or a second JSON document into stdout.
+- Each covered command writes exactly one JSON document to stdout per invocation. It never mixes prose, progress, or a second JSON document into stdout. `onboard` is covered only on its non-TTY path, which emits `tty_required` and exits 1; under a TTY it is an interactive human command and, like `login` and `init`, is exempt.
 - Diagnostics go to stderr. Blocking `setup` writes the interim `auth_required` document, including the human authorization URL, to stderr and reserves stdout for its one terminal document. `setup --start` instead returns `auth_required` as its terminal stdout document.
 - `auth_required`, `pending`, an informational `already_configured`, `completed`, `relinked`, `ok`, and `configured` exit 0. Failures and usage errors exit 1. A refused `setup --force` is the documented exception where `already_configured` exits 1 because relinking is required.
 - `login` and `init` are interactive human commands and are exempt from this JSON/stream contract.
@@ -38,6 +38,7 @@ The rows between the markers are machine parsed. Do not edit them without changi
 | `setup` | `repo_not_detected` | 1 | `stdout` | No GitHub owner/repo could be resolved from the arguments or git remote. |
 | `setup --relink` | `project_not_in_active_org` | 1 | `stdout` | The repo project is not visible in the authenticated active organization. |
 | `setup --relink` | `login_required` | 1 | `stdout` | A current origin-scoped interactive login is required before relinking. |
+| `onboard` | `tty_required` | 1 | `stdout` | The command needs an interactive terminal; run it without piping stdin or stdout. |
 | `snippet, verify, status, errors` | `no_credentials` | 1 | `stdout` | No credential matches the current API origin and repository. |
 | `snippet` | `internal_error` | 1 | `stdout` | Framework detection or patch generation failed before a snippet could be emitted. |
 | `verify` | `ok` | 0 | `stdout` | The API is reachable; has_events says whether the first event arrived. |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,15 +17,24 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: 0.3.217
         version: 0.3.217(@anthropic-ai/sdk@0.112.4(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      '@inkjs/ui':
+        specifier: 2.0.0
+        version: 2.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.8))
       chalk:
         specifier: ^5.4.0
         version: 5.6.2
       commander:
         specifier: ^13.0.0
         version: 13.1.0
+      ink:
+        specifier: 7.1.1
+        version: 7.1.1(@types/react@19.2.17)(react@19.2.8)
       inquirer:
         specifier: ^12.0.0
         version: 12.11.1(@types/node@26.1.1)
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -36,6 +45,12 @@ importers:
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
+      ink-testing-library:
+        specifier: 4.0.0
+        version: 4.0.0(@types/react@19.2.17)
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -482,6 +497,10 @@ packages:
   '@ai-sdk/provider@4.0.3':
     resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
     engines: {node: '>=22'}
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
+    engines: {node: '>=18'}
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -1878,6 +1897,12 @@ packages:
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
+
+  '@inkjs/ui@2.0.0':
+    resolution: {integrity: sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ink: '>=5'
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
@@ -3926,6 +3951,9 @@ packages:
   '@types/react@18.3.29':
     resolution: {integrity: sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==}
 
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
@@ -4394,6 +4422,10 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   autoprefixer@10.5.4:
     resolution: {integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4643,6 +4675,22 @@ packages:
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
+  cli-boxes@4.0.1:
+    resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
+    engines: {node: '>=18.20 <19 || >=20.10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
+
+  cli-truncate@6.1.1:
+    resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
+    engines: {node: '>=22'}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -4665,6 +4713,10 @@ packages:
   cluster-key-slot@1.1.1:
     resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
     engines: {node: '>=0.10.0'}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -4746,6 +4798,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
@@ -5299,6 +5355,10 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
@@ -5437,6 +5497,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -5784,6 +5848,10 @@ packages:
   impound@1.1.5:
     resolution: {integrity: sha512-5AUn+QE0UofqNHu5f2Skf6Svukdg4ehOIq8O0EtqIx4jta0CDZYBPqpIHt0zrlUTiFVYlLpeH39DoikXBjPKpA==}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -5793,6 +5861,28 @@ packages:
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ink-testing-library@4.0.0:
+    resolution: {integrity: sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  ink@7.1.1:
+    resolution: {integrity: sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -5867,12 +5957,21 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -5922,6 +6021,10 @@ packages:
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -6514,6 +6617,10 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
@@ -6733,6 +6840,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
@@ -6839,6 +6950,10 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -7273,12 +7388,22 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -7420,6 +7545,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   retext-latin@4.0.0:
     resolution: {integrity: sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==}
 
@@ -7529,6 +7658,9 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
@@ -7650,6 +7782,10 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
+
   smob@1.6.2:
     resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
     engines: {node: '>=20.0.0'}
@@ -7690,6 +7826,10 @@ packages:
     resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
     engines: {node: '>=20.16.0'}
     hasBin: true
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -7744,6 +7884,10 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -7860,6 +8004,10 @@ packages:
   terminal-link@5.0.0:
     resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
     engines: {node: '>=20'}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
 
   terser@5.49.0:
     resolution: {integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==}
@@ -8752,6 +8900,14 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -8844,6 +9000,9 @@ packages:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
 
@@ -8893,6 +9052,11 @@ snapshots:
   '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -10284,6 +10448,14 @@ snapshots:
 
   '@img/sharp-win32-x64@0.35.3':
     optional: true
+
+  '@inkjs/ui@2.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.8))':
+    dependencies:
+      chalk: 5.6.2
+      cli-spinners: 3.4.0
+      deepmerge: 4.3.1
+      figures: 6.1.0
+      ink: 7.1.1(@types/react@19.2.17)(react@19.2.8)
 
   '@inquirer/ansi@1.0.2': {}
 
@@ -12418,6 +12590,10 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/resolve@1.20.2': {}
 
   '@types/sax@1.2.7':
@@ -13081,6 +13257,8 @@ snapshots:
 
   async@3.2.6: {}
 
+  auto-bind@5.0.1: {}
+
   autoprefixer@10.5.4(postcss@8.5.20):
     dependencies:
       browserslist: 4.28.6
@@ -13312,6 +13490,19 @@ snapshots:
 
   cjs-module-lexer@2.2.0: {}
 
+  cli-boxes@4.0.1: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
+  cli-spinners@3.4.0: {}
+
+  cli-truncate@6.1.1:
+    dependencies:
+      slice-ansi: 9.0.0
+      string-width: 8.2.2
+
   cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
@@ -13331,6 +13522,10 @@ snapshots:
   clsx@2.1.1: {}
 
   cluster-key-slot@1.1.1: {}
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
 
   collapse-white-space@2.1.0: {}
 
@@ -13388,6 +13583,8 @@ snapshots:
   content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
+
+  convert-to-spaces@2.0.1: {}
 
   cookie-es@1.2.3: {}
 
@@ -14003,6 +14200,8 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@2.0.0: {}
+
   escape-string-regexp@5.0.0: {}
 
   esprima@4.0.1: {}
@@ -14180,6 +14379,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-uri-to-path@1.0.0: {}
 
@@ -14689,11 +14892,51 @@ snapshots:
       - vite
       - webpack
 
+  indent-string@5.0.0: {}
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
 
   ini@4.1.1: {}
+
+  ink-testing-library@4.0.0(@types/react@19.2.17):
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  ink@7.1.1(@types/react@19.2.17)(react@19.2.8):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.3.0
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 4.0.1
+      cli-cursor: 4.0.0
+      cli-truncate: 6.1.1
+      code-excerpt: 4.0.0
+      es-toolkit: 1.49.0
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.8
+      react-reconciler: 0.33.0(react@19.2.8)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 9.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.2
+      terminal-size: 4.0.1
+      type-fest: 5.8.0
+      widest-line: 6.0.0
+      wrap-ansi: 10.0.0
+      ws: 8.21.1
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   inline-style-parser@0.2.7: {}
 
@@ -14758,11 +15001,17 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
+
+  is-in-ci@2.0.0: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -14798,6 +15047,8 @@ snapshots:
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
+
+  is-unicode-supported@2.1.0: {}
 
   is-windows@1.0.2: {}
 
@@ -15659,6 +15910,8 @@ snapshots:
 
   mime@4.1.0: {}
 
+  mimic-fn@2.1.0: {}
+
   mimic-fn@4.0.0: {}
 
   minimatch@10.2.1:
@@ -16068,6 +16321,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
@@ -16257,6 +16514,8 @@ snapshots:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
+
+  patch-console@2.0.0: {}
 
   path-browserify@1.0.1: {}
 
@@ -16662,11 +16921,18 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-reconciler@0.33.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
   react-refresh@0.17.0: {}
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.2.8: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -16896,6 +17162,11 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
   retext-latin@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -17105,6 +17376,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  scheduler@0.27.0: {}
+
   scule@1.3.0: {}
 
   semver@6.3.1: {}
@@ -17300,6 +17573,11 @@ snapshots:
 
   slash@5.1.0: {}
 
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   smob@1.6.2: {}
 
   smol-toml@1.7.0: {}
@@ -17327,6 +17605,10 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   srvx@0.11.22: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
@@ -17410,6 +17692,11 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
@@ -17530,6 +17817,8 @@ snapshots:
     dependencies:
       ansi-escapes: 7.3.0
       supports-hyperlinks: 4.5.0
+
+  terminal-size@4.0.1: {}
 
   terser@5.49.0:
     dependencies:
@@ -18297,6 +18586,16 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.2
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.2
+      strip-ansi: 7.2.0
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -18374,6 +18673,8 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  yoga-layout@3.2.1: {}
 
   youch-core@0.3.3:
     dependencies:


### PR DESCRIPTION
Makes `opslane onboard` work end to end in a terminal: survey the repo, ask one question, wire the SDK, run the install and dev server behind consent, and confirm the app reported.

Plan: `docs/plans/2026-07-25-phase-3b-controller-and-tui.md` (14 TDD tasks).

## What it adds

- **`core.ts`** — `runOnboardCore(deps)`, the whole flow with every effect injected. Login, provisioning, both agent stages, report reconciliation, env write, install, dev server, polling, exit status. No TTY, no model, no network in its tests.
- **`tui.tsx`** — pure view. Bounded task list, and every terminal state renders something actionable rather than a spinner.
- **`app.tsx`** — the only run-and-observe file. Wires real Ink into the core, with a **queued** approval prompt (apply tool calls interleave, so a single parked resolver drops one) and a production dependency factory.
- **`command.ts`** — gains the shell load. The TTY gate, repo resolution, and signal handlers were already there from Phase 3a.
- **Engine:** `EngineResult` now carries `unsupportedReason`. It was captured and then discarded, so "no web app, because…" never reached the user.
- **Policy:** `ALLOWED_BASH` deleted. It was unreachable — `Bash` is in `disallowedTools` for both stages and `runApply` passes a Bash-free allow-set, so the "checks-only Bash" capability never existed. Now an outright denial. Giving the agent a shell was considered and rejected: `docs/decisions/agent-runs-commands.md`.

## Review

The plan went through two `/codex` passes before any code was written.

| Iteration | Found | Nature |
|---|---|---|
| 1 | 30 | Branched on a `subtype` that doesn't exist; `loginFn` missing from its own contract; tasks depending on error handling introduced two tasks later |
| 2 | 17 | All in material written to fix round 1 |

Three worth naming:

- **`runDetect` discarded the agent's explanation** (`engine.ts:364`). Became Task 1, since everything downstream needs it.
- **`slice(-0)` is `slice(0)`.** The task-bounding code did `settled.slice(-(MAX - running.length))`; when as many tools run as the cap, that negative zero returns *everything* — the exact unbounded growth the task exists to prevent.
- **Dropped failures were counted as successes.** One `droppedCount` rendered as "N done", so a failed step could vanish into the success tally. Split into `droppedDone` / `droppedFailed`.

## A regression the gate caught

`pnpm test` began failing intermittently — one subprocess case sat **162 seconds** before failing, a different case each run.

Diagnosis: the same suite passes standalone in 4s, and checking out the pre-Phase-3b tip and running the full `pnpm test` there is **clean at 323/323**. So it arrived with this work. The CLI suite grew 323 → 423 including CPU-heavy Ink renders, and `runCli` had **no timeout at all**, so a starved child hung until vitest gave up with an opaque message.

Fixed by bounding, not weakening: `runCli` SIGKILLs at 45s and reports the command plus partial stdout; each spawning case gets 60s instead of vitest's 5s unit default. Same assertions throughout.

## Verification

```
pnpm -r build                     OK
pnpm test                         OK   (CLI 423/423)
go build ./... && go test ./...   OK
docker compose config --quiet     OK
```

Live, against the real compiled binary:

- Piped → one JSON document, `tty_required`, zero ANSI.
- Real PTY in a repo with no GitHub remote → `usage_error` naming the exact `git remote add` fix.

**Revert-proofs.** Three guards were broken to confirm the tests catch them:

| Broken | Result |
|---|---|
| `editedFiles` reconciliation disabled | 1 test fails |
| Task-list bound raised to 100000 | 2 tests fail |
| Bash denial replaced with allow | 1 test fails |

## Not in scope

- **The live smoke to `app_reporting` (M5)** — blocked on `@opslane/sdk >= 1.2.0` reaching npm (#45/#46). Until then `npm install` fails ETARGET, verified. Task 13 records the preconditions, including that `~/.opslane/pending` must be cleared first: `ensureProvisioned` resumes sessions already at `app_reporting`, which is a false-success path in the product, not only in the smoke.
- Milestone B (hard repo), the design's actual acceptance bar.

## Note for the reviewer

The engine tests emit `CLAUDE_SDK_CAN_USE_TOOL_SHADOWED` warnings: the detect stage puts `report_plan`/`ask_user` in `allowedTools`, which auto-approves them so `canUseTool` is never consulted. Pre-existing, not from this PR, but worth deciding whether it is intentional — any security model that leans on that callback should treat the warning as a failure.
