### PR TITLE
feat: resolve browser stack traces from uploaded source maps

### DIFF
--- a/.changeset/sourcemap-upload-v3.md
+++ b/.changeset/sourcemap-upload-v3.md
@@ -1,0 +1,5 @@
+---
+'@opslane/sdk': major
+---
+
+The Vite plugin uploads stamped source maps to Opslane when OPSLANE_SOURCEMAP_KEY and OPSLANE_ENDPOINT are set. Maps without sourcesContent are now accepted by debug-ID fingerprinting.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,11 +197,11 @@ jobs:
       # packages/sdk/dist on disk. This job used to be part of js, which ran
       # `pnpm -r build` first and supplied that implicitly.
       #
-      # Only the SDK is needed: it has no workspace dependencies of its own,
-      # and those two fixtures depend on nothing else in the repo. Should a
-      # future runnable snippet import another package, this job fails --
-      # it is always-on, so the gap surfaces immediately rather than rotting.
-      - run: pnpm --filter @opslane/sdk build
+      # The trailing "..." pulls in the SDK's own workspace dependencies (it
+      # has one, @opslane/shared) rather than assuming it has none. Should a
+      # future runnable snippet import another package, this job fails -- it is
+      # always-on, so the gap surfaces immediately rather than rotting.
+      - run: pnpm --filter '@opslane/sdk...' build
       - run: pnpm test:repo
 
   js:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,13 @@ jobs:
       # worker's harness loop now lives in @opslane/agent-core, whose exports
       # point at dist. The login browser smoke serves the dashboard's dist via
       # vite preview, so the dashboard build must exist too.
-      - run: pnpm --filter @opslane/shared --filter @opslane/agent-core --filter @opslane/worker --filter @opslane/dashboard build
+      # The trailing "..." selects each package *and its workspace
+      # dependencies*, so this list tracks package.json instead of being
+      # hand-maintained. Spelling the members out meant the worker gaining a
+      # dependency (@opslane/sdk, for debug-ID recompute) broke this job with an
+      # unresolvable-module error that no dev machine reproduces, because there
+      # dist survives from an earlier build. Same idiom as release-npm.yml.
+      - run: pnpm --filter '@opslane/worker...' --filter '@opslane/dashboard...' build
       - name: Install Playwright chromium (browser smoke)
         run: pnpm --filter @opslane/test-e2e exec playwright install --with-deps chromium
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,11 @@ pnpm test
 docker compose config --quiet
 ```
 
+Two ways that gate reports success without having run:
+
+- `pnpm test` marks database-gated suites *skipped*, not failed, when `DATABASE_URL` is unset. Export it (Compose's Postgres) before treating a green suite as proof, and read the skip count rather than the pass count.
+- `dist/` is gitignored but survives between runs, so a local build proves nothing about a clean checkout. After adding a workspace dependency, rebuild with the dists removed.
+
 - Shared types or workspace metadata: run `pnpm -r build` and affected tests.
 - CLI: run `pnpm --filter @opslane/cli build` and `pnpm --filter @opslane/cli test`.
 - Compose or health checks: validate config, start services, and inspect health. Build any affected Compose image after Dockerfile changes.

--- a/docs/design/2026-07-29-keys-sourcemaps-s0-contracts.md
+++ b/docs/design/2026-07-29-keys-sourcemaps-s0-contracts.md
@@ -4,6 +4,25 @@
 
 **Status:** frozen
 
+## Amendment — 2026-08-03 (v1 tracer bullet)
+
+Implemented by `docs/plans/2026-08-03-v1-sourcemaps-simplification.md`. The
+following sections are superseded for v1; everything not listed stays frozen.
+
+| Section | Status |
+| --- | --- |
+| §3 key CRUD endpoints (3.4–3.7) | Keys are minted by `cmd/mint-key`; revocation is the documented exact-key SQL statement. |
+| §3.2 lifecycle invariants | Unchanged: minting does not revoke, and revocation is a separate explicit action. |
+| Onboarding “sk never touches disk” posture | Relaxed to “sk never enters a tracked file or bundle”; an operator-managed gitignored `.env.local` is acceptable. |
+| §5 SDK release | The uploading plugin is a major SDK change targeting 3.0.0 through Changesets. |
+| §6 map validity | `sourcesContent` is optional and recorded as `has_sources_content`; the canonical hash algorithm is unchanged. |
+| §6 per-file limit | 32 MiB of wire bytes. |
+| §7 batch protocol | Replaced by identity-encoded `PUT /api/v1/sourcemaps/{debugID}` and a process-local 60/minute per-project limiter. |
+| §8 batch tables | Replaced by `sourcemap_files` and `sourcemap_tombstones`. |
+| §9 verify and §11 status endpoints | Dropped for v1. |
+| §10 resolution persistence | `resolution_status` and `stack_trace_resolved` only. |
+| §12 deletion loop | Tombstone trigger plus documented manual purge; automatic sweeping is deferred. |
+
 **Parent design:** [Keys, source maps, and onboarding](./2026-07-29-keys-sourcemaps-onboarding.md)
 
 This appendix is the implementation boundary between ingestion, the browser SDK,

--- a/docs/design/2026-08-03-v1-sourcemaps-tracer-bullet-design.md
+++ b/docs/design/2026-08-03-v1-sourcemaps-tracer-bullet-design.md
@@ -1,0 +1,363 @@
+# Design: one stack trace resolves end to end
+
+Status: proposed
+Date: 2026-08-03
+Author: Abhishek Ray (with Claude + Codex review)
+Source of record for scope: `docs/plans/2026-08-03-v1-sourcemaps-simplification.md` (rev 5)
+Task breakdown: `docs/superpowers/plans/2026-08-03-v1-sourcemaps-tracer-bullet.md`
+
+## 1. Problem
+
+No source map has ever been uploaded to Opslane, and the fix agent has never
+resolved a single minified frame. This is despite three of the four needed
+components being finished and merged:
+
+- **Keys (S1, #243).** Two credential types exist with scope stored in the
+  database and enforced by one middleware (`handler/project_keys.go:15`):
+  `opslane_pk_`, the public key browsers use to send events (scope
+  `ingest`), and `opslane_sk_`, the secret key for uploading source maps
+  (scope `sourcemaps`, `db/project_keys.go:22`). "pk" and "sk" below refer
+  to these. But nothing mints an sk (every
+  `CreateProjectKey*` call site passes `ScopeIngest`), and no route accepts
+  one.
+- **Debug IDs (S2a, #249).** The Vite plugin stamps deterministic debug IDs
+  into every chunk and map; the SDK sends `debug_meta.images`; ingestion
+  sanitizes and stores it on `error_events.debug_meta`
+  (`handler/error_event.go:76`, migration `028_event_debug_meta.sql`).
+  Nothing reads that column back.
+- **Frame resolution.** `packages/worker/src/source-map.ts` parses stacks and
+  resolves positions with snippets. But its callers look maps up by
+  `(project_id, release)` in a `source_maps` table (`worker/src/db.ts:1300`)
+  that has no writer anywhere in the repo: the only inserter,
+  `InsertSourceMap` (`db/queries.go:1447`), has zero callers. Resolution
+  always returns null.
+
+The upload endpoint that would connect them was deleted in S1 (the old
+`POST /api/v1/sourcemaps` accepted the public browser key, a security hole),
+and its planned replacement, the three-step batch protocol frozen in
+`docs/design/2026-07-29-keys-sourcemaps-s0-contracts.md` §7-§8, was never
+built. Thirteen open issues (S2b through S7c) describe the productionized
+version of this pipeline; none of them ship the missing wire.
+
+This slice ships the wire.
+
+## 2. Goals / non-goals
+
+**Goal.** A browser error from a real production Vite build reaches the fix
+agent with original file, line, and source snippet, proven by one end-to-end
+test that is also the definition of done.
+
+**The one user outcome.** The investigation prompt's "Resolved Stack Trace
+(source-mapped)" block (`worker/src/investigate.ts:281`, `agent-fix.ts:220`,
+already written, never fired) lights up with real source.
+
+**Non-goals, each deliberate:**
+
+- **No onboarding or CLI changes.** Maintainer decision 2026-08-03: keys are
+  minted manually for now; onboarding integration is a separate later track
+  whose settled design (flag-gated rotation, `.env.local` delivery, guarded
+  CLI sinks) is recorded in the plan so it is not re-litigated.
+- **No batch upload protocol.** The frozen §7 design (manifest hashing,
+  idempotency keys, probe batches, expiry sweepers) is superseded for v1 by
+  a single idempotent PUT per map. See Alternatives.
+- **No key-management UI/API, no upload-health surface, no dashboard
+  warnings, no client-facing map read path (no API, session, or presigned
+  URL returns map bytes; the worker reads object storage directly,
+  server-side), no reprocessing of old events, no non-Vite build tools.**
+- **No automatic deletion sweeper.** A database trigger records a tombstone;
+  purge is a documented manual command.
+
+## 3. Requirements
+
+| # | Requirement | Verified by |
+|---|---|---|
+| R1 | Only an sk-scoped key can upload a map; a pk gets `403 insufficient_scope`; an sk cannot send events. | Route-matrix and handler tests; E2E negative floor. |
+| R2 | One bad or malicious upload can never wedge a debug ID or overwrite an accepted map. | Server recomputes the debug ID from the bytes (`409 debug_id_mismatch` on disagreement); digest-addressed object keys make concurrent-conflict overwrite structurally impossible; unit tests for both. |
+| R3 | No API returns map bytes or `sourcesContent`, and maps are project-isolated at rest and at resolution time. | No read route exists (route matrix); E2E: project B with the same `debug_meta` but no upload gets `map_not_found` while A resolves. |
+| R4 | A leaked sk is bounded and revocable. | 60/min per-project limiter (worst case ~1.9 GiB/min per replica, documented); exact-`key_id` revocation SQL printed by `mint-key`; revoked-key test. |
+| R5 | A real `vite build` uploads its maps and strips them from deployable output; upload failure never fails the customer build. | Plugin tests (429 pacing, failure warning); E2E asserts `sourcemap_files` rows plus zero `.map`/`sourceMappingURL` in output. |
+| R6 | The investigated event durably records the outcome: `resolution_status` enum plus resolved frames in a pinned envelope. | Worker unit tests per status; E2E asserts `resolution_status = 'resolved'` and envelope fields (original file, line, snippet). |
+| R7 | Resolution works with no release configured and no LLM key present. | Fixture builds with release omitted; resolution runs before the worker's `ANTHROPIC_API_KEY` check, so the E2E asserts it keylessly. |
+
+## 4. System overview
+
+```mermaid
+sequenceDiagram
+    participant CI as CI / local build (Vite plugin)
+    participant ING as Ingestion (Go)
+    participant S3 as MinIO
+    participant BR as Browser (SDK)
+    participant WK as Worker
+
+    Note over CI: OPSLANE_SOURCEMAP_KEY (sk) in env or .env.local
+    CI->>ING: PUT /api/v1/sourcemaps/{debugID} (map bytes, X-API-Key: sk)
+    ING->>ING: recompute debug ID + canonical sha256 from bytes
+    ING->>S3: put sourcemaps/{project}/{debugID}/{sha256}
+    ING->>ING: insert sourcemap_files row
+    ING-->>CI: 201 (200 on idempotent retry, 409 on conflict)
+
+    BR->>ING: POST /api/v1/events (pk) with debug_meta.images
+    Note over ING: stores debug_meta on error_events (existing, S2a)
+
+    WK->>WK: investigate job claims event
+    WK->>WK: match frames to images by exact code_file
+    WK->>ING: (via Postgres) sourcemap_files rows by (project, debug_id)
+    WK->>S3: fetch object, verify sha256 matches row
+    WK->>WK: resolveFrame (column-1 fix), build envelope
+    WK->>WK: store resolution_status + stack_trace_resolved
+    Note over WK: prompt block "Resolved Stack Trace" now fires
+```
+
+Five stages land in order so no intermediate state is dead:
+migrations + route → `cmd/mint-key` → plugin uploader (SDK 3.0.0) → worker
+resolution → build-mode E2E.
+
+## 5. Component design
+
+### 5.1 Upload route (ingestion)
+
+`PUT /api/v1/sourcemaps/{debugID}`, behind the existing
+`ProjectKey(db.ScopeSourcemaps)` middleware. It is the first route to bind
+that scope. The middleware already emits `401 invalid_api_key` /
+`403 insufficient_scope` (`handler/project_keys.go:37`), so R1 costs one
+route registration.
+
+**Why the server recomputes the debug ID.** The debug ID is derived content:
+`debugid.Compute` (`packages/ingestion/debugid/debugid.go:34`) canonicalizes
+the map (RFC 8785, minus the `debugId` field) and hashes it; the ID is the
+first 128 bits. Trusting the URL's ID would let one truncated upload occupy
+the real chunk's ID forever, with no delete path in v1. Recomputing costs one
+parse we need anyway for validation.
+
+**Why digest-addressed object keys.** The object lives at
+`sourcemaps/{projectID}/{debugID}/{content_sha256}`. Two concurrent first
+uploads with different canonical content (attack or hash collision; honest
+clients can't produce this, because the ID is recomputed) write *different*
+objects; whichever row-insert wins references its own bytes, the loser's
+object is an unreferenced orphan. Codex review round 2 showed every
+fixed-key scheme we tried had a window where the loser's `PutObject`
+clobbered the winner's bytes (`minio/client.go:90` overwrites in place).
+Addressing by digest removes the window instead of shrinking it.
+
+**Idempotency and healing.** Same `(project, debugID)` with equal digest →
+`200` no-op, after a `StatObject` check that re-puts only when the object is
+*missing* (crash between put and insert). A stat failure that is not
+not-found is `503 storage_unavailable`, never a silent 200. The frozen
+shared HTTP contract (§ error codes) assigns storage unavailability to 503.
+
+**Limits.** `http.MaxBytesReader` at 32 MiB. That matches the plugin's
+default `maxMapBytes`, comfortably covers real maps (typically single-digit
+MiB), and bounds per-request server memory since the body is buffered for
+hashing; the frozen 100 MiB limit assumed streaming the batch protocol
+never got. Identity encoding only (`415` on any `Content-Encoding` header,
+keeping the frozen §7.2 rule). 60 requests/min per project via a
+wrapper that emits the frozen `429 rate_limited` + `Retry-After` shape (the
+shared `rateLimitByProject` helper emits a code-less body, so it is wrapped,
+not reused blind). 60/min bounds a leaked sk to ~1.9 GiB/min per replica.
+Accepted, with revocation as the response.
+
+**`sourcesContent` becomes optional.** Both validators currently reject a
+map without it (`debugid.go:103`, `sdk/src/build/debug-id.ts:271`). Users
+who set `sourcemapExcludeSources` would be locked out for no security
+reason. Both implementations relax identically; a new golden vector without
+`sourcesContent` is added to the generator (`test-fixtures/debug-id/
+build-vectors.mjs`) so Go and TS cannot drift. The hash algorithm and
+existing vectors are untouched. Such maps resolve without snippets;
+`has_sources_content` is recorded on the row.
+
+### 5.2 Key minting (`cmd/mint-key`)
+
+A ~40-line Go command: `go run ./cmd/mint-key -project <uuid>` calls the
+existing, tested `db.CreateProjectKey(..., ScopeSourcemaps, ...)`, prints
+the raw key once plus its `key_id` and the exact-key revocation SQL:
+
+```sql
+UPDATE project_api_keys SET revoked_at = now() WHERE key_id = '<key_id>';
+```
+
+**Why manual.** The maintainer chose to split all onboarding work out of
+this slice ("let's just get the keys + sourcemap upload working"). Minting
+via the onboarding flow was designed (and its sharp edges found: the shared
+`provisionProjectTx` helper would have leaked sk minting into
+`POST /api/v1/projects`), then deliberately deferred with those findings
+recorded. Exact-key revocation preserves frozen §3.2's lifecycle invariants
+untouched; no blanket project-wide revoke exists.
+
+The operator pastes the key into CI as `OPSLANE_SOURCEMAP_KEY`, and/or into
+the repo's gitignored `.env.local`. Blast radius of a leak: uploads only.
+The scope cannot read incidents or send events.
+
+### 5.3 Plugin uploader (SDK, 3.0.0)
+
+The plugin already holds every stamped map in memory at the end of its
+post-order `generateBundle` hook. Upload bytes are recorded at stamp time
+(the discard sweep at `vite-plugin/index.ts:199` deletes bundle entries, not
+these copies) and uploaded in `closeBundle`.
+
+- **Env resolution:** `process.env` first (CI), then the project's Vite env
+  files via `loadEnv(config.mode, config.root, 'OPSLANE_')`, so a key pasted
+  into `.env.local` drives local production builds with no shell exports.
+  Non-`VITE_`-prefixed vars never reach browser code, so the sk cannot leak
+  into the bundle.
+- **Custody:** when maps ship to disk (`mapsWillShip()`, which covers both the
+  `sourcemaps: 'keep'` option and a project's explicitly configured maps),
+  the uploader re-reads the on-disk bytes and recomputes the debug ID
+  immediately before upload, skipping mismatches: another plugin's later
+  `writeBundle` can mutate files after our verification pass
+  (`index.ts:213` documents exactly this). When maps never reach disk, the
+  recorded in-memory bytes are the final bytes.
+- **Pacing:** on `429` the uploader waits `Retry-After` (capped 120 s) and
+  retries; one free retry on network error. A 248-map build at 60/min
+  completes in ~4-5 minutes. Without pacing, review showed a real build
+  would upload ~60 maps and silently lose the rest.
+- **Never fails the build.** Upload failure is a warning naming the files;
+  in keep mode the warning names which maps must not be deployed.
+- **3.0.0** is set directly in `package.json` (the S6a codemod gates on the
+  installed version: `OPSLANE_VITE_PLUGIN_MIN_VERSION = '3.0.0'`,
+  `cli/src/codemods/vite-contract.ts:48`), with a `./build/debug-id` export
+  subpath added so the worker can reuse `computeDebugId`.
+
+### 5.4 Worker resolution
+
+One shared resolver module replaces the duplicated, release-gated dead code
+at both call sites (`worker/src/index.ts:365,695`).
+
+- **Join rule, exact by design:** a frame resolves against the image whose
+  `code_file` equals the frame's file URL exactly. The dead code's basename
+  heuristic (`endsWith(m.filename.replace('.map',''))`) is deleted. A
+  basename match against the wrong chunk's map yields plausible wrong
+  source, which is worse for a fix agent than no source.
+- **Ordering:** resolution runs before the worker's `ANTHROPIC_API_KEY`
+  check and the repo clone in the investigate path. It depends only on
+  Postgres and MinIO; relocating it means a keyless or clone-failing worker
+  still records the outcome, and the E2E asserts resolution without an LLM
+  key (R7).
+- **Correctness fixes found in review:** browser stack columns are 1-based,
+  `@jridgewell/trace-mapping` expects 0-based. The existing `resolveFrame`
+  passes them through unadjusted (`source-map.ts:61`), an off-by-one on
+  every frame. Fetched objects are digest-verified against the row's
+  `content_sha256` before use.
+- **Durable outcome:** `resolution_status` enum (`resolved | partial |
+  no_debug_ids | map_not_found | invalid_map | resolution_failed`, migration
+  `031`) plus resolved frames in a pinned envelope stored in the existing
+  `stack_trace_resolved` column:
+
+```json
+{"version": 1, "frames": [{
+  "original_file": "src/App.vue", "original_line": 12, "original_column": 4,
+  "source_snippet": "…", "generated_file": "http://…/index-abc.js",
+  "generated_line": 1, "generated_column": 100,
+  "debug_id": "aaaaaaaa-…"
+}]}
+```
+
+  `invalid_map` means a map was actually fetched and is unusable: either
+  it fails the parse probe or its digest does not match the row (storage
+  corruption). Missing storage config classifies as `resolution_failed`,
+  never `invalid_map`.
+
+**Expand/contract:** migration `031` only adds the column. The dead
+`source_maps` table is dropped by a follow-up migration one release later,
+because dropping it alongside the worker change would break an old worker binary
+against a migrated database (compose applies migrations before service
+restarts).
+
+### 5.5 Deletion floor
+
+No project DELETE endpoint exists (`handler/routes.go:116-119`; project
+CRUD is GET/POST/PATCH), so deletion happens via manual SQL, where no
+handler can run. A `BEFORE DELETE ON projects` trigger writes a tombstone
+row (project ID + storage prefix) in migration `030`, so even a manual
+delete records which prefix holds orphaned customer source. Purge is a
+documented one-liner against that prefix; the automatic sweeper is deferred.
+
+## 6. Milestones
+
+| Stage | Deliverable | Exit criterion |
+|---|---|---|
+| 1 | Migrations 030/031 + upload route | Route matrix passes: sk uploads, pk 403s, no read path; idempotent retry returns 200; conflict 409s without object overwrite; disposable-DB double-apply is clean. |
+| 2 | `cmd/mint-key` | Minted key passes `ParseProjectKey` with scope `sourcemaps`; printed revocation SQL makes `LookupProjectKey` reject it. |
+| 3 | Plugin uploader + SDK 3.0.0 | Build of a fixture uploads exactly the stamped maps; 429-pacing test passes; env-absent build makes zero requests; a 500-ing server does not fail the build; `check:package` proves the new export subpath resolves. |
+| 4 | Worker resolution | Unit tests pass for all six statuses, the column-base conversion, digest mismatch, and the exact-join rule; both call sites consume the shared resolver; worker package compiles with `getSourceMaps` gone. |
+| 5 | Build-mode E2E | The acceptance test below passes against the compose stack. |
+
+## 7. Testing & validation
+
+**CI:** everything except stage 5. Go handler/db tests (with a map-backed
+`objectStore` fake via the `Dependencies.SourcemapStore` seam, plus gated
+integration tests against disposable Postgres/MinIO), SDK vitest (uploader
+against an in-process HTTP server; debug-id golden vectors shared with Go),
+worker vitest (resolver with injected `getMapRows`/`fetchMap`, a committed
+real Vite-emitted map fixture).
+
+**Live (the definition of done),** in `test-e2e/` against the compose stack,
+using a new build-then-serve harness (`vite build` + `vite preview`) because
+the existing dev-server harness never runs the plugin (`apply: 'build'`):
+
+1. Build `test-fixtures/vue-app` with a seeded sk, release omitted.
+2. Assert `sourcemap_files` rows created by this run, and zero `.map` files
+   or `sourceMappingURL` references in output.
+3. Throw one error in the served bundle with the pk.
+4. Assert the event this run created reaches `resolution_status='resolved'`
+   with envelope fields populated. No `ANTHROPIC_API_KEY` needed.
+5. Negative floor: pk cannot upload; sk cannot send events; GET has no
+   route; project B carrying the same `debug_meta` while A holds the map
+   gets `map_not_found`, then resolves after B's own upload (the
+   discriminating isolation proof: identical content in both projects
+   would prove nothing).
+
+All E2E polls are scoped `created_at > startedAt` with a scoped
+`sourcemap_files` cleanup in `beforeAll`, because the seed uses fixed
+project IDs and reruns would otherwise pass on stale data.
+
+## 8. Risks & mitigations
+
+- **Silent upload failure (accepted, the honest caveat).** If CI loses the
+  key, maps stop and stacks stay minified; the build-log warning is the only
+  signal, and green builds go unread. There is no health surface in v1.
+  This is the slice's real unsolved problem. First signal:
+  `resolution_status='map_not_found'` on an investigated event, which is
+  also the data a future health page needs.
+- **Leaked sk.** Bounded to uploads at ≤60/min; response is the printed
+  exact-key revocation SQL plus a fresh mint. The sk sits in plaintext in
+  the operator's `.env.local` (explicit DX decision; gitignored, cannot
+  reach the bundle).
+- **Per-file PUTs on big builds.** 248 maps ≈ 4-5 minutes of paced
+  uploading in CI. Accepted for v1; the shelved batch protocol is the known
+  fix if a design partner's build makes this hurt.
+- **Late maps don't heal old events.** No reprocessing; the next occurrence
+  resolves. Same position the S-series took.
+- **Deleted projects retain source in storage** until the documented manual
+  purge runs. The tombstone guarantees the prefix is never forgotten.
+
+## 9. Alternatives considered
+
+- **The frozen batch protocol (S2b/S2c).** Three-step create/upload/complete
+  with RFC 8785 manifest hashes, probe flags, expiry sweepers. Rejected for
+  v1: none of it exists, it defends against scale we don't have, and the
+  single PUT keeps its two real properties (idempotency, atomic visibility
+  per map) at a fraction of the surface. It remains the upgrade path.
+- **Mint the sk in onboarding (original S1 follow-up).** Designed fully,
+  then split out by maintainer decision to keep this slice shippable. The
+  design notes (mint site fencing, rotation flag, sink guards) are recorded
+  in the plan's "Deferred: onboarding track" so the work restarts warm.
+- **Release-based map matching (the legacy schema).** Requires customers to
+  configure a release string that onboarding never sets; the S-series
+  already rejected it, and the dead `source_maps` table is the evidence.
+- **Fixed object keys + row-first conflict checks.** Two review rounds of
+  patching still left a concurrent-first-upload window where a loser could
+  overwrite the winner's object. Digest-addressed keys eliminate the class.
+- **gzip upload bodies.** The only client is our own plugin holding bytes in
+  Node; encoding added a decompression-bomb surface and a hash-canonicality
+  question for zero benefit. Frozen §7.2 agreed already.
+- **`magicast`/model-driven Vite config editing, CDN-hosted maps, Sentry
+  compatibility layers** are out of scope here; the S6a codemod work that
+  ships config editing is merged and untouched by this slice.
+
+## Review trail
+
+Four adversarial review rounds ran against these documents (2 on the plan, 2
+on the implementation plan) using Codex (gpt-5.6-sol) with repo access, plus
+an earlier Claude-based pass. 40+ findings were applied; the significant
+ones are called out inline above. Transcripts: session scratchpad,
+`codex-plan-review-{1,2}.txt`, `codex-impl-review-{1,2}.txt`.

--- a/docs/guides/source-maps.md
+++ b/docs/guides/source-maps.md
@@ -1,278 +1,170 @@
 ---
 covers:
-  - cli/src/sourcemaps.ts
-  - cli/src/codemods/vite-*.ts
+  - packages/ingestion/cmd/mint-key/**
+  - packages/ingestion/handler/sourcemap_upload.go
   - packages/sdk/vite-plugin/**
-  - packages/worker/src/source-map.ts
+  - packages/worker/src/resolve-stack.ts
 ---
 # Source maps
 
-> Source-map upload is unavailable in this release. Remove `opslaneSourceMapPlugin()` from your Vite configuration until batch upload ships in [#218](https://github.com/opslane/opslane-oss/issues/218); leaving it enabled now fails the build deliberately.
+Opslane's Vite plugin stamps each production chunk with a deterministic debug
+ID, uploads the matching source map with a secret project key, and removes the
+map from the build output by default. Browser events carry the chunk URL and
+debug ID; the worker uses that exact pair to resolve original source positions.
+The SDK's `release` option is still useful deployment metadata, but it is not
+part of source-map matching.
 
-Without source maps, production stack traces point at minified bundles and investigations can end in `sourcemap_unresolved` or `unfixable_no_sourcemap`. Batch upload is tracked in [#218](https://github.com/opslane/opslane-oss/issues/218).
-Without source maps, production stack traces point at minified bundles and
-investigations end in `sourcemap_unresolved` or `unfixable_no_sourcemap`. With
-them, the worker sees your original source.
+## Configure a Vite build
 
-## What works today
-
-| Capability | Published `@opslane/sdk@2.0.1` | This repository |
-| --- | --- | --- |
-| Upload maps by release | `opslaneSourceMapPlugin` | Supported |
-| Stamp chunks and maps with deterministic debug IDs | Not published | Implemented by the next `opslaneVitePlugin` export |
-| Send matching debug images with browser events | Not published | Implemented |
-| Resolve stored maps by debug ID | Not yet | Follow-up upload/symbolication slice |
-
-Keep using `opslaneSourceMapPlugin` in installable setup instructions until a
-package containing the new export is published. Do not copy an
-`opslaneVitePlugin` import into an application pinned to 2.0.1.
-
-## Adding the plugin
-
-`opslane sourcemaps install-plugin` makes the edit below for you. It previews
-the exact two lines, states that verifying the result executes your Vite config,
-keeps the original bytes and permissions so any failure restores the file, and
-then asks your own Vite to confirm the plugin reached the resolved build.
-
-```bash
-opslane sourcemaps install-plugin          # preview, then confirm
-opslane sourcemaps install-plugin --check  # verify a manual edit, never writes
-```
-
-Without a terminal it prints the proposal as JSON and writes nothing, so an
-agent or CI job must show that disclosure to a human before re-running with
-`--yes`. Use `--app-dir` and `--config` for a monorepo or a nonstandard
-filename. Configs it cannot edit safely are refused with the two lines to paste
-instead; nothing is written in that case either.
-
-It edits the top-level `plugins` list only. If your build has web workers, add
-the `worker.plugins` entry yourself as described in [web workers](#web-workers),
-or worker chunks ship unstamped.
-
-## Current Vite setup
-
-Do not add `opslaneSourceMapPlugin()` to Vite yet. In this release the plugin fails
-production builds immediately with a clear error, because the old single-map upload route
-has been removed and the replacement batch API is not available. It does not collect,
-delete, or upload map assets.
 ```ts
 // vite.config.ts
 import { opslane } from '@opslane/sdk/vite-plugin';
 
 export default {
   plugins: [opslane()],
-  // A web worker is a separate build pass and needs the plugin too, or its
-  // chunks ship unstamped.
+  // Workers are separate Vite build passes and need their own plugin instance.
   worker: { plugins: () => [opslane()] },
 };
 ```
 
-`opslaneSourceMapPlugin()` is gone from that list on purpose. The single-map
-route it posted to has been removed, and the batch replacement is not shipped
-yet ([#218](https://github.com/opslane/opslane-oss/issues/218)), so the plugin
-now fails the build rather than deleting your maps and uploading nothing.
-`release` no longer participates in matching at all: the debug ID replaces it.
+Set these server-side build variables in CI:
 
-## Debug-ID stamping behavior
+```bash
+OPSLANE_ENDPOINT=https://your-opslane-instance.example.com
+OPSLANE_SOURCEMAP_KEY=opslane_sk_...
+```
 
-The plugin computes a deterministic ID from each source map, writes
-the same ID to the map's root `debugId` field and the chunk's
-`//# debugId=<id>` footer, and registers the exact runtime chunk URL. The SDK
-matches stack-frame URLs against that registry and sends only exact matches in
-`debug_meta.images`.
+The plugin reads `process.env` first, then Vite's `OPSLANE_` variables from the
+project's env files. A gitignored `.env.local` therefore works for local
+production builds:
 
