### PR TITLE
feat(sdk)!: remove the legacy opslaneSourceMapPlugin stub

### DIFF
--- a/.changeset/remove-legacy-sourcemap-plugin.md
+++ b/.changeset/remove-legacy-sourcemap-plugin.md
@@ -1,0 +1,5 @@
+---
+'@opslane/sdk': major
+---
+
+Remove the legacy `opslaneSourceMapPlugin` export. It had been a hard-fail stub since the key split; `opslane()` now uploads source maps itself when `OPSLANE_SOURCEMAP_KEY` and `OPSLANE_ENDPOINT` are set. Configs importing the old name fail at build time with a missing-export error; run `opslane sourcemaps install-plugin` to migrate.

--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -60,6 +60,5 @@ The event should appear in your dashboard (or via the incidents API) within seco
 ## Next
 
 - [Upload source maps](source-maps.md) so stacks resolve to your JSX/TSX
-  sources. For Vite, use the published legacy plugin today; the guide tracks
-  debug-ID plugin availability and migration order.
+  sources.
 - All init options: [SDK options reference](../reference/sdk-options.md)

--- a/docs/guides/source-maps-migration.md
+++ b/docs/guides/source-maps-migration.md
@@ -6,21 +6,22 @@ covers:
 ---
 # Migrating the legacy Vite source-map plugin
 
