### PR TITLE
chore(agent-core): mark private to hold it from npm

### DIFF
--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@opslane/agent-core",
   "version": "0.0.1",
+  "private": true,
   "description": "Provider-neutral agent loop and safe local tools for Opslane",
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
The 3.0.0 release run published `@opslane/sdk@3.0.0` successfully but exited 1: changesets also attempted a first-publish of `@opslane/agent-core@0.0.1`, which failed `ENEEDAUTH` — trusted publishing is configured per-package on npmjs.com and cannot apply to a package that has never been published.

`agent-core` is AGPL server-side code (the provider-neutral agent loop) with no external consumer; it should be held from npm exactly like the CLI was in #200. This is the only workspace package missing the flag — audited all of them:

| package | private |
|---|---|
| @opslane/sdk | intentionally public (3.0.0 live) |
| @opslane/agent-core | **was unset → now true** |
| cli, worker, shared, dashboard, test-e2e, test-reliability | already true |

With this, the next `npm release` run on main goes fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)