-You may continue sending an immutable `release` value with SDK events. Once batch upload
-ships, the value used for uploaded maps must be byte-identical to the value passed to
-`init({ release })`; a git SHA is a reliable choice.
-By default it requests hidden source maps and removes map assets after stamping.
-It respects an explicit Vite `build.sourcemap` setting:
+```dotenv
+OPSLANE_ENDPOINT=http://localhost:8082
+OPSLANE_SOURCEMAP_KEY=opslane_sk_...
+```
 
-<a id="sourcemap-mode"></a>
+Do not prefix either variable with `VITE_`, `NEXT_PUBLIC_`, or another browser
+environment prefix. The source-map key is a secret and must never enter the
+JavaScript bundle or a tracked file. Browser initialization continues to use a
+public `VITE_OPSLANE_API_KEY=opslane_pk_...` ingest key.
 
-| Vite setting | Result |
+Uploads happen during `closeBundle`. Each final map is sent with
+`PUT /api/v1/sourcemaps/{debugID}`; HTTP 200 and 201 are success. Rate-limited
+uploads honor `Retry-After`, network errors get one retry, and upload failures
+are reported without failing the production build.
+
+## Mint and revoke an upload key
+
+Self-hosted operators mint a key from the ingestion package:
+
+```bash
+cd packages/ingestion
+DATABASE_URL=postgres://... go run ./cmd/mint-key \
+  -project 00000000-0000-0000-0000-000000000000 \
+  -label "production source maps"
+```
+
+The command prints the raw `opslane_sk_` value once and prints its key ID. To
+revoke exactly that key, run the statement it prints:
+
+```sql
+UPDATE project_api_keys SET revoked_at = now() WHERE key_id = '<key-id>';
+```
+
+Minting another key does not revoke existing keys. Revocation is always an
+explicit, exact-key operation.
+
+## Map custody
+
+The default `sourcemaps: 'remove'` mode asks Vite for hidden maps, stamps them,
+uploads the final in-memory bytes, and removes the `.map` assets before deploy.
+An explicitly configured Vite source-map setting belongs to the project and is
+left in the output unless `sourcemaps: 'remove'` applies to maps the plugin
+requested itself.
+
+| Setting | Result |
 | --- | --- |
-| unset | Uses `hidden`; stamps chunks; **removes the maps it caused** |
-| `'hidden'` or `true` | Stamps; leaves your maps alone |
-| `false` | Leaves chunks unchanged and reports `OPSLANE_VITE_SOURCEMAP_DISABLED` |
-| `'inline'` | Leaves chunks unchanged and reports `OPSLANE_VITE_INLINE_MAP` |
+| Vite `build.sourcemap` unset | Generates hidden maps, stamps and uploads them, then removes them |
+| `build.sourcemap: 'hidden'` or `true` | Stamps and uploads disk-verified maps; keeps the project-owned files |
+| `build.sourcemap: false` | No map is available; emits `OPSLANE_VITE_SOURCEMAP_DISABLED` |
+| `build.sourcemap: 'inline'` | Leaves the chunk unchanged; emits `OPSLANE_VITE_INLINE_MAP` |
 
-The rule is that the plugin only cleans up after itself. With no
-`build.sourcemap` of your own, it switches maps on so there is something to
-fingerprint, then removes them again so a default install never publishes your
-source. Set `build.sourcemap` yourself and those maps are yours: the plugin
-stamps them and leaves them in the output.
+Set `opslane({ sourcemaps: 'keep' })` only when another trusted uploader needs
+the files. Retained maps can expose original source if the build directory is
+served publicly. Opslane re-reads and fingerprints every retained map at upload
+time so a later plugin cannot make the uploaded bytes disagree with the chunk.
 
-That matters if you also run a source-map uploader. Tools like
-`@sentry/vite-plugin` read the `.map` files off disk after the build writes
-them, so a plugin that deletes them first breaks the upload with a green build
-and no message. Because you had to set `build.sourcemap` to make that uploader
-work in the first place, the plugin sees an explicit setting and stays out of
-the way.
+When a project is deleted, ingestion writes a `sourcemap_tombstones` row before
+the project row disappears. Until the automatic sweeper ships, purge the
+recorded prefix manually and then remove the tombstone:
 
-Those maps then deploy with the rest of your output unless something removes
-them. That was already true before this plugin, and it stays your call: Sentry
-has `sourcemaps.filesToDeleteAfterUpload` for exactly this.
-
-<a id="web-workers"></a>
-
-### Web workers
-
-Vite builds a web worker as a separate pass with its own plugin list, then copies
-the result into the main bundle. A plugin listed only under `plugins` never runs
-for that pass, so worker chunks come out with no debug ID and errors thrown
-inside a worker cannot be symbolicated. Nothing else in the build fails, which is
-why it is easy to miss. Register the plugin in both places:
-
-```ts
-export default {
-  plugins: [opslane()],
-  worker: { plugins: () => [opslane()] },
-};
+```bash
+mc rm -r --force <bucket>/sourcemaps/<projectID>/
 ```
 
-`worker.plugins` must be a function. Vite calls it once per worker build; passing
-a shared array reuses one plugin instance across builds and its per-build
-counters go wrong.
+```sql
+DELETE FROM sourcemap_tombstones WHERE project_id = '<projectID>';
+```
 
-When the plugin finds JavaScript that no pass stamped, it reports
-`OPSLANE_VITE_ASSET_UNSTAMPED` and counts the file under `emitted without a
-debug ID` in the build summary. A worker is the usual cause, but any plugin
-that emits JavaScript alongside a map produces the same shape, so the message
-names what it can see and offers the likely reason. The map is still removed
-from the output under the default `sourcemaps: 'remove'`, so an unregistered
-worker costs you symbolication, not privacy.
+Only delete the tombstone after object removal succeeds.
 
-Removing a map from the bundle is not the same as it never reaching disk. A
-plugin ordered after this one can write it back. After the build writes, the
-plugin re-checks every map it removed and reports
-`OPSLANE_VITE_MAP_NOT_REMOVED` for any that landed anyway. It warns rather than
-deleting, because by that point the file belongs to whichever plugin restored
-it.
+## Diagnostics and limits
 
-### Supported Vite versions
+The server accepts at most 32 MiB of identity-encoded bytes per map. The plugin
+uses the same default `maxMapBytes`; raising it allows stamping but not upload
+of larger maps and emits `OPSLANE_VITE_MAP_OVER_SERVER_LIMIT`.
 
-The plugin declares `vite` as a peer on `^5 || ^6 || ^7 || ^8`, and each of those
-majors is exercised with a real `vite build` that stamps a chunk and checks the
-ID in the JavaScript against the one in its map. Vite 8 runs on Rolldown rather
-than Rollup; the plugin uses only hooks both engines implement.
+Important stable build codes include:
+
+- `OPSLANE_VITE_UPLOAD_NO_ENDPOINT`: a key is set without an endpoint.
+- `OPSLANE_VITE_UPLOAD_WRONG_KEY`: the value is not an `opslane_sk_` key.
+- `OPSLANE_VITE_UPLOAD_FAILED`: one or more maps were rejected or unavailable.
+- `OPSLANE_VITE_UPLOAD_STALE_MAP`: a retained map changed after verification.
+- `OPSLANE_VITE_MAP_VERIFY_FAILED`: disk bytes no longer match the stamped ID.
+- `OPSLANE_VITE_ASSET_UNSTAMPED`: a separate build pass, commonly a worker,
+  emitted JavaScript without running the plugin.
+- `OPSLANE_VITE_MAP_NOT_REMOVED`: another plugin restored a private map after
+  Opslane removed it from the bundle.
 
 The build options are `commitSha`, `stamp` (default `true`), `logLevel`
-(`silent` or `warn`), `sourcemaps` (`remove` or `keep`), and
-`maxMapBytes` (default 32 MiB). Each diagnostic has a stable
-`OPSLANE_VITE_*` code, and every build prints a stamped/skipped summary unless
-logging is silent.
-
-Keep generating and retaining source maps according to your deployment policy, but do not
-send them to Opslane in this release. Do not put an `opslane_sk_` source-map key or any
-other secret in a `VITE_`, `NEXT_PUBLIC_`, or browser-bundled environment variable.
-Run `opslane doctor --dist <build-output>` after a production build. The Debug
-IDs check reports how many JavaScript chunks contain the footer. Without
-`--dist`, doctor uses Vite's resolved `build.outDir`, then falls back to
-`dist/`. A missing directory means “not built yet”; a non-empty output with no
-stamps is a failure.
-
-### Output formats
-
-ES modules and script-like Rollup outputs (`iife`, `umd`, `cjs`, and `system`)
-receive a safe registry prelude. Other formats are left unchanged with
-`OPSLANE_VITE_FORMAT_UNSUPPORTED`.
-
-### Map size limit
-
-There is no upload to verify until #218 ships. If `opslaneSourceMapPlugin()` remains in a
-Vite configuration, `vite build` must fail rather than silently deleting maps or reporting
-a successful upload.
-
-## Other bundlers
-
-No other bundler has a supported upload path in this release.
-Maps larger than `maxMapBytes` are left unchanged so a pathological asset cannot
-stall the build. Raise the limit only when the map is expected and the build
-machine has sufficient memory.
+(`silent` or `warn`), `sourcemaps` (`remove` or `keep`), and `maxMapBytes`
+(default 32 MiB).
 
 ### Plugin order
 
-The debug-ID plugin must see each chunk and its sibling `.map` asset. Place it
-before any plugin that removes or renames maps. A missing sibling produces
-`OPSLANE_VITE_MAP_MISSING`.
+The plugin fingerprints in a post-ordered `generateBundle` hook so Vite has
+finished rewriting chunks. Place it before plugins that remove or rename maps.
+If another uploader needs maps, configure Vite to retain them and let that
+uploader delete them after its own successful upload.
 
-The plugin fingerprints in a `generateBundle` hook declared `order: 'post'`.
-That is deliberate: Vite's own `vite:build-import-analysis` rewrites chunk code
-during `generateBundle` and re-serialises the sibling map from `chunk.map`,
-discarding anything an earlier hook wrote. Fingerprinting last is the only way
-the map that reaches disk is the map that was hashed. A plugin that removes maps
-should therefore also declare `order: 'post'` (the deprecated
-`opslaneSourceMapPlugin` does) so that "place Opslane first" still holds.
+### Web workers
 
-### Verification
-
-After the files are written, the plugin reads each shipped `.map` back off disk
-and recomputes its fingerprint. A map that no longer matches the ID stamped into
-its JavaScript would be rejected on upload, so it is reported at error level with
-the stable code `OPSLANE_VITE_MAP_VERIFY_FAILED`, listed by file name, and
-counted in the build summary. The build still exits `0`: a broken fingerprint is
-an Opslane defect to fix, not a reason to block a deploy. Maps that another
-plugin deliberately removed from the bundle are not verified.
+Vite builds workers separately. Register `opslane()` under both `plugins` and
+`worker.plugins`; `worker.plugins` must be a function returning a fresh plugin
+instance.
 
 ### Subresource integrity
 
-Stamping changes chunk bytes. Known SRI plugins that calculate integrity first
-would make browsers reject the result, so detection disables stamping and emits
-`OPSLANE_VITE_SRI_DETECTED`. Do not combine the plugins until integrity is
-calculated after the final stamped bytes; use `stamp: false` when integrity is
-required.
+Stamping changes chunk bytes. Known SRI plugins that calculate integrity too
+early disable stamping and emit `OPSLANE_VITE_SRI_DETECTED`. Calculate SRI only
+after the final stamped bytes, or use `stamp: false`.
 
-## Migration matrix
+## Verify resolution
 
-The repository's plugin tests cover all four configurations:
-
-| Configuration | Plugin order | Result |
-| --- | --- | --- |
-| Legacy only | `opslaneSourceMapPlugin()` | Existing release-keyed upload remains unchanged |
-| New only | forthcoming debug-ID plugin | Chunks/maps are stamped; maps are kept or removed by its option |
-| Both | debug-ID plugin, then legacy upload plugin | Stamped maps remain available to the legacy uploader; the new plugin retains them for coexistence |
-| Sentry | Opslane debug-ID plugin before `sentryVitePlugin()` | Sentry receives final Opslane-stamped maps; keep Opslane before Sentry and do not add an earlier SRI pass |
-
-The “both” configuration is the migration path after the new export ships:
-retain release uploads while debug-ID storage and symbolication roll out. Remove
-the legacy plugin only after that server-side path is available.
-
-## Build provenance
-
-The plugin embeds a commit SHA when it can prove one. Resolution is explicit
-`commitSha`, then `OPSLANE_COMMIT_SHA`, `GITHUB_SHA`,
-`VERCEL_GIT_COMMIT_SHA`, `CF_PAGES_COMMIT_SHA`, `CI_COMMIT_SHA`,
-`RENDER_GIT_COMMIT`, `BITBUCKET_COMMIT`, `GIT_COMMIT`,
-`BUILD_SOURCEVERSION`, and finally `.git/HEAD`. Only lowercase 40- or
-64-character hexadecimal values are accepted. The build log names the rung that
-won; no `git` executable is invoked.
-
-## Verify the current upload path
-
-Each accepted legacy upload returns HTTP `201` with its storage key:
-
-```json
-{"status": "uploaded", "object_key": "sourcemaps/<project>/<release>/index-abc123.js.map"}
-```
-
-Self-hosters can inspect `source_maps`:
+After a production build, `sourcemap_files` should contain project-scoped rows:
 
 ```sql
-SELECT release, filename FROM source_maps ORDER BY uploaded_at DESC LIMIT 5;
+SELECT debug_id, has_sources_content, size_bytes, created_at
+FROM sourcemap_files
+WHERE project_id = '<projectID>'
+ORDER BY created_at DESC;
 ```
 
-Then trigger an error from the built app. The absence of
-`sourcemap_unresolved` / `unfixable_no_sourcemap`, plus a root-cause write-up
-that names real source files, is the observable success signal.
+Trigger an error from the built app and inspect its event. `resolution_status`
+is `resolved`, `partial`, `no_debug_ids`, `map_not_found`, `invalid_map`, or
+`resolution_failed`; successful frames are stored in the versioned
+`stack_trace_resolved` envelope. Opslane exposes no source-map download API.
 
-## Other bundlers
-
-Only Vite has a first-party plugin today. Other builds can upload maps through
-the existing release endpoint:
-
-```bash
-curl -X POST "$OPSLANE_ENDPOINT/api/v1/sourcemaps" \
-  -H "X-API-Key: $OPSLANE_API_KEY" \
-  -F "release=$GIT_SHA" \
-  -F "file=@dist/assets/index-abc123.js.map"
-```
+Only Vite has a first-party upload integration today. Other bundlers may call
+the single-map PUT route if they reproduce the same canonical debug-ID
+algorithm and stamp the matching ID into runtime debug metadata.

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,13 +32,13 @@ NEXT_PUBLIC_OPSLANE_API_KEY=<your Opslane ingest key>
 NEXT_PUBLIC_OPSLANE_RELEASE=<your git SHA>
 ```
 
-`release` should match the source maps you upload for that deploy. In CI, use the commit SHA or another immutable build identifier.
+`release` is optional deployment metadata; source maps match events by debug ID.
 
-For Vite production builds, configure the currently published
-`opslaneSourceMapPlugin` and verify the output/upload as described in the
-[source-map guide](guides/source-maps.md). Debug-ID stamping is present in this
-repository but its new plugin export is not part of the published 2.0.1
-package, so keep the legacy setup until a package release announces it.
+For Vite production builds, add `opslane()` from
+`@opslane/sdk/vite-plugin`, set private `OPSLANE_ENDPOINT` and
+`OPSLANE_SOURCEMAP_KEY` build variables, and verify the upload as described in
+the [source-map guide](guides/source-maps.md). Never expose the secret key with
+a `VITE_` or other browser-public prefix.
 
 ## Manual Fallback
 

