### PR TITLE
test(wire): add frozen v2.0.1 SDK wire fixtures

### DIFF
--- a/test-fixtures/wire/events/v2.0.1-full.json
+++ b/test-fixtures/wire/events/v2.0.1-full.json
@@ -1,0 +1,30 @@
+{
+  "timestamp": "2026-07-16T00:00:00.000Z",
+  "error": {
+    "type": "TypeError",
+    "message": "Cannot read properties of null (reading 'name')",
+    "stack": "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)"
+  },
+  "breadcrumbs": [
+    {
+      "type": "navigation",
+      "timestamp": "2026-07-16T00:00:00.000Z",
+      "category": "navigation",
+      "message": "https://app.example.com/dashboard"
+    }
+  ],
+  "context": {
+    "url": "https://app.example.com/dashboard",
+    "user_agent": "Mozilla/5.0",
+    "user": {
+      "id": "user-123",
+      "email": "jane@example.com",
+      "account_id": "acct-42",
+      "account_name": "Example Inc"
+    }
+  },
+  "sdk_version": "2.0.1",
+  "release": "web@2026.07.16",
+  "session_id": "sess-abc",
+  "environment": "staging"
+}

--- a/test-fixtures/wire/events/v2.0.1-minimal.json
+++ b/test-fixtures/wire/events/v2.0.1-minimal.json
@@ -1,0 +1,14 @@
+{
+  "timestamp": "2026-07-16T00:00:00.000Z",
+  "error": {
+    "type": "TypeError",
+    "message": "Cannot read properties of null (reading 'name')",
+    "stack": "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)"
+  },
+  "breadcrumbs": [],
+  "context": {
+    "url": "https://app.example.com/dashboard",
+    "user_agent": "Mozilla/5.0"
+  },
+  "sdk_version": "2.0.1"
+}


### PR DESCRIPTION
## Problem

`packages/sdk/src/__tests__/wire-shape.test.ts` loads a per-version frozen fixture (`v{package.json version}-{minimal,full}.json`). The Version Packages PR (#205) bumps `@opslane/sdk` to 2.0.1, so the test looks for `v2.0.1-minimal.json` / `v2.0.1-full.json`, which don't exist yet:

```
Error: ENOENT: no such file or directory, open '.../test-fixtures/wire/events/v2.0.1-minimal.json'
```

That fails **JS build and test**, and therefore `ci-ok`, blocking #205. Same failure mode as #204 (which added the v2.0.0 pair for #45).

## Fix

The 2.0.1 change is the Vite 8 peer-range widening (#199), not the events wire shape, so the payload is identical to `v2.0.0` apart from `sdk_version`. Add the `v2.0.1` pair — append-only, no existing fixture touched.

Fixtures have to land on `main` rather than on the release branch, since `changeset-release/main` is force-pushed by the changesets bot.

## Verification

- wire-shape test with `packages/sdk/package.json` temporarily at 2.0.1: **2/2 pass**
- Go `wire_compat` suite against a disposable Postgres: `v2.0.1-full` / `v2.0.1-minimal` pass in `TestWireFixtures_AcceptedAndStored` and `TestWireFixtures_StableGrouping`, plus `TestWireFixtures_UnknownFieldsTolerated` and `TestWireV110EnvironmentResolution`
- `pnpm test:repo`: green (119 + 14 pass, 0 fail), including the wire-fixture policy tests — no frozen fixture modified

## Follow-up (not in this PR)

This breaks on every SDK release and is hand-fixed each time. Worth a generator (like the Python SDK's `OPSLANE_WRITE_FIXTURES=1`) or a changesets release step that emits the pair.