### PR TITLE
fix(changesets): scope shared changesets to @opslane/sdk only

### DIFF
--- a/.changeset/agent-first-cli-onboarding.md
+++ b/.changeset/agent-first-cli-onboarding.md
@@ -1,5 +1,4 @@
 ---
-'@opslane/cli': minor
 '@opslane/sdk': patch
 ---
 

--- a/.changeset/tidy-pugs-shave.md
+++ b/.changeset/tidy-pugs-shave.md
@@ -1,6 +1,5 @@
 ---
 '@opslane/sdk': patch
-'@opslane/cli': patch
 ---
 
 Publish readiness. SDK type declarations are now bundled into flat per-entry files, inlining types from the private `@opslane/shared` package — previously the published tarball's types were unresolvable for npm consumers. CLI tarball now ships only `dist` and carries repository metadata required for npm provenance.


### PR DESCRIPTION
## Problem

After #200 marked `@opslane/cli` private, `release-npm.yml`'s `Version PR or publish` job failed on `changeset version`:

```
Error: Found mixed changeset agent-first-cli-onboarding
  Found ignored packages: @opslane/cli
  Found not ignored packages: @opslane/sdk
  Mixed changesets that contain both ignored and not ignored packages are not allowed
```

Changesets forbids a single changeset from bumping both an ignored (private) and a non-ignored package. The two shared changesets bumped both `@opslane/cli` and `@opslane/sdk`, so the version step failed and the Version Packages PR (#45) never refreshed.

## Fix

Drop the `@opslane/cli` lines from `agent-first-cli-onboarding` and `tidy-pugs-shave` so they bump only `@opslane/sdk`.

Result:
- `changeset version` succeeds.
- `@opslane/sdk` releases **2.0.0** (major, from the R2 changeset).
- `@opslane/cli` is neither bumped nor published (it stays private, unreleased).

## Verified

`changeset status` → `@opslane/sdk` at **major**, no `@opslane/cli`, no mixed-changeset error.

## Note

The CLI's changelog won't capture these two changesets; when the CLI is released later (after #3/#16), add a fresh CLI changeset summarizing its onboarding + publish-readiness work.