### PR TITLE
chore: post-#275 follow-ups (sdk changeset, docs-sync timeout)

### DIFF
--- a/.changeset/endpoint-bearing-plugin-key.md
+++ b/.changeset/endpoint-bearing-plugin-key.md
@@ -1,0 +1,12 @@
+---
+"@opslane/sdk": major
+---
+
+The Vite plugin now reads its upload destination out of the source-map key
+itself. `OPSLANE_SOURCEMAP_KEY` must be an endpoint-bearing key
+(`opslane_sk_<key id>_<secret>_<payload>`) minted by an Opslane server at or
+above this release; a key minted before the format change is refused with
+`OPSLANE_VITE_KEY_INVALID (legacy_format)` and nothing is uploaded. The
+`OPSLANE_ENDPOINT` variable is removed: a stale value is reported via
+`OPSLANE_VITE_ENDPOINT_REMOVED` and never obeyed. Re-mint your key with
+`mint-key -scope sourcemaps` and delete the endpoint variable from CI.

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -22,7 +22,9 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       !startsWith(github.event.pull_request.head.ref, 'claude/')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Per-doc reasoning is sequential, so the ceiling scales with how many
+    # covers: globs a branch hits. 15 minutes died at 11 matched docs.
+    timeout-minutes: 40
     permissions:
       contents: read
     outputs:


### PR DESCRIPTION
Two small pieces that missed the #275 squash:

- **Changeset for the plugin cutover.** #275 changed the Vite plugin's key handling (endpoint read from the key, `OPSLANE_ENDPOINT` removed, legacy keys refused) but carried no changeset, so npm would never release it. This adds the major changeset; the next Version Packages run takes @opslane/sdk to 4.0.0.
- **Docs-sync plan timeout 15 → 40 minutes.** Per-doc reasoning is sequential and scales with how many `covers:` globs a branch hits. #275 matched 11 docs and the plan job died at the 15-minute cap twice (runs 30940058902, 30939534539). This was pushed to the #275 branch minutes after the squash landed, so it never merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)