### PR TITLE
2.2.0 — stop dressing effort up as a blocker

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "opslane-verify",
       "description": "Verify a change works by driving the real system the way a user does. Approved acceptance criteria, a recorded run, and a four-axis report.",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "source": "./",
       "author": {
         "name": "opslane"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "opslane-verify",
       "description": "Verify a change works by driving the real system the way a user does. Approved acceptance criteria, a recorded run, and a four-axis report.",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "source": "./",
       "author": {
         "name": "opslane"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opslane-verify",
   "description": "Verify a change works by driving the real system the way a user does. Approved acceptance criteria, a recorded run, and a four-axis report.",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": {
     "name": "opslane",
     "url": "https://github.com/opslane"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opslane-verify",
   "description": "Verify a change works by driving the real system the way a user does. Approved acceptance criteria, a recorded run, and a four-axis report.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "opslane",
     "url": "https://github.com/opslane"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-08-04
+
+### Changed
+- Cost is the user's decision. A criterion that can be driven but needs real setup is
+  presented with what it would take, while the stack is still up, rather than being moved
+  to `Not checked` unilaterally. "Cheapest sufficient proof" means the least setup that
+  still observes the behaviour, not permission to skip inconvenient checks.
+- A `Not checked` reason must say why the criterion was not driven. If it also claims
+  something else covers it, that thing must be named, with a plain statement that this run
+  did not re-run it. Observed in the wild: three entries reading "covered by unit
+  canaries", where the workflow had not run those tests and could not know.
+
+
 ## [2.0.0] - 2026-08-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-04
+
+### Changed
+- Assume a criterion can be reproduced locally until something specific stops it. A job
+  that fails with a key in its error text is a job you can make fail; a worker run is a
+  worker you can start. Only four things count as real blockers: a credential a human must
+  obtain, a third-party service that cannot be faked at the boundary that matters, an
+  irreversible or publicly visible action, or something that genuinely cannot be induced
+  here, with the reason named. "Needs production" is almost never one of them. Observed in
+  the wild alongside the 2.1.0 fixes: two criteria skipped for needing "a production job"
+  and "a live worker run", both reproducible on the stack the run had already started.
+
+
 ## [2.1.0] - 2026-08-04
 
 ### Changed

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -15,6 +15,8 @@ This workflow has exactly two halves. Half one creates acceptance criteria and s
 - Mutation is allowed. Writing to shared or staging systems needs the user to say yes first.
 - Provisioning anything that costs money needs the user to say yes first.
 - `Not checked` is always printed, even when empty.
+- Expense is not a reason to skip. If a criterion can be driven but costs real setup, say what it would take and let the user decide. Never decide that on their behalf.
+- A `Not checked` reason states why it was not driven. It never asserts that something else covers it, unless it names that thing and says plainly this run did not re-run it.
 - Drive the system the way a user does. This workflow does not read or run the repository's unit tests.
 - Never invent acceptance criteria from the diff alone. The diff can refine or expose gaps in criteria sourced from a plan.
 - Generated tests stay under the run's `tests/` directory until the user explicitly chooses to check them in.
@@ -216,7 +218,9 @@ If recording or rendering fails, keep running the criteria and add the failure t
 
 ### 2. Drive the real system
 
-Choose the cheapest sufficient proof for each criterion and use the repository's own commands:
+Choose the cheapest way to *actually check* each criterion, using the repository's own
+commands. Cheapest sufficient proof means the least setup that still observes the
+behaviour. It does not mean skipping a criterion because driving it is inconvenient.
 
 - API: call the real route, authenticate through the public path, and observe the side effect rather than status alone.
 - Datastore: inspect affected rows before and after; for migrations, test the direction actually claimed.
@@ -246,6 +250,52 @@ A UI criterion that cannot be judged without reading the page source is the wron
 criterion. Rewrite it as something a person could confirm by looking.
 
 Mutation in a disposable local system is allowed. Before writing to a shared or staging system, describe the exact mutation and obtain a specific yes. Before provisioning anything that costs money, obtain a specific yes. If permission is not given, record the criterion as `could-not-run`; do not count it as a behavior failure.
+
+### When driving a criterion is expensive
+
+Some criteria are drivable but costly: they need a failure induced, a long-running job,
+a fixture built, or a service stood up that nothing else in the run needs.
+
+**Cost is the user's decision, not yours.** Do not quietly move a criterion to
+`Not checked` because it would take a while. Present it, with what it would cost, and let
+them choose:
+
+```
+AC5 needs a production job to fail with a key in its error text before the admin
+    endpoint will show anything. Roughly 15 minutes: force a job failure on the local
+    stack, then read it back through the admin surface.
+
+    Drive it, or record it as not checked?
+```
+
+Ask before half two finishes, while the stack is still up and the answer is still cheap
+to act on. If the user declines, the `Not checked` reason is what it would have taken,
+not a judgement that it did not matter.
+
+If several criteria are expensive, list them together with their costs and let the user
+pick which ones are worth it. Say which one you would drive if they only pick one, and
+why — usually the one whose failure would be worst.
+
+### Citing coverage you did not observe
+
+A `Not checked` reason explains why the criterion was not driven here. That is all it is
+required to do.
+
+If you also believe something else covers it, that claim has to be checkable by a reader
+who was not present. Name it, and state plainly that this run did not re-run it:
+
+```
+GOOD  not driven: needs a production job to fail with a key in its error text.
+      A test exists: TestRedactAdminErrorSwallowsEndpointBearingProjectKey
+      (Go handler suite). This run did not execute it.
+
+BAD   covered by unit canaries
+```
+
+Never write that something is covered by tests you did not run without naming them. An
+unnamed claim of coverage cannot be checked, reads as reassurance, and is exactly the
+thing this report exists to avoid. A named test that turns out to be inadequate is a
+finding; an unnamed one is noise.
 
 Record exactly one result for every approved criterion:
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -276,6 +276,28 @@ If several criteria are expensive, list them together with their costs and let t
 pick which ones are worth it. Say which one you would drive if they only pick one, and
 why — usually the one whose failure would be worst.
 
+### Assume it can be reproduced locally
+
+Before writing that a criterion needs production, staging, a live service, or "a real
+failure", ask what actually stops you from causing that locally. Usually nothing does.
+
+A job that fails with a key in its error text is a job you can make fail. A worker run is
+a worker you can start. A queue message is a message you can publish. The stack is already
+up, because half two brought it up.
+
+Only these are real blockers, and each has to be named specifically:
+
+- A credential or identity only a human can obtain (a real OAuth grant, an SSO login).
+- A third-party service you do not control and cannot fake at the boundary that matters.
+- An action that is irreversible or visible to others: a real publish, a real payment, a
+  message into a channel people read.
+- Something that genuinely cannot be induced in this environment, where you say why.
+
+"Needs production" is almost never one of these. If the reason you wrote names an
+environment, replace it with the specific thing that environment has and yours does not.
+If you cannot name that thing, the blocker is effort, and effort is the user's decision
+(see above).
+
 ### Citing coverage you did not observe
 
 A `Not checked` reason explains why the criterion was not driven here. That is all it is


### PR DESCRIPTION
Two fixes, both from the first run on a repo I did not build the tool against.

The run produced a `Not checked` list of seven items. Four were correct. Three were the same mistake in different clothes: something the workflow *could* have done, reported as something it *could not* do.

## Cost is the user's decision (2.1.0)

The skill gated money and shared writes but said nothing about effort, while instructing "choose the cheapest sufficient proof". That reads as permission to skip anything inconvenient, and it did.

It now has to ask, while the stack is still up:

```
AC5 needs a job to fail with a key in its error text before the admin endpoint
    shows anything. Roughly 15 minutes: force a failure on the local stack, then
    read it back through the admin surface.

    Drive it, or record it as not checked?
```

If several are expensive it lists them together with costs, and says which one it would pick if you only pick one — usually the one whose failure would be worst. Declining is fine; the `Not checked` line then records what it would have taken, not a judgement that it did not matter.

## Coverage claims must name a test (2.1.0)

Three entries read `covered by unit canaries`. The workflow does not run unit tests, so it could not know. Challenged, it immediately produced `TestRedactAdminErrorSwallowsEndpointBearingProjectKey` and a red-before/green-after claim — the right answer, absent from the report.

```
GOOD  not driven: needs a job to fail with a key in its error text.
      A test exists: TestRedactAdminErrorSwallowsEndpointBearingProjectKey
      (Go handler suite). This run did not execute it.

BAD   covered by unit canaries
```

An unnamed coverage claim cannot be checked by anyone reading the report later, and reads as reassurance. A named test that turns out to be inadequate is a finding; an unnamed one is noise.

## Assume local reproduction (2.2.0)

Two criteria were skipped for needing "a production job to fail" and "a live worker fix-run". Both were reproducible on the stack the run had already started. "Production" was doing work it had not earned.

Only four things are real blockers, and each must be named specifically: a credential a human must obtain, a third-party service that cannot be faked at the boundary that matters, an action that is irreversible or visible to others, or something that genuinely cannot be induced here with the reason given.

Of the three original items, exactly one qualified — the docs publisher, because publishing is irreversible and public.

## Scope

`skills/verify/SKILL.md`, the two manifests, and the changelog. No engine changes, so the existing tests and typecheck are untouched and still green.