### PR TITLE
chore(cli): hold @opslane/cli from npm (mark private)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@opslane/cli",
   "version": "0.0.1",
+  "private": true,
   "description": "CLI for installing and configuring the Opslane SDK",
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
## Why

The changesets **Version Packages** PR (#45) bumps `@opslane/cli` to `0.1.0` alongside `@opslane/sdk` `2.0.0`, because two shared changesets — `agent-first-cli-onboarding` and `tidy-pugs-shave` (publish-readiness) — touch both packages. Merging #45 would publish **both**.

The SDK 2.0.0 is wanted now (it's the Cloudflare R2 replay-upload fix, #194). The CLI isn't ready for a public npm release: no `cli/README.md`, and open readiness work (#3 hardening, #16 README + npm validation).

## Change

Add `"private": true` to `cli/package.json`. `changeset publish` skips private packages, so **merging #45 will publish only `@opslane/sdk@2.0.0`**. The CLI still version-bumps internally (no publish).

## Follow-up

When #3 and #16 land, remove `private` and cut a dedicated `@opslane/cli` release (it'll need its own npm Trusted Publisher entry, since it's a new package).