### PR TITLE
Pin onboarding to @opslane/sdk 2.x and accept Vite 8 (land before publishing 2.0.0)

### DIFF
--- a/.changeset/sdk-vite8-peer.md
+++ b/.changeset/sdk-vite8-peer.md
@@ -1,0 +1,5 @@
+---
+'@opslane/sdk': patch
+---
+
+Accept Vite 8 as a peer. The range was `^6 || ^7`, so installing the SDK into a Vite 8 project failed with `ERESOLVE` before anything else could run.

--- a/cli/src/onboard/__tests__/core.test.ts
+++ b/cli/src/onboard/__tests__/core.test.ts
@@ -325,7 +325,7 @@ describe('runOnboardCore apply stage', () => {
         aborted: false,
         reason: 'verification_failed',
         failures: [
-          'manifest does not contain an identity-capable Opslane SDK version (>=1.2.0)',
+          'manifest does not contain an identity-capable Opslane SDK version (>=2.0.0)',
         ],
       }),
       writeEnv,

--- a/cli/src/onboard/__tests__/spec.test.ts
+++ b/cli/src/onboard/__tests__/spec.test.ts
@@ -52,7 +52,7 @@ describe('apply-stage agent specification', () => {
     package_manager: 'pnpm',
     dev_script: 'dev',
     env_prefix: 'VITE_',
-    dependency: { name: '@opslane/sdk', version: '^1.2.0' },
+    dependency: { name: '@opslane/sdk', version: '^2.0.0' },
     env_vars: {
       api_key: 'VITE_OPSLANE_API_KEY',
       endpoint: 'VITE_OPSLANE_ENDPOINT',

--- a/cli/src/onboard/__tests__/verify.test.ts
+++ b/cli/src/onboard/__tests__/verify.test.ts
@@ -11,9 +11,10 @@ import { join } from 'node:path';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  OPSLANE_IDENTITY_MIN_VERSION,
+  type VerifiableOnboardingPlan,
   verifyAlreadyOnboarded,
   verifyApplied,
-  type VerifiableOnboardingPlan,
 } from '../verify.js';
 
 const hash = (value: Buffer | string) =>
@@ -58,7 +59,7 @@ describe('deterministic apply verification', () => {
       package_manager: 'pnpm',
       dev_script: 'dev',
       env_prefix: 'VITE_',
-      dependency: { name: '@opslane/sdk', version: '^1.2.0' },
+      dependency: { name: '@opslane/sdk', version: '^2.0.0' },
       env_vars: {
         api_key: 'VITE_OPSLANE_API_KEY',
         endpoint: 'VITE_OPSLANE_ENDPOINT',
@@ -169,7 +170,7 @@ describe('deterministic apply verification', () => {
         .toString('utf8')
         .replace(
           '    "vue": "^3.5.0"',
-          '    "vue": "^3.5.0",\n    "@opslane/sdk": "^1.2.0"',
+          '    "vue": "^3.5.0",\n    "@opslane/sdk": "^2.0.0"',
         ),
     );
 
@@ -196,7 +197,7 @@ describe('deterministic apply verification', () => {
     writeFileSync(join(root, 'src', 'main.ts'), entry);
     writeFileSync(
       join(root, 'package.json'),
-      '{\n  "name": "fixture",\n  "dependencies": {\n    "@opslane/sdk": "^1.2.0"\n  }\n}\n',
+      '{\n  "name": "fixture",\n  "dependencies": {\n    "@opslane/sdk": "^2.0.0"\n  }\n}\n',
     );
     expect(verify()).toEqual({ ok: true, failures: [] });
 
@@ -209,7 +210,7 @@ describe('deterministic apply verification', () => {
     };
     writeFileSync(
       join(root, 'package.json'),
-      originalManifest.toString('utf8').replace('^1.0.0', '^1.2.0'),
+      originalManifest.toString('utf8').replace('^1.0.0', '^2.0.0'),
     );
     expect(verify()).toEqual({ ok: true, failures: [] });
   });
@@ -281,7 +282,7 @@ describe('deterministic apply verification', () => {
         .toString('utf8')
         .replace(
           '    "vue": "^3.5.0"',
-          '    "vue": "^3.5.0",\n    "@opslane/sdk": "^1.2.0"',
+          '    "vue": "^3.5.0",\n    "@opslane/sdk": "^2.0.0"',
         ),
     );
 
@@ -306,7 +307,7 @@ describe('deterministic apply verification', () => {
         .toString('utf8')
         .replace(
           '    "vue": "^3.5.0"',
-          '    "vue": "^3.5.0",\n    "@opslane/sdk": "^1.2.0"',
+          '    "vue": "^3.5.0",\n    "@opslane/sdk": "^2.0.0"',
         ),
     );
 
@@ -456,16 +457,17 @@ describe('deterministic apply verification', () => {
   it('rejects no-op for an identity-broken SDK version or a nonexistent default export', () => {
     applyFixture();
     const manifest = join(root, 'package.json');
-    writeFileSync(manifest, read(manifest).replace('^1.2.0', '^1.0.0'));
+    writeFileSync(manifest, read(manifest).replace('^2.0.0', '^1.0.0'));
 
     const oldVersion = verifyAlreadyOnboarded({ root, plan });
     expect(oldVersion.ok).toBe(false);
-    expect(oldVersion.failures[0]).toMatch(/identity-capable.*>=1\.2\.0/i);
+    expect(oldVersion.failures[0])
+      .toContain(`identity-capable Opslane SDK version (>=${OPSLANE_IDENTITY_MIN_VERSION})`);
 
-    writeFileSync(manifest, read(manifest).replace('^1.0.0', '1.2.0-beta.1'));
+    writeFileSync(manifest, read(manifest).replace('^1.0.0', '2.0.0-beta.1'));
     expect(verifyAlreadyOnboarded({ root, plan }).ok).toBe(false);
 
-    writeFileSync(manifest, read(manifest).replace('1.2.0-beta.1', '^1.2.0'));
+    writeFileSync(manifest, read(manifest).replace('2.0.0-beta.1', '^2.0.0'));
     writeFileSync(
       join(root, 'src', 'main.ts'),
       [

--- a/cli/src/onboard/spec.ts
+++ b/cli/src/onboard/spec.ts
@@ -43,8 +43,8 @@ Call report_plan exactly once and make no further tool calls afterward.
   - "none" when the repository has no error or monitoring SDK at all (name: null);
   - "keep" when another SDK is present and Opslane should run alongside it (name: that SDK);
   - "migrate" when the named SDK should be replaced, including an outdated
-    @opslane/sdk version below 1.2.0 that cannot report SDK identity;
-  - "no_op" only when an identity-capable @opslane/sdk version (at least 1.2.0) is
+    @opslane/sdk version below 2.0.0 that cannot report SDK identity;
+  - "no_op" only when an identity-capable @opslane/sdk version (at least 2.0.0) is
     already imported, initialized, and nothing should change.
 - Never report secret values. Report environment-variable names only.
 `;

--- a/cli/src/onboard/verify.ts
+++ b/cli/src/onboard/verify.ts
@@ -40,7 +40,7 @@ const TRIVIAL_DOTENV_VALUES = new Set([
   'production',
   'test',
 ]);
-export const OPSLANE_IDENTITY_MIN_VERSION = '1.2.0';
+export const OPSLANE_IDENTITY_MIN_VERSION = '2.0.0';
 
 export type VerifiableOnboardingPlan = OnboardingPlan & {
   edit: OnboardingPlan['edit'] & {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -59,7 +59,7 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "vite": "^6.0.0 || ^7.0.0",
+    "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "vue": "^3.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Two fixes that have to land before `@opslane/sdk` 2.0.0 publishes, or onboarding stays broken after the release.

## 1. The pin pointed at a version that will never exist

`OPSLANE_IDENTITY_MIN_VERSION` was `1.2.0` — a forward reference to a release that hadn't happened. #196 then added a **major** changeset (`replay-chunk-upload-r2.md`), so the next publish is **2.0.0**, not 1.2.0.

The host stamps `^${OPSLANE_IDENTITY_MIN_VERSION}` into every plan (`tools.ts:19` → `tools.ts:372`; the model has no version field and is told not to supply one). So the agent writes `"@opslane/sdk": "^1.2.0"`, which means `>=1.2.0 <2.0.0`.

**2.0.0 is excluded.** After the release npm would hold `1.0.0` and `2.0.0`, and neither satisfies the range. Onboarding would still die at ETARGET — same error, new cause.

Moved to `2.0.0`. One constant covers both uses:

| | |
|---|---|
| `tools.ts:19` | the range stamped into the plan |
| `verify.ts` | the minimum `verifyApplied` accepts |

Verified both directions:

```
^2.0.0 resolves 2.0.0, 2.1.3        rejects 1.0.0
verify ACCEPTS ^2.0.0 ^2.1.0 ^3.0.0
verify REJECTS ^1.2.0 ^1.0.0 2.0.0-beta.1
```

`1.x` stays rejected on purpose — it is the release that cannot report SDK identity, so wiring it produces an app that installs, runs, and never reaches `app_reporting`.

## 2. The Vite 8 peer was never widened

`peerDependencies.vite` was `^6.0.0 || ^7.0.0`. Vite is on 8.x, so installing the SDK into a current Vite project fails `ERESOLVE` before anything else runs. Reproduced against the published `1.0.0`:

```
npm error Could not resolve dependency:
npm error peerOptional vite@"^6.0.0 || ^7.0.0" from @opslane/sdk@1.0.0
npm error Conflicting peer dependency: vite@7.3.6
```

This was recorded as a design prerequisite (`2026-07-22-onboarding-10x-design.md:136`, "Found live") and never done. Now `^6.0.0 || ^7.0.0 || ^8.0.0`, with a patch changeset.

## Timing matters

The peer fix only helps in a release that **contains** it. If 2.0.0 publishes from current main, it ships with `^6 || ^7` and every Vite 8 user is broken until a 2.0.1. Landing this first means 2.0.0 works on day one.

The pin change is CLI-side and unaffected either way, but it has to be on main before anyone runs onboarding against the published SDK.

## One durability change

The verify test now derives its expected message from `OPSLANE_IDENTITY_MIN_VERSION` instead of hardcoding the number. A hardcoded `>=1\.2\.0` regex is precisely what survived my first pass at this change, and it is the same staleness that caused the underlying problem. The next bump cannot leave it behind.

## Verification

```
pnpm -r build                     OK
pnpm test                         OK   (CLI 423/423)
go build ./...                    OK
docker compose config --quiet     OK
pnpm --filter @opslane/sdk check:package   OK
```