--- a/docs/plans/2026-08-03-v1-sourcemaps-simplification.md
+++ b/docs/plans/2026-08-03-v1-sourcemaps-simplification.md
@@ -1,0 +1,337 @@
+# V1 source maps: one stack trace resolves end to end
+
+Status: implemented (revision 5)
+Date: 2026-08-03
+Supersedes-for-v1: the unimplemented sections of `docs/design/2026-07-29-keys-sourcemaps-s0-contracts.md` (see "Contract amendment")
+
+## Problem
+
+The S1–S7 issue series (14 open issues) grew far beyond the actual v1 goal, which was:
+
+1. Separate the public (write-events) key from the secret (upload-source-maps) key.
+2. Get source maps uploaded.
+3. Make the fix agent read them.
+
+Goal 1 is merged (S1, #243). The stamping half of goal 2 is merged (S2a, #249),
+and the Vite-config codemod exists (S6a, #253). But **no source map has ever been
+uploaded and the fix agent has never resolved a frame**, because:
+
+- Nothing mints an `opslane_sk_` key (the scope exists; zero mint sites).
+- No upload route exists (`POST /api/v1/sourcemaps` was deleted in S1; the frozen
+  three-step batch API was never built).
+- The Vite plugin stamps debug IDs but uploads nothing.
+- The worker's resolver (`packages/worker/src/source-map.ts`) looks maps up by
+  `(project_id, release)` in a `source_maps` table that has no writer, so it
+  always resolves null. It never reads `error_events.debug_meta`.
+
+Three finished components with the wires between them cut.
+
+Maintainer decision (2026-08-03): this is **standalone new work**. The existing
+S-series issues will all be closed by the maintainer; nothing here tracks or
+amends them individually. Onboarding/CLI integration is a **separate later
+track** (see "Deferred: onboarding track").
+
+## Plan: one tracer-bullet slice
+
+Ship **"one stack trace resolves end to end."** Ugly path allowed. One fixture
+app, one map, one error. It touches SDK, ingestion, and worker, and it proves
+the idea works at all — which nothing currently does.
+
+It keeps four non-negotiables; everything else defers:
+
+- Uploads use a real sk-scoped secret key (S1's middleware makes this free).
+- The server recomputes the debug ID from the uploaded bytes — one bad upload
+  must not wedge a chunk's ID forever.
+- A leaked sk can be revoked (v1: one documented SQL statement).
+- No API can download a map; storage is project-isolated.
+
+Stages, in landing order so no intermediate state is dead:
+**(1)** migrations + upload route → **(2)** mint-key command →
+**(3)** plugin uploader + SDK 3.0.0 → **(4)** worker resolution →
+**(5)** build harness + E2E.
+
+### 1. Mint the sk manually (ingestion)
+
+No onboarding or CLI changes in this slice. A ~40-line
+`packages/ingestion/cmd/mint-key` command (`go run ./cmd/mint-key -project
+<uuid>`) reuses the existing, tested `db.CreateProjectKey(...,
+ScopeSourcemaps, ...)`, prints the raw `opslane_sk_` value exactly once
+together with its `key_id`, and prints the **exact-key** revocation statement
+alongside it (preserving frozen §3.2's one-exact-key rule — no blanket
+project-wide revoke):
+
+```sql
+UPDATE project_api_keys SET revoked_at = now() WHERE key_id = '<key_id printed above>';
+```
+
+That is the entire v1 key lifecycle. The operator (us, right now) pastes the
+key into CI as `OPSLANE_SOURCEMAP_KEY`, and/or into the repo's gitignored
+`.env.local` for local production builds (see §3 — the plugin reads both).
+The sk's blast radius on leak is uploads only: scope `sourcemaps` cannot read
+incidents or send events.
+
+The server-side leak floor from S1 stays: request logger records only
+method/path/status, `masking.go` redacts `opslane_sk_`, and the CLI's
+`envfile.ts` continues to refuse sk values (it writes browser-bundle env
+only; the operator edits `.env.local` by hand for this slice).
+
+### 2. One dumb upload route (ingestion)
+
+- `PUT /api/v1/sourcemaps/{debugID}` behind the existing
+  `ProjectKey(db.ScopeSourcemaps)` middleware — the first route to accept an
+  sk. Per-project rate limit via the existing `rateLimitByProject` helper at
+  **60/min** (a 248-map build finishes in ~4 minutes; deploys are rare). The
+  worst case is then 60 × 32 MiB ≈ 1.9 GiB/min per replica for a leaked key —
+  bounded, visible in disk metrics, and revocable with one SQL statement. The
+  limiter is process-local and the compose deployment is single-replica; the
+  frozen §7's cluster-wide byte budgets return with the batch protocol if it
+  is ever needed.
+- Body = identity-encoded source-map bytes. **No gzip in v1** (frozen §7.2
+  agreed; the only client is our own plugin, which holds the bytes in Node).
+  Any `Content-Encoding` header → 415. Wire cap via `http.MaxBytesReader` at
+  32 MiB.
+- **The server recomputes the debug ID** from the map bytes using
+  `packages/ingestion/debugid/` and rejects a mismatch with the URL param
+  (`409 debug_id_mismatch`). The `{debugID}` param is regex-validated before
+  any storage access, so it can never contribute path segments to an object
+  key. Recompute doubles as validation: non-source-map bytes are rejected.
+- **`content_sha256` is the canonical hash `debugid.Compute` already
+  returns** (RFC 8785 canonical bytes minus root `debugId`) — never a raw
+  wire-byte hash. Two serializations that canonicalize identically are the
+  same map; a same-ID/different-canonical-digest upload is
+  `409 debug_id_conflict` (frozen §6's code), reachable only by attack or
+  hash-collision, and it can never wedge honest retries.
+- **`sourcesContent` becomes optional.** This requires relaxing the `debugid`
+  validator (Go and TS mirror) and an explicit amendment to frozen §6's
+  validity rules — the hash algorithm and existing golden vectors are
+  unaffected, and a **new golden vector without `sourcesContent`** is added to the vector
+  GENERATOR (`test-fixtures/debug-id/build-vectors.mjs`) and the regenerated
+  `vectors.json`, so the Go and TS implementations cannot drift on the newly
+  accepted shape and regeneration cannot silently drop the case. Record `has_sources_content` on
+  the row; such maps resolve without snippets.
+- Storage: **digest-addressed object keys** make overwrite structurally
+  impossible (the frozen §8 insight, kept in miniature): the object key is
+  `sourcemaps/{projectID}/{debugID}/{content_sha256}`, and the row stores it.
+  Two concurrent first uploads with different canonical content (attack or
+  hash collision — the server recomputed the ID from the bytes) write two
+  DIFFERENT objects; whichever row insert wins, its `object_key` points at
+  its own bytes, and the loser's object is an unreferenced orphan (cleaned
+  with the prefix, never readable — resolution reads only row-referenced
+  keys). Sequence: (1) SELECT the row for `(project_id, debug_id)`: same
+  digest → heal (re-put only when `StatObject` fails) → 200 no-op; different
+  digest → `409 debug_id_conflict` without any object write. (2) Otherwise
+  put the digest-keyed object, then `INSERT ... ON CONFLICT DO NOTHING`; on
+  losing the race, re-read and compare digests — equal → 200, different →
+  409 (the loser's object stays orphaned and unreferenced). Existing bucket,
+  distinct `sourcemaps/` prefix (the retention sweeper only touches session
+  prefixes; state this co-tenancy in the PR).
+- **The worker verifies what it fetches:** before use, recompute the fetched
+  object's canonical digest and compare with the row's `content_sha256`; a
+  mismatch counts as `invalid_map`, so silent object corruption cannot feed
+  wrong source to the fix agent.
+- The dead `InsertSourceMap` Go code is deleted; the legacy release-keyed
+  `source_maps` table is dropped by a follow-up migration in the NEXT release
+  (expand/contract — dropping it alongside the worker change would break an
+  old worker against a migrated database). New migrations start at `030`
+  (append-only numbering; the `028` pair is already a collision).
+- **No read path.** No GET, no presigned URL, no dashboard/admin route returns
+  map bytes or `sourcesContent`. The route simply does not exist.
+- **Deletion floor:** no project DELETE endpoint exists, so the tombstone
+  cannot live in a handler. The `030` migration adds a `BEFORE DELETE ON
+  projects` trigger writing a tombstone row (project ID + storage prefix) so
+  even a manual SQL delete records which object prefixes hold orphaned
+  customer source. The object sweeper itself is deferred.
+
+### 3. Plugin uploads what it stamped (SDK)
+
+- The plugin resolves `OPSLANE_SOURCEMAP_KEY` and `OPSLANE_ENDPOINT` from
+  `process.env` first (CI), falling back to the project's Vite env files via
+  `loadEnv(config.mode, config.root, 'OPSLANE_')` — so a key pasted into the
+  gitignored `.env.local` makes local production builds upload with no shell
+  exports. Non-`VITE_`-prefixed vars never reach browser code, so this
+  cannot leak the sk into the bundle.
+- When both are present, upload each stamped map. Payload bytes are
+  **recorded at stamp time** (each stamp path stores the final map string in
+  an upload buffer keyed by map file name; the later restamp path overwrites
+  its entry) — the discard sweep removes bundle entries, not these recorded
+  copies, so remove mode always has bytes to upload. Uploads run in
+  `closeBundle`. Custody per mode: **remove mode (the default when the
+  plugin itself enabled source maps; a project's explicitly configured maps
+  are kept, matching existing behavior)** uploads the recorded in-memory
+  bytes; **keep mode** re-reads
+  the on-disk bytes at upload time and **recomputes each file's debug ID
+  immediately before upload**, skipping and warning on any mismatch — this
+  closes the window where another plugin's later `writeBundle` mutates files
+  after our verification pass.
+- **The uploader paces itself against the server limit:** on 429 it waits
+  the `Retry-After` (default 30 s, capped at 120 s) and retries the file; one
+  retry on network error; concurrency stays small (4). A 248-map build at
+  60/min therefore completes in ~4–5 minutes instead of losing everything
+  after the first 60 requests. The per-file cap is enforced on the FINAL
+  stamped bytes at upload time (the plugin's existing `maxMapBytes` check
+  runs pre-stamp, so it alone cannot guarantee the wire size): oversized
+  entries are skipped with a warning naming the file.
+- A key not matching `opslane_sk_` is refused with a warning. Upload failure
+  (after retries) logs a clear warning naming the files and never fails the
+  customer build; in keep mode the warning names which maps must not be
+  deployed.
+- Warn when the user-configured `maxMapBytes` exceeds the server's 32 MiB cap.
+- Version via the Changesets workflow: one new major changeset joins the two
+  already pending for `@opslane/sdk`, and the next release consumes them all
+  as a single 2.0.1 → 3.0.0 bump (majors don't stack). The S6a codemod's
+  `OPSLANE_VITE_PLUGIN_MIN_VERSION = '3.0.0'` gate un-inerts when that
+  release ships, not at merge.
+
+### 4. Worker resolves by debug ID (worker)
+
+- Extend the worker's event query to select `debug_meta`
+  (`getErrorEvent` in `packages/worker/src/db.ts` currently doesn't).
+- **Drop the `event?.release` gate** at both call sites in
+  `packages/worker/src/index.ts` — debug-ID lookup needs no release.
+- **Run resolution before the LLM-key check and the repo clone** in the
+  investigate path: resolution depends only on the database and object
+  storage, and relocating it means a keyless or clone-failing worker still
+  records the resolution outcome (and the E2E needs no `ANTHROPIC_API_KEY`
+  to assert it).
+- **Fix the column base:** browser stack columns are 1-based;
+  `@jridgewell/trace-mapping` expects 0-based columns. The current
+  `resolveFrame` passes them through unadjusted — an off-by-one on every
+  frame. The shared resolver subtracts 1 (floored at 0) and a test pins a
+  known position.
+- Extract the duplicated per-event resolution loop into **one shared resolver
+  module**; both the investigate and fix paths consume its output.
+- Join rule, stated so it cannot be improvised: a stack frame resolves against
+  the image whose `code_file` **exactly equals** the frame's file URL. No
+  basename fallback (the current dead code's heuristic is deleted with it).
+- Fetch `sourcemap_files` rows by `(project_id, debug_id)`, fetch objects
+  from the shared bucket prefix, resolve with the existing `resolveFrame`.
+- Store the frozen `resolution_status` enum value (`resolved | partial |
+  no_debug_ids | map_not_found | invalid_map | resolution_failed`) on the
+  event row (**new migration**), and **persist the resolved frames into the
+  existing `stack_trace_resolved` column in a pinned v1 envelope**:
+
+  ```json
+  {"version": 1, "frames": [{
+    "original_file": "src/App.vue", "original_line": 12, "original_column": 4,
+    "source_snippet": "…", "generated_file": "http://…/index-abc.js",
+    "generated_line": 1, "generated_column": 100,
+    "debug_id": "aaaaaaaa-…"
+  }]}
+  ```
+
+  (snake_case, generated position and debug ID included so the frame is
+  auditable without re-resolution; the resolver output is extended
+  accordingly). `invalid_map` is distinguished from `resolution_failed` by
+  an explicit map-parse probe, not inferred from a shared null. Frozen
+  §10's remaining fields (frame counters, `resolution_problem`, consistency
+  constraints) are explicitly superseded for v1 — see the amendment.
+  Written at investigation time for the investigated sample event; a seed
+  for later health surfaces, not a census.
+- The "Resolved Stack Trace (source-mapped)" prompt blocks in
+  `investigate.ts` / `agent-fix.ts` already exist and light up unchanged.
+
+### 5. Prove it (E2E)
+
+**New harness required.** The existing browser E2E boots fixtures with a Vite
+dev server, but the plugin is `apply: 'build'`. The slice includes a
+build-then-serve harness (`vite build` + `vite preview`) for
+`test-fixtures/vue-app`. Known prerequisites: config injection via the
+fixture's existing `VITE_*` env pattern at build time; make the fixture's
+hardcoded `release` env-controlled so the run can omit it; seed two projects
+with pks and sks in `scripts/seed-e2e.sql` for the isolation assertion.
+
+Acceptance, which is also the v1 definition of done:
+
+1. Build the fixture with the plugin and a seeded sk in env.
+2. Assert `sourcemap_files` has the expected rows (positive signal — "no maps
+   in build output" alone is vacuous in remove mode) **and** no `.map` files
+   or `sourceMappingURL` references are in the build output.
+3. Serve the built bundle, throw one error with the pk, no release configured.
+4. Assert the stored event resolves — database assertions, no LLM key needed
+   because resolution runs before the LLM-key check: `resolution_status =
+   'resolved'` and `stack_trace_resolved` contains the original file, line,
+   and snippet. (That the prompt renders stored frames is covered by the
+   existing "Resolved Stack Trace" formatting unit tests.)
+5. Negative floor: a pk cannot upload (`403 insufficient_scope`); an sk cannot
+   send events; no route returns map bytes. Isolation is proved by a
+   DISCRIMINATING check (identical content in both projects would prove
+   nothing): project B sends an event carrying the same `debug_meta` while B
+   has uploaded no map — B's event must record `map_not_found` while A's
+   resolves; after B uploads, B's next event resolves.
+
+## Contract amendment
+
+`docs/design/2026-07-29-keys-sourcemaps-s0-contracts.md` is marked frozen, but
+most of it was never implemented. Amend the doc explicitly (repo guardrail:
+change contracts explicitly, never silently):
+
+- **Stays frozen (shipped or shipping here):** event `debug_meta` wire shape,
+  debug-ID algorithm, canonical `content_sha256`, and golden vectors, key
+  formats, the sk-only authorization boundary, server-side debug-ID recompute
+  on upload with `debug_id_mismatch` / `debug_id_conflict`, the
+  `resolution_status` enum.
+- **Superseded for v1, each named:** §3's key CRUD endpoints → manual
+  `cmd/mint-key` + documented SQL revocation (key management returns with
+  the onboarding track); §5's "2.1.0" version note → 3.0.0; **§6 map-validity
+  rules → `sourcesContent` optional** (hash and vectors unaffected); §6's
+  100 MiB per-file limit → 32 MiB; §7 batch protocol → single-map identity-
+  encoded PUT (its "no Content-Encoding in v1" rule is kept and enforced with
+  415); §7's cluster-wide upload throttles → one
+  process-local 60/min per-project limiter (single-replica deployment; byte
+  budgets return with the batch protocol); §8 batch tables →
+  `sourcemap_files` with digest-addressed object keys
+  (`sourcemaps/{project}/{debugID}/{content_sha256}` — conflicting concurrent
+  uploads write different objects, so overwrite is structurally unreachable); §9 verify endpoint and §11 status endpoint →
+  dropped; **§10 resolution persistence → `resolution_status` +
+  `stack_trace_resolved` only** (frame counters, `resolution_problem`, and
+  the consistency CHECKs are dropped for v1); §12's deletion loop → tombstone
+  trigger plus a documented manual purge command (see risks); the "sk never
+  touches disk" onboarding posture → "sk never enters a tracked file or the
+  bundle" (operator-managed `.env.local` is acceptable).
+
+## Deferred: onboarding track (settled decisions, not in this slice)
+
+Decisions already made with the maintainer for when onboarding integration is
+built, recorded so they are not re-litigated:
+
+- `opslane onboard` mints the sk in `ProvisionOnboardSession` only (never in
+  the shared `provisionProjectTx` — `POST /api/v1/projects` must not mint).
+- Plain rerun is never destructive; an explicit `--rotate-sourcemap-key` flag
+  revokes prior sks in the mint transaction and tells the user to update CI.
+- The CLI writes the sk to the gitignored `.env.local` (non-`VITE_`-prefixed)
+  and prints the CI instruction; every other CLI sink (agent-credentials,
+  pending sessions, run log, sealed session key) is guarded against sk values.
+- The S6a codemod (`opslane sourcemaps install-plugin`) gets wired into the
+  onboarding flow with its consent screen.
+
+## Risks and accepted trade-offs
+
+- **Manual key handling.** Minting requires database access and the Go
+  toolchain; fine while the operators are the maintainers. The onboarding
+  track replaces it.
+- **Per-file uploads on big builds.** A 248-map build makes 248 PUTs. With a
+  generous per-project limit and idempotent retries this is acceptable now;
+  the shelved batch protocol is the known fix if it hurts.
+- **No upload-health visibility (accepted explicitly).** If CI loses the key,
+  maps silently stop; the build log warns but green builds go unread. The
+  first signal is `resolution_status = 'map_not_found'` on an investigated
+  event. S5b remains the successor.
+- **Late maps don't heal old events.** No reprocessing; the next occurrence
+  resolves.
+- **Deleting a project does not automatically purge its maps.** The trigger
+  records a tombstone; the operator runs the documented one-liner against
+  object storage (`mc rm -r --force <bucket>/sourcemaps/<projectID>/` or the
+  ingestion client's `RemovePrefix`) and deletes the tombstone. The automatic
+  sweeper stays deferred; the tombstone guarantees the prefix is never
+  forgotten.
+- **The sk sits in plaintext in the operator's `.env.local`** (explicit DX
+  decision). Exposure via backups or local tooling is accepted for v1; the
+  response to any suspicion is the printed exact-key revocation SQL plus a
+  fresh mint.
+
+## What v1 explicitly does not do
+
+Batch/atomic uploads, probe batches, gzip upload bodies, upload health UI,
+key-management UI/API, any onboarding or CLI changes, dashboard missing-map
+warnings, deployed-commit checkout, the project-deletion object sweeper
+(tombstone trigger only), verify/status endpoints, non-Vite build tools.

--- a/docs/reference/http-routes.md
+++ b/docs/reference/http-routes.md
@@ -44,6 +44,12 @@ The agent callback requires `code`, `installation_id`, and UUID `state`; definit
 | POST | `/api/v1/sessions/{sessionID}/chunks/{seq}` | yes | Store and commit one gzipped replay chunk (max 5MiB) |
 | POST | `/api/v1/ingest/ping` | no | Verify that a public ingest key still authenticates; returns 204 without project data |
 
+## Source-map upload (X-API-Key)
+
+| Method | Path | Auth | Purpose |
+| --- | --- | --- | --- |
+| PUT | `/api/v1/sourcemaps/{debugID}` | secret source-map key | Upload one immutable source map after server-side debug-ID verification |
+
 ## Session (dashboard/CLI)
 
 | Method | Path | Purpose |

--- a/docs/reference/sdk-options.md
+++ b/docs/reference/sdk-options.md
@@ -6,7 +6,7 @@ All options accepted by `init()` from `@opslane/sdk`, mirrored from `SdkInitOpti
 | --- | --- | --- | --- |
 | `apiKey` | `string` | *(required)* | Project-scoped public ingest key. It must start with `opslane_pk_`; `init` refuses to start without it. |
 | `endpoint` | `string` | `https://api.opslane.com` | Your Opslane instance; validated as an http(s) URL. |
-| `release` | `string` | `''` | Immutable build identifier (git SHA); must match uploaded source maps. |
+| `release` | `string` | `''` | Optional immutable deployment identifier; source maps match by debug ID. |
 | `environment` | `string` | `''` | Optional deployment name sent with events and session initialization. The server uses it only when payload overrides are enabled for the project; existing session environment assignment takes precedence. |
 | `maxBreadcrumbs` | `number` | `50` | Ring-buffer size for breadcrumbs attached to each event. |
 | `breadcrumbMaxAge` | `number` | `30000` | Milliseconds before a breadcrumb is considered stale and dropped. |
@@ -26,18 +26,17 @@ before `beforeSend`, so the hook can inspect, alter, or remove `debug_meta` and
 
 ## Vite build options
 
-The repository's forthcoming debug-ID plugin accepts:
+The Vite debug-ID and source-map upload plugin accepts:
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | **commitSha** | `string` | detected | Explicit build commit; must be lowercase 40- or 64-character hex. |
 | **stamp** | `boolean` | `true` | Enables source-map fingerprinting, chunk stamping, and runtime registration. |
-| **logLevel** | `'silent' \| 'warn' \| 'debug'` | `'warn'` | Controls stable diagnostics and the build summary. |
+| **logLevel** | `'silent' \| 'warn'` | `'warn'` | Controls stable diagnostics and the build summary. |
 | **sourcemaps** | `'remove' \| 'keep'` | `'remove'` | Keeps or removes stamped map assets from the output. |
 | **maxMapBytes** | `number` | `33554432` | Raw source-map size limit. Oversized maps and chunks are left unchanged. |
 
-The export is not present in published `@opslane/sdk@2.0.1`; keep using
-`opslaneSourceMapPlugin` until the package release containing it is available.
-See the [source-map migration matrix](../guides/source-maps.md#migration-matrix).
+Uploads require private build-time `OPSLANE_ENDPOINT` and
+`OPSLANE_SOURCEMAP_KEY` variables. See the [source-map guide](../guides/source-maps.md).
 
-Related exports: `captureException(err)`, `setUser({ id })`, `clearUser()`, `destroy()`, `opslaneVuePlugin`, and (from `@opslane/sdk/react`) `OpslaneErrorBoundary` / `captureReactError`. The `@opslane/sdk/vite-plugin` export is temporarily fail-loud while batch source-map upload is unavailable — see the [SDK README](../../packages/sdk/README.md).
+Related exports: `captureException(err)`, `setUser({ id })`, `clearUser()`, `destroy()`, `opslaneVuePlugin`, and (from `@opslane/sdk/react`) `OpslaneErrorBoundary` / `captureReactError`. The `@opslane/sdk/vite-plugin` export stamps and uploads source maps during production builds — see the [SDK README](../../packages/sdk/README.md).

--- a/packages/ingestion/cmd/mint-key/main.go
+++ b/packages/ingestion/cmd/mint-key/main.go
@@ -1,0 +1,51 @@
+// Command mint-key mints a sourcemaps-scoped project key and prints it once.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/opslane/opslane/packages/ingestion/db"
+)
+
+func main() {
+	projectID := flag.String("project", "", "project UUID")
+	label := flag.String("label", "ci source maps", "key label")
+	flag.Parse()
+	if *projectID == "" {
+		fmt.Fprintln(os.Stderr, "usage: mint-key -project <uuid> [-label <text>]")
+		os.Exit(2)
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		fmt.Fprintln(os.Stderr, "DATABASE_URL is required")
+		os.Exit(2)
+	}
+
+	ctx := context.Background()
+	pool, err := db.Connect(ctx)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "connect:", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+
+	minted, err := db.New(pool).CreateProjectKey(
+		ctx, *projectID, db.ScopeSourcemaps, *label, nil,
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mint:", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Source-map upload key (shown once — not retrievable later):")
+	fmt.Println("  " + minted.Raw)
+	fmt.Println()
+	fmt.Println("Set OPSLANE_SOURCEMAP_KEY to this value in CI, and/or in the")
+	fmt.Println("repo's gitignored .env.local for local production builds.")
+	fmt.Println()
+	fmt.Println("Key ID (for exact revocation): " + minted.KeyID)
+	fmt.Println("To revoke exactly this key:")
+	fmt.Printf("  UPDATE project_api_keys SET revoked_at = now() WHERE key_id = '%s';\n", minted.KeyID)
+}

--- a/packages/ingestion/db/migrations/030_sourcemap_files.sql
+++ b/packages/ingestion/db/migrations/030_sourcemap_files.sql
@@ -1,0 +1,38 @@
+-- Debug-ID-keyed source maps (v1 single-map upload; supersedes the frozen
+-- batch tables per docs/plans/2026-08-03-v1-sourcemaps-simplification.md).
+CREATE TABLE IF NOT EXISTS sourcemap_files (
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  debug_id TEXT NOT NULL CHECK (
+    debug_id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+  ),
+  content_sha256 TEXT NOT NULL CHECK (content_sha256 ~ '^[0-9a-f]{64}$'),
+  has_sources_content BOOLEAN NOT NULL,
+  size_bytes BIGINT NOT NULL CHECK (size_bytes > 0),
+  object_key TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, debug_id)
+);
+
+-- No FK: a tombstone must survive the project row it describes. It records
+-- which object-storage prefixes hold orphaned customer source until the
+-- deferred sweeper runs. A trigger also covers manual SQL deletes.
+CREATE TABLE IF NOT EXISTS sourcemap_tombstones (
+  project_id UUID NOT NULL,
+  storage_prefix TEXT NOT NULL,
+  deleted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id)
+);
+
+CREATE OR REPLACE FUNCTION write_sourcemap_tombstone() RETURNS trigger AS $$
+BEGIN
+  INSERT INTO sourcemap_tombstones (project_id, storage_prefix)
+  VALUES (OLD.id, 'sourcemaps/' || OLD.id || '/')
+  ON CONFLICT (project_id) DO NOTHING;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS projects_sourcemap_tombstone ON projects;
+CREATE TRIGGER projects_sourcemap_tombstone
+  BEFORE DELETE ON projects
+  FOR EACH ROW EXECUTE FUNCTION write_sourcemap_tombstone();

--- a/packages/ingestion/db/migrations/031_resolution_status.sql
+++ b/packages/ingestion/db/migrations/031_resolution_status.sql
@@ -1,0 +1,7 @@
+-- Source-map resolution outcome, written by the worker at investigation time.
+ALTER TABLE error_events ADD COLUMN IF NOT EXISTS resolution_status TEXT
+  CHECK (resolution_status IN
+    ('resolved','partial','no_debug_ids','map_not_found','invalid_map','resolution_failed'));
+
+-- The legacy release-keyed source_maps table remains for N-1 compatibility.
+-- A later expand/contract migration can drop it after old workers are gone.

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -1444,16 +1444,6 @@ func (q *Queries) CompleteReplay(ctx context.Context, replayID string, signals s
 	return tx.Commit(ctx)
 }
 
-// InsertSourceMap upserts a source map entry.
-func (q *Queries) InsertSourceMap(ctx context.Context, projectID, release, filename, objectKey string) error {
-	_, err := q.pool.Exec(ctx,
-		`INSERT INTO source_maps (project_id, release, filename, object_key)
-		 VALUES ($1, $2, $3, $4)
-		 ON CONFLICT (project_id, release, filename) DO UPDATE SET object_key = $4, uploaded_at = now()`,
-		projectID, release, filename, objectKey)
-	return err
-}
-
 // UpdateErrorGroupStatus updates the status of an error group.
 // If status is 'needs_human', reason fields are required.
 type StatusUpdate struct {

--- a/packages/ingestion/db/sourcemaps.go
+++ b/packages/ingestion/db/sourcemaps.go
@@ -1,0 +1,63 @@
+package db
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// SourceMapFile is one immutable, debug-ID-addressed source-map row.
+type SourceMapFile struct {
+	ProjectID         string
+	DebugID           string
+	ContentSHA256     string
+	HasSourcesContent bool
+	SizeBytes         int64
+	ObjectKey         string
+}
+
+// UpsertSourceMapFile inserts f, or returns the existing row for the same
+// project and debug ID. inserted=false distinguishes an idempotent retry or a
+// lost race so the caller can compare the immutable content digest.
+func (q *Queries) UpsertSourceMapFile(ctx context.Context, f SourceMapFile) (SourceMapFile, bool, error) {
+	tag, err := q.pool.Exec(ctx, `
+		INSERT INTO sourcemap_files
+		  (project_id, debug_id, content_sha256, has_sources_content, size_bytes, object_key)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (project_id, debug_id) DO NOTHING`,
+		f.ProjectID, f.DebugID, f.ContentSHA256, f.HasSourcesContent, f.SizeBytes, f.ObjectKey,
+	)
+	if err != nil {
+		return SourceMapFile{}, false, err
+	}
+	if tag.RowsAffected() == 1 {
+		return f, true, nil
+	}
+	stored, found, err := q.GetSourceMapFile(ctx, f.ProjectID, f.DebugID)
+	if err != nil {
+		return SourceMapFile{}, false, err
+	}
+	if !found {
+		return SourceMapFile{}, false, pgx.ErrNoRows
+	}
+	return stored, false, nil
+}
+
+// GetSourceMapFile reads one project-scoped row. found is false when absent.
+func (q *Queries) GetSourceMapFile(ctx context.Context, projectID, debugID string) (SourceMapFile, bool, error) {
+	var stored SourceMapFile
+	err := q.pool.QueryRow(ctx, `
+		SELECT project_id, debug_id, content_sha256, has_sources_content, size_bytes, object_key
+		FROM sourcemap_files WHERE project_id = $1 AND debug_id = $2`,
+		projectID, debugID,
+	).Scan(&stored.ProjectID, &stored.DebugID, &stored.ContentSHA256,
+		&stored.HasSourcesContent, &stored.SizeBytes, &stored.ObjectKey)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return SourceMapFile{}, false, nil
+	}
+	if err != nil {
+		return SourceMapFile{}, false, err
+	}
+	return stored, true, nil
+}

--- a/packages/ingestion/db/sourcemaps_test.go
+++ b/packages/ingestion/db/sourcemaps_test.go
@@ -1,0 +1,53 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opslane/opslane/packages/ingestion/db"
+)
+
+func TestUpsertSourceMapFileIdempotentAndProjectScoped(t *testing.T) {
+	pool := testPool(t)
+	q := db.New(pool)
+	ctx := context.Background()
+	org, err := q.CreateOrg(ctx, "source-map-files")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cleanupTenant(t, pool, org.ID) })
+	first, err := q.ProvisionProject(ctx, org.ID, "source-map-a", nil, "source-map-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := q.ProvisionProject(ctx, org.ID, "source-map-b", nil, "source-map-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f := db.SourceMapFile{
+		ProjectID:         first.Project.ID,
+		DebugID:           "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		ContentSHA256:     "1111111111111111111111111111111111111111111111111111111111111111",
+		HasSourcesContent: true,
+		SizeBytes:         10,
+		ObjectKey:         "sourcemaps/a/map",
+	}
+	if _, inserted, err := q.UpsertSourceMapFile(ctx, f); err != nil || !inserted {
+		t.Fatalf("first insert: inserted=%v err=%v", inserted, err)
+	}
+	stored, inserted, err := q.UpsertSourceMapFile(ctx, f)
+	if err != nil || inserted {
+		t.Fatalf("second insert: inserted=%v err=%v", inserted, err)
+	}
+	if stored.ContentSHA256 != f.ContentSHA256 {
+		t.Fatalf("stored digest = %q, want %q", stored.ContentSHA256, f.ContentSHA256)
+	}
+
+	other := f
+	other.ProjectID = second.Project.ID
+	other.ObjectKey = "sourcemaps/b/map"
+	if _, inserted, err := q.UpsertSourceMapFile(ctx, other); err != nil || !inserted {
+		t.Fatalf("second project insert: inserted=%v err=%v", inserted, err)
+	}
+}

--- a/packages/ingestion/debugid/debugid.go
+++ b/packages/ingestion/debugid/debugid.go
@@ -26,8 +26,9 @@ func (e *Error) Error() string {
 
 // Result contains the 128-bit debug ID and the full content digest.
 type Result struct {
-	DebugID       string
-	ContentSHA256 string
+	DebugID           string
+	ContentSHA256     string
+	HasSourcesContent bool
 }
 
 // Compute validates and canonicalizes a source map before hashing it.
@@ -49,6 +50,7 @@ func Compute(input []byte) (Result, error) {
 	if err := validateSourceMap(root); err != nil {
 		return Result{}, err
 	}
+	_, hasSourcesContent := root["sourcesContent"]
 
 	delete(root, "debugId")
 	reduced, err := json.Marshal(root)
@@ -64,7 +66,8 @@ func Compute(input []byte) (Result, error) {
 	contentSHA256 := hex.EncodeToString(digest[:])
 	id := contentSHA256[:32]
 	return Result{
-		ContentSHA256: contentSHA256,
+		ContentSHA256:     contentSHA256,
+		HasSourcesContent: hasSourcesContent,
 		DebugID: fmt.Sprintf(
 			"%s-%s-%s-%s-%s",
 			id[:8],
@@ -100,12 +103,14 @@ func validateSourceMap(root map[string]json.RawMessage) error {
 	if raw, ok := root["mappings"]; !ok || json.Unmarshal(raw, &mappings) != nil {
 		return reject("bad_field_type")
 	}
-	sourcesContent, err := stringArray(root["sourcesContent"])
-	if err != nil {
-		return reject("bad_field_type")
-	}
-	if len(sources) != len(sourcesContent) {
-		return reject("sources_content_mismatch")
+	if raw, ok := root["sourcesContent"]; ok {
+		sourcesContent, err := stringArray(raw)
+		if err != nil {
+			return reject("bad_field_type")
+		}
+		if len(sources) != len(sourcesContent) {
+			return reject("sources_content_mismatch")
+		}
 	}
 	return nil
 }

--- a/packages/ingestion/debugid/debugid_test.go
+++ b/packages/ingestion/debugid/debugid_test.go
@@ -67,3 +67,32 @@ func TestCompute(t *testing.T) {
 		})
 	}
 }
+
+func TestComputeWithoutSourcesContent(t *testing.T) {
+	input := []byte(`{"version":3,"sources":["a.ts"],"names":[],"mappings":"AAAA"}`)
+	result, err := Compute(input)
+	if err != nil {
+		t.Fatalf("expected acceptance without sourcesContent, got %v", err)
+	}
+	if result.HasSourcesContent {
+		t.Fatal("HasSourcesContent must be false when the field is absent")
+	}
+}
+
+func TestComputeSourcesContentPresent(t *testing.T) {
+	input := []byte(`{"version":3,"sources":["a.ts"],"sourcesContent":["x"],"names":[],"mappings":"AAAA"}`)
+	result, err := Compute(input)
+	if err != nil {
+		t.Fatalf("expected acceptance, got %v", err)
+	}
+	if !result.HasSourcesContent {
+		t.Fatal("HasSourcesContent must be true when the field is present")
+	}
+}
+
+func TestComputeSourcesContentLengthMismatchStillRejected(t *testing.T) {
+	input := []byte(`{"version":3,"sources":["a.ts","b.ts"],"sourcesContent":["x"],"names":[],"mappings":"AAAA"}`)
+	if _, err := Compute(input); err == nil {
+		t.Fatal("expected sources_content_mismatch rejection")
+	}
+}

--- a/packages/ingestion/handler/auth.go
+++ b/packages/ingestion/handler/auth.go
@@ -85,8 +85,11 @@ type Dependencies struct {
 	resetSessionStore passwordResetSessionStore
 	Health            *HealthChecker
 	MinIO             *minioPkg.Client
-	JWTSecret         []byte
-	PendingCipher     *auth.PendingCipher
+	// SourcemapStore is a narrow upload-handler test seam. Production falls
+	// back to MinIO when it is nil.
+	SourcemapStore objectStore
+	JWTSecret      []byte
+	PendingCipher  *auth.PendingCipher
 	// AuthProvider is selected explicitly at boot. Nil retains the OSS GitHub
 	// default for narrow tests that construct Dependencies directly.
 	AuthProvider auth.AuthProvider

--- a/packages/ingestion/handler/export_test.go
+++ b/packages/ingestion/handler/export_test.go
@@ -9,6 +9,10 @@ func RateLimitByProjectForTest(maxPerMinute int) func(http.Handler) http.Handler
 	return rateLimitByProject(newRateLimiter(maxPerMinute))
 }
 
+func SourcemapRateLimitForTest(maxPerMinute int) func(http.Handler) http.Handler {
+	return sourcemapRateLimit(newRateLimiter(maxPerMinute))
+}
+
 func WithProjectIDForTest(ctx context.Context, projectID string) context.Context {
 	return context.WithValue(ctx, ctxProjectID, projectID)
 }

--- a/packages/ingestion/handler/route_matrix_test.go
+++ b/packages/ingestion/handler/route_matrix_test.go
@@ -29,11 +29,12 @@ const (
 )
 
 type matrixRoute struct {
-	method  string
-	pattern string
-	path    string
-	body    string
-	read    bool
+	method    string
+	pattern   string
+	path      string
+	body      string
+	read      bool
+	sourcemap bool
 }
 
 type matrixEnvironment struct {
@@ -130,18 +131,21 @@ func TestRouteMatrixDenyByDefault(t *testing.T) {
 
 	routes := []matrixRoute{
 		{http.MethodPost, "/api/v1/events", "/api/v1/events",
-			`{"timestamp":"2026-07-30T00:00:00Z","error":{"type":"Error","message":"matrix","stack":"at x (a.js:1:1)"}}`, false},
+			`{"timestamp":"2026-07-30T00:00:00Z","error":{"type":"Error","message":"matrix","stack":"at x (a.js:1:1)"}}`, false, false},
 		{http.MethodPost, "/api/v1/replays/init", "/api/v1/replays/init",
-			`{"session_id":"matrix-replay","trigger_type":"manual"}`, false},
-		{http.MethodPost, "/api/v1/replays/{replayID}/complete", "/api/v1/replays/00000000-0000-0000-0000-000000000000/complete", `{}`, false},
-		{http.MethodPost, "/api/v1/replays/{replayID}/fail", "/api/v1/replays/00000000-0000-0000-0000-000000000000/fail", `{}`, false},
+			`{"session_id":"matrix-replay","trigger_type":"manual"}`, false, false},
+		{http.MethodPost, "/api/v1/replays/{replayID}/complete", "/api/v1/replays/00000000-0000-0000-0000-000000000000/complete", `{}`, false, false},
+		{http.MethodPost, "/api/v1/replays/{replayID}/fail", "/api/v1/replays/00000000-0000-0000-0000-000000000000/fail", `{}`, false, false},
 		{http.MethodPost, "/api/v1/sessions/init", "/api/v1/sessions/init",
-			`{"session_id":"matrix-session"}`, false},
-		{http.MethodPost, "/api/v1/sessions/{sessionID}/chunks/{seq}", "/api/v1/sessions/matrix-session/chunks/0", `{}`, false},
-		{http.MethodPost, "/api/v1/ingest/ping", "/api/v1/ingest/ping", ``, false},
-		{http.MethodGet, "/api/v1/projects/{projectID}/event-count", "/api/v1/projects/" + env.projectID + "/event-count", ``, true},
-		{http.MethodGet, "/api/v1/projects/{projectID}/incidents", "/api/v1/projects/" + env.projectID + "/incidents", ``, true},
-		{http.MethodGet, "/api/v1/projects/{projectID}/incidents/{incidentID}", "/api/v1/projects/" + env.projectID + "/incidents/00000000-0000-0000-0000-000000000000", ``, true},
+			`{"session_id":"matrix-session"}`, false, false},
+		{http.MethodPost, "/api/v1/sessions/{sessionID}/chunks/{seq}", "/api/v1/sessions/matrix-session/chunks/0", `{}`, false, false},
+		{http.MethodPost, "/api/v1/ingest/ping", "/api/v1/ingest/ping", ``, false, false},
+		{method: http.MethodPut, pattern: "/api/v1/sourcemaps/{debugID}",
+			path: "/api/v1/sourcemaps/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			body: `{}`, sourcemap: true},
+		{http.MethodGet, "/api/v1/projects/{projectID}/event-count", "/api/v1/projects/" + env.projectID + "/event-count", ``, true, false},
+		{http.MethodGet, "/api/v1/projects/{projectID}/incidents", "/api/v1/projects/" + env.projectID + "/incidents", ``, true, false},
+		{http.MethodGet, "/api/v1/projects/{projectID}/incidents/{incidentID}", "/api/v1/projects/" + env.projectID + "/incidents/00000000-0000-0000-0000-000000000000", ``, true, false},
 	}
 
 	credentials := []matrixCredential{
@@ -168,6 +172,25 @@ func TestRouteMatrixDenyByDefault(t *testing.T) {
 					if credential != matrixNone && credential != matrixSession &&
 						code != "invalid_api_key" {
 						t.Fatalf("read rejection code=%q, want invalid_api_key", code)
+					}
+					return
+				}
+
+				if route.sourcemap {
+					if credential == matrixSK {
+						if status == http.StatusUnauthorized || status == http.StatusForbidden {
+							t.Fatalf("valid source-map key failed authentication: status=%d code=%q", status, code)
+						}
+						return
+					}
+					if credential == matrixPK || credential == matrixOtherPK {
+						if status != http.StatusForbidden || code != "insufficient_scope" {
+							t.Fatalf("ingest key status/code=%d/%q, want 403/insufficient_scope", status, code)
+						}
+						return
+					}
+					if status != http.StatusUnauthorized || code != "invalid_api_key" {
+						t.Fatalf("%s status/code=%d/%q, want 401/invalid_api_key", credential, status, code)
 					}
 					return
 				}
@@ -223,6 +246,7 @@ func TestRouteMatrixCoversEveryProjectKeyRoute(t *testing.T) {
 		"POST /api/v1/sessions/init":                     true,
 		"POST /api/v1/sessions/{sessionID}/chunks/{seq}": true,
 		"POST /api/v1/ingest/ping":                       true,
+		"PUT /api/v1/sourcemaps/{debugID}":               true,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("project-key routes = %#v, want %#v", got, want)

--- a/packages/ingestion/handler/routes.go
+++ b/packages/ingestion/handler/routes.go
@@ -93,6 +93,10 @@ func NewRouterWithPool(deps *Dependencies, pool *pgxpool.Pool) *chi.Mux {
 		r.With(ingestKey, rateLimitByProject(eventsLimiter)).Post("/ingest/ping",
 			func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
 
+		// Source-map uploads use the secret, sourcemaps-scoped project key.
+		sourcemapKey := deps.ProjectKey(db.ScopeSourcemaps)
+		r.With(sourcemapKey, sourcemapRateLimit(sourcemapsLimiter)).Put("/sourcemaps/{debugID}", deps.UploadSourceMap)
+
 		// Session-authenticated endpoints (dashboard + CLI)
 		r.With(deps.AuthenticateUserSession).Get("/auth/me", deps.AuthMe)
 		r.With(deps.AuthenticateUserSession).Get("/auth/verify", deps.AuthVerify)

--- a/packages/ingestion/handler/sourcemap_upload.go
+++ b/packages/ingestion/handler/sourcemap_upload.go
@@ -1,0 +1,167 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/opslane/opslane/packages/ingestion/db"
+	"github.com/opslane/opslane/packages/ingestion/debugid"
+	minioPkg "github.com/opslane/opslane/packages/ingestion/minio"
+)
+
+const maxSourceMapBytes = 32 << 20
+
+var (
+	sourcemapsLimiter = newRateLimiter(60)
+	debugIDPattern    = regexp.MustCompile(
+		`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+)
+
+type objectStore interface {
+	PutObject(ctx context.Context, objectKey string, data []byte, contentType string) error
+	StatObject(ctx context.Context, objectKey string) (int64, error)
+}
+
+func (d *Dependencies) sourcemapStore() objectStore {
+	if d.SourcemapStore != nil {
+		return d.SourcemapStore
+	}
+	if d.MinIO != nil {
+		return d.MinIO
+	}
+	return nil
+}
+
+// sourcemapRateLimit uses the source-map upload contract's stable response
+// code and tells clients when to retry.
+func sourcemapRateLimit(limiter *rateLimiter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			projectID := ProjectIDFromCtx(r.Context())
+			if projectID == "" {
+				writeJSONErrorCode(w, http.StatusUnauthorized, "missing project context", "invalid_api_key")
+				return
+			}
+			if !limiter.allow(projectID) {
+				w.Header().Set("Retry-After", "60")
+				writeJSONErrorCode(w, http.StatusTooManyRequests, "too many uploads", "rate_limited")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// UploadSourceMap stores one immutable source map keyed by project and debug ID.
+func (d *Dependencies) UploadSourceMap(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Content-Encoding") != "" {
+		writeJSONErrorCode(w, http.StatusUnsupportedMediaType,
+			"Content-Encoding is not supported; send identity-encoded bytes", "unsupported_media_type")
+		return
+	}
+
+	urlID := chi.URLParam(r, "debugID")
+	if !debugIDPattern.MatchString(urlID) {
+		writeJSONErrorCode(w, http.StatusBadRequest,
+			"debug ID is not in canonical form", "invalid_debug_id")
+		return
+	}
+	store := d.sourcemapStore()
+	if store == nil {
+		writeJSONErrorCode(w, http.StatusServiceUnavailable,
+			"object storage unavailable", "storage_unavailable")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxSourceMapBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeJSONErrorCode(w, http.StatusRequestEntityTooLarge,
+				"source map exceeds the 32 MiB limit", "payload_too_large")
+			return
+		}
+		writeJSONErrorCode(w, http.StatusBadRequest,
+			"could not read request body", "invalid_request")
+		return
+	}
+
+	computed, err := debugid.Compute(body)
+	if err != nil {
+		writeJSONErrorCode(w, http.StatusBadRequest,
+			"body is not a fingerprintable source map", "invalid_source_map")
+		return
+	}
+	if computed.DebugID != urlID {
+		writeJSONErrorCode(w, http.StatusConflict,
+			"map content does not produce the debug ID in the URL", "debug_id_mismatch")
+		return
+	}
+
+	projectID := ProjectIDFromCtx(r.Context())
+	objectKey := fmt.Sprintf("sourcemaps/%s/%s/%s", projectID, urlID, computed.ContentSHA256)
+	row := db.SourceMapFile{
+		ProjectID: projectID, DebugID: urlID,
+		ContentSHA256:     computed.ContentSHA256,
+		HasSourcesContent: computed.HasSourcesContent,
+		SizeBytes:         int64(len(body)), ObjectKey: objectKey,
+	}
+
+	existing, found, err := d.Queries.GetSourceMapFile(r.Context(), projectID, urlID)
+	if err != nil {
+		writeJSONErrorCode(w, http.StatusInternalServerError, "internal error", "internal_error")
+		return
+	}
+	if found {
+		if existing.ContentSHA256 != computed.ContentSHA256 {
+			writeJSONErrorCode(w, http.StatusConflict,
+				"a different map is already stored under this debug ID", "debug_id_conflict")
+			return
+		}
+		if _, statErr := store.StatObject(r.Context(), existing.ObjectKey); statErr != nil {
+			if !errors.Is(statErr, minioPkg.ErrObjectNotFound) {
+				writeJSONErrorCode(w, http.StatusServiceUnavailable,
+					"object storage unavailable", "storage_unavailable")
+				return
+			}
+			if putErr := store.PutObject(r.Context(), existing.ObjectKey, body, "application/json"); putErr != nil {
+				writeJSONErrorCode(w, http.StatusServiceUnavailable,
+					"object storage unavailable", "storage_unavailable")
+				return
+			}
+		}
+		writeJSONStatus(w, http.StatusOK, "exists")
+		return
+	}
+
+	if err := store.PutObject(r.Context(), objectKey, body, "application/json"); err != nil {
+		writeJSONErrorCode(w, http.StatusServiceUnavailable,
+			"object storage unavailable", "storage_unavailable")
+		return
+	}
+	stored, inserted, err := d.Queries.UpsertSourceMapFile(r.Context(), row)
+	if err != nil {
+		writeJSONErrorCode(w, http.StatusInternalServerError, "internal error", "internal_error")
+		return
+	}
+	if !inserted && stored.ContentSHA256 != computed.ContentSHA256 {
+		writeJSONErrorCode(w, http.StatusConflict,
+			"a different map is already stored under this debug ID", "debug_id_conflict")
+		return
+	}
+	if inserted {
+		writeJSONStatus(w, http.StatusCreated, "created")
+		return
+	}
+	writeJSONStatus(w, http.StatusOK, "exists")
+}
+
+func writeJSONStatus(w http.ResponseWriter, statusCode int, status string) {
+	writeJSON(w, statusCode, map[string]string{"status": status})
+}

--- a/packages/ingestion/handler/sourcemap_upload_test.go
+++ b/packages/ingestion/handler/sourcemap_upload_test.go
@@ -1,0 +1,255 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/opslane/opslane/packages/ingestion/db"
+	"github.com/opslane/opslane/packages/ingestion/debugid"
+	"github.com/opslane/opslane/packages/ingestion/handler"
+	minioPkg "github.com/opslane/opslane/packages/ingestion/minio"
+)
+
+type memorySourceMapStore struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+	statErr error
+	putErr  error
+}
+
+func newMemorySourceMapStore() *memorySourceMapStore {
+	return &memorySourceMapStore{objects: make(map[string][]byte)}
+}
+
+func (s *memorySourceMapStore) PutObject(_ context.Context, key string, data []byte, _ string) error {
+	if s.putErr != nil {
+		return s.putErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.objects[key] = append([]byte(nil), data...)
+	return nil
+}
+
+func (s *memorySourceMapStore) StatObject(_ context.Context, key string) (int64, error) {
+	if s.statErr != nil {
+		return 0, s.statErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, ok := s.objects[key]
+	if !ok {
+		return 0, minioPkg.ErrObjectNotFound
+	}
+	return int64(len(data)), nil
+}
+
+func setupSourceMapUpload(t *testing.T) (http.Handler, *db.Queries, string, string, string, *memorySourceMapStore) {
+	t.Helper()
+	_, q, pool := authTestRouter(t)
+	ctx := context.Background()
+	org, err := q.CreateOrg(ctx, "source-map-upload")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cleanupTenantHandler(t, pool, org.ID) })
+	project, err := q.ProvisionProject(ctx, org.ID, "source-map-upload", nil, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pk, err := q.CreateProjectKey(ctx, project.Project.ID, db.ScopeIngest, "pk", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk, err := q.CreateProjectKey(ctx, project.Project.ID, db.ScopeSourcemaps, "sk", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := newMemorySourceMapStore()
+	router := handler.NewRouter(&handler.Dependencies{Queries: q, SourcemapStore: store})
+	return router, q, project.Project.ID, pk.Raw, sk.Raw, store
+}
+
+func uploadRequest(router http.Handler, key, debugID, body string, headers map[string]string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/sourcemaps/"+debugID, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if key != "" {
+		req.Header.Set("X-API-Key", key)
+	}
+	for name, value := range headers {
+		req.Header.Set(name, value)
+	}
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func responseCode(t *testing.T, response *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return body.Code
+}
+
+func TestSourceMapUploadCreatesAndRetriesIdempotently(t *testing.T) {
+	router, q, projectID, _, sk, store := setupSourceMapUpload(t)
+	mapSource := `{"version":3,"sources":["src/a.ts"],"names":[],"mappings":"AAAA"}`
+	computed, err := debugid.Compute([]byte(mapSource))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created := uploadRequest(router, sk, computed.DebugID, mapSource, nil)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("first upload = %d %s, want 201", created.Code, created.Body.String())
+	}
+	stored, found, err := q.GetSourceMapFile(context.Background(), projectID, computed.DebugID)
+	if err != nil || !found {
+		t.Fatalf("stored row: found=%v err=%v", found, err)
+	}
+	if stored.HasSourcesContent {
+		t.Fatal("map without sourcesContent stored has_sources_content=true")
+	}
+	if _, ok := store.objects[stored.ObjectKey]; !ok {
+		t.Fatalf("object %q was not stored", stored.ObjectKey)
+	}
+
+	retry := uploadRequest(router, sk, computed.DebugID, mapSource, nil)
+	if retry.Code != http.StatusOK {
+		t.Fatalf("retry = %d %s, want 200", retry.Code, retry.Body.String())
+	}
+
+	delete(store.objects, stored.ObjectKey)
+	healed := uploadRequest(router, sk, computed.DebugID, mapSource, nil)
+	if healed.Code != http.StatusOK {
+		t.Fatalf("healing retry = %d %s, want 200", healed.Code, healed.Body.String())
+	}
+	if _, ok := store.objects[stored.ObjectKey]; !ok {
+		t.Fatal("retry did not restore the missing object")
+	}
+}
+
+func TestSourceMapUploadAuthAndValidation(t *testing.T) {
+	router, _, _, pk, sk, _ := setupSourceMapUpload(t)
+	mapSource := `{"version":3,"sources":[],"names":[],"mappings":"","sourcesContent":[]}`
+	computed, err := debugid.Compute([]byte(mapSource))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name, key, id, body string
+		headers             map[string]string
+		status              int
+		code                string
+	}{
+		{"public key denied", pk, computed.DebugID, mapSource, nil, 403, "insufficient_scope"},
+		{"missing key denied", "", computed.DebugID, mapSource, nil, 401, "invalid_api_key"},
+		{"invalid id", sk, "ZZZ", mapSource, nil, 400, "invalid_debug_id"},
+		{"invalid map", sk, computed.DebugID, "not json", nil, 400, "invalid_source_map"},
+		{"id mismatch", sk, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", mapSource, nil, 409, "debug_id_mismatch"},
+		{"content encoding", sk, computed.DebugID, mapSource, map[string]string{"Content-Encoding": "gzip"}, 415, "unsupported_media_type"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := uploadRequest(router, test.key, test.id, test.body, test.headers)
+			if response.Code != test.status || responseCode(t, response) != test.code {
+				t.Fatalf("response = %d/%q %s, want %d/%q",
+					response.Code, responseCode(t, response), response.Body.String(), test.status, test.code)
+			}
+		})
+	}
+}
+
+func TestSourceMapUploadWithoutStorageIsUnavailable(t *testing.T) {
+	_, q, _, _, sk, _ := setupSourceMapUpload(t)
+	router := handler.NewRouter(&handler.Dependencies{Queries: q})
+	response := uploadRequest(router, sk, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", `{}`, nil)
+	if response.Code != http.StatusServiceUnavailable || responseCode(t, response) != "storage_unavailable" {
+		t.Fatalf("response = %d %s", response.Code, response.Body.String())
+	}
+}
+
+func TestSourceMapUploadRejectsConflictingStoredDigest(t *testing.T) {
+	router, q, projectID, _, sk, _ := setupSourceMapUpload(t)
+	mapSource := `{"version":3,"sources":[],"names":[],"mappings":"","sourcesContent":[]}`
+	computed, err := debugid.Compute([]byte(mapSource))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, inserted, err := q.UpsertSourceMapFile(context.Background(), db.SourceMapFile{
+		ProjectID: projectID, DebugID: computed.DebugID,
+		ContentSHA256: strings.Repeat("0", 64), HasSourcesContent: true,
+		SizeBytes: 1, ObjectKey: "sourcemaps/conflicting",
+	})
+	if err != nil || !inserted {
+		t.Fatalf("seed conflict: inserted=%v err=%v", inserted, err)
+	}
+	response := uploadRequest(router, sk, computed.DebugID, mapSource, nil)
+	if response.Code != http.StatusConflict || responseCode(t, response) != "debug_id_conflict" {
+		t.Fatalf("response = %d %s", response.Code, response.Body.String())
+	}
+}
+
+func TestSourceMapUploadReturnsStorageFailureOnStatError(t *testing.T) {
+	router, _, _, _, sk, store := setupSourceMapUpload(t)
+	mapSource := `{"version":3,"sources":[],"names":[],"mappings":"","sourcesContent":[]}`
+	computed, err := debugid.Compute([]byte(mapSource))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response := uploadRequest(router, sk, computed.DebugID, mapSource, nil); response.Code != http.StatusCreated {
+		t.Fatalf("seed upload = %d %s", response.Code, response.Body.String())
+	}
+	store.statErr = errors.New("storage offline")
+	response := uploadRequest(router, sk, computed.DebugID, mapSource, nil)
+	if response.Code != http.StatusServiceUnavailable || responseCode(t, response) != "storage_unavailable" {
+		t.Fatalf("response = %d %s", response.Code, response.Body.String())
+	}
+}
+
+func TestSourceMapUploadRejectsOversizedWireBody(t *testing.T) {
+	router, _, _, _, sk, _ := setupSourceMapUpload(t)
+	response := uploadRequest(
+		router,
+		sk,
+		"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		strings.Repeat("x", (32<<20)+1),
+		nil,
+	)
+	if response.Code != http.StatusRequestEntityTooLarge || responseCode(t, response) != "payload_too_large" {
+		t.Fatalf("response = %d %s", response.Code, response.Body.String())
+	}
+}
+
+func TestSourceMapUploadRateLimitContract(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	h := handler.SourcemapRateLimitForTest(1)(next)
+	call := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/sourcemaps/id", nil)
+		req = req.WithContext(handler.WithProjectIDForTest(req.Context(), "project"))
+		response := httptest.NewRecorder()
+		h.ServeHTTP(response, req)
+		return response
+	}
+	if first := call(); first.Code != http.StatusNoContent {
+		t.Fatalf("first response = %d", first.Code)
+	}
+	second := call()
+	if second.Code != http.StatusTooManyRequests || responseCode(t, second) != "rate_limited" {
+		t.Fatalf("second response = %d %s", second.Code, second.Body.String())
+	}
+	if second.Header().Get("Retry-After") != "60" {
+		t.Fatalf("Retry-After = %q, want 60", second.Header().Get("Retry-After"))
+	}
+}

--- a/packages/ingestion/minio/client.go
+++ b/packages/ingestion/minio/client.go
@@ -3,6 +3,7 @@ package minio
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -11,6 +12,10 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
+
+// ErrObjectNotFound reports a StatObject/GetObject miss. Callers use
+// errors.Is so storage fakes can share the concrete client's semantics.
+var ErrObjectNotFound = errors.New("object not found")
 
 // Client wraps the MinIO SDK client with bucket and endpoint configuration.
 type Client struct {
@@ -99,9 +104,16 @@ func (c *Client) PutObject(ctx context.Context, objectKey string, data []byte, c
 func (c *Client) StatObject(ctx context.Context, objectKey string) (int64, error) {
 	info, err := c.mc.StatObject(ctx, c.bucket, objectKey, minio.StatObjectOptions{})
 	if err != nil {
-		return 0, err
+		return 0, mapStatObjectError(err, objectKey)
 	}
 	return info.Size, nil
+}
+
+func mapStatObjectError(err error, objectKey string) error {
+	if minio.ToErrorResponse(err).Code == "NoSuchKey" {
+		return fmt.Errorf("%w: %s", ErrObjectNotFound, objectKey)
+	}
+	return err
 }
 
 // GetObject downloads the object at objectKey and returns its bytes. Callers should

--- a/packages/ingestion/minio/client_internal_test.go
+++ b/packages/ingestion/minio/client_internal_test.go
@@ -1,0 +1,22 @@
+package minio
+
+import (
+	"errors"
+	"testing"
+
+	minioSDK "github.com/minio/minio-go/v7"
+)
+
+func TestMapStatObjectErrorNotFound(t *testing.T) {
+	err := mapStatObjectError(minioSDK.ErrorResponse{Code: "NoSuchKey"}, "missing.map")
+	if !errors.Is(err, ErrObjectNotFound) {
+		t.Fatalf("error = %v, want ErrObjectNotFound", err)
+	}
+}
+
+func TestMapStatObjectErrorPreservesOtherErrors(t *testing.T) {
+	original := errors.New("storage offline")
+	if got := mapStatObjectError(original, "map"); !errors.Is(got, original) {
+		t.Fatalf("error = %v, want original", got)
+	}
+}

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -29,7 +29,7 @@ must start with `opslane_pk_`. Never put an `opslane_sk_` source-map key in brow
 
 `init` installs global `error`/`unhandledrejection` handlers and instruments `console`, `fetch`, and `XMLHttpRequest` for breadcrumbs. Calling it twice is a no-op. `destroy()` reverses everything.
 
-`release` should match the source maps you upload for that deploy — use the commit SHA or another immutable build identifier.
+`release` is optional deployment metadata. Source maps match by debug ID, not release.
 
 ## Framework integrations
 
@@ -64,24 +64,30 @@ React and Vue are optional peer dependencies — installing the SDK pulls in nei
 
 ### Vite source maps
 
-> Source-map upload is unavailable in this release. Remove `opslaneSourceMapPlugin()` from your Vite configuration until batch upload ships in [#218](https://github.com/opslane/opslane-oss/issues/218); leaving it enabled now fails the build deliberately.
+The Vite plugin stamps and uploads production source maps when the two private
+build variables `OPSLANE_ENDPOINT` and `OPSLANE_SOURCEMAP_KEY` are set:
 
-Keep the plugin out of your Vite configuration for now. It does not remove or upload map
-assets while the replacement batch API is unavailable.
+```ts
+import { opslane } from '@opslane/sdk/vite-plugin';
 
-`opslaneSourceMapPlugin` is the setup supported by the currently published
-`@opslane/sdk@2.0.1`. This repository also contains the next debug-ID stamping
-plugin, but do not import its `opslaneVitePlugin` export from 2.0.1: that export
-has not been published yet. See the [source-map guide](../../docs/guides/source-maps.md)
-for the availability and migration matrix.
+export default {
+  plugins: [opslane()],
+  worker: { plugins: () => [opslane()] },
+};
+```
 
-When that export ships, its build options will be:
+Never use a `VITE_` prefix for the secret `opslane_sk_` key. The plugin also
+reads gitignored Vite env files such as `.env.local`. Upload errors are reported
+without failing the build, and generated maps are removed from output by
+default. See the [source-map guide](../../docs/guides/source-maps.md).
+
+Build options:
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `commitSha` | `string` | CI environment or `.git/HEAD` | Lowercase 40- or 64-character build commit. |
 | `stamp` | `boolean` | `true` | Set `false` to leave chunks and maps unchanged. |
-| `logLevel` | `'silent' \| 'warn' \| 'debug'` | `'warn'` | Build diagnostics and summary verbosity. |
+| `logLevel` | `'silent' \| 'warn'` | `'warn'` | Build diagnostics and summary verbosity. |
 | `sourcemaps` | `'remove' \| 'keep'` | `'remove'` | Whether emitted map assets remain in the build output. |
 | `maxMapBytes` | `number` | `33554432` | Maximum raw map size eligible for stamping. |
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -24,6 +24,10 @@
     "./vite-plugin": {
       "types": "./dist/vite-plugin.d.ts",
       "import": "./dist/vite-plugin.js"
+    },
+    "./build/debug-id": {
+      "types": "./dist/debug-id.d.ts",
+      "import": "./dist/build/debug-id.js"
     }
   },
   "files": [

--- a/packages/sdk/src/__tests__/debug-id.test.ts
+++ b/packages/sdk/src/__tests__/debug-id.test.ts
@@ -24,6 +24,24 @@ const vectors = JSON.parse(
 ) as { cases: DebugIdVector[] };
 
 describe('computeDebugId', () => {
+
+  it('accepts a map without sourcesContent', async () => {
+    const map = JSON.stringify({ version: 3, sources: ['a.ts'], names: [], mappings: 'AAAA' });
+    const result = await computeDebugId(new TextEncoder().encode(map));
+    expect(result.debugId).toMatch(/^[0-9a-f]{8}-/);
+  });
+
+  it('still rejects a sources/sourcesContent length mismatch', async () => {
+    const map = JSON.stringify({
+      version: 3,
+      sources: ['a.ts', 'b.ts'],
+      sourcesContent: ['x'],
+      names: [],
+      mappings: 'AAAA',
+    });
+    await expect(computeDebugId(new TextEncoder().encode(map))).rejects.toThrow();
+  });
+
   for (const vector of vectors.cases.filter((entry) => entry.outcome === 'ok')) {
     it(`${vector.name}: matches the frozen fingerprint`, async () => {
       const bytes = Buffer.from(vector.input_b64, 'base64');

--- a/packages/sdk/src/__tests__/vite-plugin.test.ts
+++ b/packages/sdk/src/__tests__/vite-plugin.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+vi.mock('vite', () => ({ loadEnv: vi.fn(() => ({})) }));
 import {
   opslane,
   opslaneSourceMapPlugin,
@@ -328,6 +329,80 @@ describe('Vite debug-ID plugin', () => {
     );
   });
 
+  it('uploads exactly the final stamped maps when private build env is set', async () => {
+    const previousKey = process.env['OPSLANE_SOURCEMAP_KEY'];
+    const previousEndpoint = process.env['OPSLANE_ENDPOINT'];
+    process.env['OPSLANE_SOURCEMAP_KEY'] = 'opslane_sk_test';
+    process.env['OPSLANE_ENDPOINT'] = 'https://ingestion.example';
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('', { status: 201 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      const plugin = opslaneVitePlugin({ logLevel: 'silent' });
+      (plugin.config as Function).call(plugin, {});
+      const bundle = makeBundle();
+      await stamp(plugin, bundle);
+      await (plugin.closeBundle as Function).call(plugin);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, request] = fetchMock.mock.calls[0] ?? [];
+      expect(String(url)).toMatch(/\/api\/v1\/sourcemaps\/[0-9a-f-]+$/);
+      expect(request?.body).toContain('"debugId"');
+      expect(bundle['assets/index.js.map']).toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+      if (previousKey === undefined) delete process.env['OPSLANE_SOURCEMAP_KEY'];
+      else process.env['OPSLANE_SOURCEMAP_KEY'] = previousKey;
+      if (previousEndpoint === undefined) delete process.env['OPSLANE_ENDPOINT'];
+      else process.env['OPSLANE_ENDPOINT'] = previousEndpoint;
+    }
+  });
+
+  it('does not upload without a source-map key', async () => {
+    const previousKey = process.env['OPSLANE_SOURCEMAP_KEY'];
+    delete process.env['OPSLANE_SOURCEMAP_KEY'];
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      const plugin = opslaneVitePlugin({ logLevel: 'silent' });
+      (plugin.config as Function).call(plugin, {});
+      const bundle = makeBundle();
+      await stamp(plugin, bundle);
+      await (plugin.closeBundle as Function).call(plugin);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      if (previousKey === undefined) delete process.env['OPSLANE_SOURCEMAP_KEY'];
+      else process.env['OPSLANE_SOURCEMAP_KEY'] = previousKey;
+    }
+  });
+
+  it('reports a rejected upload without failing the build', async () => {
+    const previousKey = process.env['OPSLANE_SOURCEMAP_KEY'];
+    const previousEndpoint = process.env['OPSLANE_ENDPOINT'];
+    process.env['OPSLANE_SOURCEMAP_KEY'] = 'opslane_sk_test';
+    process.env['OPSLANE_ENDPOINT'] = 'https://ingestion.example';
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('', { status: 500 }),
+    ));
+    try {
+      const plugin = opslaneVitePlugin({ logLevel: 'silent' });
+      (plugin.config as Function).call(plugin, {});
+      const bundle = makeBundle();
+      await stamp(plugin, bundle);
+      await expect(
+        (plugin.closeBundle as Function).call(plugin),
+      ).resolves.toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+      if (previousKey === undefined) delete process.env['OPSLANE_SOURCEMAP_KEY'];
+      else process.env['OPSLANE_SOURCEMAP_KEY'] = previousKey;
+      if (previousEndpoint === undefined) delete process.env['OPSLANE_ENDPOINT'];
+      else process.env['OPSLANE_ENDPOINT'] = previousEndpoint;
+    }
+  });
+
   it('leaves a chunk unchanged when its map is invalid', async () => {
     const plugin = opslaneVitePlugin({
       sourcemaps: 'keep',
@@ -349,6 +424,25 @@ describe('Vite debug-ID plugin', () => {
     await stamp(plugin, bundle);
 
     expect(bundle['assets/index.js.map']).toBeUndefined();
+  });
+
+  it('removes standalone sourceMappingURL directives with private maps', async () => {
+    const plugin = opslaneVitePlugin({ logLevel: 'silent' });
+    (plugin.config as Function).call(plugin, {});
+    const bundle = makeBundle([
+      'const parser = /\\/\\*# sourceMappingURL=/;',
+      '/*# sourceMappingURL=vendor.js.map */',
+      'console.log("hello");',
+      '//# sourceMappingURL=index.js.map',
+    ].join('\n'));
+
+    await stamp(plugin, bundle);
+
+    const code = bundle['assets/index.js'].code as string;
+    expect(code).toContain('const parser = /\\/\\*# sourceMappingURL=/;');
+    expect(code.split(/\r?\n/).some(
+      (line) => /^(?:\/\/[@#]|\/\*[@#])\s*sourceMappingURL\s*=/.test(line.trim()),
+    )).toBe(false);
   });
 
   // Vite runs a worker build as a nested build and copies its output into the

--- a/packages/sdk/src/build/debug-id.ts
+++ b/packages/sdk/src/build/debug-id.ts
@@ -274,14 +274,20 @@ function validateSourceMap(value: JsonValue): asserts value is JsonObject {
     !sources.values.every((entry) => typeof entry === 'string') ||
     !isArray(names) ||
     !names.values.every((entry) => typeof entry === 'string') ||
-    typeof mappings !== 'string' ||
-    !isArray(sourcesContent) ||
-    !sourcesContent.values.every((entry) => typeof entry === 'string')
+    typeof mappings !== 'string'
   ) {
     throw new DebugIdError('bad_field_type');
   }
-  if (sources.values.length !== sourcesContent.values.length) {
-    throw new DebugIdError('sources_content_mismatch');
+  if (sourcesContent !== undefined) {
+    if (
+      !isArray(sourcesContent) ||
+      !sourcesContent.values.every((entry) => typeof entry === 'string')
+    ) {
+      throw new DebugIdError('bad_field_type');
+    }
+    if (sources.values.length !== sourcesContent.values.length) {
+      throw new DebugIdError('sources_content_mismatch');
+    }
   }
 }
 

--- a/packages/sdk/vite-plugin/__tests__/env-upload.test.ts
+++ b/packages/sdk/vite-plugin/__tests__/env-upload.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expect, it, vi } from 'vitest';
+import { opslaneVitePlugin } from '../index.js';
+
+it('loads private upload credentials from the project .env.local', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'opslane-vite-env-'));
+  writeFileSync(
+    join(root, '.env.local'),
+    'OPSLANE_ENDPOINT=https://env.example\nOPSLANE_SOURCEMAP_KEY=opslane_sk_from_file\n',
+  );
+  const priorEndpoint = process.env['OPSLANE_ENDPOINT'];
+  const priorKey = process.env['OPSLANE_SOURCEMAP_KEY'];
+  delete process.env['OPSLANE_ENDPOINT'];
+  delete process.env['OPSLANE_SOURCEMAP_KEY'];
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+    new Response('', { status: 201 }),
+  );
+  vi.stubGlobal('fetch', fetchMock);
+  try {
+    const plugin = opslaneVitePlugin({ logLevel: 'silent' });
+    (plugin.config as Function).call(plugin, {});
+    await (plugin.configResolved as Function).call(plugin, {
+      root,
+      mode: 'production',
+      build: { outDir: 'dist' },
+      plugins: [{ name: 'opslane-debug-ids' }],
+    });
+    const bundle = {
+      'assets/app.js': {
+        type: 'chunk', fileName: 'assets/app.js', code: 'console.log("app")',
+      },
+      'assets/app.js.map': {
+        type: 'asset', fileName: 'assets/app.js.map',
+        source: JSON.stringify({
+          version: 3,
+          sources: ['src/app.ts'],
+          sourcesContent: ['console.log("app")'],
+          names: [],
+          mappings: 'AAAA',
+        }),
+      },
+    };
+    const generate = plugin.generateBundle as {
+      handler(options: unknown, output: unknown): Promise<void>;
+    };
+    await generate.handler.call(plugin, { format: 'es' }, bundle);
+    await (plugin.closeBundle as Function).call(plugin);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toMatch(
+      /^https:\/\/env\.example\/api\/v1\/sourcemaps\//,
+    );
+  } finally {
+    vi.unstubAllGlobals();
+    if (priorEndpoint === undefined) delete process.env['OPSLANE_ENDPOINT'];
+    else process.env['OPSLANE_ENDPOINT'] = priorEndpoint;
+    if (priorKey === undefined) delete process.env['OPSLANE_SOURCEMAP_KEY'];
+    else process.env['OPSLANE_SOURCEMAP_KEY'] = priorKey;
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/sdk/vite-plugin/__tests__/upload.test.ts
+++ b/packages/sdk/vite-plugin/__tests__/upload.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+import { uploadSourceMaps, type UploadEntry } from '../upload.js';
+
+const ENTRY: UploadEntry = {
+  debugId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  fileName: 'assets/app.js.map',
+  mapSource: '{"version":3}',
+};
+
+describe('uploadSourceMaps', () => {
+  it.each([200, 201])('treats HTTP %d as success', async (status) => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('', { status }),
+    );
+    const result = await uploadSourceMaps([ENTRY], {
+      endpoint: 'https://ingestion.example/',
+      key: 'opslane_sk_test',
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ uploaded: 1, failed: [] });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      `https://ingestion.example/api/v1/sourcemaps/${ENTRY.debugId}`,
+      expect.objectContaining({
+        method: 'PUT',
+        headers: {
+          'X-API-Key': 'opslane_sk_test',
+          'Content-Type': 'application/json',
+        },
+        body: ENTRY.mapSource,
+      }),
+    );
+  });
+
+  it('collects HTTP failures without throwing', async () => {
+    const result = await uploadSourceMaps([ENTRY], {
+      endpoint: 'https://ingestion.example',
+      key: 'opslane_sk_test',
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(
+        new Response('', { status: 403 }),
+      ),
+    });
+    expect(result.uploaded).toBe(0);
+    expect(result.failed).toEqual([
+      { fileName: ENTRY.fileName, reason: 'HTTP 403' },
+    ]);
+  });
+
+  it('retries one network failure and then reports it', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(
+      new Error('connection refused'),
+    );
+    const result = await uploadSourceMaps([ENTRY], {
+      endpoint: 'http://127.0.0.1:1',
+      key: 'opslane_sk_test',
+      fetchImpl,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.failed[0]?.reason).toContain('connection refused');
+  });
+
+  it('paces on 429 and retries the same map', async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('', {
+        status: 429,
+        headers: { 'Retry-After': '0' },
+      }))
+      .mockResolvedValueOnce(new Response('', {
+        status: 429,
+        headers: { 'Retry-After': '0' },
+      }))
+      .mockResolvedValueOnce(new Response('', { status: 201 }));
+    const result = await uploadSourceMaps([ENTRY], {
+      endpoint: 'https://ingestion.example',
+      key: 'opslane_sk_test',
+      fetchImpl,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({ uploaded: 1, failed: [] });
+  });
+
+  // A 429 from an intermediary (nginx, a CDN, a load balancer) often carries no
+  // Retry-After at all. Retrying that with no delay turns the pacing loop into
+  // an amplifier against the limiter it is meant to respect.
+  it('waits the documented default when a 429 omits Retry-After', async () => {
+    const delays: number[] = [];
+    const timeout = vi.spyOn(globalThis, 'setTimeout').mockImplementation(
+      ((callback: () => void, ms?: number) => {
+        delays.push(ms ?? 0);
+        callback();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }) as unknown as typeof setTimeout,
+    );
+    try {
+      const fetchImpl = vi.fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('', { status: 429 }))
+        .mockResolvedValueOnce(new Response('', { status: 201 }));
+      const result = await uploadSourceMaps([ENTRY], {
+        endpoint: 'https://ingestion.example',
+        key: 'opslane_sk_test',
+        fetchImpl,
+      });
+      expect(result).toEqual({ uploaded: 1, failed: [] });
+      expect(delays).toEqual([30_000]);
+    } finally {
+      timeout.mockRestore();
+    }
+  });
+
+  it('skips maps over the server cap', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const result = await uploadSourceMaps([
+      { ...ENTRY, mapSource: 'x'.repeat(32 * 1024 * 1024 + 1) },
+    ], {
+      endpoint: 'https://ingestion.example',
+      key: 'opslane_sk_test',
+      fetchImpl,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result.failed[0]?.reason).toContain('32 MiB');
+  });
+});

--- a/packages/sdk/vite-plugin/index.ts
+++ b/packages/sdk/vite-plugin/index.ts
@@ -1,6 +1,10 @@
 import type { Plugin, UserConfig } from 'vite';
 import { computeDebugId } from '../src/build/debug-id.js';
 import {
+  uploadSourceMaps,
+  type UploadEntry,
+} from './upload.js';
+import {
   COMMIT_SHA_GLOBAL,
   DEBUG_ID_PLACEHOLDER,
   REGISTRY_GLOBAL,
@@ -92,6 +96,8 @@ export function opslaneVitePlugin(
   // Per-build state. Cleared at buildStart so watch rebuilds and multiple
   // outputs never verify against a previous build's fingerprints.
   const stampedIds = new Map<string, string>();
+  /** Final stamped map bytes, used when the privacy mode removes maps. */
+  const uploadPayloads = new Map<string, UploadEntry>();
   /** Maps removed from the bundle, re-checked on disk after the build writes. */
   const discardedMaps = new Set<string>();
   const loggedCodes = new Set<string>();
@@ -101,6 +107,7 @@ export function opslaneVitePlugin(
   /** True when this plugin, not the project, switched source maps on. */
   let pluginRequestedMaps = false;
   let projectRoot: string | undefined;
+  let fileEnv: Record<string, string> = {};
   /** Where the build wrote, captured so closeBundle can re-read it. */
   let writtenDir: string | undefined;
   let outDir = 'dist';
@@ -236,6 +243,40 @@ export function opslaneVitePlugin(
     );
   };
 
+  /** Re-read retained maps at upload time and only send bytes that still
+   * match the debug ID stamped into their JavaScript. */
+  const collectVerifiedFromDisk = async (): Promise<UploadEntry[]> => {
+    const readFileSync = nodeFs()?.readFileSync;
+    if (!writtenDir || !readFileSync) return [];
+    const entries: UploadEntry[] = [];
+    for (const [fileName, expectedID] of stampedIds) {
+      if (
+        stats.verifyFailed.some((failure) => failure.startsWith(fileName))
+      ) {
+        continue;
+      }
+      try {
+        const bytes = readFileSync(`${writtenDir}/${fileName}`);
+        const { debugId } = await computeDebugId(bytes);
+        if (debugId !== expectedID) {
+          warnOnce(
+            'OPSLANE_VITE_UPLOAD_STALE_MAP',
+            `${fileName} changed on disk after verification; skipping its upload.`,
+          );
+          continue;
+        }
+        entries.push({
+          debugId,
+          mapSource: new TextDecoder().decode(bytes),
+          fileName,
+        });
+      } catch {
+        // A later plugin may have removed a map after writeBundle.
+      }
+    }
+    return entries;
+  };
+
   /** The build summary's source-map sentence. */
   const describeMaps = (): string => {
     if (sourcemapSetting === 'false') return 'Source maps: disabled.';
@@ -278,6 +319,9 @@ export function opslaneVitePlugin(
     if (!stampingEnabled) return;
     if (!JS_ASSET.test(value.fileName)) return;
     if (typeof value.source !== 'string') return;
+    if (!mapsWillShip()) {
+      value.source = stripSourceMappingURLDirectives(value.source);
+    }
 
     const mapKey = `${value.fileName}.map`;
     const mapAsset = (bundle as Record<string, MapAsset | undefined>)[mapKey];
@@ -316,6 +360,13 @@ export function opslaneVitePlugin(
       if (debugId === existing[1]) {
         stats.stamped++;
         settle(debugId);
+        uploadPayloads.set(mapKey, {
+          debugId,
+          mapSource: typeof mapAsset.source === 'string'
+            ? mapAsset.source
+            : new TextDecoder().decode(mapAsset.source),
+          fileName: mapKey,
+        });
         return;
       }
     } catch {
@@ -338,6 +389,11 @@ export function opslaneVitePlugin(
       mapAsset.source = stamped.mapSource;
       stats.stamped++;
       settle(stamped.debugId);
+      uploadPayloads.set(mapKey, {
+        debugId: stamped.debugId,
+        mapSource: stamped.mapSource,
+        fileName: mapKey,
+      });
     } catch (error) {
       reportStampFailure(value.fileName, error);
     }
@@ -354,6 +410,7 @@ export function opslaneVitePlugin(
       stats.skipped.clear();
       stats.verifyFailed.length = 0;
       stampedIds.clear();
+      uploadPayloads.clear();
       discardedMaps.clear();
       writtenDir = undefined;
     },
@@ -401,7 +458,7 @@ export function opslaneVitePlugin(
       return result;
     },
 
-    configResolved(config) {
+    async configResolved(config) {
       projectRoot = canonicalFilesystemPath(config.root);
       outDir = isAbsolutePath(config.build.outDir)
         ? canonicalFilesystemPath(config.build.outDir)
@@ -416,6 +473,14 @@ export function opslaneVitePlugin(
           `[opslane] OPSLANE_VITE_SRI_DETECTED: ${detectedSRI} computes integrity before debug-ID stamping. Stamping was disabled to prevent browsers rejecting every chunk. Remove the integrity plugin or set stamp:false explicitly. See docs/guides/source-maps.md#subresource-integrity.`,
         );
       }
+      if (maxMapBytes > DEFAULT_MAX_MAP_BYTES) {
+        warnOnce(
+          'OPSLANE_VITE_MAP_OVER_SERVER_LIMIT',
+          `maxMapBytes=${formatBytes(maxMapBytes)} exceeds the server upload limit of ${formatBytes(DEFAULT_MAX_MAP_BYTES)}; larger maps will stamp but fail to upload.`,
+        );
+      }
+      const { loadEnv } = await import('vite');
+      fileEnv = loadEnv(config.mode || 'production', config.root, 'OPSLANE_');
     },
 
     // `order: 'post'` is load-bearing. Vite's own `vite:build-import-analysis`
@@ -432,6 +497,9 @@ export function opslaneVitePlugin(
         }
         stats.chunks++;
         const chunk = value;
+        if (!mapsWillShip()) {
+          chunk.code = stripSourceMappingURLDirectives(chunk.code);
+        }
 
         if (!stampingEnabled) {
           skip(
@@ -472,6 +540,11 @@ export function opslaneVitePlugin(
           // Atomic mutation: nothing above this point changes the bundle.
           chunk.code = stamped.code;
           mapAsset.source = stamped.mapSource;
+          uploadPayloads.set(mapKey, {
+            debugId: stamped.debugId,
+            mapSource: stamped.mapSource,
+            fileName: mapKey,
+          });
           // Vite and Rollup both re-serialise from `chunk.map` on some paths
           // (workers, later code rewrites), so the map object has to agree
           // with the asset or a different map reaches disk than was hashed.
@@ -527,8 +600,44 @@ export function opslaneVitePlugin(
       }
     },
 
-    closeBundle() {
+    async closeBundle() {
       reportRestoredMaps();
+
+      const key = process.env['OPSLANE_SOURCEMAP_KEY']
+        ?? fileEnv['OPSLANE_SOURCEMAP_KEY'];
+      const endpoint = process.env['OPSLANE_ENDPOINT']
+        ?? fileEnv['OPSLANE_ENDPOINT'];
+      if (key) {
+        if (!endpoint) {
+          warnOnce(
+            'OPSLANE_VITE_UPLOAD_NO_ENDPOINT',
+            'OPSLANE_SOURCEMAP_KEY is set but OPSLANE_ENDPOINT is not; skipping source-map upload.',
+          );
+        } else if (!key.startsWith('opslane_sk_')) {
+          warnOnce(
+            'OPSLANE_VITE_UPLOAD_WRONG_KEY',
+            'OPSLANE_SOURCEMAP_KEY is not an opslane_sk_ secret key; skipping source-map upload.',
+          );
+        } else {
+          const entries = mapsWillShip()
+            ? await collectVerifiedFromDisk()
+            : [...uploadPayloads.values()];
+          const outcome = await uploadSourceMaps(entries, { endpoint, key });
+          if (outcome.failed.length > 0 && logLevel !== 'silent') {
+            console.error(
+              `[opslane] OPSLANE_VITE_UPLOAD_FAILED: ${outcome.failed.length} source map(s) failed to upload; stack traces for these chunks will stay minified.`
+              + (keepSourceMaps
+                ? ' The listed .map files are still in your build output — do not deploy them.'
+                : '')
+              + `\n  ${outcome.failed.map((failure) => `${failure.fileName}: ${failure.reason}`).join('\n  ')}`,
+            );
+          }
+          if (logLevel !== 'silent') {
+            console.warn(`[opslane] Uploaded ${outcome.uploaded}/${entries.length} source maps.`);
+          }
+        }
+      }
+
       if (logLevel === 'silent') return;
       const skipped = stats.chunks - stats.stamped;
       const detail = [...stats.skipped.entries()]
@@ -589,6 +698,26 @@ export function opslaneSourceMapPlugin(_options: SourceMapPluginOptions) {
 
 function stripMapSuffix(filePath: string): string {
   return filePath.endsWith('.map') ? filePath.slice(0, -4) : filePath;
+}
+
+/**
+ * Remove standalone source-map URL directives when maps are private.
+ *
+ * Each replacement leaves the newline itself in place, so generated line
+ * numbers and the sibling map stay aligned. Anchoring to a whole trimmed line
+ * avoids corrupting libraries that parse the directive with a regex or carry
+ * the text in a string literal.
+ */
+function stripSourceMappingURLDirectives(code: string): string {
+  return code
+    .replace(
+      /^[ \t]*\/\*[@#][ \t]*sourceMappingURL[ \t]*=[^\r\n]*?\*\/[ \t]*(?=\r?$)/gm,
+      '',
+    )
+    .replace(
+      /^[ \t]*\/\/[@#][ \t]*sourceMappingURL[ \t]*=[^\r\n]*(?=\r?$)/gm,
+      '',
+    );
 }
 
 interface MapAsset {

--- a/packages/sdk/vite-plugin/upload.ts
+++ b/packages/sdk/vite-plugin/upload.ts
@@ -1,0 +1,120 @@
+export interface UploadEntry {
+  debugId: string;
+  mapSource: string;
+  fileName: string;
+}
+
+export interface UploadOutcome {
+  uploaded: number;
+  failed: { fileName: string; reason: string }[];
+}
+
+const CONCURRENCY = 4;
+const MAX_MAP_BYTES = 32 * 1024 * 1024;
+const RETRY_AFTER_DEFAULT_SECONDS = 30;
+const RETRY_AFTER_CAP_SECONDS = 120;
+const MAX_ATTEMPTS = 8;
+
+export async function uploadSourceMaps(
+  entries: UploadEntry[],
+  opts: { endpoint: string; key: string; fetchImpl?: typeof fetch },
+): Promise<UploadOutcome> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const base = opts.endpoint.replace(/\/+$/, '');
+  const outcome: UploadOutcome = { uploaded: 0, failed: [] };
+  const queue = [...entries];
+  const sleep = (ms: number) =>
+    new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+  async function putOnce(entry: UploadEntry): Promise<
+    | { ok: true }
+    | { ok: false; retryAfterSeconds?: number; reason?: string }
+  > {
+    try {
+      const response = await fetchImpl(
+        `${base}/api/v1/sourcemaps/${entry.debugId}`,
+        {
+          method: 'PUT',
+          headers: {
+            'X-API-Key': opts.key,
+            'Content-Type': 'application/json',
+          },
+          body: entry.mapSource,
+        },
+      );
+      if (response.status === 200 || response.status === 201) {
+        return { ok: true };
+      }
+      if (response.status === 429) {
+        // An absent header reads as `null`, and `Number(null)` is 0 — finite
+        // and non-negative, so a naive parse would retry with no delay at all
+        // and amplify the load the limiter is trying to shed. Only a header
+        // that is actually present and numeric overrides the default.
+        const header = response.headers.get('Retry-After');
+        const parsed = header === null || header.trim() === ''
+          ? Number.NaN
+          : Number(header);
+        return {
+          ok: false,
+          retryAfterSeconds: Math.min(
+            Number.isFinite(parsed) && parsed >= 0
+              ? parsed
+              : RETRY_AFTER_DEFAULT_SECONDS,
+            RETRY_AFTER_CAP_SECONDS,
+          ),
+        };
+      }
+      return { ok: false, reason: `HTTP ${response.status}` };
+    } catch (error: unknown) {
+      return {
+        ok: false,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  async function worker(): Promise<void> {
+    for (let entry = queue.shift(); entry; entry = queue.shift()) {
+      if (new TextEncoder().encode(entry.mapSource).byteLength > MAX_MAP_BYTES) {
+        outcome.failed.push({
+          fileName: entry.fileName,
+          reason: 'over 32 MiB server limit',
+        });
+        continue;
+      }
+
+      let lastReason = 'unknown';
+      let uploaded = false;
+      let networkRetried = false;
+      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+        const result = await putOnce(entry);
+        if (result.ok) {
+          outcome.uploaded += 1;
+          uploaded = true;
+          break;
+        }
+        if (result.retryAfterSeconds !== undefined) {
+          lastReason = 'HTTP 429';
+          if (attempt + 1 < MAX_ATTEMPTS) {
+            await sleep(result.retryAfterSeconds * 1_000);
+          }
+          continue;
+        }
+        lastReason = result.reason ?? 'unknown';
+        if (!lastReason.startsWith('HTTP') && !networkRetried) {
+          networkRetried = true;
+          continue;
+        }
+        break;
+      }
+      if (!uploaded) {
+        outcome.failed.push({ fileName: entry.fileName, reason: lastReason });
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, entries.length) }, worker),
+  );
+  return outcome;
+}

--- a/packages/sdk/vite.config.ts
+++ b/packages/sdk/vite.config.ts
@@ -17,11 +17,12 @@ export default defineConfig({
         index: resolve(__dirname, 'src/index.ts'),
         react: resolve(__dirname, 'src/react.tsx'),
         'vite-plugin': resolve(__dirname, 'vite-plugin/index.ts'),
+        'build/debug-id': resolve(__dirname, 'src/build/debug-id.ts'),
       },
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['vue', 'react', 'react-dom', 'react/jsx-runtime'],
+      external: ['vue', 'react', 'react-dom', 'react/jsx-runtime', 'vite'],
     },
     sourcemap: false,
     outDir: 'dist',

--- a/packages/worker/Dockerfile
+++ b/packages/worker/Dockerfile
@@ -12,16 +12,19 @@ WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY shared/package.json shared/
 COPY packages/agent-core/package.json packages/agent-core/
+COPY packages/sdk/package.json packages/sdk/
 COPY packages/worker/package.json packages/worker/
 
 RUN corepack enable pnpm && pnpm install --frozen-lockfile
 
 COPY shared/ shared/
 COPY packages/agent-core/ packages/agent-core/
+COPY packages/sdk/ packages/sdk/
 COPY packages/worker/ packages/worker/
 
 RUN pnpm --filter @opslane/shared build && \
     pnpm --filter @opslane/agent-core build && \
+    pnpm --filter @opslane/sdk build && \
     pnpm --filter @opslane/worker build
 
 RUN chown -R opslane:opslane /app

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -17,6 +17,7 @@
     "@arizeai/openinference-instrumentation-anthropic": "^0.1.15",
     "@aws-sdk/client-s3": "^3.1091.0",
     "@opslane/agent-core": "workspace:*",
+    "@opslane/sdk": "workspace:*",
     "@opslane/shared": "workspace:*",
     "@jridgewell/trace-mapping": "^0.3.31",
     "@langfuse/otel": "^5.9.1",

--- a/packages/worker/src/__tests__/db-queries.test.ts
+++ b/packages/worker/src/__tests__/db-queries.test.ts
@@ -19,7 +19,8 @@ import {
   getSessionPointerForGroup,
   getPlayableChunkMetas,
   getReplayArtifacts,
-  getSourceMaps,
+  getSourceMapRows,
+  setEventResolution,
   requeueStaleJobs,
   getFrictionSignalsForGroup,
   getScrubbedChunksForSession,
@@ -265,6 +266,7 @@ describe('getErrorEvent', () => {
       rows: [{
         id: 'e1', error_type: 'TypeError', error_message: 'x is not defined',
         stack_trace_raw: 'at foo.js:1', stack_trace_resolved: null,
+        debug_meta: null,
         breadcrumbs: '[]', context: '{}', release: 'v1.0.0', session_id: 'sess-1',
       }],
     });
@@ -274,6 +276,7 @@ describe('getErrorEvent', () => {
     }));
     expect(mockQuery.mock.calls[0][0]).toContain('breadcrumbs::text AS breadcrumbs');
     expect(mockQuery.mock.calls[0][0]).toContain('context::text AS context');
+    expect(mockQuery.mock.calls[0][0]).toContain('debug_meta::text AS debug_meta');
     expect(mockQuery.mock.calls[0][1]).toEqual(['e1', 'p1']);
   });
 });
@@ -374,22 +377,61 @@ describe('getReplayArtifacts', () => {
   });
 });
 
-describe('getSourceMaps', () => {
+describe('source-map resolution queries', () => {
   beforeEach(() => mockQuery.mockReset());
 
-  it('returns source map entries for release', async () => {
+  it('returns project-scoped rows for debug IDs', async () => {
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 's1', filename: 'main.js', object_key: 'sourcemaps/p1/v1/main.js.map' }],
+      rows: [{
+        debug_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        object_key: 'sourcemaps/p1/a/map',
+        content_sha256: '1'.repeat(64),
+      }],
     });
-    const maps = await getSourceMaps('p1', 'v1.0.0');
+    const maps = await getSourceMapRows('p1', [
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    ]);
     expect(maps).toHaveLength(1);
-    expect(maps[0].filename).toBe('main.js');
+    expect(maps[0]?.object_key).toContain('sourcemaps/p1/');
+    expect(mockQuery.mock.calls[0]?.[1]).toEqual([
+      'p1',
+      ['aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'],
+    ]);
   });
 
-  it('returns empty array when no maps exist', async () => {
+  it('persists status and the pinned envelope with event and project scope', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    const maps = await getSourceMaps('p1', 'v2.0.0');
-    expect(maps).toEqual([]);
+    await setEventResolution('e1', 'p1', 'resolved', {
+      version: 1,
+      frames: [{
+        original_file: 'src/a.ts', original_line: 1, original_column: 0,
+        source_snippet: 'source', generated_file: 'app.js',
+        generated_line: 1, generated_column: 1,
+        debug_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      }],
+    });
+    expect(mockQuery.mock.calls[0]?.[0]).toContain(
+      'WHERE id = $1 AND project_id = $2',
+    );
+    expect(mockQuery.mock.calls[0]?.[1]?.slice(0, 3)).toEqual([
+      'e1', 'p1', 'resolved',
+    ]);
+  });
+
+  // Investigate and fix both resolve the same sample event, so a fix job
+  // running during a storage blip must not erase the frames investigate stored.
+  it('never overwrites a stored envelope with a failed re-resolution', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await setEventResolution('e1', 'p1', 'resolution_failed', null);
+    const sql = mockQuery.mock.calls[0]?.[0] as string;
+    expect(sql).toContain(
+      'stack_trace_resolved = COALESCE($4::jsonb, stack_trace_resolved)',
+    );
+    // The status has to move with the envelope or the pair can disagree.
+    expect(sql).toContain(
+      'WHEN $4::jsonb IS NULL AND stack_trace_resolved IS NOT NULL',
+    );
+    expect(mockQuery.mock.calls[0]?.[1]?.[3]).toBeNull();
   });
 });
 

--- a/packages/worker/src/__tests__/index.test.ts
+++ b/packages/worker/src/__tests__/index.test.ts
@@ -23,7 +23,8 @@ vi.mock('../db.js', () => ({
   getEnvironmentNamesForGroup: vi.fn(async () => ({ names: [], totalCount: 0 })),
   getPlayableChunkMetas: vi.fn(),
   getReplayArtifacts: vi.fn(),
-  getSourceMaps: vi.fn(),
+  getSourceMapRows: vi.fn(async () => []),
+  setEventResolution: vi.fn(),
   requeueStaleJobs: vi.fn(),
   resolveInactiveGroups: vi.fn(),
   resolveSilentMergedGroups: vi.fn(),
@@ -59,6 +60,15 @@ vi.mock('../github-app.js', () => ({ getInstallationToken: vi.fn() }));
 vi.mock('../setup-pr.js', () => ({ processSetupPrJob: vi.fn() }));
 vi.mock('../pr.js', () => ({}));
 vi.mock('../source-map.js', () => ({ parseStackFrames: vi.fn(() => []), resolveFrame: vi.fn() }));
+// Only the storage-backed resolver is stubbed. framesFromEnvelope is a pure
+// reshape of an already-stored row, so the real one keeps this suite honest
+// about the shape the prompts actually receive.
+vi.mock('../resolve-stack.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../resolve-stack.js')>()),
+  resolveEventStack: vi.fn(async () => ({
+    status: 'no_debug_ids', frames: null, envelope: null,
+  })),
+}));
 vi.mock('../tracing.js', () => ({
   initTracing: vi.fn(),
   shutdownTracing: vi.fn(),
@@ -137,6 +147,7 @@ function makeEvent(stack: string): ErrorEventData {
     error_message: 'Script error.',
     stack_trace_raw: stack,
     stack_trace_resolved: null,
+    debug_meta: null,
     breadcrumbs: '[]',
     context: '{}',
     release: null,
@@ -246,6 +257,7 @@ describe('processFixJob — preserves writeup on failure (no revert/null)', () =
     mockGetErrorEvent.mockResolvedValue({
       id: 'e1', error_type: 'TypeError', error_message: 'x of undefined',
       stack_trace_raw: 'at App.vue:42', stack_trace_resolved: null,
+      debug_meta: null,
       breadcrumbs: '[]', context: '{}', release: null, session_id: null,
     } as ErrorEventData);
     mockGetProject.mockResolvedValue({
@@ -259,7 +271,7 @@ describe('processFixJob — preserves writeup on failure (no revert/null)', () =
     vi.mocked(db.getProjectGitHubInstallation).mockResolvedValue(null as never);
     vi.mocked(db.getReplayForGroup).mockResolvedValue(null as never);
     vi.mocked(db.getReplayArtifacts).mockResolvedValue([] as never);
-    vi.mocked(db.getSourceMaps).mockResolvedValue([] as never);
+    vi.mocked(db.getSourceMapRows).mockResolvedValue([] as never);
     vi.mocked(db.getGroupInvestigation).mockResolvedValue({ rootCause: 'null deref in App.vue', suggestedMitigation: 'guard' });
     process.env['GITHUB_TOKEN'] = 'gh-test';
   });
@@ -347,7 +359,7 @@ describe('processFixJob — preserves writeup on failure (no revert/null)', () =
       platform: 'python',
       customerRuntime: { name: 'CPython', version: '3.11.8' },
     }));
-    expect(db.getSourceMaps).not.toHaveBeenCalled();
+    expect(db.getSourceMapRows).not.toHaveBeenCalled();
   });
 
   it('rethrows verification infrastructure errors while the job has retries remaining', async () => {
@@ -453,7 +465,7 @@ describe('friction worker path', () => {
 
     expect(mockGetErrorEvent).not.toHaveBeenCalled();
     expect(db.getReplayForGroup).not.toHaveBeenCalled();
-    expect(db.getSourceMaps).not.toHaveBeenCalled();
+    expect(db.getSourceMapRows).not.toHaveBeenCalled();
     expect(db.updateGroupAndCreateFixJob).not.toHaveBeenCalled();
     expect(db.updateGroupInvestigation).toHaveBeenCalledWith(
       'grp-1', 'proj-1', 'awaiting_approval', expect.objectContaining({ confidence: 'high' }),

--- a/packages/worker/src/__tests__/python-production-path.test.ts
+++ b/packages/worker/src/__tests__/python-production-path.test.ts
@@ -24,7 +24,10 @@ vi.mock('../poller.js', () => ({ createPoller: vi.fn(() => ({ start: vi.fn(), st
 vi.mock('../github-app.js', () => ({ getInstallationToken: vi.fn() }));
 vi.mock('../setup-pr.js', () => ({ processSetupPrJob: vi.fn() }));
 vi.mock('../source-map.js', () => ({ parseStackFrames: vi.fn(() => []), resolveFrame: vi.fn() }));
-vi.mock('../resolve-stack.js', () => ({
+// Only the storage-backed resolver is stubbed; framesFromEnvelope is a pure
+// reshape of an already-stored row and the real one is what index.ts calls.
+vi.mock('../resolve-stack.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../resolve-stack.js')>()),
   resolveEventStack: vi.fn(async () => ({
     status: 'no_debug_ids', frames: null, envelope: null,
   })),

--- a/packages/worker/src/__tests__/python-production-path.test.ts
+++ b/packages/worker/src/__tests__/python-production-path.test.ts
@@ -24,6 +24,11 @@ vi.mock('../poller.js', () => ({ createPoller: vi.fn(() => ({ start: vi.fn(), st
 vi.mock('../github-app.js', () => ({ getInstallationToken: vi.fn() }));
 vi.mock('../setup-pr.js', () => ({ processSetupPrJob: vi.fn() }));
 vi.mock('../source-map.js', () => ({ parseStackFrames: vi.fn(() => []), resolveFrame: vi.fn() }));
+vi.mock('../resolve-stack.js', () => ({
+  resolveEventStack: vi.fn(async () => ({
+    status: 'no_debug_ids', frames: null, envelope: null,
+  })),
+}));
 vi.mock('../visual-analysis.js', () => ({ runVisualAnalysis: vi.fn() }));
 vi.mock('../ci-watch.js', () => ({ processCIWatchJob: vi.fn() }));
 vi.mock('../tracing.js', () => ({

--- a/packages/worker/src/__tests__/resolve-stack.test.ts
+++ b/packages/worker/src/__tests__/resolve-stack.test.ts
@@ -1,0 +1,237 @@
+import { computeDebugId } from '@opslane/sdk/build/debug-id';
+import { describe, expect, it } from 'vitest';
+import {
+  framesFromEnvelope,
+  resolveEventStack,
+  type ResolveDeps,
+  type SourceMapRow,
+} from '../resolve-stack.js';
+
+const APP_FILE = 'http://app.example/assets/index-abc.js';
+const VENDOR_FILE = 'http://app.example/assets/vendor-def.js';
+const APP_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const VENDOR_ID = 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff';
+const STACK = `Error: boom
+    at fn (${APP_FILE}:1:1)
+    at ${VENDOR_FILE}:1:1`;
+const MAP = JSON.stringify({
+  version: 3,
+  sources: ['src/App.vue'],
+  sourcesContent: ['const value = missing.value;\n'],
+  names: [],
+  mappings: 'AAAA',
+});
+
+function meta(images: { code_file: string; debug_id: string }[]): string {
+  return JSON.stringify({
+    images: images.map((image) => ({ type: 'sourcemap', ...image })),
+  });
+}
+
+async function deps(
+  rows: SourceMapRow[],
+  maps: Record<string, string | null>,
+): Promise<ResolveDeps> {
+  return {
+    getMapRows: async () => rows,
+    fetchMap: async (key) => maps[key] ?? null,
+  };
+}
+
+async function row(debugID = APP_ID, objectKey = 'app.map', source = MAP): Promise<SourceMapRow> {
+  const fingerprint = await computeDebugId(new TextEncoder().encode(source));
+  return {
+    debug_id: debugID,
+    object_key: objectKey,
+    content_sha256: fingerprint.contentSha256,
+  };
+}
+
+describe('resolveEventStack', () => {
+  it('returns no_debug_ids for empty images', async () => {
+    const result = await resolveEventStack(
+      { stackTraceRaw: STACK, debugMeta: '{"images":[]}', projectId: 'p' },
+      await deps([], {}),
+    );
+    expect(result.status).toBe('no_debug_ids');
+  });
+
+  it('requires an exact code_file match and never falls back to basename', async () => {
+    const result = await resolveEventStack(
+      {
+        stackTraceRaw: STACK,
+        debugMeta: meta([{
+          code_file: 'http://other.example/assets/index-abc.js',
+          debug_id: APP_ID,
+        }]),
+        projectId: 'p',
+      },
+      await deps([], {}),
+    );
+    expect(result.status).toBe('no_debug_ids');
+  });
+
+  it('returns map_not_found when matched IDs have no rows', async () => {
+    const result = await resolveEventStack(
+      {
+        stackTraceRaw: STACK,
+        debugMeta: meta([{ code_file: APP_FILE, debug_id: APP_ID }]),
+        projectId: 'p',
+      },
+      await deps([], {}),
+    );
+    expect(result.status).toBe('map_not_found');
+  });
+
+  it('returns invalid_map for malformed fetched bytes', async () => {
+    const validRow = await row();
+    const result = await resolveEventStack(
+      {
+        stackTraceRaw: STACK,
+        debugMeta: meta([{ code_file: APP_FILE, debug_id: APP_ID }]),
+        projectId: 'p',
+      },
+      await deps([validRow], { 'app.map': 'not json' }),
+    );
+    expect(result.status).toBe('invalid_map');
+  });
+
+  it('resolves a 1-based browser column and emits the pinned envelope', async () => {
+    const validRow = await row();
+    const result = await resolveEventStack(
+      {
+        stackTraceRaw: STACK,
+        debugMeta: meta([{ code_file: APP_FILE, debug_id: APP_ID }]),
+        projectId: 'p',
+      },
+      await deps([validRow], { 'app.map': MAP }),
+    );
+    expect(result.status).toBe('resolved');
+    expect(result.frames?.[0]?.originalFile).toBe('src/App.vue');
+    expect(result.envelope).toEqual({
+      version: 1,
+      frames: [expect.objectContaining({
+        original_file: 'src/App.vue',
+        original_line: 1,
+        generated_column: 1,
+        debug_id: APP_ID,
+      })],
+    });
+  });
+
+  it('returns partial when only one of two matched frames resolves', async () => {
+    const appRow = await row();
+    const result = await resolveEventStack(
+      {
+        stackTraceRaw: STACK,
+        debugMeta: meta([
+          { code_file: APP_FILE, debug_id: APP_ID },
+          { code_file: VENDOR_FILE, debug_id: VENDOR_ID },
+        ]),
+        projectId: 'p',
+      },
+      await deps([appRow], { 'app.map': MAP }),
+    );
+    expect(result.status).toBe('partial');
+    expect(result.frames).toHaveLength(1);
+  });
+
+  it('returns resolution_failed when storage throws', async () => {
+    const validRow = await row();
+    const result = await resolveEventStack(
+      {
+        stackTraceRaw: STACK,
+        debugMeta: meta([{ code_file: APP_FILE, debug_id: APP_ID }]),
+        projectId: 'p',
+      },
+      {
+        getMapRows: async () => [validRow],
+        fetchMap: async () => { throw new Error('storage offline'); },
+      },
+    );
+    expect(result.status).toBe('resolution_failed');
+  });
+
+  it('keeps frames from reachable maps when one object fetch throws', async () => {
+    const appRow = await row();
+    const vendorRow = await row(VENDOR_ID, 'vendor.map');
+    const result = await resolveEventStack(
+      {
+        stackTraceRaw: STACK,
+        debugMeta: meta([
+          { code_file: APP_FILE, debug_id: APP_ID },
+          { code_file: VENDOR_FILE, debug_id: VENDOR_ID },
+        ]),
+        projectId: 'p',
+      },
+      {
+        getMapRows: async () => [appRow, vendorRow],
+        fetchMap: async (objectKey) => {
+          if (objectKey === 'vendor.map') throw new Error('storage offline');
+          return MAP;
+        },
+      },
+    );
+    expect(result.status).toBe('partial');
+    expect(result.frames).toHaveLength(1);
+    expect(result.envelope?.frames[0]?.debug_id).toBe(APP_ID);
+  });
+
+  it('rejects a fetched map whose canonical digest changed', async () => {
+    const validRow = await row();
+    const changed = JSON.stringify({
+      version: 3,
+      sources: ['src/Other.ts'],
+      sourcesContent: ['other'],
+      names: [],
+      mappings: 'AAAA',
+    });
+    const result = await resolveEventStack(
+      {
+        stackTraceRaw: STACK,
+        debugMeta: meta([{ code_file: APP_FILE, debug_id: APP_ID }]),
+        projectId: 'p',
+      },
+      await deps([validRow], { 'app.map': changed }),
+    );
+    expect(result.status).toBe('invalid_map');
+  });
+});
+
+describe('framesFromEnvelope', () => {
+  it('converts a stored v1 envelope into the prompt frame shape', () => {
+    expect(framesFromEnvelope({
+      version: 1,
+      frames: [{
+        original_file: 'src/App.vue', original_line: 12, original_column: 4,
+        source_snippet: 'const value = missing.value;',
+        generated_file: APP_FILE, generated_line: 1, generated_column: 100,
+        debug_id: APP_ID,
+      }],
+    })).toEqual([{
+      originalFile: 'src/App.vue',
+      originalLine: 12,
+      originalColumn: 4,
+      sourceSnippet: 'const value = missing.value;',
+    }]);
+  });
+
+  it('round-trips a resolver envelope so both prompt paths agree', async () => {
+    const result = await resolveEventStack(
+      {
+        stackTraceRaw: STACK,
+        debugMeta: meta([{ code_file: APP_FILE, debug_id: APP_ID }]),
+        projectId: 'p',
+      },
+      await deps([await row()], { 'app.map': MAP }),
+    );
+    expect(framesFromEnvelope(result.envelope)).toEqual(result.frames);
+  });
+
+  it('returns null for absent, malformed, or empty stored values', () => {
+    expect(framesFromEnvelope(null)).toBeNull();
+    expect(framesFromEnvelope({ version: 1, frames: [] })).toBeNull();
+    expect(framesFromEnvelope({ version: 1, frames: [{ nope: 1 }] })).toBeNull();
+    expect(framesFromEnvelope('not an envelope')).toBeNull();
+  });
+});

--- a/packages/worker/src/db.ts
+++ b/packages/worker/src/db.ts
@@ -1041,6 +1041,7 @@ export interface ErrorEventData {
   error_message: string;
   stack_trace_raw: string;
   stack_trace_resolved: unknown;
+  debug_meta: string | null;
   breadcrumbs: string;
   context: string;
   release: string | null;
@@ -1052,6 +1053,7 @@ export async function getErrorEvent(eventId: string, projectId: string): Promise
   const pool = getPool();
   const { rows } = await pool.query<ErrorEventData>(
     `SELECT id, error_type, error_message, stack_trace_raw, stack_trace_resolved,
+            debug_meta::text AS debug_meta,
             breadcrumbs::text AS breadcrumbs, context::text AS context, release, session_id, platform
      FROM error_events WHERE id = $1 AND project_id = $2`,
     [eventId, projectId],
@@ -1291,20 +1293,75 @@ export async function getReplayArtifacts(replayId: string, projectId: string): P
   return rows;
 }
 
-export interface SourceMapEntry {
-  id: string;
-  filename: string;
+export interface SourceMapRow {
+  debug_id: string;
   object_key: string;
+  content_sha256: string;
 }
 
-export async function getSourceMaps(projectId: string, release: string): Promise<SourceMapEntry[]> {
+export async function getSourceMapRows(
+  projectId: string,
+  debugIds: string[],
+): Promise<SourceMapRow[]> {
   const pool = getPool();
-  const { rows } = await pool.query<SourceMapEntry>(
-    `SELECT id, filename, object_key
-     FROM source_maps WHERE project_id = $1 AND release = $2`,
-    [projectId, release],
+  const { rows } = await pool.query<SourceMapRow>(
+    `SELECT debug_id, object_key, content_sha256
+     FROM sourcemap_files WHERE project_id = $1 AND debug_id = ANY($2)`,
+    [projectId, debugIds],
   );
   return rows;
+}
+
+export interface ResolvedStackEnvelope {
+  version: 1;
+  frames: {
+    original_file: string;
+    original_line: number;
+    original_column: number;
+    source_snippet: string | null;
+    generated_file: string;
+    generated_line: number;
+    generated_column: number;
+    debug_id: string;
+  }[];
+}
+
+/**
+ * Record one resolution outcome, without ever destroying a better one.
+ *
+ * Both the investigate and the fix job resolve the same sample event, so this
+ * runs more than once per event and the two runs can disagree. Resolution
+ * depends on object storage, so the disagreement is usually a transient fetch
+ * failure rather than new information: a fix job running while MinIO blinks
+ * would otherwise overwrite a stored envelope with NULL and downgrade a
+ * `resolved` event to `resolution_failed`, losing frames nothing recomputes.
+ *
+ * A run that produced no envelope therefore leaves a stored one alone, and the
+ * status stays with it so the pair can never describe different outcomes.
+ */
+export async function setEventResolution(
+  eventId: string,
+  projectId: string,
+  status: string,
+  envelope: ResolvedStackEnvelope | null,
+): Promise<void> {
+  const pool = getPool();
+  await pool.query(
+    `UPDATE error_events
+     SET resolution_status = CASE
+           WHEN $4::jsonb IS NULL AND stack_trace_resolved IS NOT NULL
+             THEN resolution_status
+           ELSE $3
+         END,
+         stack_trace_resolved = COALESCE($4::jsonb, stack_trace_resolved)
+     WHERE id = $1 AND project_id = $2`,
+    [
+      eventId,
+      projectId,
+      status,
+      envelope === null ? null : JSON.stringify(envelope),
+    ],
+  );
 }
 
 // === Investigation lifecycle queries ===

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import http from 'node:http';
-import type { ClaimedJob } from './db.js';
+import type { ClaimedJob, ErrorEventData } from './db.js';
 import * as db from './db.js';
 import { requeueStaleJobs, updateGroupStatus, closePool, updateGroupInvestigation, updateGroupAndCreateFixJob, getGroupInvestigation, resolveInactiveGroups, resolveSilentMergedGroups, updateJobTraceUrl } from './db.js';
 import { buildReason } from './reason-codes.js';
@@ -14,7 +14,8 @@ import { getInstallationToken } from './github-app.js';
 import { type ReplaySignals } from './pr.js';
 import { processSetupPrJob } from './setup-pr.js';
 
-import { parseStackFrames, resolveFrame, type ResolvedFrame } from './source-map.js';
+import type { ResolvedFrame } from './source-map.js';
+import { framesFromEnvelope, resolveEventStack } from './resolve-stack.js';
 import { initTracing, shutdownTracing, withJobTrace, getActiveTraceId, buildLangfuseTraceUrl } from './tracing.js';
 import { runVisualAnalysis, type VisualAnalysisOutput } from './visual-analysis.js';
 import {
@@ -118,6 +119,36 @@ function checkAbort(signal: AbortSignal): void {
   if (signal.aborted) {
     throw new Error('Pipeline aborted: lease lost');
   }
+}
+
+async function resolveStackForEvent(
+  event: ErrorEventData,
+  projectId: string,
+  platform: string,
+): Promise<ResolvedFrame[] | null> {
+  if (platform !== 'javascript') return null;
+  const minioConfig = getMinIOConfig();
+  const resolution = await resolveEventStack(
+    {
+      stackTraceRaw: event.stack_trace_raw,
+      debugMeta: event.debug_meta,
+      projectId,
+    },
+    {
+      getMapRows: db.getSourceMapRows,
+      fetchMap: async (objectKey) => {
+        if (!minioConfig) return null;
+        return (await fetchObject(objectKey, minioConfig)).toString('utf-8');
+      },
+    },
+  );
+  await db.setEventResolution(
+    event.id,
+    projectId,
+    resolution.status,
+    resolution.envelope,
+  );
+  return resolution.frames;
 }
 
 export async function processJob(job: ClaimedJob, signal: AbortSignal): Promise<void> {
@@ -299,6 +330,12 @@ export async function processInvestigateJob(job: ClaimedJob & { errorGroupId: st
     return;
   }
 
+  // Debug-ID resolution depends only on Postgres and object storage. Persist
+  // it before LLM credentials or repository access can terminate the job.
+  const resolvedStack = event
+    ? await resolveStackForEvent(event, job.projectId, platform)
+    : null;
+
   const project = await db.getProject(job.projectId);
   if (!project) throw new Error(`Project ${job.projectId} not found`);
 
@@ -359,32 +396,7 @@ export async function processInvestigateJob(job: ClaimedJob & { errorGroupId: st
   }
 
   try {
-    // Source map resolution
-    const [replay, sourceMaps] = await Promise.all([
-      db.getReplayForGroup(job.errorGroupId, job.projectId),
-      platform === 'javascript' && event?.release ? db.getSourceMaps(job.projectId, event.release) : Promise.resolve([]),
-    ]);
-
-    const minioConfig = getMinIOConfig();
-    let resolvedStack: ResolvedFrame[] | null = null;
-    if (sourceMaps.length > 0 && event) {
-      if (minioConfig) {
-        const frames = parseStackFrames(event.stack_trace_raw);
-        const resolved: ResolvedFrame[] = [];
-        for (const frame of frames.slice(0, 5)) {
-          const basename = frame.file.split('/').pop() ?? frame.file;
-          const mapEntry = sourceMaps.find((m) =>
-            basename.endsWith(m.filename.replace('.map', '')),
-          );
-          if (mapEntry) {
-            const mapContent = await fetchObject(mapEntry.object_key, minioConfig);
-            const result = resolveFrame(frame, mapContent.toString('utf-8'));
-            if (result) resolved.push(result);
-          }
-        }
-        if (resolved.length > 0) resolvedStack = resolved;
-      }
-    }
+    const replay = await db.getReplayForGroup(job.errorGroupId, job.projectId);
 
     checkAbort(signal);
 
@@ -396,7 +408,7 @@ export async function processInvestigateJob(job: ClaimedJob & { errorGroupId: st
       title: group.title,
       errorMessage: event?.error_message ?? '',
       stackTrace: event?.stack_trace_raw ?? '',
-      resolvedStackTrace: resolvedStack ?? event?.stack_trace_resolved ?? null,
+      resolvedStackTrace: resolvedStack ?? framesFromEnvelope(event?.stack_trace_resolved) ?? null,
       breadcrumbs: event?.breadcrumbs ?? '[]',
     }, repoDir);
     checkAbort(signal);
@@ -682,6 +694,9 @@ export async function processFixJob(job: ClaimedJob & { errorGroupId: string }, 
     ? await db.getErrorEvent(group.sample_event_id, job.projectId)
     : null;
   const customerRuntime = parseRuntimeInfo(event?.context ?? '');
+  const resolvedStack = event
+    ? await resolveStackForEvent(event, job.projectId, platform)
+    : null;
 
   const project = await db.getProject(job.projectId);
   if (!project) throw new Error(`Project ${job.projectId} not found`);
@@ -690,9 +705,8 @@ export async function processFixJob(job: ClaimedJob & { errorGroupId: string }, 
   const investigation = await getGroupInvestigation(job.errorGroupId, job.projectId);
 
   // Parallel fetch for independent data
-  const [replay, sourceMaps, sessionPointer, environmentContext] = await Promise.all([
+  const [replay, sessionPointer, environmentContext] = await Promise.all([
     db.getReplayForGroup(job.errorGroupId, job.projectId),
-    platform === 'javascript' && event?.release ? db.getSourceMaps(job.projectId, event.release) : Promise.resolve([]),
     db.getSessionPointerForGroup(job.errorGroupId, job.projectId),
     db.getEnvironmentNamesForGroup(job.errorGroupId, job.projectId, group.kind),
   ]);
@@ -742,27 +756,6 @@ export async function processFixJob(job: ClaimedJob & { errorGroupId: string }, 
   const minioConfig = getMinIOConfig();
 
   try {
-    // Source map resolution
-    let resolvedStack: ResolvedFrame[] | null = null;
-    if (sourceMaps.length > 0 && event) {
-      if (minioConfig) {
-        const frames = parseStackFrames(event.stack_trace_raw);
-        const resolved: ResolvedFrame[] = [];
-        for (const frame of frames.slice(0, 5)) {
-          const basename = frame.file.split('/').pop() ?? frame.file;
-          const mapEntry = sourceMaps.find((m) =>
-            basename.endsWith(m.filename.replace('.map', '')),
-          );
-          if (mapEntry) {
-            const mapContent = await fetchObject(mapEntry.object_key, minioConfig);
-            const result = resolveFrame(frame, mapContent.toString('utf-8'));
-            if (result) resolved.push(result);
-          }
-        }
-        if (resolved.length > 0) resolvedStack = resolved;
-      }
-    }
-
     // Visual analysis
     let visualOutput: VisualAnalysisOutput | null = null;
     if (sessionPointer) {
@@ -851,7 +844,7 @@ export async function processFixJob(job: ClaimedJob & { errorGroupId: string }, 
       errorType: event?.error_type ?? 'Unknown',
       errorMessage: event?.error_message ?? '',
       stackTrace: event?.stack_trace_raw ?? '',
-      resolvedStackTrace: resolvedStack ?? event?.stack_trace_resolved ?? null,
+      resolvedStackTrace: resolvedStack ?? framesFromEnvelope(event?.stack_trace_resolved) ?? null,
       breadcrumbs: event?.breadcrumbs ?? '[]',
       context: event?.context ?? '{}',
       environmentNames: environmentContext.names,

--- a/packages/worker/src/resolve-stack.ts
+++ b/packages/worker/src/resolve-stack.ts
@@ -1,0 +1,208 @@
+import { computeDebugId } from '@opslane/sdk/build/debug-id';
+import type { ResolvedStackEnvelope } from './db.js';
+import {
+  isParseableMap,
+  parseStackFrames,
+  resolveFrame,
+  type ResolvedFrame,
+  type StackFrame,
+} from './source-map.js';
+
+const MAX_FRAMES = 10;
+const DEBUG_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export type ResolutionStatus =
+  | 'resolved'
+  | 'partial'
+  | 'no_debug_ids'
+  | 'map_not_found'
+  | 'invalid_map'
+  | 'resolution_failed';
+
+export interface StackResolution {
+  status: ResolutionStatus;
+  frames: ResolvedFrame[] | null;
+  envelope: ResolvedStackEnvelope | null;
+}
+
+export interface SourceMapRow {
+  debug_id: string;
+  object_key: string;
+  content_sha256: string;
+}
+
+export interface ResolveDeps {
+  getMapRows(projectId: string, debugIds: string[]): Promise<SourceMapRow[]>;
+  fetchMap(objectKey: string): Promise<string | null>;
+}
+
+interface DebugImage {
+  type: 'sourcemap';
+  code_file: string;
+  debug_id: string;
+}
+
+function parseImages(debugMeta: string | null): DebugImage[] {
+  if (!debugMeta) return [];
+  try {
+    const parsed = JSON.parse(debugMeta) as unknown;
+    if (typeof parsed !== 'object' || parsed === null) return [];
+    const images = (parsed as { images?: unknown }).images;
+    if (!Array.isArray(images)) return [];
+    return images.filter((image): image is DebugImage => {
+      if (typeof image !== 'object' || image === null) return false;
+      const candidate = image as Record<string, unknown>;
+      return candidate['type'] === 'sourcemap'
+        && typeof candidate['code_file'] === 'string'
+        && typeof candidate['debug_id'] === 'string'
+        && DEBUG_ID.test(candidate['debug_id']);
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read frames a previous job stored, in the shape the prompts already use.
+ *
+ * `stack_trace_resolved` holds the pinned v1 envelope (snake_case, with the
+ * generated position and debug ID for auditing); the prompt builders receive
+ * `ResolvedFrame[]`. Both get serialized straight into the model's context, so
+ * handing over the raw envelope would put two different schemas under the same
+ * "Resolved Stack Trace" heading depending on which branch produced it.
+ */
+export function framesFromEnvelope(stored: unknown): ResolvedFrame[] | null {
+  if (typeof stored !== 'object' || stored === null) return null;
+  const frames = (stored as { frames?: unknown }).frames;
+  if (!Array.isArray(frames)) return null;
+  const mapped: ResolvedFrame[] = [];
+  for (const frame of frames) {
+    if (typeof frame !== 'object' || frame === null) continue;
+    const candidate = frame as Record<string, unknown>;
+    const file = candidate['original_file'];
+    const line = candidate['original_line'];
+    const column = candidate['original_column'];
+    if (
+      typeof file !== 'string'
+      || typeof line !== 'number'
+      || typeof column !== 'number'
+    ) {
+      continue;
+    }
+    const snippet = candidate['source_snippet'];
+    mapped.push({
+      originalFile: file,
+      originalLine: line,
+      originalColumn: column,
+      sourceSnippet: typeof snippet === 'string' ? snippet : null,
+    });
+  }
+  return mapped.length > 0 ? mapped : null;
+}
+
+export async function resolveEventStack(
+  input: { stackTraceRaw: string; debugMeta: string | null; projectId: string },
+  deps: ResolveDeps,
+): Promise<StackResolution> {
+  try {
+    const images = parseImages(input.debugMeta);
+    if (images.length === 0) {
+      return { status: 'no_debug_ids', frames: null, envelope: null };
+    }
+
+    const byCodeFile = new Map(
+      images.map((image) => [image.code_file, image.debug_id]),
+    );
+    const matched = parseStackFrames(input.stackTraceRaw)
+      .map((frame) => ({ frame, debugId: byCodeFile.get(frame.file) }))
+      .filter(
+        (entry): entry is { frame: StackFrame; debugId: string } =>
+          entry.debugId !== undefined,
+      )
+      .slice(0, MAX_FRAMES);
+    if (matched.length === 0) {
+      return { status: 'no_debug_ids', frames: null, envelope: null };
+    }
+
+    const rows = await deps.getMapRows(
+      input.projectId,
+      [...new Set(matched.map(({ debugId }) => debugId))],
+    );
+    if (rows.length === 0) {
+      return { status: 'map_not_found', frames: null, envelope: null };
+    }
+    const rowByDebugID = new Map(rows.map((row) => [row.debug_id, row]));
+    const mapCache = new Map<string, string | null>();
+    const resolved: ResolvedFrame[] = [];
+    const envelopeFrames: ResolvedStackEnvelope['frames'] = [];
+    let fetchedAny = false;
+    let sawValidMap = false;
+
+    for (const { frame, debugId } of matched) {
+      const row = rowByDebugID.get(debugId);
+      if (!row) continue;
+
+      let mapContent = mapCache.get(row.object_key);
+      if (mapContent === undefined) {
+        // Scoped to the one object. A stack usually spans several chunks, and
+        // letting a single unreachable map reach the function-wide catch would
+        // discard every frame the other maps could still resolve.
+        try {
+          mapContent = await deps.fetchMap(row.object_key);
+        } catch {
+          mapContent = null;
+        }
+        if (mapContent !== null) {
+          fetchedAny = true;
+          try {
+            const { contentSha256 } = await computeDebugId(
+              new TextEncoder().encode(mapContent),
+            );
+            if (contentSha256 !== row.content_sha256) mapContent = null;
+          } catch {
+            mapContent = null;
+          }
+        }
+        mapCache.set(row.object_key, mapContent);
+      }
+      if (mapContent === null) continue;
+
+      const result = resolveFrame(
+        { ...frame, column: Math.max(0, frame.column - 1) },
+        mapContent,
+      );
+      if (result) {
+        sawValidMap = true;
+        resolved.push(result);
+        envelopeFrames.push({
+          original_file: result.originalFile,
+          original_line: result.originalLine,
+          original_column: result.originalColumn,
+          source_snippet: result.sourceSnippet,
+          generated_file: frame.file,
+          generated_line: frame.line,
+          generated_column: frame.column,
+          debug_id: debugId,
+        });
+      } else if (isParseableMap(mapContent)) {
+        sawValidMap = true;
+      }
+    }
+
+    const envelope: ResolvedStackEnvelope | null = envelopeFrames.length > 0
+      ? { version: 1, frames: envelopeFrames }
+      : null;
+    if (resolved.length === matched.length) {
+      return { status: 'resolved', frames: resolved, envelope };
+    }
+    if (resolved.length > 0) {
+      return { status: 'partial', frames: resolved, envelope };
+    }
+    if (fetchedAny && !sawValidMap) {
+      return { status: 'invalid_map', frames: null, envelope: null };
+    }
+    return { status: 'resolution_failed', frames: null, envelope: null };
+  } catch {
+    return { status: 'resolution_failed', frames: null, envelope: null };
+  }
+}

--- a/packages/worker/src/source-map.ts
+++ b/packages/worker/src/source-map.ts
@@ -20,6 +20,18 @@ export interface StackFrame {
   column: number;
 }
 
+/** True when the content constructs a usable TraceMap. */
+export function isParseableMap(sourceMapContent: string): boolean {
+  try {
+    new TraceMap(
+      JSON.parse(sourceMapContent) as ConstructorParameters<typeof TraceMap>[0],
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Extracts structured stack frames from a raw stack trace string.
  * Handles V8 formats:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       '@opslane/agent-core':
         specifier: workspace:*
         version: link:../agent-core
+      '@opslane/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       '@opslane/shared':
         specifier: workspace:*
         version: link:../../shared

--- a/scripts/run-reliability-system.sh
+++ b/scripts/run-reliability-system.sh
@@ -20,13 +20,17 @@ docker compose exec -T postgres dropdb --if-exists -U opslane "${RELIABILITY_DAT
 docker compose exec -T postgres createdb -U opslane "${RELIABILITY_DATABASE}"
 docker compose run --rm migrate
 
-# The worker source these suites import resolves @opslane/agent-core and
-# @opslane/shared through their package entry points, which name dist. Build
-# both first. Missing dist shows up two ways: vitest fails to resolve
-# agent-core at runtime, and tsc reports "Cannot find module '@opslane/shared'"
-# across every worker file it pulls in. Neither reproduces on a dev machine,
-# where dist is left over from an earlier build and gitignored.
-pnpm --filter @opslane/shared --filter @opslane/agent-core build
+# The worker source these suites import resolves its workspace dependencies
+# through their package entry points, which name dist. Build them first.
+# Missing dist shows up two ways: vitest fails to resolve the dependency at
+# runtime, and tsc reports "Cannot find module" across every worker file it
+# pulls in. Neither reproduces on a dev machine, where dist is left over from
+# an earlier build and gitignored.
+#
+# The trailing "..." selects the worker and its dependencies from the
+# dependency graph rather than a hand-written list, which is what went stale
+# when the worker took on @opslane/sdk for debug-ID recompute.
+pnpm --filter '@opslane/worker...' build
 
 DATABASE_URL="${LOCAL_RELIABILITY_DATABASE_URL}" \
 OPSLANE_RELIABILITY_DB_TESTS=1 \

--- a/scripts/seed-e2e.sql
+++ b/scripts/seed-e2e.sql
@@ -37,6 +37,72 @@ ON CONFLICT (id) DO UPDATE SET
   revoked_at = NULL,
   revoked_by_user_id = NULL;
 
+-- Secret source-map key for the primary fixture (raw, shown only for E2E):
+-- opslane_sk_nbxw6ytboi3damrrgi3tknzxgq_E2ESOURCEMAPSECRETAAAAAAAAAAAAAAAAAAAAAAAAA
+INSERT INTO project_api_keys
+  (id, key_id, project_id, scope, token_prefix, secret_hash, label)
+VALUES
+  ('00000000-0000-0000-0000-000000001100',
+   'nbxw6ytboi3damrrgi3tknzxgq',
+   '00000000-0000-0000-0000-000000000010',
+   'sourcemaps',
+   'opslane_sk',
+   '67d260caf3fb036990b4d21bf0733af700155609945bfcb1ae7355a5b6357ee9',
+   'e2e source maps')
+ON CONFLICT (id) DO UPDATE SET
+  project_id = EXCLUDED.project_id,
+  secret_hash = EXCLUDED.secret_hash,
+  revoked_at = NULL,
+  revoked_by_user_id = NULL;
+
+-- A second fixed project makes cross-project source-map isolation
+-- discriminating: it can report an event carrying project 1's debug ID before
+-- project 2 uploads the same map.
+INSERT INTO projects (id, org_id, name, github_repo, default_branch) VALUES
+  ('00000000-0000-0000-0000-000000000020', '00000000-0000-0000-0000-000000000001',
+   'Opslane Isolation Fixture', 'opslane/defender-test-fixture', 'main')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO environments (id, project_id, name) VALUES
+  ('00000000-0000-0000-0000-000000000200', '00000000-0000-0000-0000-000000000020', 'production')
+ON CONFLICT (id) DO NOTHING;
+
+-- Raw project-2 ingest key:
+-- opslane_pk_ndxw6ytboi3damrrgi3tknzxgq_E2EINGESTSECRETBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+INSERT INTO project_api_keys
+  (id, key_id, project_id, scope, token_prefix, secret_hash, label)
+VALUES
+  ('00000000-0000-0000-0000-000000002000',
+   'ndxw6ytboi3damrrgi3tknzxgq',
+   '00000000-0000-0000-0000-000000000020',
+   'ingest',
+   'opslane_pk',
+   '8560f0955838c94371bc064e9f40ce4a2390107a0d80651e3886251e675a90a4',
+   'e2e isolation ingest')
+ON CONFLICT (id) DO UPDATE SET
+  project_id = EXCLUDED.project_id,
+  secret_hash = EXCLUDED.secret_hash,
+  revoked_at = NULL,
+  revoked_by_user_id = NULL;
+
+-- Raw project-2 source-map key:
+-- opslane_sk_ncxw6ytboi3damrrgi3tknzxgq_E2ESOURCEMAPSECRETBBBBBBBBBBBBBBBBBBBBBBBBB
+INSERT INTO project_api_keys
+  (id, key_id, project_id, scope, token_prefix, secret_hash, label)
+VALUES
+  ('00000000-0000-0000-0000-000000002100',
+   'ncxw6ytboi3damrrgi3tknzxgq',
+   '00000000-0000-0000-0000-000000000020',
+   'sourcemaps',
+   'opslane_sk',
+   'a61a22ece1ef51461677aae27b2014ed72e33eae0de334d7188c16e47acd0e36',
+   'e2e isolation source maps')
+ON CONFLICT (id) DO UPDATE SET
+  project_id = EXCLUDED.project_id,
+  secret_hash = EXCLUDED.secret_hash,
+  revoked_at = NULL,
+  revoked_by_user_id = NULL;
+
 -- Test user for auth E2E (password: testpassword123, bcrypt cost 10)
 INSERT INTO users (id, org_id, email, password_hash, name) VALUES
   ('00000000-0000-0000-0000-000000010000', '00000000-0000-0000-0000-000000000001',

--- a/test-e2e/build-helpers.ts
+++ b/test-e2e/build-helpers.ts
@@ -1,0 +1,94 @@
+/**
+ * Build-mode fixture harness. The SDK package must be built before this runs:
+ * the fixture config resolves @opslane/sdk/vite-plugin through workspace dist.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const SDK_SOURCE = resolve(__dirname, '../packages/sdk/src');
+
+export interface BuiltFixture {
+  url: string;
+  outDir: string;
+  close(): Promise<void>;
+}
+
+export async function startBuiltFixture(opts: {
+  fixtureDir: string;
+  apiKey: string;
+  ingestionUrl: string;
+  sourcemapKey?: string;
+  release?: string;
+}): Promise<BuiltFixture> {
+  const { build, preview } = await import('vite');
+  const outDir = mkdtempSync(join(tmpdir(), 'opslane-built-fixture-'));
+  const cacheDir = mkdtempSync(join(tmpdir(), 'opslane-built-cache-'));
+  const managed = [
+    'VITE_OPSLANE_ENDPOINT',
+    'VITE_OPSLANE_API_KEY',
+    'VITE_OPSLANE_RELEASE',
+    'OPSLANE_ENDPOINT',
+    'OPSLANE_SOURCEMAP_KEY',
+  ] as const;
+  const saved = new Map(managed.map((key) => [key, process.env[key]]));
+  const values: Record<(typeof managed)[number], string | undefined> = {
+    VITE_OPSLANE_ENDPOINT: opts.ingestionUrl,
+    VITE_OPSLANE_API_KEY: opts.apiKey,
+    VITE_OPSLANE_RELEASE: opts.release ?? '',
+    OPSLANE_ENDPOINT: opts.ingestionUrl,
+    OPSLANE_SOURCEMAP_KEY: opts.sourcemapKey,
+  };
+
+  for (const key of managed) {
+    const value = values[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+
+  try {
+    await build({
+      root: opts.fixtureDir,
+      logLevel: 'error',
+      cacheDir,
+      resolve: {
+        alias: [
+          { find: '@opslane/sdk/react', replacement: resolve(SDK_SOURCE, 'react.tsx') },
+          { find: '@opslane/sdk/_replay', replacement: resolve(SDK_SOURCE, 'replay.ts') },
+          { find: '@opslane/sdk', replacement: resolve(SDK_SOURCE, 'index.ts') },
+        ],
+      },
+      build: { outDir, emptyOutDir: true },
+    });
+  } catch (error) {
+    rmSync(outDir, { recursive: true, force: true });
+    throw error;
+  } finally {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+
+  const server = await preview({
+    root: opts.fixtureDir,
+    build: { outDir },
+    preview: { host: '127.0.0.1', port: 0 },
+    logLevel: 'error',
+  });
+  const address = server.httpServer.address();
+  if (!address || typeof address === 'string') {
+    await server.close();
+    rmSync(outDir, { recursive: true, force: true });
+    throw new Error('Vite preview did not expose a TCP port');
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    outDir,
+    close: async () => {
+      await server.close();
+      rmSync(outDir, { recursive: true, force: true });
+    },
+  };
+}

--- a/test-e2e/sourcemap-resolution.test.ts
+++ b/test-e2e/sourcemap-resolution.test.ts
@@ -3,16 +3,18 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { computeDebugId } from '../packages/sdk/src/build/debug-id.js';
-import { closePool, getConfig, getPool } from './helpers.js';
+import { closePool, getConfig, getPool, seedTenant, type TestTenant } from './helpers.js';
 import { isPlaywrightAvailable } from './browser-helpers.js';
 import { startBuiltFixture } from './build-helpers.js';
 
-const PROJECT_A = '00000000-0000-0000-0000-000000000010';
-const PROJECT_B = '00000000-0000-0000-0000-000000000020';
-const PK_A = 'opslane_pk_mzxw6ytboi3damrrgi3tknzxgq_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq';
-const PK_B = 'opslane_pk_ndxw6ytboi3damrrgi3tknzxgq_E2EINGESTSECRETBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
-const SK_A = 'opslane_sk_nbxw6ytboi3damrrgi3tknzxgq_E2ESOURCEMAPSECRETAAAAAAAAAAAAAAAAAAAAAAAAA';
-const SK_B = 'opslane_sk_ncxw6ytboi3damrrgi3tknzxgq_E2ESOURCEMAPSECRETBBBBBBBBBBBBBBBBBBBBBBBBB';
+// Two tenants seeded at run time, the way every other suite here gets its
+// credentials. An earlier revision hardcoded the UUIDs and keys from
+// scripts/seed-e2e.sql, which is a local-dev convenience applied by hand --
+// nothing in CI runs it, so every upload came back 401 and the isolation
+// assertion could only ever pass on a machine where someone had seeded first.
+let tenantA: TestTenant;
+let tenantB: TestTenant;
+
 const FIXTURE = resolve(__dirname, '../test-fixtures/vue-app');
 const playwrightAvailable = await isPlaywrightAvailable();
 
@@ -76,10 +78,10 @@ describe.skipIf(!playwrightAvailable).sequential(
   'source maps resolve end to end',
   () => {
     beforeAll(async () => {
-      await getPool().query(
-        `DELETE FROM sourcemap_files WHERE project_id = ANY($1::uuid[])`,
-        [[PROJECT_A, PROJECT_B]],
-      );
+      // Fresh projects per run, so no cleanup is needed: their sourcemap_files
+      // and error_events start empty by construction.
+      tenantA = await seedTenant();
+      tenantB = await seedTenant();
     });
 
     afterAll(async () => {
@@ -90,9 +92,9 @@ describe.skipIf(!playwrightAvailable).sequential(
       const startedAt = new Date();
       const fixture = await startBuiltFixture({
         fixtureDir: FIXTURE,
-        apiKey: PK_A,
+        apiKey: tenantA.ingestKey,
         ingestionUrl: getConfig().ingestionUrl,
-        sourcemapKey: SK_A,
+        sourcemapKey: tenantA.sourceMapKey,
       });
       const { chromium } = await import('@playwright/test');
       const browser = await chromium.launch();
@@ -100,7 +102,7 @@ describe.skipIf(!playwrightAvailable).sequential(
         const rows = await getPool().query<{ debug_id: string }>(
           `SELECT debug_id FROM sourcemap_files
            WHERE project_id = $1 AND created_at > $2`,
-          [PROJECT_A, startedAt],
+          [tenantA.projectId, startedAt],
         );
         expect(rows.rowCount).toBeGreaterThan(0);
 
@@ -126,7 +128,7 @@ describe.skipIf(!playwrightAvailable).sequential(
         await page.click('[data-testid="debug-id-eager"]');
         expect((await posted).status()).toBe(202);
 
-        const event = await pollResolution(PROJECT_A, startedAt);
+        const event = await pollResolution(tenantA.projectId, startedAt);
         expect(event.resolution_status).toBe('resolved');
         const envelope = event.stack_trace_resolved as {
           version: number;
@@ -155,14 +157,14 @@ describe.skipIf(!playwrightAvailable).sequential(
       const { debugId } = await computeDebugId(new TextEncoder().encode(map));
       const denied = await fetch(
         `${getConfig().ingestionUrl}/api/v1/sourcemaps/${debugId}`,
-        { method: 'PUT', headers: { 'X-API-Key': PK_A }, body: map },
+        { method: 'PUT', headers: { 'X-API-Key': tenantA.ingestKey }, body: map },
       );
       expect(denied.status).toBe(403);
       expect((await denied.json() as { code: string }).code).toBe('insufficient_scope');
 
       const eventDenied = await fetch(`${getConfig().ingestionUrl}/api/v1/events`, {
         method: 'POST',
-        headers: { 'X-API-Key': SK_A, 'Content-Type': 'application/json' },
+        headers: { 'X-API-Key': tenantA.sourceMapKey, 'Content-Type': 'application/json' },
         body: '{}',
       });
       expect(eventDenied.status).toBe(403);
@@ -187,22 +189,22 @@ describe.skipIf(!playwrightAvailable).sequential(
         { method: 'PUT', headers: { 'X-API-Key': key }, body: map },
       );
 
-      expect([200, 201]).toContain((await upload(SK_A)).status);
+      expect([200, 201]).toContain((await upload(tenantA.sourceMapKey)).status);
       const firstStart = new Date();
-      expect((await postCraftedEvent(PK_B, debugId, `isolation-before-${Date.now()}`)).status).toBe(202);
-      expect((await pollResolution(PROJECT_B, firstStart)).resolution_status).toBe('map_not_found');
+      expect((await postCraftedEvent(tenantB.ingestKey, debugId, `isolation-before-${Date.now()}`)).status).toBe(202);
+      expect((await pollResolution(tenantB.projectId, firstStart)).resolution_status).toBe('map_not_found');
 
-      expect([200, 201]).toContain((await upload(SK_B)).status);
+      expect([200, 201]).toContain((await upload(tenantB.sourceMapKey)).status);
       const secondStart = new Date();
-      expect((await postCraftedEvent(PK_B, debugId, `isolation-after-${Date.now()}`)).status).toBe(202);
-      expect((await pollResolution(PROJECT_B, secondStart)).resolution_status).toBe('resolved');
+      expect((await postCraftedEvent(tenantB.ingestKey, debugId, `isolation-after-${Date.now()}`)).status).toBe(202);
+      expect((await pollResolution(tenantB.projectId, secondStart)).resolution_status).toBe('resolved');
 
       const stored = await getPool().query<{ object_key: string }>(
         `SELECT object_key FROM sourcemap_files
          WHERE project_id = $1 AND debug_id = $2`,
-        [PROJECT_B, debugId],
+        [tenantB.projectId, debugId],
       );
-      expect(stored.rows[0]?.object_key).toContain(`sourcemaps/${PROJECT_B}/`);
+      expect(stored.rows[0]?.object_key).toContain(`sourcemaps/${tenantB.projectId}/`);
     }, 180_000);
   },
 );

--- a/test-e2e/sourcemap-resolution.test.ts
+++ b/test-e2e/sourcemap-resolution.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment node
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { computeDebugId } from '../packages/sdk/src/build/debug-id.js';
+import { closePool, getConfig, getPool } from './helpers.js';
+import { isPlaywrightAvailable } from './browser-helpers.js';
+import { startBuiltFixture } from './build-helpers.js';
+
+const PROJECT_A = '00000000-0000-0000-0000-000000000010';
+const PROJECT_B = '00000000-0000-0000-0000-000000000020';
+const PK_A = 'opslane_pk_mzxw6ytboi3damrrgi3tknzxgq_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq';
+const PK_B = 'opslane_pk_ndxw6ytboi3damrrgi3tknzxgq_E2EINGESTSECRETBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const SK_A = 'opslane_sk_nbxw6ytboi3damrrgi3tknzxgq_E2ESOURCEMAPSECRETAAAAAAAAAAAAAAAAAAAAAAAAA';
+const SK_B = 'opslane_sk_ncxw6ytboi3damrrgi3tknzxgq_E2ESOURCEMAPSECRETBBBBBBBBBBBBBBBBBBBBBBBBB';
+const FIXTURE = resolve(__dirname, '../test-fixtures/vue-app');
+const playwrightAvailable = await isPlaywrightAvailable();
+
+interface ResolutionRow {
+  resolution_status: string;
+  stack_trace_resolved: unknown;
+}
+
+async function pollResolution(
+  projectID: string,
+  startedAt: Date,
+  timeoutMs = 90_000,
+): Promise<ResolutionRow> {
+  const db = getPool();
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await db.query<ResolutionRow>(
+      `SELECT resolution_status, stack_trace_resolved
+       FROM error_events
+       WHERE project_id = $1 AND created_at > $2
+         AND resolution_status IS NOT NULL
+       ORDER BY created_at DESC LIMIT 1`,
+      [projectID, startedAt],
+    );
+    if (result.rows[0]) return result.rows[0];
+    await new Promise((resolvePoll) => setTimeout(resolvePoll, 1_000));
+  }
+  throw new Error(`resolution did not complete for ${projectID}`);
+}
+
+async function postCraftedEvent(
+  key: string,
+  debugID: string,
+  message: string,
+): Promise<Response> {
+  return fetch(`${getConfig().ingestionUrl}/api/v1/events`, {
+    method: 'POST',
+    headers: { 'X-API-Key': key, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      timestamp: new Date().toISOString(),
+      error: {
+        type: 'Error',
+        message,
+        stack: `Error: ${message}\n    at run (https://fixture.example/assets/known.js:1:1)`,
+      },
+      breadcrumbs: [],
+      context: { url: 'https://fixture.example/' },
+      sdk_version: 'e2e',
+      debug_meta: {
+        images: [{
+          type: 'sourcemap',
+          code_file: 'https://fixture.example/assets/known.js',
+          debug_id: debugID,
+        }],
+      },
+    }),
+  });
+}
+
+describe.skipIf(!playwrightAvailable).sequential(
+  'source maps resolve end to end',
+  () => {
+    beforeAll(async () => {
+      await getPool().query(
+        `DELETE FROM sourcemap_files WHERE project_id = ANY($1::uuid[])`,
+        [[PROJECT_A, PROJECT_B]],
+      );
+    });
+
+    afterAll(async () => {
+      await closePool();
+    });
+
+    it('uploads build maps, removes public artifacts, and resolves a browser event', async () => {
+      const startedAt = new Date();
+      const fixture = await startBuiltFixture({
+        fixtureDir: FIXTURE,
+        apiKey: PK_A,
+        ingestionUrl: getConfig().ingestionUrl,
+        sourcemapKey: SK_A,
+      });
+      const { chromium } = await import('@playwright/test');
+      const browser = await chromium.launch();
+      try {
+        const rows = await getPool().query<{ debug_id: string }>(
+          `SELECT debug_id FROM sourcemap_files
+           WHERE project_id = $1 AND created_at > $2`,
+          [PROJECT_A, startedAt],
+        );
+        expect(rows.rowCount).toBeGreaterThan(0);
+
+        const files = readdirSync(fixture.outDir, { recursive: true }) as string[];
+        expect(files.filter((file) => file.endsWith('.map'))).toEqual([]);
+        for (const file of files.filter((candidate) => /\.(?:js|mjs)$/.test(candidate))) {
+          const hasSourceMapDirective = readFileSync(join(fixture.outDir, file), 'utf8')
+            .split(/\r?\n/)
+            .some((line) => /^(?:\/\/[@#]|\/\*[@#])\s*sourceMappingURL\s*=/.test(line.trim()));
+          expect(
+            hasSourceMapDirective,
+            `${file} must not publish a sourceMappingURL directive`,
+          ).toBe(false);
+        }
+
+        const page = await browser.newPage();
+        await page.goto(fixture.url);
+        const posted = page.waitForResponse(
+          (response) => response.url().endsWith('/api/v1/events')
+            && response.request().method() === 'POST',
+          { timeout: 20_000 },
+        );
+        await page.click('[data-testid="debug-id-eager"]');
+        expect((await posted).status()).toBe(202);
+
+        const event = await pollResolution(PROJECT_A, startedAt);
+        expect(event.resolution_status).toBe('resolved');
+        const envelope = event.stack_trace_resolved as {
+          version: number;
+          frames: {
+            original_file: string;
+            original_line: number;
+            source_snippet: string | null;
+          }[];
+        };
+        expect(envelope.version).toBe(1);
+        expect(envelope.frames[0]?.original_file).toMatch(/^src\//);
+        expect(envelope.frames[0]?.original_line).toBeGreaterThan(0);
+        expect(envelope.frames[0]?.source_snippet).toBeTruthy();
+        await page.close();
+      } finally {
+        await browser.close();
+        await fixture.close();
+      }
+    }, 180_000);
+
+    it('enforces the credential and no-read-path privacy floor', async () => {
+      const map = JSON.stringify({
+        version: 3, sources: ['src/a.ts'], sourcesContent: ['x'],
+        names: [], mappings: 'AAAA',
+      });
+      const { debugId } = await computeDebugId(new TextEncoder().encode(map));
+      const denied = await fetch(
+        `${getConfig().ingestionUrl}/api/v1/sourcemaps/${debugId}`,
+        { method: 'PUT', headers: { 'X-API-Key': PK_A }, body: map },
+      );
+      expect(denied.status).toBe(403);
+      expect((await denied.json() as { code: string }).code).toBe('insufficient_scope');
+
+      const eventDenied = await fetch(`${getConfig().ingestionUrl}/api/v1/events`, {
+        method: 'POST',
+        headers: { 'X-API-Key': SK_A, 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      expect(eventDenied.status).toBe(403);
+
+      const read = await fetch(
+        `${getConfig().ingestionUrl}/api/v1/sourcemaps/${debugId}`,
+      );
+      expect([404, 405]).toContain(read.status);
+    });
+
+    it('isolates identical debug IDs by project', async () => {
+      const map = JSON.stringify({
+        version: 3,
+        sources: ['src/known.ts'],
+        sourcesContent: ['export function run() { throw new Error("known"); }'],
+        names: [],
+        mappings: 'AAAA',
+      });
+      const { debugId } = await computeDebugId(new TextEncoder().encode(map));
+      const upload = async (key: string) => fetch(
+        `${getConfig().ingestionUrl}/api/v1/sourcemaps/${debugId}`,
+        { method: 'PUT', headers: { 'X-API-Key': key }, body: map },
+      );
+
+      expect([200, 201]).toContain((await upload(SK_A)).status);
+      const firstStart = new Date();
+      expect((await postCraftedEvent(PK_B, debugId, `isolation-before-${Date.now()}`)).status).toBe(202);
+      expect((await pollResolution(PROJECT_B, firstStart)).resolution_status).toBe('map_not_found');
+
+      expect([200, 201]).toContain((await upload(SK_B)).status);
+      const secondStart = new Date();
+      expect((await postCraftedEvent(PK_B, debugId, `isolation-after-${Date.now()}`)).status).toBe(202);
+      expect((await pollResolution(PROJECT_B, secondStart)).resolution_status).toBe('resolved');
+
+      const stored = await getPool().query<{ object_key: string }>(
+        `SELECT object_key FROM sourcemap_files
+         WHERE project_id = $1 AND debug_id = $2`,
+        [PROJECT_B, debugId],
+      );
+      expect(stored.rows[0]?.object_key).toContain(`sourcemaps/${PROJECT_B}/`);
+    }, 180_000);
+  },
+);

--- a/test-fixtures/debug-id/build-vectors.mjs
+++ b/test-fixtures/debug-id/build-vectors.mjs
@@ -18,6 +18,11 @@ const ESCAPES =
 const ESCAPES_CANONICAL =
   '{"mappings":";AACA","names":[],"sourceRoot":"https://example.com/雪/","sources":["src/escape.ts"],"sourcesContent":["line 1\\nline 2\\t\\"quoted\\"\\\\slash\\u0001"],"version":3}';
 
+const WITHOUT_SOURCES_CONTENT =
+  '{"version":3,"sources":["src/no-content.ts"],"names":[],"mappings":"AAAA"}';
+const WITHOUT_SOURCES_CONTENT_CANONICAL =
+  '{"mappings":"AAAA","names":[],"sources":["src/no-content.ts"],"version":3}';
+
 const cases = [
   {
     name: 'basic-debugid-excluded',
@@ -55,6 +60,14 @@ const cases = [
     canonical_b64: b64(BASIC_CANONICAL),
     sha256: '158399f31dad138635b298c34317d52e058db2d329438e3161b0c04bcd82b9df',
     debug_id: '158399f3-1dad-1386-35b2-98c34317d52e',
+  },
+  {
+    name: 'without-sources-content',
+    input_b64: b64(WITHOUT_SOURCES_CONTENT),
+    outcome: 'ok',
+    canonical_b64: b64(WITHOUT_SOURCES_CONTENT_CANONICAL),
+    sha256: 'd69d15a47db4e7b0137dd6845c4c4db5d6a3866056164d581670fcb0362d7230',
+    debug_id: 'd69d15a4-7db4-e7b0-137d-d6845c4c4db5',
   },
 ];
 

--- a/test-fixtures/debug-id/vectors.json
+++ b/test-fixtures/debug-id/vectors.json
@@ -34,6 +34,14 @@
       "debug_id": "158399f3-1dad-1386-35b2-98c34317d52e"
     },
     {
+      "name": "without-sources-content",
+      "input_b64": "eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNyYy9uby1jb250ZW50LnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBIn0=",
+      "outcome": "ok",
+      "canonical_b64": "eyJtYXBwaW5ncyI6IkFBQUEiLCJuYW1lcyI6W10sInNvdXJjZXMiOlsic3JjL25vLWNvbnRlbnQudHMiXSwidmVyc2lvbiI6M30=",
+      "sha256": "d69d15a47db4e7b0137dd6845c4c4db5d6a3866056164d581670fcb0362d7230",
+      "debug_id": "d69d15a4-7db4-e7b0-137d-d6845c4c4db5"
+    },
+    {
       "name": "reject-bom",
       "input_b64": "77u/eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiIsInNvdXJjZXNDb250ZW50IjpbXX0=",
       "outcome": "reject",

--- a/test-fixtures/vue-app/src/main.ts
+++ b/test-fixtures/vue-app/src/main.ts
@@ -5,11 +5,13 @@ import { init, opslaneVuePlugin } from '@opslane/sdk';
 // Endpoint/key are overridable so the same fixture drives any local stack
 // (e.g. the Batch 4 dogfood on non-default ports, or a staging environment
 // key for isolation runs). Defaults preserve the standard compose setup.
+const release = import.meta.env['VITE_OPSLANE_RELEASE'] ?? 'e2e-fixture-v1';
+
 init({
   endpoint: import.meta.env['VITE_OPSLANE_ENDPOINT'] ?? 'http://localhost:8082',
   apiKey: import.meta.env['VITE_OPSLANE_API_KEY']
     ?? 'opslane_pk_mzxw6ytboi3damrrgi3tknzxgq_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq',
-  release: 'e2e-fixture-v1',
+  ...(release ? { release } : {}),
   environment: import.meta.env['VITE_OPSLANE_ENVIRONMENT'] ?? 'development',
   reporting: { enabled: import.meta.env['VITE_OPSLANE_REPORTING'] !== 'false' },
   replay: { enabled: true },


### PR DESCRIPTION
## What this does

Three finished components had the wires between them cut. Nothing minted an `opslane_sk_` key, no upload route existed (`POST /api/v1/sourcemaps` was deleted in S1 and the frozen batch API was never built), the Vite plugin stamped debug IDs but uploaded nothing, and the worker looked maps up by `(project_id, release)` in a `source_maps` table with no writer — so it always resolved null and never read `error_events.debug_meta`.

This is the one tracer-bullet slice that makes **a single stack trace resolve end to end**: the plugin uploads stamped maps with a secret key, ingestion stores them privately by debug ID, and the worker resolves the investigated event's frames to original source for the fix agent.

Spec: `docs/plans/2026-08-03-v1-sourcemaps-simplification.md`.

## Non-negotiables it keeps

- Uploads require a real `sk`-scoped secret key. `pk` gets `403 insufficient_scope`.
- **The server recomputes the debug ID from the uploaded bytes**, so one bad upload cannot wedge a chunk's ID forever. Recompute doubles as validation — non-source-map bytes are rejected.
- A leaked `sk` is revocable with one documented SQL statement, printed by `cmd/mint-key` at mint time.
- **No API can download a map.** No GET, no presigned URL, no dashboard route returns map bytes or `sourcesContent`. The route does not exist.

## Design notes worth a reviewer's attention

**Digest-addressed object keys make overwrite structurally unreachable.** The key is `sourcemaps/{projectID}/{debugID}/{content_sha256}`. Two concurrent first uploads with different canonical content write two *different* objects; whichever row insert wins, its `object_key` points at its own bytes and the loser is an unreferenced orphan. Resolution only ever reads row-referenced keys.

**`content_sha256` is the canonical hash**, not a wire-byte hash — two serializations that canonicalize identically are the same map, so honest retries can never conflict.

**`sourcesContent` is now optional**, relaxed in both the Go validator and its TS mirror. The hash algorithm and existing golden vectors are unaffected, and a new vector without `sourcesContent` was added to the *generator* (`build-vectors.mjs`) as well as `vectors.json`, so the two implementations cannot drift and regeneration cannot silently drop the case.

**Storage co-tenancy:** maps live in the existing bucket under a distinct `sourcemaps/` prefix. The retention sweeper only touches session prefixes.

**Column base fix:** browser stack columns are 1-based, `@jridgewell/trace-mapping` expects 0-based. The old `resolveFrame` passed them through unadjusted — an off-by-one on *every* frame. The shared resolver subtracts 1 and a test pins a known position.

**Join rule, stated so it can't be improvised:** a frame resolves against the image whose `code_file` *exactly equals* the frame's file URL. No basename fallback; the old heuristic is deleted with its dead code.

## Contract amendment

`docs/design/2026-07-29-keys-sourcemaps-s0-contracts.md` is marked frozen but most of it was never implemented, so it's amended **explicitly** rather than silently (repo guardrail).

Stays frozen: the `debug_meta` wire shape, debug-ID algorithm, canonical `content_sha256` and golden vectors, key formats, the sk-only authorization boundary, server-side recompute with `debug_id_mismatch`/`debug_id_conflict`, and the `resolution_status` enum.

Superseded for v1, each named in the doc: §3 key CRUD → manual `cmd/mint-key`; §6 map-validity → `sourcesContent` optional; §6's 100 MiB → 32 MiB; §7 batch protocol → single-map identity-encoded PUT (its no-`Content-Encoding` rule kept, enforced with 415); §7 cluster-wide throttles → one process-local 60/min per-project limiter; §8 batch tables → `sourcemap_files`; §9 and §11 endpoints → dropped; §10 → `resolution_status` + `stack_trace_resolved` only.

## Review found and fixed

A pre-landing review caught three defects, all fixed with regression tests:

1. **A 429 without a `Retry-After` header retried 8 times with zero delay.** `Number(null)` is `0`, which passes a `>= 0` check, so the documented 30 s default was unreachable — turning the pacing loop into an amplifier against the limiter it exists to respect.
2. **The fix job destroyed good resolutions.** Both investigate and fix resolve the same event, and the write was unconditional, so a transient storage blip at fix time overwrote a stored envelope with `NULL`. A run producing no envelope now leaves a stored one alone, status included.
3. **A single unreachable object discarded every frame.** The fetch sat under a function-wide catch. It's now scoped per object, so one dead map costs one map instead of the whole trace.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — green across all 12 packages
- **Migrations** apply cleanly to a fresh database and are idempotent (schema snapshot byte-identical on reapply); the `projects_sourcemap_tombstone` trigger fires and records the right prefix. Note the repo's migration tests skip silently without a `psql` binary, so this was verified through pgx with per-statement autocommit, matching `scripts/run-migrations.sh`.
- `@opslane/worker` — 580 tests pass
- `@opslane/sdk` — 300 tests pass
- `@opslane/test-e2e` — typecheck clean; `sourcemap-resolution.test.ts` asserts the full path including a **discriminating** isolation check (project B sends the same `debug_meta` with no map uploaded → `map_not_found` while A resolves; after B uploads, B resolves)

## Accepted trade-offs

- **Manual key handling** — minting needs database access and the Go toolchain. Fine while operators are maintainers; the onboarding track replaces it.
- **No upload-health visibility** — if CI loses the key, maps silently stop. The build log warns, but the first real signal is `resolution_status = 'map_not_found'`.
- **Late maps don't heal old events** — no reprocessing; the next occurrence resolves.
- **Project deletion doesn't auto-purge maps** — the tombstone trigger records the prefix; the operator runs the documented one-liner. The sweeper is deferred.
- **No byte budget on the upload route** — worst case for a leaked key is 60 × 32 MiB ≈ 1.9 GiB/min per replica: bounded, visible in disk metrics, revocable with one statement.

## Not in this slice

Batch/atomic uploads, gzip bodies, upload health UI, key-management UI/API, any onboarding or CLI changes, deployed-commit checkout, the project-deletion object sweeper, verify/status endpoints, non-Vite build tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
