### PR TITLE
test(wire): add frozen v2.0.0 SDK wire fixtures

### DIFF
--- a/test-fixtures/wire/events/v2.0.0-full.json
+++ b/test-fixtures/wire/events/v2.0.0-full.json
@@ -1,0 +1,30 @@
+{
+  "timestamp": "2026-07-16T00:00:00.000Z",
+  "error": {
+    "type": "TypeError",
+    "message": "Cannot read properties of null (reading 'name')",
+    "stack": "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)"
+  },
+  "breadcrumbs": [
+    {
+      "type": "navigation",
+      "timestamp": "2026-07-16T00:00:00.000Z",
+      "category": "navigation",
+      "message": "https://app.example.com/dashboard"
+    }
+  ],
+  "context": {
+    "url": "https://app.example.com/dashboard",
+    "user_agent": "Mozilla/5.0",
+    "user": {
+      "id": "user-123",
+      "email": "jane@example.com",
+      "account_id": "acct-42",
+      "account_name": "Example Inc"
+    }
+  },
+  "sdk_version": "2.0.0",
+  "release": "web@2026.07.16",
+  "session_id": "sess-abc",
+  "environment": "staging"
+}

--- a/test-fixtures/wire/events/v2.0.0-minimal.json
+++ b/test-fixtures/wire/events/v2.0.0-minimal.json
@@ -1,0 +1,14 @@
+{
+  "timestamp": "2026-07-16T00:00:00.000Z",
+  "error": {
+    "type": "TypeError",
+    "message": "Cannot read properties of null (reading 'name')",
+    "stack": "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)"
+  },
+  "breadcrumbs": [],
+  "context": {
+    "url": "https://app.example.com/dashboard",
+    "user_agent": "Mozilla/5.0"
+  },
+  "sdk_version": "2.0.0"
+}


### PR DESCRIPTION
## Problem

`packages/sdk/src/__tests__/wire-shape.test.ts` loads a per-version frozen fixture named after `packages/sdk/package.json`'s version: `v{version}-{minimal,full}.json`.

The Version Packages PR (#45) bumps `@opslane/sdk` 1.1.0 → **2.0.0**, so the test looks for `v2.0.0-minimal.json` / `v2.0.0-full.json`, which don't exist:

```
Error: ENOENT: no such file or directory, open '.../test-fixtures/wire/events/v2.0.0-minimal.json'
```

That fails **"JS build and test"** → **`ci-ok`** (a required check) → #45 is blocked. The changesets bot can't add these itself.

## Fix

Add `v2.0.0-{minimal,full}.json`. The 2.0.0 change is replay chunk upload (#194), **not** the events wire shape, so the payload is identical to `v1.1.0` apart from `sdk_version`. Existing fixtures are untouched (append-only, per the wire-contract rule).

## Verification

- Temporarily set `packages/sdk/package.json` to 2.0.0 and ran the wire-shape test → **2/2 pass** against these fixtures (then reverted the version — this PR contains only the two fixtures).
- `scripts/check-wire-fixtures.mjs` → green (no changed fixtures).

## Unblocks

Merge this → `release-npm.yml` regenerates #45 off main (now with the fixtures) → #45 CI passes → merge #45 → `@opslane/sdk@2.0.0` publishes.