### PR TITLE
fix(docs-sync): verify the snippet contract at repo-check time

### DIFF
--- a/scripts/__tests__/check-docs-scope.test.mjs
+++ b/scripts/__tests__/check-docs-scope.test.mjs
@@ -102,6 +102,9 @@ test('new loader-allowed content enters P instead of being hidden by a duplicate
     root,
     loaderSource,
     sidebarSource: 'export default { sidebar: [] };',
+    // Injected like every other source here: this root is a bare docs tree with
+    // no scripts/ directory to read a manifest from.
+    snippetManifest: { version: 1, documents: { 'docs/install.md': { fences: [] } } },
     policy: {
       prose: ['docs/install.md'],
       deterministic: [],
@@ -113,5 +116,52 @@ test('new loader-allowed content enters P instead of being hidden by a duplicate
   assert.ok(result.published.includes('docs/new-public/page.md'));
   assert.ok(
     result.problems.includes('docs/new-public/page.md is published but has no declared policy'),
+  );
+});
+
+// The snippet contract used to be checked only when docs-sync happened to
+// target a page, so a guide could be added -- or gain a fence -- and stay
+// broken for many merges. These pin both halves at repo-check time.
+test('flags a published setup doc with no snippet-manifest entry', () => {
+  const manifest = { version: 1, documents: {} };
+  const result = checkDocsScope({ root: ROOT, snippetManifest: manifest });
+
+  assert.ok(
+    result.problems.some((problem) =>
+      problem.startsWith('docs/guides/source-maps.md:')
+      && problem.includes('not classified'),
+    ),
+    `expected an undeclared-setup-doc problem, got ${JSON.stringify(result.problems)}`,
+  );
+});
+
+test('flags a snippet-manifest entry whose fence count has drifted', () => {
+  const manifest = JSON.parse(
+    readFileSync(join(ROOT, 'scripts/docs-sync/snippets.json'), 'utf8'),
+  );
+  manifest.documents['docs/guides/source-maps.md'].fences.pop();
+  const result = checkDocsScope({ root: ROOT, snippetManifest: manifest });
+
+  assert.ok(
+    result.problems.some((problem) =>
+      problem.includes('docs/guides/source-maps.md')
+      && problem.includes('count mismatch'),
+    ),
+    `expected a fence-count problem, got ${JSON.stringify(result.problems)}`,
+  );
+});
+
+test('flags a snippet-manifest entry for a page that is not published', () => {
+  const manifest = JSON.parse(
+    readFileSync(join(ROOT, 'scripts/docs-sync/snippets.json'), 'utf8'),
+  );
+  manifest.documents['docs/guides/does-not-exist.md'] = { fences: [] };
+  const result = checkDocsScope({ root: ROOT, snippetManifest: manifest });
+
+  assert.ok(
+    result.problems.includes(
+      'docs/guides/does-not-exist.md has a snippet-manifest entry but is not a published page',
+    ),
+    `expected an unpublished-entry problem, got ${JSON.stringify(result.problems)}`,
   );
 });

--- a/scripts/check-docs-scope.mjs
+++ b/scripts/check-docs-scope.mjs
@@ -7,6 +7,12 @@ import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  isSetupDoc,
+  loadSnippetManifest,
+  parseMarkdownFences,
+  validateSnippetContract,
+} from './docs-sync/validation.mjs';
+import {
   MANUAL_DOC_COVERS,
   PUBLISHED_DOCS_POLICY,
   docTypeOf,
@@ -94,12 +100,17 @@ export function publishedDocs(root, loaderSource) {
     .sort();
 }
 
+function readDoc(root, path) {
+  return readFileSync(join(root, path), 'utf8');
+}
+
 export function checkDocsScope({
   root = DEFAULT_ROOT,
   policy = PUBLISHED_DOCS_POLICY,
   manualMappings = MANUAL_DOC_COVERS,
   loaderSource = readFileSync(join(root, 'docs-site/src/loaders/repo-docs.ts'), 'utf8'),
   sidebarSource = readFileSync(join(root, 'docs-site/astro.config.mjs'), 'utf8'),
+  snippetManifest = loadSnippetManifest(join(root, 'scripts/docs-sync/snippets.json')),
 } = {}) {
   const problems = [];
   const published = publishedDocs(root, loaderSource);
@@ -159,6 +170,29 @@ export function checkDocsScope({
   for (const path of Object.keys(manualMappings)) {
     if (!(policy.manual ?? []).includes(path)) {
       problems.push(`${path} has a manual staleness mapping but is not manual policy`);
+    }
+  }
+
+  // Hold every published setup doc to the contract docs-sync will enforce on it
+  // later. Both halves of that contract used to be invisible until a sync
+  // happened to target the page, which can be many merges after it drifted: a
+  // page added under docs/guides/ was never declared at all, and an edit that
+  // added a fence to a declared page left the counts disagreeing. Running the
+  // real validator here -- rather than re-deriving a weaker version of it --
+  // means the two can never diverge.
+  for (const path of published) {
+    if (!isSetupDoc(path)) continue;
+    try {
+      validateSnippetContract(path, parseMarkdownFences(readDoc(root, path)), snippetManifest);
+    } catch (error) {
+      problems.push(`${path}: ${error.message}`);
+    }
+  }
+  for (const path of Object.keys(snippetManifest.documents ?? {})) {
+    if (!published.includes(path)) {
+      problems.push(`${path} has a snippet-manifest entry but is not a published page`);
+    } else if (!isSetupDoc(path)) {
+      problems.push(`${path} has a snippet-manifest entry but is not setup documentation`);
     }
   }
 

--- a/scripts/docs-sync/snippets.json
+++ b/scripts/docs-sync/snippets.json
@@ -22,6 +22,16 @@
         }
       ]
     },
+    "docs/quickstart/agent.md": {
+      "fences": [
+        { "language": "bash", "classification": "illustrative" },
+        { "language": "json", "classification": "expected-output" },
+        { "language": "bash", "classification": "config-template" },
+        { "language": "bash", "classification": "illustrative" },
+        { "language": "bash", "classification": "illustrative" },
+        { "language": "bash", "classification": "config-template" }
+      ]
+    },
     "docs/quickstart/self-host.md": {
       "fences": [
         { "language": "bash", "classification": "illustrative" },
@@ -56,15 +66,32 @@
     "docs/guides/replay-privacy.md": {
       "fences": [
         { "language": "html", "classification": "fragment" },
+        { "language": "ts", "classification": "fragment" },
+        { "language": "ts", "classification": "fragment" },
         { "language": "ts", "classification": "fragment" }
       ]
+    },
+    "docs/guides/slack-notifications.md": {
+      "fences": [
+        { "language": "bash", "classification": "config-template" }
+      ]
+    },
+    "docs/guides/source-map-privacy.md": {
+      "fences": []
+    },
+    "docs/guides/source-maps-migration.md": {
+      "fences": []
     },
     "docs/guides/source-maps.md": {
       "fences": [
         { "language": "ts", "classification": "config-template" },
-        { "language": "yaml", "classification": "config-template" },
-        { "language": "json", "classification": "expected-output" },
-        { "language": "bash", "classification": "config-template" }
+        { "language": "bash", "classification": "config-template" },
+        { "language": "dotenv", "classification": "config-template" },
+        { "language": "bash", "classification": "config-template" },
+        { "language": "sql", "classification": "config-template" },
+        { "language": "bash", "classification": "config-template" },
+        { "language": "sql", "classification": "config-template" },
+        { "language": "sql", "classification": "config-template" }
       ]
     },
     "docs/guides/vanilla.md": {

--- a/scripts/docs-sync/validation.mjs
+++ b/scripts/docs-sync/validation.mjs
@@ -155,7 +155,7 @@ function assertNoSymlinkParents(root, target) {
   }
 }
 
-function isSetupDoc(docPath) {
+export function isSetupDoc(docPath) {
   return docPath === 'docs/install.md' || docPath.startsWith('docs/guides/') || docPath.startsWith('docs/quickstart/');
 }
 


### PR DESCRIPTION
## The failure

The docs-sync `plan` job failed on #261:

```
setup fences are not classified for docs/guides/source-map-privacy.md
```

`validateSnippetContract` treats everything under `docs/guides/` as setup documentation and refuses a page that has no entry in `scripts/docs-sync/snippets.json`. That page has been published since #253 and was never declared.

Nothing caught it because the contract was only ever evaluated when a sync happened to target the page — which, in this case, was many merges after the page was added.

## It was systemic, not one entry

Holding every published setup doc to the contract turned up six problems, not one:

| Page | Problem |
| --- | --- |
| `docs/guides/source-map-privacy.md` | never declared |
| `docs/guides/slack-notifications.md` | never declared |
| `docs/guides/source-maps-migration.md` | never declared |
| `docs/quickstart/agent.md` | never declared |
| `docs/guides/replay-privacy.md` | declared 2 fences, has 4 |
| `docs/guides/source-maps.md` | declared 4 fences, has 8 — and the languages were wrong too |

The last one is fallout from #261, which rewrote that page: it added `dotenv` and `sql` snippets while the manifest still described the `yaml` and `json` ones they replaced. Every one of these was a latent job failure waiting for the sync that happened to touch it.

All six are now declared to match their pages, classified against the conventions already in the manifest: placeholder-bearing commands and SQL are `config-template`, verbatim commands are `illustrative`, sample responses are `expected-output`.

## The actual fix

Declaring the six entries clears today's failures. The reason it went unnoticed for months is the more useful thing to fix, so `check-docs-scope` now enforces the contract itself:

- Every published setup doc is run through **the real `validateSnippetContract`**, not a re-derived approximation — so the check and the thing it guards cannot drift apart.
- A manifest entry naming a page that is not published, or not setup documentation, is flagged too. That mirrors the bidirectional check already there for manual staleness mappings.

Both failure modes now surface in `pnpm test:repo`, which is always-on in the `repo-checks` job, instead of in an AI job that runs opportunistically. `isSetupDoc` is exported so the rule keeps a single definition.

## Verification

- `node scripts/check-docs-scope.mjs` — passes; fails with all six problems named if the entries are removed
- Real validator run across all 12 declared docs — all pass
- `pnpm docs:map:test` — 122 pass
- `pnpm test:repo` — exit 0
- docs-sync's own suites (`validation`, `plan`, `publish`, `validation-job`) — 29 pass

Three tests added, one per new failure mode: undeclared setup doc, drifted fence count, manifest entry for an unpublished page. The existing temp-root test now injects a manifest, the same way it already injects its policy, loader, and sidebar sources.

## Note

This does not re-run the docs-sync planner, so it clears the validation error but cannot prove the AI planning step succeeds end to end. That runs on PRs by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