-The legacy API uses `opslaneSourceMapPlugin({ endpoint, apiKey, release })`.
-The zero-argument `opslane()` plugin tracked in
-[#224](https://github.com/opslane/opslane-oss/issues/224) replaces it.
+The legacy API was `opslaneSourceMapPlugin({ endpoint, apiKey, release })`.
+It was removed in `@opslane/sdk` 3.0.0: the zero-argument `opslane()` plugin
+replaces it, uploading maps itself when `OPSLANE_SOURCEMAP_KEY` and
+`OPSLANE_ENDPOINT` are set in the build environment. A config that still
+imports the legacy name fails at build time with a missing-export error.
 
 `opslane sourcemaps install-plugin` intentionally refuses to add a second
 registration when it finds the legacy import. A double registration can change
 which uploader sees or removes a map.
 
-Until #224 is published, leave the legacy setup in place or skip source maps.
-After the new SDK version is installed:
+To migrate after installing the 3.x SDK:
 
 1. Remove the legacy import and `opslaneSourceMapPlugin(...)` call.
 2. Run `opslane sourcemaps install-plugin`.
-3. Watch the first production build and confirm the new uploader reports a
-   completed batch.
+3. Set `OPSLANE_SOURCEMAP_KEY` and `OPSLANE_ENDPOINT` where the production
+   build runs, then watch the first build log for `Uploaded N/N source maps`.
 4. Run `opslane sourcemaps install-plugin --check` to verify the resolved Vite
    config contains the new plugin.
 

--- a/docs/guides/source-maps.md
+++ b/docs/guides/source-maps.md
@@ -11,8 +11,6 @@ Opslane's Vite plugin stamps each production chunk with a deterministic debug
 ID, uploads the matching source map with a secret project key, and removes the
 map from the build output by default. Browser events carry the chunk URL and
 debug ID; the worker uses that exact pair to resolve original source positions.
-The SDK's `release` option is still useful deployment metadata, but it is not
-part of source-map matching.
 
 ## Configure a Vite build
 

--- a/docs/guides/vue.md
+++ b/docs/guides/vue.md
@@ -61,6 +61,6 @@ The event should appear in your dashboard (or via the incidents API) within seco
 ## Next
 
 - [Upload source maps](source-maps.md) so stacks resolve to your `.vue`
-  sources. For Vite, use the published legacy plugin today; the guide tracks
-  debug-ID plugin availability and migration order.
+  sources. The plugin uploads them when OPSLANE_SOURCEMAP_KEY and
+  OPSLANE_ENDPOINT are set.
 - All init options: [SDK options reference](../reference/sdk-options.md)

--- a/packages/sdk/src/__tests__/build.test.ts
+++ b/packages/sdk/src/__tests__/build.test.ts
@@ -17,8 +17,8 @@ describe('SDK Package Exports', () => {
     expect(typeof sdk.opslaneVuePlugin.install).toBe('function');
   });
 
-  it('should export opslaneSourceMapPlugin from vite-plugin', async () => {
-    const plugin = await import('../../vite-plugin/index');
-    expect(typeof plugin.opslaneSourceMapPlugin).toBe('function');
+  it('should not export the removed opslaneSourceMapPlugin', async () => {
+    const plugin = await import('../../vite-plugin/index') as Record<string, unknown>;
+    expect(plugin['opslaneSourceMapPlugin']).toBeUndefined();
   });
 });

--- a/packages/sdk/src/__tests__/vite-plugin-contract.test.ts
+++ b/packages/sdk/src/__tests__/vite-plugin-contract.test.ts
@@ -45,10 +45,9 @@ describe('built @opslane/sdk/vite-plugin contract', () => {
   it('exports the plugin name as a value, not just a literal in source', async () => {
     const mod = await import(entry);
     expect(mod.OPSLANE_VITE_PLUGIN_NAME).toBe('opslane-debug-ids');
-    expect(mod.LEGACY_VITE_PLUGIN_NAME).toBe('opslane-source-map');
-    // The two must stay distinct. Sharing a name would make the working plugin
-    // and the throwing stub indistinguishable in a resolved plugin list.
-    expect(mod.OPSLANE_VITE_PLUGIN_NAME).not.toBe(mod.LEGACY_VITE_PLUGIN_NAME);
+    // The retired legacy name must never be reused for the working plugin:
+    // tooling that still meets old builds tells the two apart by name.
+    expect(mod.OPSLANE_VITE_PLUGIN_NAME).not.toBe('opslane-source-map');
   });
 
   it('registers under exactly the exported name', async () => {
@@ -57,8 +56,8 @@ describe('built @opslane/sdk/vite-plugin contract', () => {
     expect(mod.opslaneVitePlugin().name).toBe(mod.OPSLANE_VITE_PLUGIN_NAME);
   });
 
-  // Tooling matches on the imported identifier to tell the current plugin from
-  // the deprecated one. Both spellings are public and both must be accepted.
+  // Tooling matches on the imported identifier. Both spellings are public and
+  // both must be accepted.
   it('offers both factory names, callable with no arguments', async () => {
     const mod = await import(entry);
     for (const name of ['opslane', 'opslaneVitePlugin']) {
@@ -68,17 +67,11 @@ describe('built @opslane/sdk/vite-plugin contract', () => {
     expect(mod.opslane).toBe(mod.opslaneVitePlugin);
   });
 
-  // Constructing it is fine; the build must die at configResolved. Asserting
-  // the hook rather than the factory keeps this honest about where it fails.
-  it('keeps the deprecated uploader failing loudly rather than silently', async () => {
-    const mod = await import(entry);
-    const legacy = mod.opslaneSourceMapPlugin({
-      endpoint: 'https://example.com',
-      apiKey: 'opslane_sk_x',
-    });
-    expect(legacy.name).toBe(mod.LEGACY_VITE_PLUGIN_NAME);
-    expect(() => legacy.configResolved()).toThrow(
-      /source-map upload is unavailable/,
-    );
+  // Removed in 3.0.0: importing the legacy uploader must fail at build time
+  // with a missing export, not resolve to something that throws later.
+  it('no longer exports the legacy uploader', async () => {
+    const mod = await import(entry) as Record<string, unknown>;
+    expect(mod['opslaneSourceMapPlugin']).toBeUndefined();
+    expect(mod['LEGACY_VITE_PLUGIN_NAME']).toBeUndefined();
   });
 });

--- a/packages/sdk/src/__tests__/vite-plugin.test.ts
+++ b/packages/sdk/src/__tests__/vite-plugin.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('vite', () => ({ loadEnv: vi.fn(() => ({})) }));
 import {
   opslane,
-  opslaneSourceMapPlugin,
   opslaneVitePlugin,
 } from '../../vite-plugin/index';
 import { computeDebugId } from '../build/debug-id';
@@ -649,20 +648,12 @@ describe('Vite debug-ID plugin', () => {
   });
 });
 
-// From main: the legacy uploader now fails the build rather than silently
-// deleting maps and posting to a route that no longer exists (#218).
-describe('legacy opslaneSourceMapPlugin', () => {
-  const legacyOpts = { apiKey: 'unused', endpoint: 'https://api.test' };
-
-  it('fails the build instead of silently dropping source maps', () => {
-    const plugin = opslaneSourceMapPlugin(legacyOpts) as {
-      configResolved: (config: unknown) => void;
-    };
-    expect(() => plugin.configResolved({})).toThrow(/source-map upload is unavailable/);
-  });
-
-  it('no longer removes map assets from the bundle', () => {
-    const plugin = opslaneSourceMapPlugin(legacyOpts) as Record<string, unknown>;
-    expect(plugin.generateBundle).toBeUndefined();
+// The legacy opslaneSourceMapPlugin was removed in 3.0.0; old imports fail at
+// build time with a missing-export error.
+describe('legacy opslaneSourceMapPlugin removal', () => {
+  it('is no longer exported', async () => {
+    const mod = await import('../../vite-plugin/index') as Record<string, unknown>;
+    expect(mod['opslaneSourceMapPlugin']).toBeUndefined();
+    expect(mod['LEGACY_VITE_PLUGIN_NAME']).toBeUndefined();
   });
 });

--- a/packages/sdk/vite-plugin/index.ts
+++ b/packages/sdk/vite-plugin/index.ts
@@ -50,14 +50,11 @@ interface StampStats {
  * 100%-failure: the install looks fine, the check never matches, and a correct
  * edit gets rolled back. Import this instead of retyping it.
  *
- * Deliberately not `opslane-source-map`: that name belongs to the deprecated
- * uploader stub below, which throws. Sharing a name would make the working
- * plugin and the failing one indistinguishable in a plugin list.
+ * Deliberately not `opslane-source-map`: that name belonged to the legacy
+ * uploader removed in 3.0.0. Never reuse it, or tooling that still encounters
+ * old builds could confuse the two.
  */
 export const OPSLANE_VITE_PLUGIN_NAME = 'opslane-debug-ids';
-
-/** The deprecated uploader stub's name. It throws; do not match on it. */
-export const LEGACY_VITE_PLUGIN_NAME = 'opslane-source-map';
 
 /** Every extension Vite emits JavaScript under, and the maps beside them. */
 const JS_ASSET = /\.(?:js|mjs|cjs)$/;
@@ -663,37 +660,12 @@ export function opslaneVitePlugin(
 
 export { opslaneVitePlugin as opslane };
 
-export interface SourceMapPluginOptions {
-  endpoint: string;
-  apiKey: string;
-  release?: string;
-}
-
-
-
-/**
- * @deprecated Use opslaneVitePlugin for deterministic debug IDs. This legacy
- * uploader remains unchanged until the authenticated upload flow replaces it.
- */
-export function opslaneSourceMapPlugin(_options: SourceMapPluginOptions) {
-  return {
-    name: LEGACY_VITE_PLUGIN_NAME,
-    apply: 'build' as const,
-    enforce: 'post' as const,
-
-    configResolved(): never {
-      // Source-map upload moved to a batch API that does not exist yet
-      // (tracked in #218). Failing the build is better than silently
-      // deleting maps and uploading nothing, which is what a 404 here
-      // would produce.
-      throw new Error(
-        '[opslane] source-map upload is unavailable in this release. ' +
-        'Remove opslaneSourceMapPlugin() from your Vite plugins until @opslane/sdk ships batch upload ' +
-        '(see opslane/opslane-oss#218).',
-      );
-    },
-  };
-}
+// opslaneSourceMapPlugin (the release-keyed legacy uploader, later a
+// hard-fail stub) was removed in 3.0.0. opslane() uploads maps itself when
+// OPSLANE_SOURCEMAP_KEY and OPSLANE_ENDPOINT are set; old imports now fail
+// at build time with a missing-export error, and
+// `opslane sourcemaps install-plugin` still detects and reports configs that
+// reference the old name.
 
 
 function stripMapSuffix(filePath: string): string {

--- a/scripts/check-packed-packages.mjs
+++ b/scripts/check-packed-packages.mjs
@@ -31,9 +31,10 @@ const TARGETS = [
         [
           "import { init, captureException, OpslaneSDK } from '@opslane/sdk';",
           "import type { SdkInitOptions } from '@opslane/sdk';",
-          "import { opslane, opslaneSourceMapPlugin } from '@opslane/sdk/vite-plugin';",
+          "import * as vitePluginModule from '@opslane/sdk/vite-plugin';",
+          "const { opslane } = vitePluginModule;",
           'const opts: SdkInitOptions = { apiKey: "k", endpoint: "https://example.com" };',
-          'void opts; void init; void captureException; void OpslaneSDK; void opslane; void opslaneSourceMapPlugin;',
+          'void opts; void init; void captureException; void OpslaneSDK; void opslane;',
         ].join('\n')
       );
       writeFileSync(
@@ -73,7 +74,8 @@ const TARGETS = [
           "import { readFileSync, readdirSync } from 'node:fs';",
           "import { join } from 'node:path';",
           "import { build } from 'vite';",
-          "import { opslane, opslaneSourceMapPlugin } from '@opslane/sdk/vite-plugin';",
+          "import * as vitePluginModule from '@opslane/sdk/vite-plugin';",
+          "const { opslane } = vitePluginModule;",
           'const run = (outDir, plugin) => build({',
           '  root: process.cwd(), configFile: false, logLevel: "silent", plugins: [plugin],',
           '  build: { outDir, emptyOutDir: true, rollupOptions: { input: join(process.cwd(), "main.js") } },',
@@ -83,14 +85,18 @@ const TARGETS = [
           'if (!debugName || !readFileSync(join("dist-debug/assets", debugName), "utf8").includes("//# debugId=")) {',
           '  throw new Error("new Vite plugin export did not stamp the consumer build");',
           '}',
-          'await run("dist-legacy", opslaneSourceMapPlugin({ endpoint: "https://invalid.example", apiKey: "" }));',
+          '// Removed in 3.0.0: a packed tarball must not quietly reintroduce the',
+          '// legacy uploader whose only behavior was failing the build.',
+          'if ("opslaneSourceMapPlugin" in vitePluginModule) {',
+          '  throw new Error("legacy opslaneSourceMapPlugin is still exported from the packed tarball");',
+          '}',
         ].join('\n'),
       );
       execFileSync('node', ['probe-build.mjs'], {
         cwd: consumerDir,
         stdio: 'inherit',
       });
-      console.log(`  ✓ both Vite plugin exports build in a clean consumer`);
+      console.log(`  ✓ Vite plugin builds in a clean consumer; legacy export absent`);
     },
   },
   {

--- a/test-fixtures/vue-app/vite.config.ts
+++ b/test-fixtures/vue-app/vite.config.ts
@@ -3,8 +3,6 @@ import vue from '@vitejs/plugin-vue';
 import { opslaneVitePlugin } from '@opslane/sdk/vite-plugin';
 
 export default defineConfig({
-  // opslaneSourceMapPlugin is deliberately absent: it fails the build until
-  // batch upload ships (#218).
   worker: {
     format: 'es',
     // A worker is a separate build pass; without this its chunks ship unstamped.


### PR DESCRIPTION
## Why

The `npm release` workflow is red on main: its clean-consumer probe builds with **both** Vite plugin exports and expects both to succeed, but `opslaneSourceMapPlugin` has been an intentional hard-fail stub since the key split (#243). Its error message — *"upload is unavailable in this release"* — became false when #261 shipped the real uploader in `opslane()`.

## What

- Remove the `opslaneSourceMapPlugin` stub, its `SourceMapPluginOptions` type, and `LEGACY_VITE_PLUGIN_NAME` from the SDK. Old imports now fail at build time with a missing-export error instead of resolving to a function whose only behavior is crashing the build with an outdated message.
- Update the release probe (`scripts/check-packed-packages.mjs`) to assert the legacy export is **absent** from the packed tarball, guarding against accidental reintroduction.
- Update the migration guide for the 3.0.0 reality; drop the stale fixture comment; add a major changeset (collapses into the pending 3.0.0).

`opslane sourcemaps install-plugin` still detects configs importing the old name — its `legacy_opslane_plugin` detection is import-string based, unaffected by the export's removal (CLI tests covering it pass unchanged).

## Verification

- `node scripts/check-packed-packages.mjs` — the exact check failing in CI — now fully green locally (tarball clean, clean-room install, consumer typecheck, probe build, legacy-export-absent assertion, audit signatures).
- SDK: build + 34/35 test files pass (the 1 failure is the pre-existing environmental WebKit browser-matrix launch on this host).
- CLI: 640/640. Docs drift: clean.

Unblocks: green `npm release` on main → npm Trusted Publishing setup (#45) → merge Version Packages (#248) → `@opslane/sdk@3.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)