### PR TITLE
fix(worker): a dying sandbox no longer burns fix attempts or blames the customer

### DIFF
--- a/docs/architecture/precision.md
+++ b/docs/architecture/precision.md
@@ -18,7 +18,7 @@ A PR is opened ready for review only when **all** of the following held during t
 3. The project's test suite was run once before the patch and once after it. Opslane compares per-test results where Vitest JSON is available: pre-existing failures are recorded and excluded, while pass→fail regressions and unexplained collection drops block the PR (E1). A coarse runner can support E1 only when its post-patch run exits cleanly.
 4. The fix carries **high confidence**. This is a hard, independent guard for locally verified delivery. (Medium/low-confidence *investigations* stop before fix generation entirely, posting their analysis as `investigated` for you to review and trigger.)
 
-If dependency installation fails, the test runner crashes, or a verification gate times out, Opslane records an `infra_error`. Infrastructure errors are retried and never count as evidence for or against the patch; persistent failure terminates as `verification_infra_error` only after the job retry budget is exhausted.
+If dependency installation fails, the test runner crashes, the sandbox becomes unavailable, or a verification gate times out, Opslane records an `infra_error`. Infrastructure errors are retried and never count as evidence for or against the patch; persistent failure terminates as `verification_infra_error` only after the job retry budget is exhausted.
 
 ## Evidence tiers
 

--- a/docs/decisions/sandbox-runtime-failure-contract.md
+++ b/docs/decisions/sandbox-runtime-failure-contract.md
@@ -1,0 +1,68 @@
+# The sandbox runtime declares its own failure contract
+
+- **Status:** ACCEPTED (2026-08-04).
+- **Applies to:** `packages/worker/src/harness/sandbox-runtime.ts` and every caller of `SandboxRuntime`.
+- **Measured:** 2026-08-04. Live E2B probe against `opslane/merch-store`, the repository behind the incidents in #255.
+- **Prompted by:** #255.
+
+`SandboxRuntime` describes only the happy path. It declares `run(): Promise<SandboxCommandResult>`
+and says nothing about what may be thrown. Every caller therefore invents its own failure
+classification by string-matching the error message — the same regex appears in
+`test-runner.ts` and twice in `sandbox-repo.ts`.
+
+The runtime now declares what it throws. `sandbox-runtime.ts` — the only file that imports a
+provider SDK — maps each backend's failures onto two errors the harness owns:
+
+- **`SandboxUnavailableError`** — the machine is gone. Never evidence about the patch; retryable.
+- **`CommandFailedError`** — the command ran and exited non-zero. Carries `exitCode`, `stdout`, `stderr`.
+
+Callers test the error type. They never import `e2b` and never inspect message text.
+
+## Why the string matching had to go
+
+The regex was `/timed out|timeout/i`. A live probe measured what E2B actually throws when a
+sandbox reaches its lifetime mid-run:
+
+```
+constructor : SandboxNotFoundError
+message     : "Sandbox is probably not running anymore"
+```
+
+No match. So a vanished sandbox was classified `failed` rather than `infra_error`: the agent was
+told its own patch broke the build, retried against a dead machine, exhausted its budget, and
+terminated as `budget_exhausted` — the one exit path that cannot requeue. This contradicted
+`docs/architecture/precision.md`, which states infrastructure errors "never count as evidence for
+or against the patch".
+
+The tests did not catch it. `test-runner.test.ts:219` triggers the infra path by throwing
+`'Command timed out after 240000ms'` — verbatim the **local** backend's message format
+(`sandbox-runtime.ts:170`). The regex was written against the test double and only ever worked
+there. E2B's real errors were never in the test set.
+
+That is the argument against simply adding another alternation to the regex: it preserves the
+mechanism that produced a green suite over blind production. E2B exports a typed hierarchy
+(`SandboxNotFoundError`, `TimeoutError`, `CommandExitError`, `NotEnoughSpaceError`, …). The
+information was always there; the code discarded it and re-derived a worse answer from prose.
+
+## Considered alternatives
+
+**Import E2B's error classes at the call sites.** Fifteen minutes' work. Rejected: it puts the
+provider in three more files, and the `local` backend throws a plain `Error`, so the deterministic
+harness could never exercise the sandbox-death path — the fix would ship untested.
+
+**Extend the regex with the new message.** Five minutes. Rejected for the reason above: the next
+provider message phrased differently fails identically and silently.
+
+## Consequences
+
+- Both backends must map their failures onto these two errors. A new backend that does not is
+  incorrect, not merely untested.
+- The `local` backend can now raise `SandboxUnavailableError` on demand, so sandbox death is
+  reachable in the deterministic harness and the fix carries a real regression test.
+- `buildFailureExitCode()` in `sandbox-repo.ts`, which recovers an exit code by regexing
+  `"exited with code (\d+)"` out of a message, becomes dead code — `CommandFailedError` carries the
+  number directly.
+- The `res.exitCode === 0 ? passed : failed` branch in `runBuildGate` was already unreachable on
+  E2B (the SDK throws `CommandExitError` on non-zero exit rather than returning it) and is removed.
+- This does **not** make the runtime provider-neutral on its own. `/home/user/repo` remains
+  hardcoded across seven files, and lifetime policy still lives in the factory. Tracked in #274.

--- a/docs/plans/2026-08-04-sandbox-death-misclassification.md
+++ b/docs/plans/2026-08-04-sandbox-death-misclassification.md
@@ -1,0 +1,293 @@
+# Sandbox death is misclassified as a failed patch
+
+Plan for opslane-oss#255.
+
+Revision 3 — two rounds of independent review, each of which falsified part of the
+prior revision. Corrections are marked **[r2]** and **[r3]**. The r3 round found
+that r2's central design did not work at all; that correction is in "The change".
+
+## The failure, as measured
+
+The JavaScript verification sandbox is killed 300s after creation, and **no code
+path treats that as an infrastructure failure**.
+
+Two live E2B probes against `opslane/merch-store` — the repository behind these
+incidents — on 2026-08-04:
+
+**Probe 1, setup timing.** Setup completes in **30.9s**: clone 1.0s,
+`ensureModernNode` 3.3s, `npm install` **19.6s**, baseline suite 4.3s. Install
+succeeds; `node_modules/.bin/vitest` is present afterwards.
+
+**Probe 2, expiry.** Tool calls succeeded through T+298.7s and failed at T+313.8s:
+
+```
+constructor : SandboxNotFoundError
+message     : "Sandbox is probably not running anymore"
+```
+
+`Sandbox.create()` with no options applies the SDK default of 300s
+(`node_modules/e2b/dist/index.js:4631`). Nothing calls `setTimeout()` to extend it.
+
+**[r2] What the probes do and do not prove.** They establish that a sandbox dies at
+300s and that the death is misclassified. They do **not** prove dependency install
+was healthy during the seven historical runs — a successful install today says
+nothing about network or registry state weeks ago. Revision 1 claimed "npm install
+was never the problem". That claim is withdrawn; install is simply not *required*
+to explain the failures.
+
+### Why the sandbox dies
+
+Setup uses ~31s of 300s. From Langfuse (n=42-65): `agent-loop` p50 26.4s, p95
+93.4s, max 135.3s, running up to 4× per job (2 tiers × 2 attempts,
+`MAX_TEST_RETRIES = 1`). Worst observed run ≈606s.
+
+## [r2/r3] How a dead sandbox actually terminates
+
+Revision 1 asserted a single chain ending in `budget_exhausted`. That was wrong.
+The outcome depends on **when** the sandbox dies. Four paths are named below because
+each needs different handling; **[r3]** they are not exhaustive — see "Other deaths".
+
+**A. Death during the agent loop → agent-reported terminal state.**
+`agent-core/tool-loop.ts:202-212` converts every tool exception into model-visible
+text, so the agent keeps working against a corpse. **[r3]** The end state is *not*
+deterministically `budget_exhausted` — it can also be max-turns, a model `give_up`,
+or apparent success followed by a failure in `extractDiff`. All seven production
+incidents landed on `budget_exhausted`, but the plan must not assume that.
+
+**B. Death at a gate, after the agent produced a diff → `worker_runtime_error`.**
+The gate is misclassified as `failed`, and the reset at `agent-fix.ts:939` and
+`:968` — `git checkout -- . && git clean -fd`, **not wrapped in try/catch** —
+throws. It propagates to the outer catch and terminates as `worker_runtime_error`.
+
+**C. Death before the post-patch suite → `worker_runtime_error`.**
+`runSuite` executes `rm -f <results path>` at `test-runner.ts:204`, **outside** its
+try block. It throws and propagates the same way.
+
+**D. Death before the build gate → silent `skipped_no_runner`.**
+This is the worst one. `fileExists` (`sandbox-repo.ts:378-385`) swallows every
+error and returns `false`. So on a dead sandbox `runBuildGate` reads no
+`package.json`, finds no `tsconfig.json`, and `selectBuildCommand` returns null →
+`{ outcome: 'skipped_no_runner' }`. That is **not** an error outcome, and
+`computeTier` (`evidence.ts:31`) explicitly accepts it:
+
+```ts
+const buildOk = e0 || build === 'skipped_no_runner';
+```
+
+A vanished machine is indistinguishable from a repository that legitimately has no
+build script. This is a false-negative in the verification gate, not merely a
+misleading incident.
+
+### [r3] Other deaths
+
+A-D are the paths needing distinct handling, not a complete enumeration. Also
+reachable: death during clone or branch resolution (→ `clone_failed`); during
+install aftermath, the baseline commit, or setup commands (→ `worker_runtime_error`);
+during baseline-suite cleanup, tracked-file discovery, tier reset, or `extractDiff`
+(→ `worker_runtime_error`); and silently swallowed during file preloading or scope
+review. Items 1 and 3 below cover these generically, which is why the design raises
+at the boundary rather than enumerating call sites.
+
+### Why every path stays invisible
+
+Infrastructure failure is detected by regex against the message text, in
+`test-runner.ts:217` and `sandbox-repo.ts:371`:
+
+```ts
+if (/timed out|timeout/i.test(errorMessage)) { return { outcome: 'infra_error', ... }; }
+```
+
+`"Sandbox is probably not running anymore"` does not match.
+
+### Why the tests did not catch it
+
+`test-runner.test.ts:219` triggers the infra path with
+`'Command timed out after 240000ms'` — verbatim the **local** backend's message
+format (`sandbox-runtime.ts:170`). The regex was written against the test double
+and only ever worked there.
+
+### This violates a documented contract
+
+`docs/architecture/precision.md` (`covers:` names `agent-fix.ts` and `harness/**`)
+states infrastructure errors "never count as evidence for or against the patch".
+Path D goes further and lets an infrastructure failure count as *satisfying* a gate.
+
+## The change
+
+**[r3] Design correction, again.** Revision 2 proposed raising a typed error at the
+runtime boundary and translating once in `runAgentFix`'s outer catch. That does not
+work for path A — the path matching all seven incidents.
+
+`agent-core/tool-loop.ts:202-212` erases the error type **twice**: the inner catch
+rethrows `new Error(redact(message))`, destroying the class, and the outer catch
+converts it to `output = "Error: ..."` with `isError = true`. This is deliberate
+(the comment explains it protects the tracing exporter). No exception escapes
+`runAgentLoop`, so no outer catch can ever observe sandbox death during the agent
+loop.
+
+The fix is **state, not exceptions**: the adapter records unavailability on the
+runtime object, and the worker reads that flag at points where it matters.
+
+### 1. Adapter raises a typed error and records a flag
+
+`sandbox-runtime.ts` is the only file importing a provider SDK. `Sandbox.create()`
+currently returns the SDK object directly, so this requires a real adapter wrapping
+`commands.run`, `files.read`, and `files.write`.
+
+```ts
+export class SandboxUnavailableError extends Error {}
+
+interface SandboxRuntime {
+  readonly id: string;
+  readonly createdAt: number;      // required — id + lifetimeMs cannot yield age-at-error
+  readonly lifetimeMs: number;
+  /** Set once the provider reports the machine is gone. Never resets. */
+  readonly unavailable: boolean;
+}
+```
+
+On `SandboxNotFoundError`, the adapter sets `unavailable = true` **and** throws
+`SandboxUnavailableError`. The flag survives `tool-loop`'s type erasure; the throw
+serves every path outside the agent loop.
+
+**[r3] Map only `SandboxNotFoundError`.** Do **not** map E2B's `TimeoutError`.
+Its documented variants cover both sandbox expiry and ordinary per-command deadline
+exceeded; mapping it would convert agent-issued command timeouts — which today
+return feedback to the model — into whole-job retries. That is an unrelated
+behavioural change. Verify at implementation time that `SandboxNotFoundError` is
+exported by the installed E2B version; assert it in a test.
+
+### 2. Check the flag where the agent loop returns
+
+Immediately after `runAgentLoop` returns in `agent-fix.ts`, check
+`sandbox.unavailable` and throw `VerificationInfraError`. This is the only fix for
+path A.
+
+**[r3] This replaces the precedence rules proposed in r2.** Revision 2 wanted
+`verificationInfraError` consulted at `budget_exhausted`, `gaveUp`, and
+`malformed_diff` separately. Raising at the point failure becomes persistent makes
+all three unnecessary and avoids recreating the enumeration problem. One check, not
+three.
+
+### 3. Translate escaping errors at the outer catch
+
+`runAgentFix`'s outer catch translates any `SandboxUnavailableError` into
+`VerificationInfraError`, covering paths B, C, and the setup/clone/reset/extractDiff
+deaths enumerated below.
+
+**[r3] Evidence hole.** `VerificationInfraError` requires a non-optional
+`EvidenceRecord` (`errors.ts:8-14`), but `evidence` is null until after
+`createRepoSandbox` returns — so a setup-time death cannot construct the error.
+Fix: move `evidence = createEvidenceRecorder()` **above** the `createRepoSandbox`
+call. Additionally, the catch must record an explicit `infra_error` check naming the
+failing operation; otherwise a terminalized incident carries evidence containing
+only passing checks and nothing identifying the real failure.
+
+### 4. Stop `fileExists` from disguising a dead sandbox
+
+`fileExists` must rethrow `SandboxUnavailableError`.
+
+**[r3] Weakened claim.** Rethrowing only `SandboxUnavailableError` does *not* make
+the remaining `false` mean "genuinely absent" — permission errors and provider
+transport failures still report absent. Either match the provider's actual
+file-not-found error, or state the limitation. Do not claim the stronger property.
+
+### 5. Give the sandbox a lifetime that fits the work
+
+`SANDBOX_LIFETIME_MS`, default `1_800_000`, floor `900_000`, both platforms.
+
+**[r3] Floor is now stated as a constant and is above the measurement.** Revision 2
+proposed 600,000 while citing a measured worst case of ~606s — internally
+inconsistent. 900,000 sits above the measurement with margin. The floor is a guard
+against gross misconfiguration, **not** a proof of sufficiency: the phase caps
+(suite 240s ×2, build 240s ×2, install 300s, clone 120s) sum well past 1,500s, and
+r2's claim that they are "not simultaneously reachable" was asserted without
+control-flow evidence. Drop that claim. The lifetime is empirical.
+
+**Upper bound:** the Python path already runs `timeoutMs: 1_800_000` in production
+(`sandbox-runtime.ts:13,49`), which is direct evidence this account accepts it. Do
+not exceed without checking the tier limit.
+
+**Crash exposure:** the ceiling is not a reservation (`agent-fix.ts:1213-1216` kills
+in a `finally`, E2B bills actual uptime), but a worker crash skips `finally` and the
+orphan now leaks up to 30 minutes instead of 5 — a real 6× increase. Accept
+deliberately, matching Python, and say so in the comment rather than deleting it.
+
+### 6. Record sandbox identity at the point of failure
+
+**[r3] One design, not two.** Revision 2 offered "phase spans or root span, or
+alternatively extend `traceSpan`" — competing sketches, not a plan.
+
+`traceSpan(name, attributes, fn)` (`tracing.ts:116`) sets attributes at start and
+has no mutation callback, and `sandbox-setup` has ended before any gate runs. Use
+`trace.getActiveSpan()` from `@opentelemetry/api` (already imported in
+`tracing.ts:14`) at the point the failure is caught, and set attributes there:
+`sandbox.id`, `sandbox.created_at`, `sandbox.lifetime_ms`, `sandbox.age_at_error_ms`,
+`error.class`, `error.phase`. Emit the same fields via `logger.error`, so the record
+survives when Langfuse keys are unset.
+
+**Blast radius:** adding required fields to `SandboxRuntime` breaks every structural
+fake — four test files: `sandbox-repo.test.ts`, `sandbox-repo-setup.test.ts`,
+`test-runner.test.ts`, `sandbox-runtime.test.ts`.
+
+## Explicitly not in this plan
+
+- `CommandFailedError`, `buildFailureExitCode()` removal, the unreachable
+  `res.exitCode === 0` branch → #274.
+- Fail-fast on `installFailed`. **[r2]** Kept out, but the revision-1 justification
+  ("install was never the problem") is withdrawn — see above. It stays out because
+  it is not required to fix any of paths A-D.
+- Redacting internal faults from customer evidence → #273 (blocked on item 6).
+- Provider-neutral `SandboxRuntime` → #274.
+- Invalidating evidence recorded before a death. `computeTier` yields `tier: null`
+  once the gates are `infra_error`. **[r3]** This holds only if item 3 records an
+  explicit `infra_error` check — a direct runtime failure whose evidence contains no
+  infra entry would not be covered.
+
+## [r3] Backfill — decided: out of scope
+
+The seven existing incidents are terminal in the database and will not retry
+themselves. This plan changes future classification only. **They stay
+`needs_human`.** Revision 2 left this as "decide before closing #255", which left
+the scope undefined; it is now decided. If a one-off requeue is wanted, file it
+separately — it is a data operation, not part of this fix.
+
+## Verification
+
+**[r3] Test with a fake `SandboxRuntime`, not the local backend.** Revision 2
+proposed adding a fault-injection hook so the local backend could die mid-command.
+That is unnecessary scope: `ensureRunning()` is checked only before spawning and
+`kill()` does not terminate an in-flight child, but a structural fake that throws
+`SandboxUnavailableError` from an in-flight promise tests the classification
+directly. Do not modify the local backend for this.
+
+- Unit: `sandbox.unavailable` set after `runAgentLoop` yields `VerificationInfraError`,
+  regardless of whether the agent reported budget exhaustion, max turns, `give_up`,
+  or success (path A — the fix that matters).
+- Unit: `runBuildGate` against an unavailable sandbox yields `infra_error`, **not**
+  `skipped_no_runner` (path D).
+- Unit: `fileExists` rethrows `SandboxUnavailableError`.
+- Unit: an escaping `SandboxUnavailableError` becomes `VerificationInfraError` with a
+  non-empty evidence record naming the failing operation (paths B, C, and setup
+  deaths — covers the r3 evidence hole).
+- Unit: a setup-time death (before `createRepoSandbox` returns) constructs a valid
+  `VerificationInfraError`, proving the recorder was moved above the call.
+- Unit: E2B exports `SandboxNotFoundError` at the installed version.
+- Unit: `SANDBOX_LIFETIME_MS` below the 900,000 floor falls back to the default.
+- **[r3]** Integration: target `processJobInner` directly (`index.ts:158` holds the
+  rethrow logic; the poller calls `processJob` at `:154`, and `processFixJob` is at
+  `:661`). Two focused tests beat one heavily mocked end-to-end: non-final attempt
+  rethrows so the poller calls `failJob` without terminalizing the group; final
+  attempt writes `verification_infra_error` with evidence.
+- **[r3]** Lifetime check needs no 1,800s wait — read the sandbox's reported expiry
+  from the provider immediately after creation.
+- `pnpm --filter @opslane/worker test`, `pnpm -r build`, the root `AGENTS.md` smoke.
+- Document `SANDBOX_LIFETIME_MS` in `docs/reference/environment-variables.md`
+  (`scripts/check-docs-drift.mjs` gate).
+
+## The premise worth testing rather than assuming
+
+#255 assumes these seven would have become PRs with a healthy sandbox. Not
+established. They may fail honestly as `tests_failed`. That is still a real fix —
+correct classification, no wasted budget, no fabricated explanations, and path D
+closed — but the "most direct lever on PR conversion" framing would be wrong.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -82,6 +82,7 @@ Ingestion reads **only** the `REPLAY_STORE_*` names; `MINIO_*` names appear in i
 | `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` / `LANGFUSE_BASE_URL` / `LANGFUSE_PROJECT_ID` | no | Optional LLM tracing |
 | `ANTHROPIC_BASE_URL` | no (Anthropic default) | Alternate Claude API endpoint; used by the hermetic test harness's fake model server |
 | `OPSLANE_SANDBOX_BACKEND` | no (`e2b`) | Fix-verification sandbox backend; `local` is only for trusted reliability fixtures and also requires `OPSLANE_RELIABILITY_HARNESS=1` |
+| `SANDBOX_LIFETIME_MS` | no (`1800000`) | Wall-clock ceiling for a verification sandbox. Values below `900000` fall back to the default; values above `1800000` are clamped to it (E2B enforces account-tier maximums). The ceiling is not billed unless consumed; raising it increases orphan exposure if the worker crashes. |
 | `OPSLANE_PYTHON_PIPELINE` | no (off) | Enables durable Python incident routing for `1` or `true`; the effective platform is persisted on the fix job. |
 | `OPSLANE_E2B_PYTHON_TEMPLATE` | no (`opslane-python`) | Overrides the E2B template name used by Python fix jobs. |
 | `OPSLANE_RELIABILITY_HARNESS` | no | Explicit guard required before the non-isolating local sandbox test transport can run |

--- a/docs/superpowers/plans/2026-08-04-sandbox-death-misclassification.md
+++ b/docs/superpowers/plans/2026-08-04-sandbox-death-misclassification.md
@@ -1,0 +1,1236 @@
+# Sandbox Death Misclassification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a verification sandbox that dies mid-run classify as retryable infrastructure failure instead of a failed patch, and give it a lifetime long enough to finish the work.
+
+**Known gap, accepted:** a sandbox that dies during `git clone` or branch
+resolution still terminates as `clone_failed`. `GitRunner`'s catch converts the
+error to `exitCode: 1`, the clone catch rewraps it as `Error("clone failed…")`,
+and `runAgentFix`'s setup catch returns `cloneFailureReason` before reaching the
+outer translation. Fixing that means threading the type through three rewrites;
+it is out of scope here and is not one of the paths in opslane-oss#255.
+
+**Architecture:** A thin adapter wraps the E2B SDK inside `sandbox-runtime.ts` (the only file importing a provider). On `SandboxNotFoundError` it both throws a typed `SandboxUnavailableError` **and** latches an `unavailable` flag on the runtime object. The throw serves every code path outside the agent loop; the flag is required because `agent-core/tool-loop.ts:202-212` deliberately erases exception types, so no exception can escape `runAgentLoop`. The worker checks the flag immediately after the agent loop returns and translates escaping errors in its outer catch.
+
+**Tech Stack:** Node 22, TypeScript (strict, ESM), Vitest, E2B SDK v2.35, OpenTelemetry API.
+
+## Global Constraints
+
+- ESM and strict TypeScript. Use `unknown` plus narrowing, never `any`.
+- Tests colocated in `__tests__` directories, Vitest only.
+- Preserve terminal-status and lease contracts. Fix implementation or test setup, never weaken the contract.
+- Only `packages/worker/src/harness/sandbox-runtime.ts` may import from `e2b`.
+- Do **not** map E2B `TimeoutError` — its variants include ordinary per-command deadlines, and mapping it would convert agent command timeouts into whole-job retries.
+- Do **not** modify `packages/agent-core/` — its type erasure is deliberate and documented.
+- Do **not** modify the local sandbox backend to simulate mid-command death; structural fakes cover that.
+- Every terminal `needs_human` result keeps a non-empty `reason_code`, `reason_message`, and `remediation`.
+- Source plan: `docs/plans/2026-08-04-sandbox-death-misclassification.md` (revision 3).
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `packages/worker/src/harness/sandbox-runtime.ts` | Provider adapter, error type, lifetime config | Modify |
+| `packages/worker/src/harness/sandbox-repo.ts` | `fileExists`, `runBuildGate` classification | Modify |
+| `packages/worker/src/harness/test-runner.ts` | `runSuite` classification | Modify |
+| `packages/worker/src/agent-fix.ts` | Flag check, outer-catch translation, evidence ordering | Modify |
+| `packages/worker/src/harness/__tests__/sandbox-runtime.test.ts` | Adapter + lifetime tests | Modify |
+| `packages/worker/src/harness/__tests__/test-runner.test.ts` | Suite classification tests, fake update | Modify |
+| `packages/worker/src/harness/__tests__/sandbox-repo.test.ts` | Fake update | Modify |
+| `packages/worker/src/harness/__tests__/sandbox-repo-setup.test.ts` | Fake update | Modify |
+| `packages/worker/src/__tests__/agent-fix.test.ts` | Path A / B classification, e2b mock repair | Modify |
+| `packages/worker/src/__tests__/index.test.ts` | Evidence assertion on terminalization | Modify |
+| `docs/reference/environment-variables.md` | `SANDBOX_LIFETIME_MS` entry | Modify |
+
+---
+
+### Task 1: Typed error, runtime metadata, and the E2B adapter
+
+**Files:**
+- Modify: `packages/worker/src/harness/sandbox-runtime.ts`
+- Test: `packages/worker/src/harness/__tests__/sandbox-runtime.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (foundational task).
+- Produces: `export class SandboxUnavailableError extends Error`; `SandboxRuntime` gains `readonly id: string`, `readonly createdAt: number`, `readonly lifetimeMs: number`, `readonly unavailable: boolean`. Every later task depends on these exact names.
+
+- [ ] **Step 1: Repair the E2B mocks first — they will break on import**
+
+Two test files mock `e2b` with a factory that exports **only** `Sandbox`:
+`harness/__tests__/sandbox-runtime.test.ts:10` and `__tests__/agent-fix.test.ts:4`.
+Once production imports `SandboxNotFoundError`, module loading fails in both. A
+plain factory also means `instanceof SandboxNotFoundError` is false against the
+real class, so the adapter would never trigger under test.
+
+In **both** files, replace the factory with a partial mock that preserves the
+real exports:
+
+```ts
+vi.mock('e2b', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('e2b')>()),
+  Sandbox: { create: createE2BSandbox },
+}));
+```
+
+In `agent-fix.test.ts` the local binding is `vi.fn()` inline; hoist it first so
+the factory can reference it:
+
+```ts
+const { createE2BSandbox } = vi.hoisted(() => ({ createE2BSandbox: vi.fn() }));
+vi.mock('e2b', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('e2b')>()),
+  Sandbox: { create: createE2BSandbox },
+}));
+```
+
+Every `createE2BSandbox.mockResolvedValue(...)` in `agent-fix.test.ts` must now
+include **`sandboxId`**. This is a *provider* field read by the adapter — it is
+not the same as the four wrapper fields (`id`, `createdAt`, `lifetimeMs`,
+`unavailable`) added to structural `SandboxRuntime` fakes in Step 6. A fake that
+has the wrapper fields but no `sandboxId` still yields `id: undefined`.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `packages/worker/src/harness/__tests__/sandbox-runtime.test.ts`, inside the existing `describe('createSandboxRuntime', ...)` block:
+
+```ts
+  it('exports SandboxNotFoundError from the installed E2B version', async () => {
+    const e2b = await vi.importActual<typeof import('e2b')>('e2b');
+    expect(typeof e2b.SandboxNotFoundError).toBe('function');
+  });
+
+  it('latches unavailable and throws SandboxUnavailableError when E2B reports the sandbox is gone', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    const { SandboxNotFoundError } = await vi.importActual<typeof import('e2b')>('e2b');
+    const dead = new SandboxNotFoundError('Sandbox is probably not running anymore');
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-test-1',
+      commands: { run: vi.fn().mockRejectedValue(dead) },
+      files: { read: vi.fn().mockRejectedValue(dead), write: vi.fn() },
+      kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime();
+    expect(runtime.id).toBe('sbx-test-1');
+    expect(runtime.unavailable).toBe(false);
+
+    await expect(runtime.commands.run('echo hi')).rejects.toBeInstanceOf(SandboxUnavailableError);
+    expect(runtime.unavailable).toBe(true);
+  });
+
+  it('does not latch unavailable for an ordinary command failure', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-test-2',
+      commands: { run: vi.fn().mockRejectedValue(new Error('Command exited with code 1')) },
+      files: { read: vi.fn(), write: vi.fn() },
+      kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime();
+    await expect(runtime.commands.run('false')).rejects.toThrow('Command exited with code 1');
+    expect(runtime.unavailable).toBe(false);
+  });
+
+  it('raises SandboxUnavailableError from the local backend after kill', async () => {
+    process.env['OPSLANE_SANDBOX_BACKEND'] = 'local';
+    process.env['OPSLANE_RELIABILITY_HARNESS'] = '1';
+    const sandbox = await createSandboxRuntime();
+    await sandbox.kill();
+    await expect(sandbox.commands.run('echo hi')).rejects.toBeInstanceOf(SandboxUnavailableError);
+    expect(sandbox.unavailable).toBe(true);
+  });
+```
+
+Update the import at the top of that test file:
+
+```ts
+import { createSandboxRuntime, SandboxUnavailableError } from '../sandbox-runtime.js';
+```
+
+Also **update the existing identity assertion**. The current test at
+`sandbox-runtime.test.ts:45-52` asserts `resolves.toBe(e2bRuntime)` — the exact
+SDK object. The adapter returns a wrapper, so identity no longer holds. Replace it:
+
+```ts
+  it('uses E2B by default', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-default',
+      commands: { run: vi.fn() },
+      files: { read: vi.fn(), write: vi.fn() },
+      kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime();
+    expect(runtime.id).toBe('sbx-default');
+    expect(createE2BSandbox).toHaveBeenCalledOnce();
+  });
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm --filter @opslane/worker test -- sandbox-runtime`
+Expected: FAIL — `SandboxUnavailableError` is not exported.
+
+- [ ] **Step 4: Write minimal implementation**
+
+In `packages/worker/src/harness/sandbox-runtime.ts`, change the import on line 6 and add the error class plus the interface fields:
+
+```ts
+import { Sandbox, SandboxNotFoundError } from 'e2b';
+```
+
+```ts
+/**
+ * The verification machine is gone — expired, evicted, or never existed.
+ * Distinct from a command that ran and failed: no verdict about the patch is
+ * possible once this is raised. Callers must classify it as infra_error.
+ */
+export class SandboxUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SandboxUnavailableError';
+  }
+}
+```
+
+Extend the interface (keep the existing `commands`/`files`/`kill` members exactly as they are):
+
+```ts
+export interface SandboxRuntime {
+  /** Provider's sandbox identifier, for correlating an incident to the machine. */
+  readonly id: string;
+  /** Epoch ms at creation. Required: id and lifetimeMs alone cannot yield age-at-error. */
+  readonly createdAt: number;
+  /** Wall-clock ceiling this sandbox was provisioned with. */
+  readonly lifetimeMs: number;
+  /**
+   * Latched once the provider reports the machine is gone. Never resets.
+   * Exists because agent-core/tool-loop.ts converts every tool exception into
+   * model-visible text, so no exception can escape runAgentLoop. State can.
+   */
+  readonly unavailable: boolean;
+  commands: {
+    run(command: string, options?: { timeoutMs?: number }): Promise<SandboxCommandResult>;
+  };
+  files: {
+    read(path: string): Promise<string>;
+    write(path: string, data: string): Promise<unknown>;
+  };
+  kill(): Promise<unknown>;
+}
+```
+
+Add the adapter above `createSandboxRuntime`:
+
+```ts
+/** The E2B object shape this adapter needs. Avoids importing SDK types wholesale. */
+interface E2BSandboxLike {
+  sandboxId: string;
+  commands: { run(command: string, options?: { timeoutMs?: number }): Promise<SandboxCommandResult> };
+  files: { read(path: string): Promise<string>; write(path: string, data: string): Promise<unknown> };
+  kill(): Promise<unknown>;
+}
+
+/**
+ * Wrap the provider so a vanished sandbox becomes a typed, latched signal.
+ * Only SandboxNotFoundError is mapped: E2B's TimeoutError also covers ordinary
+ * per-command deadlines, and mapping it would turn an agent command timeout
+ * into a whole-job retry.
+ */
+function adaptE2BSandbox(sbx: E2BSandboxLike, lifetimeMs: number, createdAt: number): SandboxRuntime {
+  let unavailable = false;
+
+  const guard = async <T>(operation: () => Promise<T>): Promise<T> => {
+    try {
+      return await operation();
+    } catch (err: unknown) {
+      if (err instanceof SandboxNotFoundError) {
+        unavailable = true;
+        throw new SandboxUnavailableError(err.message);
+      }
+      throw err;
+    }
+  };
+
+  return {
+    id: sbx.sandboxId,
+    createdAt,
+    lifetimeMs,
+    get unavailable() { return unavailable; },
+    commands: {
+      run: (command, options) => guard(() => sbx.commands.run(command, options)),
+    },
+    files: {
+      read: (path) => guard(() => sbx.files.read(path)),
+      write: (path, data) => guard(() => sbx.files.write(path, data)),
+    },
+    kill: () => sbx.kill(),
+  };
+}
+```
+
+**Wire the adapter in this task.** Leaving `createSandboxRuntime` returning the
+raw SDK object would break the `SandboxRuntime` return type and make Task 1
+un-typecheckable on its own. Replace the `backend === 'e2b'` branch now, keeping
+the *existing* lifetime behaviour — Task 2 changes only where the number comes
+from:
+
+```ts
+  if (backend === 'e2b') {
+    // Captured BEFORE the await: creation takes real time, and age-at-error must
+    // measure from when provisioning started, not when the promise resolved.
+    const createdAt = Date.now();
+    if (platform !== 'python') {
+      // 300_000 is E2B's default. `Sandbox.defaultSandboxTimeoutMs` is
+      // `protected static` in v2.35 and will not compile. Task 2 deletes this line.
+      return adaptE2BSandbox(await Sandbox.create(), 300_000, createdAt);
+    }
+    const template = process.env['OPSLANE_E2B_PYTHON_TEMPLATE']?.trim() || DEFAULT_PYTHON_TEMPLATE;
+    return adaptE2BSandbox(
+      await Sandbox.create(template, { timeoutMs: PYTHON_SANDBOX_LIFETIME_MS }),
+      PYTHON_SANDBOX_LIFETIME_MS,
+      createdAt,
+    );
+  }
+```
+
+In `createLocalSandboxRuntime`, replace the body of `ensureRunning` and add the metadata fields to the returned object:
+
+```ts
+  const ensureRunning = (): void => {
+    if (killed) throw new SandboxUnavailableError('Sandbox has been killed');
+  };
+```
+
+Add `ensureRunning()` as the first statement of the local `run` implementation if it is not already there, and extend the returned object:
+
+```ts
+  const createdAt = Date.now();
+
+  return {
+    id: `local-${createdAt}`,
+    createdAt,
+    // 0 means "no provider-imposed ceiling" — it lives until killed. Do NOT use
+    // Number.POSITIVE_INFINITY: OpenTelemetry attributes must be finite and JSON
+    // logging serializes it as null.
+    lifetimeMs: 0,
+    get unavailable() { return killed; },
+    // commands, files, and kill keep their existing implementations verbatim —
+    // only the four metadata members above are added to the returned object.
+    commands: { async run(command, options) { /* existing body, unchanged */ } },
+    files: {
+      async read(path) { /* existing body, unchanged */ },
+      async write(path, data) { /* existing body, unchanged */ },
+    },
+    async kill() { /* existing body, unchanged */ },
+  };
+```
+
+Do not retype the existing bodies — add the four metadata members to the object
+literal that is already there and leave `commands`, `files`, and `kill` untouched.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @opslane/worker test -- sandbox-runtime`
+Expected: PASS (4 new tests).
+
+- [ ] **Step 6: Fix the broken structural fakes**
+
+`SandboxRuntime` now has required fields, so every structural fake fails to typecheck. In each of `test-runner.test.ts`, `sandbox-repo.test.ts`, `sandbox-repo-setup.test.ts`, **and any fake inside `__tests__/agent-fix.test.ts`**, add these four properties to the object literal returned by the local `fakeSandbox` (or equivalent) helper:
+
+```ts
+    id: 'fake-sandbox',
+    createdAt: 0,
+    lifetimeMs: 1_800_000,
+    unavailable: false,
+```
+
+Run: `pnpm --filter @opslane/worker build && pnpm --filter @opslane/worker test`
+Expected: no type errors, full worker suite green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/worker/src/harness/sandbox-runtime.ts packages/worker/src/harness/__tests__/ packages/worker/src/__tests__/agent-fix.test.ts
+git commit -m "feat(worker): latch and type sandbox unavailability at the provider boundary"
+```
+
+---
+
+### Task 2: SANDBOX_LIFETIME_MS with a validated floor
+
+**Files:**
+- Modify: `packages/worker/src/harness/sandbox-runtime.ts:11-13,40-50`
+- Modify: `docs/reference/environment-variables.md`
+- Test: `packages/worker/src/harness/__tests__/sandbox-runtime.test.ts`
+
+**Interfaces:**
+- Consumes: `SandboxRuntime.lifetimeMs` from Task 1.
+- Produces: `SANDBOX_LIFETIME_MS` env var; both platforms provisioned with the same ceiling.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+  it('provisions the JavaScript sandbox with an explicit lifetime, not the SDK default', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    delete process.env['SANDBOX_LIFETIME_MS'];
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-life', commands: { run: vi.fn() },
+      files: { read: vi.fn(), write: vi.fn() }, kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime('javascript');
+    expect(runtime.lifetimeMs).toBe(1_800_000);
+    expect(createE2BSandbox).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 1_800_000 }));
+  });
+
+  it('clamps a lifetime below the floor back to the default', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    process.env['SANDBOX_LIFETIME_MS'] = '60000';
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-low', commands: { run: vi.fn() },
+      files: { read: vi.fn(), write: vi.fn() }, kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime('javascript');
+    expect(runtime.lifetimeMs).toBe(1_800_000);
+  });
+
+  it('honours a lifetime at or above the floor', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    process.env['SANDBOX_LIFETIME_MS'] = '900000';
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-ok', commands: { run: vi.fn() },
+      files: { read: vi.fn(), write: vi.fn() }, kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime('javascript');
+    expect(runtime.lifetimeMs).toBe(900_000);
+    // Assert the provisioning argument, not just the metadata: the two could
+    // disagree and the sandbox would still be created with the wrong ceiling.
+    expect(createE2BSandbox).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 900_000 }));
+  });
+
+  it('clamps a lifetime above the account ceiling', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    process.env['SANDBOX_LIFETIME_MS'] = '999999999';
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-high', commands: { run: vi.fn() },
+      files: { read: vi.fn(), write: vi.fn() }, kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime('javascript');
+    expect(runtime.lifetimeMs).toBe(1_800_000);
+  });
+```
+
+Add `'SANDBOX_LIFETIME_MS'` to the `ENV_KEYS` array at the top of the test file so it is saved and restored.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @opslane/worker test -- sandbox-runtime`
+Expected: FAIL — `runtime.lifetimeMs` is not 1800000; `createE2BSandbox` called with no arguments.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the `PYTHON_SANDBOX_LIFETIME_MS` constant (line 13) with:
+
+```ts
+/**
+ * Measured worst-case run is ~606s (Langfuse agent-loop p100 x4 attempts plus
+ * gates, opslane-oss#255). The floor guards against gross misconfiguration; it
+ * is not a proof of sufficiency, because the phase timeout caps are not all
+ * simultaneously reachable and their sum exceeds this. The default matches the
+ * Python path, which already runs 1_800_000 in production and therefore proves
+ * this account's tier accepts it.
+ */
+const SANDBOX_LIFETIME_FLOOR_MS = 900_000;
+const SANDBOX_LIFETIME_DEFAULT_MS = 1_800_000;
+/**
+ * E2B enforces account-tier maximums and rejects creation above them. 1_800_000
+ * is the only value proven acceptable on this account (the Python path has run
+ * it in production). Anything higher is clamped rather than risking a creation
+ * failure that would look like an unrelated outage.
+ */
+const SANDBOX_LIFETIME_CEILING_MS = 1_800_000;
+
+function resolveSandboxLifetimeMs(): number {
+  const raw = parseInt(process.env['SANDBOX_LIFETIME_MS'] ?? String(SANDBOX_LIFETIME_DEFAULT_MS), 10);
+  if (!Number.isInteger(raw)) return SANDBOX_LIFETIME_DEFAULT_MS;
+  if (raw < SANDBOX_LIFETIME_FLOOR_MS) return SANDBOX_LIFETIME_DEFAULT_MS;
+  if (raw > SANDBOX_LIFETIME_CEILING_MS) return SANDBOX_LIFETIME_CEILING_MS;
+  return raw;
+}
+```
+
+Replace the body of the `backend === 'e2b'` branch:
+
+```ts
+  if (backend === 'e2b') {
+    // The lifetime is a ceiling, not a reservation: agent-fix.ts kills the
+    // sandbox in a finally and E2B bills actual uptime, so a job finishing in
+    // 60s costs 60s regardless. The accepted cost is crash exposure — if the
+    // worker process dies, finally never runs and the orphan leaks for up to
+    // the ceiling rather than 5 minutes. The Python path already carries this.
+    const lifetimeMs = resolveSandboxLifetimeMs();
+    const createdAt = Date.now();
+    if (platform !== 'python') {
+      return adaptE2BSandbox(await Sandbox.create({ timeoutMs: lifetimeMs }), lifetimeMs, createdAt);
+    }
+    const template = process.env['OPSLANE_E2B_PYTHON_TEMPLATE']?.trim() || DEFAULT_PYTHON_TEMPLATE;
+    return adaptE2BSandbox(await Sandbox.create(template, { timeoutMs: lifetimeMs }), lifetimeMs, createdAt);
+  }
+```
+
+Delete the stale comment block on lines 43-46 that claims raising the JavaScript lifetime has "no benefit".
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @opslane/worker test -- sandbox-runtime`
+Expected: PASS.
+
+- [ ] **Step 5: Document the variable**
+
+Add a row to the table in `docs/reference/environment-variables.md`, matching the existing column format:
+
+```
+| `SANDBOX_LIFETIME_MS` | no (`1800000`) | Wall-clock ceiling for a verification sandbox. Values below `900000` fall back to the default; values above `1800000` are clamped to it (E2B enforces account-tier maximums). The ceiling is not billed unless consumed; raising it increases orphan exposure if the worker crashes. |
+```
+
+Run: `node scripts/check-docs-drift.mjs`
+Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/worker/src/harness/sandbox-runtime.ts packages/worker/src/harness/__tests__/sandbox-runtime.test.ts docs/reference/environment-variables.md
+git commit -m "feat(worker): configurable sandbox lifetime with a validated floor"
+```
+
+---
+
+### Task 3: Stop fileExists disguising a dead sandbox (path D)
+
+**Files:**
+- Modify: `packages/worker/src/harness/sandbox-repo.ts:378-385,363-375`
+- Test: `packages/worker/src/harness/__tests__/sandbox-repo.test.ts`
+
+**Interfaces:**
+- Consumes: `SandboxUnavailableError` from Task 1.
+- Produces: `runBuildGate` returns `outcome: 'infra_error'` for an unavailable sandbox.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/worker/src/harness/__tests__/sandbox-repo.test.ts`:
+
+```ts
+import { SandboxUnavailableError } from '../sandbox-runtime.js';
+
+describe('runBuildGate against an unavailable sandbox', () => {
+  const deadSandbox: SandboxRuntime = {
+    id: 'dead', createdAt: 0, lifetimeMs: 1_800_000, unavailable: true,
+    commands: {
+      run: async () => { throw new SandboxUnavailableError('Sandbox is probably not running anymore'); },
+    },
+    files: {
+      read: async () => { throw new SandboxUnavailableError('Sandbox is probably not running anymore'); },
+      write: async () => undefined,
+    },
+    kill: async () => undefined,
+  };
+
+  it('reports infra_error, never skipped_no_runner', async () => {
+    const result = await runBuildGate(deadSandbox, 'javascript');
+    // skipped_no_runner is the dangerous answer: computeTier accepts it as
+    // buildOk, so a vanished machine would satisfy the build gate.
+    expect(result.outcome).not.toBe('skipped_no_runner');
+    expect(result.outcome).toBe('infra_error');
+  });
+
+  it('reports infra_error when the sandbox dies AFTER package.json is read', async () => {
+    // Without this case the suite passes even if fileExists still swallows
+    // sandbox death: the package.json read throws first and short-circuits.
+    let reads = 0;
+    const diesLater: SandboxRuntime = {
+      ...deadSandbox,
+      files: {
+        read: async (path: string) => {
+          reads++;
+          if (path.endsWith('package.json')) return JSON.stringify({ scripts: {} });
+          throw new SandboxUnavailableError('Sandbox is probably not running anymore');
+        },
+        write: async () => undefined,
+      },
+    };
+
+    const result = await runBuildGate(diesLater, 'javascript');
+    expect(reads).toBeGreaterThan(1);
+    expect(result.outcome).toBe('infra_error');
+  });
+
+  it('reports infra_error for the python syntax gate too', async () => {
+    const result = await runBuildGate(deadSandbox, 'python');
+    expect(result.outcome).toBe('infra_error');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @opslane/worker test -- sandbox-repo`
+Expected: FAIL — received `'skipped_no_runner'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Import the error at the top of `sandbox-repo.ts`:
+
+```ts
+import { createSandboxRuntime, SandboxUnavailableError, type SandboxRuntime } from './sandbox-runtime.js';
+```
+
+Replace `fileExists` (lines 378-385):
+
+```ts
+/**
+ * Note the deliberate asymmetry: a vanished sandbox must not read as "file
+ * absent", because runBuildGate would then report skipped_no_runner and
+ * computeTier accepts that as a satisfied build gate. Other read failures
+ * (permissions, transport) still return false — this narrows the hole, it does
+ * not close it.
+ */
+async function fileExists(sandbox: SandboxRuntime, path: string): Promise<boolean> {
+  try {
+    await sandbox.files.read(path);
+    return true;
+  } catch (err: unknown) {
+    if (err instanceof SandboxUnavailableError) throw err;
+    return false;
+  }
+}
+```
+
+In `runBuildGate`, the `package.json` read at lines 341-346 also swallows the error. Change its catch:
+
+```ts
+  try {
+    const raw = await sandbox.files.read(`${SANDBOX_REPO}/package.json`);
+    pkg = JSON.parse(raw) as PackageJsonLike;
+  } catch (err: unknown) {
+    if (err instanceof SandboxUnavailableError) {
+      return { outcome: 'infra_error', output: scrubSecrets(err.message) };
+    }
+    // no package.json
+  }
+```
+
+Wrap the remaining probe calls so a rethrown `SandboxUnavailableError` becomes `infra_error` rather than propagating out of the gate. Replace the `tsconfigExists`/`pm` block:
+
+```ts
+  let tsconfigExists: boolean;
+  let pm: 'npm' | 'pnpm' | 'yarn';
+  try {
+    tsconfigExists = await fileExists(sandbox, `${SANDBOX_REPO}/tsconfig.json`);
+    pm = (await fileExists(sandbox, `${SANDBOX_REPO}/pnpm-lock.yaml`)) ? 'pnpm'
+      : (await fileExists(sandbox, `${SANDBOX_REPO}/yarn.lock`)) ? 'yarn'
+        : 'npm';
+  } catch (err: unknown) {
+    if (err instanceof SandboxUnavailableError) {
+      return { outcome: 'infra_error', output: scrubSecrets(err.message) };
+    }
+    throw err;
+  }
+```
+
+Add a typed branch to the existing catch at lines 363-375, **before** the `/timed out|timeout/i` test:
+
+```ts
+  } catch (err: unknown) {
+    if (err instanceof SandboxUnavailableError) {
+      return { outcome: 'infra_error', output: scrubSecrets(err.message) };
+    }
+    const failure = err as BuildFailureLike;
+```
+
+Apply the **identical** branch to `runPythonSyntaxGate`'s catch at lines 316-327.
+`runBuildGate` delegates to it for `platform === 'python'` before any of the
+JavaScript probes run, so fixing only the JavaScript path leaves Python
+classifying a dead sandbox as `failed`:
+
+```ts
+  } catch (err: unknown) {
+    if (err instanceof SandboxUnavailableError) {
+      return { outcome: 'infra_error', output: scrubSecrets(err.message) };
+    }
+    const failure = err as BuildFailureLike;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @opslane/worker test -- sandbox-repo`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/worker/src/harness/sandbox-repo.ts packages/worker/src/harness/__tests__/sandbox-repo.test.ts
+git commit -m "fix(worker): a dead sandbox no longer reads as a repo with no build runner"
+```
+
+---
+
+### Task 4: Classify sandbox death in the suite runner (path C)
+
+**Files:**
+- Modify: `packages/worker/src/harness/test-runner.ts:204,216-227`
+- Test: `packages/worker/src/harness/__tests__/test-runner.test.ts`
+
+**Interfaces:**
+- Consumes: `SandboxUnavailableError` from Task 1.
+- Produces: `runSuite` returns `outcome: 'infra_error'` for an unavailable sandbox, including from the pre-run cleanup.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { SandboxUnavailableError } from '../sandbox-runtime.js';
+
+  it('classifies a vanished sandbox during the SUITE COMMAND as infra_error', async () => {
+    // Cleanup succeeds; only the suite command hits the dead machine.
+    const run = await runSuite(
+      fakeSandbox({
+        onRun: (command) => {
+          if (command.startsWith('rm -f')) return { exitCode: 0 };
+          throw new SandboxUnavailableError('Sandbox is probably not running anymore');
+        },
+      }),
+      { kind: 'vitest', command: './node_modules/.bin/vitest run' },
+    );
+    expect(run.outcome).toBe('infra_error');
+  });
+
+  it('classifies a vanished sandbox during PRE-RUN CLEANUP as infra_error', async () => {
+    // `rm -f <results path>` used to sit outside the try, so a dead sandbox
+    // threw straight past every classifier and out of runSuite entirely.
+    const run = await runSuite(
+      fakeSandbox({
+        onRun: (command) => {
+          if (command.startsWith('rm -f')) {
+            throw new SandboxUnavailableError('Sandbox is probably not running anymore');
+          }
+          return { exitCode: 0 };
+        },
+      }),
+      { kind: 'vitest', command: './node_modules/.bin/vitest run' },
+    );
+    expect(run.outcome).toBe('infra_error');
+  });
+
+  it('treats an ordinary cleanup failure as infra_error, never a failed suite', async () => {
+    // A failed `rm` must never read as the customer's tests failing, and must
+    // not continue — a stale results file would be parsed as this run's result.
+    const run = await runSuite(
+      fakeSandbox({
+        onRun: (command) => {
+          if (command.startsWith('rm -f')) throw new Error('rm: permission denied');
+          return { exitCode: 0, stdout: '{"testResults":[],"numTotalTests":0}' };
+        },
+      }),
+      { kind: 'npm-script', command: 'npm test' },
+    );
+    expect(run.outcome).toBe('infra_error');
+  });
+```
+
+The existing `fakeSandbox` helper only supports `throwMsg`. Extend its `onRun` return handling so a thrown error propagates — change the helper's `run` to call `opts.onRun` outside the `throwMsg` check and let real exceptions escape:
+
+```ts
+      run: async (command: string) => {
+        const behavior = opts.onRun?.(command);   // may itself throw
+        if (behavior?.throwMsg) {
+```
+
+(No change needed if `onRun` already throws directly — it does, because the callback is invoked synchronously inside `run`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @opslane/worker test -- test-runner`
+Expected: FAIL — the suite-command test receives `'failed'`; the cleanup test rejects with `SandboxUnavailableError` instead of returning a result.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Import the error in `test-runner.ts`:
+
+```ts
+import { SandboxUnavailableError, type SandboxRuntime } from './sandbox-runtime.js';
+```
+
+Move the cleanup **inside** the try and add the typed branch. Replace lines 204-227:
+
+```ts
+  // Cleanup gets its OWN catch. Folding it into the suite try would let an
+  // ordinary `rm` failure be reported as the customer's tests failing; leaving
+  // it uncaught (the current code) lets a dead sandbox throw past every
+  // classifier and surface as worker_runtime_error.
+  try {
+    await sandbox.commands.run(
+      `rm -f ${plan.kind === 'pytest' ? PYTEST_RESULTS_PATH : SUITE_RESULTS_PATH}`,
+      { timeoutMs: 10_000 },
+    );
+  } catch (error: unknown) {
+    // EVERY cleanup failure is infrastructure, not a verdict. Continuing would
+    // let the parser read a results file left by a previous run and report it
+    // as this patch's outcome — a stale-evidence false positive.
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      outcome: 'infra_error',
+      command: plan.command,
+      tests: null,
+      total: null,
+      output: bound(scrubSecrets(detail)),
+    };
+  }
+
+  let rawOutput = '';
+  let exitCode = 0;
+  try {
+    const result = await sandbox.commands.run(
+      `cd ${SANDBOX_REPO} && ${plan.command}`,
+      { timeoutMs: SUITE_TIMEOUT_MS },
+    );
+    exitCode = result.exitCode;
+    rawOutput = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+  } catch (error: unknown) {
+    if (error instanceof SandboxUnavailableError) {
+      return {
+        outcome: 'infra_error',
+        command: plan.command,
+        tests: null,
+        total: null,
+        output: bound(scrubSecrets(error.message)),
+      };
+    }
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const output = failureOutput(error);
+    if (/timed out|timeout/i.test(errorMessage)) {
+      return {
+        outcome: 'infra_error',
+        command: plan.command,
+        tests: null,
+        total: null,
+        output: bound(output),
+      };
+    }
+    exitCode = failureExitCode(error) ?? 1;
+    rawOutput = output;
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @opslane/worker test -- test-runner`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/worker/src/harness/test-runner.ts packages/worker/src/harness/__tests__/test-runner.test.ts
+git commit -m "fix(worker): classify a vanished sandbox as infra_error in the suite runner"
+```
+
+---
+
+### Task 5: Check the flag after the agent loop and translate escaping errors (paths A and B)
+
+**Files:**
+- Modify: `packages/worker/src/agent-fix.ts:3,603-640,850,1199-1212`
+- Test: `packages/worker/src/__tests__/agent-fix.test.ts` (extend the existing suite — it already mocks `e2b`, `runAgentLoop`, `sandbox-repo`, and `test-runner`)
+
+**Interfaces:**
+- Consumes: `SandboxRuntime.unavailable` and `SandboxUnavailableError` from Task 1; `VerificationInfraError` from `harness/errors.ts`.
+- Produces: `runAgentFix` throws `VerificationInfraError` (carrying a non-empty `EvidenceRecord`) whenever the sandbox became unavailable, regardless of what the agent reported.
+
+- [ ] **Step 1: Write the failing test**
+
+This must call `runAgentFix`. A test that only constructs errors and evidence
+proves nothing and would pass the moment Task 1 lands.
+
+Three constraints the test must respect, all learned the hard way:
+1. The helper in `agent-fix.test.ts` is **`makeInput()`** (line 88). Use it.
+2. Setup must survive `resolveClonedBranch` — start from the E2B fake used by an
+   existing **passing** `runAgentFix` test in this file and override only what
+   this case needs. A hand-written fake that returns empty stdout for `ls-remote`
+   fails with `empty_repository` before the agent ever runs.
+3. Setting a `dead` flag does **not** latch anything. The latch flips only when an
+   *adapted* sandbox operation throws. The mocked `runAgentLoop` must therefore
+   invoke a tool and swallow the error the way `agent-core/tool-loop.ts` does.
+
+```ts
+import { VerificationInfraError } from '../harness/errors.js';
+import { logger } from '../logger.js';
+
+describe('sandbox unavailability outranks any agent-reported outcome', () => {
+  /** Setup shared by every test here; beforeEach resets mocks, so call it per test. */
+  async function arrangeDeathDuringAgentLoop(): Promise<void> {
+    const { SandboxNotFoundError } = await import('e2b');
+    let dead = false;
+
+    // Start from the fake the passing tests use, then make it die on demand.
+    const base = passingSandboxFake();  // reuse the existing local helper
+    createE2BSandbox.mockResolvedValue({
+      ...base,
+      sandboxId: 'sbx-dies',
+      commands: {
+        run: vi.fn(async (command: string, opts?: { timeoutMs?: number }) => {
+          if (dead) throw new SandboxNotFoundError('Sandbox is probably not running anymore');
+          return base.commands.run(command, opts);
+        }),
+      },
+    });
+
+    vi.mocked(runAgentLoop).mockImplementation(async (options) => {
+      dead = true;
+      // Mimic tool-loop.ts:202-212 — invoke a tool, swallow the exception, and
+      // report success anyway. This is exactly how the latch must be reached.
+      const read = options.tools.find((t) => t.name === 'read');
+      try { await read?.execute({ path: '/home/user/repo/src/index.ts' }); } catch { /* erased */ }
+      return {
+        success: true, summary: 'fixed it', toolCallCount: 1, toolHistory: [],
+        tokenUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      } as never;
+    });
+  }
+
+  it('throws VerificationInfraError even when the agent reported success', async () => {
+    await arrangeDeathDuringAgentLoop();
+    await expect(runAgentFix(makeInput())).rejects.toBeInstanceOf(VerificationInfraError);
+  });
+
+  it('carries a non-empty evidence record naming the failure', async () => {
+    await arrangeDeathDuringAgentLoop();
+    await runAgentFix(makeInput()).then(
+      () => { throw new Error('expected rejection'); },
+      (err: VerificationInfraError) => {
+        expect(err.evidence.checks.some((c) => c.outcome === 'infra_error')).toBe(true);
+      },
+    );
+  });
+});
+```
+
+If no reusable `passingSandboxFake()` helper exists in the file, extract one from
+the nearest passing `runAgentFix` test rather than inventing sandbox behaviour.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @opslane/worker test -- agent-fix`
+Expected: FAIL — `runAgentFix` resolves (or rejects with something else) because
+the latch is not yet consulted.
+
+- [ ] **Step 3: Move the evidence recorder above sandbox creation**
+
+`VerificationInfraError` requires a non-optional `EvidenceRecord`, but `evidence` is currently assigned at line 640 — after `createRepoSandbox`. A death during setup therefore cannot construct the error.
+
+In `agent-fix.ts`, move the assignment. Replace line 604:
+
+```ts
+  let sandbox: SandboxRuntime | null = null;
+  // Created before the sandbox: a setup-time death must still be able to
+  // construct a VerificationInfraError, which requires an evidence record.
+  // Note the type is no longer nullable — it was `EvidenceRecorder | null`
+  // only because assignment happened after createRepoSandbox returned.
+  const evidence: EvidenceRecorder = createEvidenceRecorder();
+```
+
+Because `evidence` is now non-nullable, drop the `evidence?.` optional chaining
+and the `...(evidence ? { evidence: evidence.record() } : {})` spread further
+down in this function; they become dead guards and will not typecheck cleanly as
+written.
+
+Delete the later re-assignment at line 640 (`evidence = createEvidenceRecorder();`) so the setup checks are not discarded.
+
+- [ ] **Step 4: Check the flag immediately after the agent loop**
+
+Insert directly after the `result = await traceSpan('agent-loop', ...)` call closes (line 850), **before** the `agentState.gaveUp` check:
+
+```ts
+        // agent-core/tool-loop.ts converts every tool exception into
+        // model-visible text, so a dead sandbox cannot surface as an exception
+        // here — only as this latched flag. Checked before the gaveUp and
+        // budget branches because no agent verdict is trustworthy once the
+        // machine is gone.
+        if (sandbox.unavailable) {
+          evidence.addCheck('sandbox', 'infra_error', {
+            command: '',
+            output: 'The verification sandbox became unavailable during the fix attempt',
+          });
+          throw new VerificationInfraError(
+            'The verification sandbox became unavailable during the fix attempt, so the fix could not be proven either way.',
+            evidence.record(),
+          );
+        }
+```
+
+- [ ] **Step 5: Translate escaping errors in the outer catch**
+
+Replace line 1200 in the outer catch:
+
+```ts
+  } catch (err: unknown) {
+    if (err instanceof VerificationInfraError) throw err;
+    // Paths that throw rather than latch: the uncaught `git checkout` resets,
+    // clone/branch resolution, install, baseline cleanup, tracked-file
+    // discovery, tier reset, and extractDiff. Without this they all terminate
+    // as worker_runtime_error and never requeue.
+    // Also consult the latch: a dead sandbox can surface as some *other* plain
+    // error thrown downstream of the failure, which would otherwise terminate
+    // as worker_runtime_error.
+    if (err instanceof SandboxUnavailableError || sandbox?.unavailable) {
+      const detail = err instanceof Error ? err.message : String(err);
+      evidence.addCheck('sandbox', 'infra_error', { command: '', output: scrubSecrets(detail) });
+      throw new VerificationInfraError(
+        'The verification sandbox became unavailable, so the fix could not be proven either way.',
+        evidence.record(),
+      );
+    }
+    const rawMessage = err instanceof Error ? err.message : String(err);
+```
+
+**Replace** — do not add — the existing import at `agent-fix.ts:3`. It already
+imports `SandboxRuntime`; adding a second import of the same module creates a
+duplicate binding:
+
+```ts
+// before: import type { SandboxRuntime } from './harness/sandbox-runtime.js';
+import { SandboxUnavailableError, type SandboxRuntime } from './harness/sandbox-runtime.js';
+```
+
+- [ ] **Step 6: Run the full worker suite**
+
+Run: `pnpm --filter @opslane/worker test`
+Expected: PASS. If any existing test asserted `budget_exhausted` or `worker_runtime_error` for a dead-sandbox scenario, update the expectation to `VerificationInfraError` — that is the intended behaviour change, not a regression.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/worker/src/agent-fix.ts packages/worker/src/__tests__/agent-fix.test.ts
+git commit -m "fix(worker): sandbox unavailability outranks agent-reported outcomes"
+```
+
+---
+
+### Task 6: Record sandbox identity where the failure is caught
+
+**Files:**
+- Modify: `packages/worker/src/agent-fix.ts` (three sites — see Step 2)
+- Test: extend `packages/worker/src/__tests__/agent-fix.test.ts` with a logger assertion.
+
+**Interfaces:**
+- Consumes: `SandboxRuntime.id`, `.createdAt`, `.lifetimeMs` from Task 1.
+- Produces: span attributes `sandbox.id`, `sandbox.created_at`, `sandbox.lifetime_ms`, `sandbox.age_at_error_ms`, `error.class`, `error.phase`, plus an equivalent `logger.error` line.
+
+- [ ] **Step 1: Add the recorder helper**
+
+`traceSpan(name, attributes, fn)` sets attributes at span start and has no mutation
+callback, and `sandbox-setup` has already ended by the time a gate runs. Use the
+active span instead. Note this attaches to whichever span is active at the catch
+point — in practice the job root span, **not** the `agent-loop` span, which has
+already closed. That is acceptable: the job span is where an operator looks.
+Add near the top of `agent-fix.ts`:
+
+```ts
+import { trace } from '@opentelemetry/api';
+
+/**
+ * Record the machine's identity at the moment it failed. sandboxId appears
+ * nowhere in the worker today, so an incident cannot currently be correlated to
+ * the provider's own records. Logged as well as traced, because Langfuse export
+ * is a no-op when its keys are unset.
+ */
+function recordSandboxFailure(sandbox: SandboxRuntime, phase: string, errorClass: string): void {
+  const ageAtErrorMs = Date.now() - sandbox.createdAt;
+  const fields = {
+    'sandbox.id': sandbox.id,
+    'sandbox.created_at': sandbox.createdAt,
+    'sandbox.lifetime_ms': sandbox.lifetimeMs,
+    'sandbox.age_at_error_ms': ageAtErrorMs,
+    'error.class': errorClass,
+    'error.phase': phase,
+  };
+  const span = trace.getActiveSpan();
+  if (span) {
+    for (const [key, value] of Object.entries(fields)) span.setAttribute(key, value);
+  }
+  logger.error('sandbox became unavailable', fields);
+}
+```
+
+- [ ] **Step 2: Call it at both throw sites**
+
+In the post-agent-loop check from Task 5, before the `throw`:
+
+```ts
+          recordSandboxFailure(sandbox, 'agent-loop', 'SandboxUnavailableError');
+```
+
+In the outer catch branch from Task 5, before the `throw`. `sandbox` is null when
+the death happened during `createRepoSandbox`, so identity is genuinely
+unavailable there — log the phase without it rather than skipping the record:
+
+```ts
+      if (sandbox) {
+        recordSandboxFailure(sandbox, 'harness', 'SandboxUnavailableError');
+      } else {
+        logger.error('sandbox became unavailable before it was returned', {
+          'error.class': 'SandboxUnavailableError',
+          'error.phase': 'sandbox-setup',
+        });
+      }
+```
+
+**Third site — the gate-driven throw.** `runSuite` and `runBuildGate` convert
+death into `infra_error` (Tasks 3 and 4), which sets `verificationInfraError` and
+reaches the pre-existing throw at `agent-fix.ts:1061`. That is neither Task 5
+site, and the outer catch rethrows `VerificationInfraError` immediately — so
+without this, the most common gate path records no sandbox identity at all. Add
+before that throw:
+
+```ts
+      if (sandbox.unavailable) recordSandboxFailure(sandbox, 'verification-gate', 'SandboxUnavailableError');
+```
+
+- [ ] **Step 3: Assert the record is actually written**
+
+`recordSandboxFailure` writes to both a span and the logger. Spans are a no-op
+without Langfuse keys, so assert on the logger. Add `import { logger } from '../logger.js';`
+to the test file if Step 1 of Task 5 did not already:
+
+```ts
+  it('records sandbox identity and age when the machine dies', async () => {
+    // beforeEach resets mocks, so arrange explicitly — do not rely on a prior test.
+    await arrangeDeathDuringAgentLoop();
+    const errorSpy = vi.spyOn(logger, 'error');
+    await expect(runAgentFix(makeInput())).rejects.toBeInstanceOf(VerificationInfraError);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'sandbox became unavailable',
+      expect.objectContaining({
+        'sandbox.id': 'sbx-dies',
+        'error.phase': expect.any(String),
+        'sandbox.age_at_error_ms': expect.any(Number),
+      }),
+    );
+  });
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `pnpm --filter @opslane/worker test && pnpm --filter @opslane/worker build`
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/worker/src/agent-fix.ts packages/worker/src/__tests__/agent-fix.test.ts
+git commit -m "feat(worker): record sandbox id, age, and phase when a sandbox dies"
+```
+
+---
+
+### Task 7: Confirm the existing requeue coverage still holds
+
+**Files:**
+- Verify only: `packages/worker/src/__tests__/index.test.ts:365-390`
+
+**Interfaces:**
+- Consumes: `VerificationInfraError` from Task 5.
+- Produces: nothing new.
+
+The requeue-vs-terminalize contract is **already covered**. `index.test.ts:365`
+("rethrows verification infrastructure errors while the job has retries
+remaining") and `:379` ("converts a final verification infrastructure failure to
+needs_human with evidence") drive it through `mockRunPipeline.mockRejectedValue`.
+
+Do **not** write a new `process-job-infra.test.ts`. An earlier draft of this plan
+proposed one; it would have duplicated these tests and could not have worked as
+written — `processJobInner` branches on `job.jobType`, and `processFixJob` is a
+module-local lexical binding that `vi.spyOn` cannot replace.
+
+- [ ] **Step 1: Run the existing coverage**
+
+Run: `pnpm --filter @opslane/worker test -- index`
+Expected: PASS, including the two tests above.
+
+- [ ] **Step 2: Confirm the evidence assertion is meaningful**
+
+Both existing tests build the fixture as `{ version: 1, tier: 'E0', checks: [] }`
+(`index.test.ts:366`) — an **empty** checks array, which contradicts the guarantee
+Task 5 now makes. Change both fixtures to carry a real infra check and assert it
+survives terminalization:
+
+```ts
+    const evidence = {
+      version: 1 as const,
+      tier: null,
+      checks: [{ name: 'sandbox', outcome: 'infra_error' as const, command: '', output_tail: 'gone' }],
+    };
+```
+
+Then in the final-attempt test, assert the record reaches `updateGroupStatus`:
+
+```ts
+    expect(entry?.[3]?.evidence?.checks).toHaveLength(1);
+```
+
+- [ ] **Step 3: Commit (only if Step 2 changed anything)**
+
+```bash
+git add packages/worker/src/__tests__/index.test.ts
+git commit -m "test(worker): assert infra failures carry evidence to terminalization"
+```
+
+## Final Verification
+
+- [ ] `pnpm install --frozen-lockfile`
+- [ ] `pnpm -r build`
+- [ ] `pnpm --filter @opslane/worker test` — read the **skip count**, not just the pass count
+- [ ] `node scripts/check-docs-drift.mjs`
+- [ ] `docker compose config --quiet`
+- [ ] Confirm only `sandbox-runtime.ts` imports `e2b`:
+      `grep -rn "from 'e2b'" packages/worker/src --include=*.ts | grep -v __tests__`
+      Expected: exactly one hit.
+- [ ] **Live pipeline smoke — required.** The root `AGENTS.md` mandates this for
+      pipeline behaviour changes: apply migrations, run `scripts/seed-e2e.sql`,
+      rebuild ingestion and worker, POST an event to
+      `$INGESTION_URL/api/v1/events`, and confirm the job reaches its expected
+      terminal state. From a worktree, export the free-port triple and derived
+      URLs as a unit (see root `AGENTS.md`), and confirm
+      `(cd packages/ingestion && go test ./...)` reports **zero** skips.
+- [ ] Live lifetime check (needs `E2B_API_KEY`). `SandboxRuntime` exposes no expiry
+      field and only `sandbox-runtime.ts` may import `e2b`, so use a throwaway
+      script. It must run from **`packages/worker`** so pnpm resolves the
+      workspace-local `e2b`; a script in the repo root will not resolve it:
+
+      ```bash
+      cd packages/worker
+      node --input-type=module -e "
+        import { Sandbox } from 'e2b';
+        const s = await Sandbox.create({ timeoutMs: 1_800_000 });
+        console.log(s.sandboxId, await s.getInfo?.());
+        await s.kill();
+      "
+      ```
+
+      If `getInfo()` is unavailable in v2.35, assert instead that creation with
+      `timeoutMs: 1_800_000` succeeds — a tier rejection surfaces as a creation
+      error, which is the failure this check exists to rule out.
+
+## Out of Scope
+
+Do not implement these here; they are tracked separately.
+
+- `CommandFailedError`, removing `buildFailureExitCode()`, removing the unreachable `res.exitCode === 0` branch in `runBuildGate` → **#274**
+- Redacting Opslane-side faults from customer-facing evidence → **#273** (blocked on Task 6 landing and being confirmed in production)
+- Provider-neutral `SandboxRuntime` (`/home/user/repo` hardcoded 13× across 7 files) → **#274**
+- Fail-fast on `installFailed` — a real latent bug, but not required to fix any path in this plan
+- Requeuing the seven existing incidents — decided out of scope; they stay `needs_human`

--- a/packages/worker/src/__tests__/agent-fix.test.ts
+++ b/packages/worker/src/__tests__/agent-fix.test.ts
@@ -66,6 +66,8 @@ import { runAgentLoop } from '../harness/agent-loop.js';
 import { judgeDiff } from '../harness/diff-judge.js';
 import { runBuildGate } from '../harness/sandbox-repo.js';
 import { planTests, runSuite } from '../harness/test-runner.js';
+import { VerificationInfraError } from '../harness/errors.js';
+import { logger } from '../logger.js';
 
 function makeAgentResult(overrides?: Partial<AgentCompletionResult>): AgentCompletionResult {
   return {
@@ -147,6 +149,27 @@ function mockSandboxWithPassingTests() {
     if (cmd.includes('git diff')) return { exitCode: 0, stdout: DIFF_STDOUT, stderr: '' };
     return { exitCode: 0, stdout: '', stderr: '' };
   });
+}
+
+/** Provider-shaped fake that carries a runAgentFix run all the way to fix_ready.
+ *  Extracted from the passing tests above so death tests can start from a setup
+ *  that is already known to survive clone + branch resolution. */
+function passingSandboxFake() {
+  return {
+    sandboxId: 'sbx-passing',
+    commands: {
+      run: async (cmd: string, _options?: { timeoutMs?: number }) => {
+        const resolution = gitResolutionResult(cmd);
+        if (resolution) return resolution;
+        if (cmd.includes('vitest.config') && cmd.includes('echo')) return { exitCode: 0, stdout: 'vitest', stderr: '' };
+        if (cmd.includes('npx vitest run')) return { exitCode: 0, stdout: '3 tests passed', stderr: '' };
+        if (cmd.includes('git diff')) return { exitCode: 0, stdout: DIFF_STDOUT, stderr: '' };
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    },
+    files: { read: async (_path: string) => '', write: async () => undefined },
+    kill: vi.fn(async () => undefined),
+  };
 }
 
 /** Helper: mock triage to return fixable (default for most tests) */
@@ -1111,5 +1134,57 @@ describe('runAgentFix', () => {
     expect(systemPrompt).toContain('env-19');
     expect(systemPrompt).not.toContain('env-20');
     expect(systemPrompt).toContain('[5 more environments omitted]');
+  });
+});
+
+describe('sandbox unavailability outranks any agent-reported outcome', () => {
+  /** Setup shared by every test here; beforeEach resets mocks, so call it per test. */
+  async function arrangeDeathDuringAgentLoop(): Promise<void> {
+    const { SandboxNotFoundError } = await import('e2b');
+    let dead = false;
+
+    // Start from the fake the passing tests use, then make it die on demand.
+    const base = passingSandboxFake();
+    createE2BSandbox.mockResolvedValue({
+      ...base,
+      sandboxId: 'sbx-dies',
+      commands: {
+        run: vi.fn(async (command: string, opts?: { timeoutMs?: number }) => {
+          if (dead) throw new SandboxNotFoundError('Sandbox is probably not running anymore');
+          return base.commands.run(command, opts);
+        }),
+      },
+      files: {
+        read: vi.fn(async (path: string) => {
+          if (dead) throw new SandboxNotFoundError('Sandbox is probably not running anymore');
+          return base.files.read(path);
+        }),
+        write: base.files.write,
+      },
+    });
+
+    vi.mocked(runAgentLoop).mockImplementation(async (options) => {
+      dead = true;
+      // Mimic tool-loop.ts:202-212 — invoke a tool, swallow the exception, and
+      // report success anyway. This is exactly how the latch must be reached.
+      const read = options.tools.find((t) => t.name === 'read');
+      try { await read?.execute({ path: '/home/user/repo/src/index.ts' }); } catch { /* erased */ }
+      return makeAgentResult({ summary: 'fixed it', testsRan: true });
+    });
+  }
+
+  it('throws VerificationInfraError even when the agent reported success', async () => {
+    await arrangeDeathDuringAgentLoop();
+    await expect(runAgentFix(makeInput())).rejects.toBeInstanceOf(VerificationInfraError);
+  });
+
+  it('carries a non-empty evidence record naming the failure', async () => {
+    await arrangeDeathDuringAgentLoop();
+    await runAgentFix(makeInput()).then(
+      () => { throw new Error('expected rejection'); },
+      (err: VerificationInfraError) => {
+        expect(err.evidence.checks.some((c) => c.outcome === 'infra_error')).toBe(true);
+      },
+    );
   });
 });

--- a/packages/worker/src/__tests__/agent-fix.test.ts
+++ b/packages/worker/src/__tests__/agent-fix.test.ts
@@ -1187,4 +1187,19 @@ describe('sandbox unavailability outranks any agent-reported outcome', () => {
       },
     );
   });
+
+  it('records sandbox identity and age when the machine dies', async () => {
+    // beforeEach resets mocks, so arrange explicitly — do not rely on a prior test.
+    await arrangeDeathDuringAgentLoop();
+    const errorSpy = vi.spyOn(logger, 'error');
+    await expect(runAgentFix(makeInput())).rejects.toBeInstanceOf(VerificationInfraError);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'sandbox became unavailable',
+      expect.objectContaining({
+        'sandbox.id': 'sbx-dies',
+        'error.phase': expect.any(String),
+        'sandbox.age_at_error_ms': expect.any(Number),
+      }),
+    );
+  });
 });

--- a/packages/worker/src/__tests__/agent-fix.test.ts
+++ b/packages/worker/src/__tests__/agent-fix.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock e2b
-vi.mock('e2b', () => ({
-  Sandbox: {
-    create: vi.fn(),
-  },
+// Mock e2b. The factory MUST preserve the real exports: production code imports
+// SandboxNotFoundError, and `instanceof` only holds against the real class.
+const { createE2BSandbox } = vi.hoisted(() => ({ createE2BSandbox: vi.fn() }));
+vi.mock('e2b', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('e2b')>()),
+  Sandbox: { create: createE2BSandbox },
 }));
 
 // Mock the agent loop
@@ -79,7 +80,9 @@ function makeAgentResult(overrides?: Partial<AgentCompletionResult>): AgentCompl
   };
 }
 
+/** Provider-shaped fake: `sandboxId` is what the adapter reads to expose `id`. */
 const mockSandbox = {
+  sandboxId: 'sbx-mock',
   files: { read: vi.fn(), write: vi.fn() },
   commands: { run: vi.fn() },
   kill: vi.fn(),

--- a/packages/worker/src/__tests__/agent-fix.test.ts
+++ b/packages/worker/src/__tests__/agent-fix.test.ts
@@ -1203,3 +1203,89 @@ describe('sandbox unavailability outranks any agent-reported outcome', () => {
     );
   });
 });
+
+describe('sandbox death before the agent loop', () => {
+  /** Fake whose commands.run dies only on the commands matching `dieOn`. */
+  function sandboxDyingOn(dieOn: (cmd: string) => boolean, SandboxNotFoundError: new (m: string) => Error) {
+    const base = passingSandboxFake();
+    return {
+      ...base,
+      sandboxId: 'sbx-early-death',
+      commands: {
+        run: vi.fn(async (cmd: string, opts?: { timeoutMs?: number }) => {
+          if (dieOn(cmd)) throw new SandboxNotFoundError('Sandbox is probably not running anymore');
+          return base.commands.run(cmd, opts);
+        }),
+      },
+    };
+  }
+
+  it('classifies a death during git clone as infra, not a clone failure', async () => {
+    // sandbox-repo.ts wraps clone-phase errors in `clone failed: ...`, and
+    // agent-fix matches that string and RETURNS needs_human. If the typed class
+    // is not preserved, this job terminalizes as the customer's repo being
+    // unclonable and never requeues.
+    const { SandboxNotFoundError } = await import('e2b');
+    createE2BSandbox.mockResolvedValue(
+      sandboxDyingOn((cmd) => cmd.includes('git clone'), SandboxNotFoundError),
+    );
+
+    await expect(runAgentFix(makeInput())).rejects.toBeInstanceOf(VerificationInfraError);
+  });
+
+  it('classifies a death during BRANCH RESOLUTION as infra, not a clone failure', async () => {
+    // The GitRunner adapter synthesizes { exitCode: 1 } from any thrown error.
+    // If it swallows the typed class, resolveClonedBranch reports
+    // CloneResolutionError and the customer is blamed for an E2B outage.
+    // Clone succeeds here; only the ls-remote/rev-parse probes hit the corpse.
+    const { SandboxNotFoundError } = await import('e2b');
+    createE2BSandbox.mockResolvedValue(
+      sandboxDyingOn(
+        (cmd) => cmd.includes('ls-remote') || cmd.includes('symbolic-ref'),
+        SandboxNotFoundError,
+      ),
+    );
+
+    await expect(runAgentFix(makeInput())).rejects.toBeInstanceOf(VerificationInfraError);
+  });
+
+  it('carries evidence for a setup-time death, before any sandbox is returned', async () => {
+    // Proves the evidence recorder really is constructed above createRepoSandbox:
+    // VerificationInfraError requires a non-optional EvidenceRecord.
+    const { SandboxNotFoundError } = await import('e2b');
+    createE2BSandbox.mockResolvedValue(
+      sandboxDyingOn((cmd) => cmd.includes('git clone'), SandboxNotFoundError),
+    );
+
+    await runAgentFix(makeInput()).then(
+      () => { throw new Error('expected rejection'); },
+      (err: VerificationInfraError) => {
+        expect(err.evidence.checks.some((c) => c.outcome === 'infra_error')).toBe(true);
+      },
+    );
+  });
+
+  it('does not start the agent cascade when setup already latched a death', async () => {
+    // `rm -f /home/user/.netrc` is swallowed by design (`.catch(() => {})`), so
+    // the death latches without throwing. Entering the cascade anyway would burn
+    // the whole agent budget against a machine already known to be gone.
+    // The credential cleanup only runs when a token was supplied.
+    // Match only the cleanup `rm -f`; the earlier `chmod 600 /home/user/.netrc`
+    // is NOT swallowed and would exercise the setup path instead.
+    const { SandboxNotFoundError } = await import('e2b');
+    const errorSpy = vi.spyOn(logger, 'error');
+    createE2BSandbox.mockResolvedValue(
+      sandboxDyingOn((cmd) => cmd.startsWith('rm -f /home/user/.netrc'), SandboxNotFoundError),
+    );
+
+    await expect(runAgentFix(makeInput({ githubToken: 'ghp_test' })))
+      .rejects.toBeInstanceOf(VerificationInfraError);
+    expect(vi.mocked(runAgentLoop)).not.toHaveBeenCalled();
+    // Assert the phase: without it this passes via the setup-death path and
+    // says nothing about the pre-cascade check.
+    expect(errorSpy).toHaveBeenCalledWith(
+      'sandbox became unavailable',
+      expect.objectContaining({ 'error.phase': 'pre-agent-loop' }),
+    );
+  });
+});

--- a/packages/worker/src/__tests__/index.test.ts
+++ b/packages/worker/src/__tests__/index.test.ts
@@ -363,7 +363,11 @@ describe('processFixJob — preserves writeup on failure (no revert/null)', () =
   });
 
   it('rethrows verification infrastructure errors while the job has retries remaining', async () => {
-    const evidence = { version: 1 as const, tier: 'E0' as const, checks: [] };
+    const evidence = {
+      version: 1 as const,
+      tier: null,
+      checks: [{ name: 'sandbox', outcome: 'infra_error' as const, command: '', output_tail: 'gone' }],
+    };
     mockRunPipeline.mockRejectedValue(new VerificationInfraError('runner crashed', evidence));
 
     await expect(processJobInner(
@@ -377,7 +381,11 @@ describe('processFixJob — preserves writeup on failure (no revert/null)', () =
   });
 
   it('converts a final verification infrastructure failure to needs_human with evidence', async () => {
-    const evidence = { version: 1 as const, tier: 'E0' as const, checks: [] };
+    const evidence = {
+      version: 1 as const,
+      tier: null,
+      checks: [{ name: 'sandbox', outcome: 'infra_error' as const, command: '', output_tail: 'gone' }],
+    };
     mockRunPipeline.mockRejectedValue(new VerificationInfraError('runner crashed', evidence));
 
     await processJobInner(
@@ -390,6 +398,7 @@ describe('processFixJob — preserves writeup on failure (no revert/null)', () =
     );
     expect(call?.[2]).toBe('needs_human');
     expect(call?.[3]?.evidence).toEqual(evidence);
+    expect(call?.[3]?.evidence?.checks).toHaveLength(1);
   });
 
   it('prefers session-pointer evidence fetched through ingestion', async () => {

--- a/packages/worker/src/__tests__/tool-bridge.test.ts
+++ b/packages/worker/src/__tests__/tool-bridge.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createToolBridge } from '../harness/tool-bridge.js';
 import type { AgentState } from '../harness/types.js';
+import type { SandboxRuntime } from '../harness/sandbox-runtime.js';
 
 function makeMockSandbox() {
   return {
+    id: 'fake-sandbox',
+    createdAt: 0,
+    lifetimeMs: 1_800_000,
+    unavailable: false,
     files: {
       read: vi.fn(),
       write: vi.fn(),
@@ -11,6 +16,7 @@ function makeMockSandbox() {
     commands: {
       run: vi.fn(),
     },
+    kill: vi.fn(),
   };
 }
 
@@ -31,7 +37,7 @@ function makeState(): AgentState {
 describe('createToolBridge', () => {
   it('creates 8 tools (read, write, edit, bash, read_many, search, patch, give_up)', () => {
     const sandbox = makeMockSandbox();
-    const tools = createToolBridge(sandbox as unknown as import('e2b').Sandbox, makeState());
+    const tools = createToolBridge(sandbox as unknown as SandboxRuntime, makeState());
     const names = tools.map(t => t.name).sort();
     expect(names).toEqual(['bash', 'edit', 'give_up', 'patch', 'read', 'read_many', 'search', 'write']);
   });
@@ -39,7 +45,7 @@ describe('createToolBridge', () => {
   it('read tool returns file contents from sandbox', async () => {
     const sandbox = makeMockSandbox();
     sandbox.files.read.mockResolvedValue('const x = 1;');
-    const tools = createToolBridge(sandbox as unknown as import('e2b').Sandbox, makeState());
+    const tools = createToolBridge(sandbox as unknown as SandboxRuntime, makeState());
     const readTool = tools.find(t => t.name === 'read')!;
     const result = await readTool.execute({ path: '/home/user/repo/src/foo.ts' });
     expect(result).toBe('const x = 1;');
@@ -48,7 +54,7 @@ describe('createToolBridge', () => {
   it('edit tool replaces exact string in file', async () => {
     const sandbox = makeMockSandbox();
     sandbox.files.read.mockResolvedValue('const x = 1;\nconst y = 2;');
-    const tools = createToolBridge(sandbox as unknown as import('e2b').Sandbox, makeState());
+    const tools = createToolBridge(sandbox as unknown as SandboxRuntime, makeState());
     const editTool = tools.find(t => t.name === 'edit')!;
     const result = await editTool.execute({
       path: '/home/user/repo/src/foo.ts',
@@ -65,7 +71,7 @@ describe('createToolBridge', () => {
   it('edit tool errors when old_string not found', async () => {
     const sandbox = makeMockSandbox();
     sandbox.files.read.mockResolvedValue('const x = 1;');
-    const tools = createToolBridge(sandbox as unknown as import('e2b').Sandbox, makeState());
+    const tools = createToolBridge(sandbox as unknown as SandboxRuntime, makeState());
     const editTool = tools.find(t => t.name === 'edit')!;
     const result = await editTool.execute({
       path: '/home/user/repo/src/foo.ts',
@@ -78,7 +84,7 @@ describe('createToolBridge', () => {
   it('bash tool returns stdout on success', async () => {
     const sandbox = makeMockSandbox();
     sandbox.commands.run.mockResolvedValue({ exitCode: 0, stdout: 'hello', stderr: '' });
-    const tools = createToolBridge(sandbox as unknown as import('e2b').Sandbox, makeState());
+    const tools = createToolBridge(sandbox as unknown as SandboxRuntime, makeState());
     const bashTool = tools.find(t => t.name === 'bash')!;
     const result = await bashTool.execute({ command: 'echo hello' });
     expect(result).toBe('hello');
@@ -87,7 +93,7 @@ describe('createToolBridge', () => {
   it('bash tool returns stderr on failure', async () => {
     const sandbox = makeMockSandbox();
     sandbox.commands.run.mockResolvedValue({ exitCode: 1, stdout: '', stderr: 'not found' });
-    const tools = createToolBridge(sandbox as unknown as import('e2b').Sandbox, makeState());
+    const tools = createToolBridge(sandbox as unknown as SandboxRuntime, makeState());
     const bashTool = tools.find(t => t.name === 'bash')!;
     const result = await bashTool.execute({ command: 'bad-cmd' });
     expect(result).toContain('Exit code: 1');
@@ -97,7 +103,7 @@ describe('createToolBridge', () => {
   it('give_up tool sets state.gaveUp and stores reason', async () => {
     const sandbox = makeMockSandbox();
     const state = makeState();
-    const tools = createToolBridge(sandbox as unknown as import('e2b').Sandbox, state);
+    const tools = createToolBridge(sandbox as unknown as SandboxRuntime, state);
     const giveUpTool = tools.find(t => t.name === 'give_up')!;
     await giveUpTool.execute({
       reason_code: 'worker_runtime_error',

--- a/packages/worker/src/agent-fix.ts
+++ b/packages/worker/src/agent-fix.ts
@@ -787,6 +787,27 @@ export async function runAgentFix(input: AgentFixInput): Promise<AgentFixResult>
     // Summary from previous tier, passed to next tier to avoid repeating work
     let priorTierSummary: string | undefined;
 
+    // No agent verdict is trustworthy once the machine is gone, so every site
+    // that reads the latch raises the same way.
+    const raiseSandboxGone = (phase: string): never => {
+      evidence.addCheck('sandbox', 'infra_error', {
+        command: '',
+        output: 'The verification sandbox became unavailable during the fix attempt',
+      });
+      recordSandboxFailure(sandbox!, phase, 'SandboxUnavailableError');
+      throw new VerificationInfraError(
+        'The verification sandbox became unavailable during the fix attempt, so the fix could not be proven either way.',
+        evidence.record(),
+      );
+    };
+
+    // Setup, planTests, and the baseline suite all ran above, and each can latch
+    // a death without throwing (planTests swallows non-sandbox read failures by
+    // design). Entering the cascade anyway would spend the whole agent budget —
+    // up to 2 tiers x 2 attempts of real model calls — against a corpse, which
+    // is the burn opslane-oss#255 is named after.
+    if (sandbox.unavailable) raiseSandboxGone('pre-agent-loop');
+
     // Model cascade: try each model in order, escalate on failure or poor quality
     for (let tierIdx = 0; tierIdx < cascade.length; tierIdx++) {
       const tier = cascade[tierIdx];
@@ -885,17 +906,7 @@ export async function runAgentFix(input: AgentFixInput): Promise<AgentFixResult>
         // here — only as this latched flag. Checked before the gaveUp and
         // budget branches because no agent verdict is trustworthy once the
         // machine is gone.
-        if (sandbox.unavailable) {
-          evidence.addCheck('sandbox', 'infra_error', {
-            command: '',
-            output: 'The verification sandbox became unavailable during the fix attempt',
-          });
-          recordSandboxFailure(sandbox, 'agent-loop', 'SandboxUnavailableError');
-          throw new VerificationInfraError(
-            'The verification sandbox became unavailable during the fix attempt, so the fix could not be proven either way.',
-            evidence.record(),
-          );
-        }
+        if (sandbox.unavailable) raiseSandboxGone('agent-loop');
 
         // Agent explicitly gave up — not fixable with code, don't escalate
         if (agentState.gaveUp && agentState.giveUpReason) {

--- a/packages/worker/src/agent-fix.ts
+++ b/packages/worker/src/agent-fix.ts
@@ -1,6 +1,6 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import { createAnthropicClient } from './anthropic-client.js';
-import type { SandboxRuntime } from './harness/sandbox-runtime.js';
+import { SandboxUnavailableError, type SandboxRuntime } from './harness/sandbox-runtime.js';
 import { runAgentLoop } from './harness/agent-loop.js';
 import { createToolBridge } from './harness/tool-bridge.js';
 import { createDefaultMiddleware } from './harness/tool-middleware.js';
@@ -601,7 +601,11 @@ export async function runAgentFix(input: AgentFixInput): Promise<AgentFixResult>
   }
 
   let sandbox: SandboxRuntime | null = null;
-  let evidence: EvidenceRecorder | null = null;
+  // Created before the sandbox: a setup-time death must still be able to
+  // construct a VerificationInfraError, which requires an evidence record.
+  // Note the type is no longer nullable — it was `EvidenceRecorder | null`
+  // only because assignment happened after createRepoSandbox returned.
+  const evidence: EvidenceRecorder = createEvidenceRecorder();
 
   try {
     let repoSandbox: RepoSandbox;
@@ -637,7 +641,6 @@ export async function runAgentFix(input: AgentFixInput): Promise<AgentFixResult>
     sandbox = repoSandbox.sandbox;
     const installOutcome = repoSandbox.installOutcome;
     const installFailed = installOutcome === 'failed';
-    evidence = createEvidenceRecorder();
 
     let verificationInfraError = false;
     const withInfraRetry = async <T extends { outcome: CheckOutcome }>(run: () => Promise<T>): Promise<T> => {
@@ -848,6 +851,22 @@ export async function runAgentFix(input: AgentFixInput): Promise<AgentFixResult>
             userMsg,
           ),
         );
+
+        // agent-core/tool-loop.ts converts every tool exception into
+        // model-visible text, so a dead sandbox cannot surface as an exception
+        // here — only as this latched flag. Checked before the gaveUp and
+        // budget branches because no agent verdict is trustworthy once the
+        // machine is gone.
+        if (sandbox.unavailable) {
+          evidence.addCheck('sandbox', 'infra_error', {
+            command: '',
+            output: 'The verification sandbox became unavailable during the fix attempt',
+          });
+          throw new VerificationInfraError(
+            'The verification sandbox became unavailable during the fix attempt, so the fix could not be proven either way.',
+            evidence.record(),
+          );
+        }
 
         // Agent explicitly gave up — not fixable with code, don't escalate
         if (agentState.gaveUp && agentState.giveUpReason) {
@@ -1199,6 +1218,21 @@ export async function runAgentFix(input: AgentFixInput): Promise<AgentFixResult>
     };
   } catch (err: unknown) {
     if (err instanceof VerificationInfraError) throw err;
+    // Paths that throw rather than latch: the uncaught `git checkout` resets,
+    // clone/branch resolution, install, baseline cleanup, tracked-file
+    // discovery, tier reset, and extractDiff. Without this they all terminate
+    // as worker_runtime_error and never requeue.
+    // Also consult the latch: a dead sandbox can surface as some *other* plain
+    // error thrown downstream of the failure, which would otherwise terminate
+    // as worker_runtime_error.
+    if (err instanceof SandboxUnavailableError || sandbox?.unavailable) {
+      const detail = err instanceof Error ? err.message : String(err);
+      evidence.addCheck('sandbox', 'infra_error', { command: '', output: scrubSecrets(detail) });
+      throw new VerificationInfraError(
+        'The verification sandbox became unavailable, so the fix could not be proven either way.',
+        evidence.record(),
+      );
+    }
     const rawMessage = err instanceof Error ? err.message : String(err);
     const message = rawMessage.replace(/https:\/\/[^@]+@/g, 'https://***@');
     return {
@@ -1208,7 +1242,7 @@ export async function runAgentFix(input: AgentFixInput): Promise<AgentFixResult>
         reason_message: `Agent harness error: ${message}`,
         remediation: 'Review the error manually — the agent harness encountered an unexpected error',
       },
-      ...(evidence ? { evidence: evidence.record() } : {}),
+      evidence: evidence.record(),
     };
   } finally {
     if (sandbox) {

--- a/packages/worker/src/agent-fix.ts
+++ b/packages/worker/src/agent-fix.ts
@@ -10,6 +10,7 @@ import { judgeDiff } from './harness/diff-judge.js';
 import { investigateError } from './investigate.js';
 import { logger } from './logger.js';
 import { traceSpan } from './tracing.js';
+import { trace } from '@opentelemetry/api';
 import type { CheckOutcome, ConfidenceLevel, EvidenceRecord, NeedsHumanReason, ReasonCode } from '@opslane/shared';
 import type { Platform } from './platform.js';
 import type { RuntimeInfo } from './runtime-info.js';
@@ -33,6 +34,33 @@ import {
   type FixNarrative,
   type NarrativeFallbackInput,
 } from './narrative.js';
+
+/**
+ * Record the machine's identity at the moment it failed. sandboxId appears
+ * nowhere in the worker today, so an incident cannot currently be correlated to
+ * the provider's own records. Logged as well as traced, because Langfuse export
+ * is a no-op when its keys are unset.
+ *
+ * Attaches to whichever span is active at the catch point — in practice the job
+ * root span, not the `agent-loop` span, which has already closed. That is
+ * acceptable: the job span is where an operator looks.
+ */
+function recordSandboxFailure(sandbox: SandboxRuntime, phase: string, errorClass: string): void {
+  const ageAtErrorMs = Date.now() - sandbox.createdAt;
+  const fields = {
+    'sandbox.id': sandbox.id,
+    'sandbox.created_at': sandbox.createdAt,
+    'sandbox.lifetime_ms': sandbox.lifetimeMs,
+    'sandbox.age_at_error_ms': ageAtErrorMs,
+    'error.class': errorClass,
+    'error.phase': phase,
+  };
+  const span = trace.getActiveSpan();
+  if (span) {
+    for (const [key, value] of Object.entries(fields)) span.setAttribute(key, value);
+  }
+  logger.error('sandbox became unavailable', fields);
+}
 
 export interface AgentFixInput {
   platform?: Platform;
@@ -862,6 +890,7 @@ export async function runAgentFix(input: AgentFixInput): Promise<AgentFixResult>
             command: '',
             output: 'The verification sandbox became unavailable during the fix attempt',
           });
+          recordSandboxFailure(sandbox, 'agent-loop', 'SandboxUnavailableError');
           throw new VerificationInfraError(
             'The verification sandbox became unavailable during the fix attempt, so the fix could not be proven either way.',
             evidence.record(),
@@ -1078,6 +1107,10 @@ export async function runAgentFix(input: AgentFixInput): Promise<AgentFixResult>
       const { diff, affectedFiles } = candidateDiff ?? { diff: '', affectedFiles: [] };
 
       if (verificationInfraError) {
+        // runSuite and runBuildGate convert sandbox death into infra_error, so
+        // the most common gate path reaches this throw without passing either
+        // of the two sites above.
+        if (sandbox.unavailable) recordSandboxFailure(sandbox, 'verification-gate', 'SandboxUnavailableError');
         throw new VerificationInfraError(
           'Verification infrastructure failed (dependency install, test runner, build, or timeout), so the fix could not be proven either way.',
           evidence.record(),
@@ -1228,6 +1261,15 @@ export async function runAgentFix(input: AgentFixInput): Promise<AgentFixResult>
     if (err instanceof SandboxUnavailableError || sandbox?.unavailable) {
       const detail = err instanceof Error ? err.message : String(err);
       evidence.addCheck('sandbox', 'infra_error', { command: '', output: scrubSecrets(detail) });
+      if (sandbox) {
+        recordSandboxFailure(sandbox, 'harness', 'SandboxUnavailableError');
+      } else {
+        // Death during createRepoSandbox: identity is genuinely unavailable.
+        logger.error('sandbox became unavailable before it was returned', {
+          'error.class': 'SandboxUnavailableError',
+          'error.phase': 'sandbox-setup',
+        });
+      }
       throw new VerificationInfraError(
         'The verification sandbox became unavailable, so the fix could not be proven either way.',
         evidence.record(),

--- a/packages/worker/src/harness/__tests__/sandbox-repo-setup.test.ts
+++ b/packages/worker/src/harness/__tests__/sandbox-repo-setup.test.ts
@@ -13,6 +13,10 @@ const state = vi.hoisted(() => ({
 
 vi.mock('../sandbox-runtime.js', () => ({
   createSandboxRuntime: vi.fn(async (): Promise<SandboxRuntime> => ({
+    id: 'fake-sandbox',
+    createdAt: 0,
+    lifetimeMs: 1_800_000,
+    unavailable: false,
     commands: {
       run: async (command: string) => {
         state.commands.push(command);

--- a/packages/worker/src/harness/__tests__/sandbox-repo-setup.test.ts
+++ b/packages/worker/src/harness/__tests__/sandbox-repo-setup.test.ts
@@ -11,7 +11,10 @@ const state = vi.hoisted(() => ({
   kill: vi.fn(async () => undefined),
 }));
 
-vi.mock('../sandbox-runtime.js', () => ({
+// Preserve the real exports: sandbox-repo.ts narrows on SandboxUnavailableError,
+// and a factory that returns only createSandboxRuntime makes `instanceof` throw.
+vi.mock('../sandbox-runtime.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../sandbox-runtime.js')>()),
   createSandboxRuntime: vi.fn(async (): Promise<SandboxRuntime> => ({
     id: 'fake-sandbox',
     createdAt: 0,

--- a/packages/worker/src/harness/__tests__/sandbox-repo.test.ts
+++ b/packages/worker/src/harness/__tests__/sandbox-repo.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { SandboxRuntime } from '../sandbox-runtime.js';
+import { SandboxUnavailableError, type SandboxRuntime } from '../sandbox-runtime.js';
 import { parseAffectedFiles, runBuildGate, selectBuildCommand } from '../sandbox-repo.js';
 
 function buildSandbox(opts: {
@@ -94,5 +94,53 @@ describe('runBuildGate taxonomy', () => {
       outcome: 'skipped_no_runner',
       output: 'no build script or tsconfig',
     });
+  });
+});
+
+describe('runBuildGate against an unavailable sandbox', () => {
+  const deadSandbox: SandboxRuntime = {
+    id: 'dead', createdAt: 0, lifetimeMs: 1_800_000, unavailable: true,
+    commands: {
+      run: async () => { throw new SandboxUnavailableError('Sandbox is probably not running anymore'); },
+    },
+    files: {
+      read: async () => { throw new SandboxUnavailableError('Sandbox is probably not running anymore'); },
+      write: async () => undefined,
+    },
+    kill: async () => undefined,
+  };
+
+  it('reports infra_error, never skipped_no_runner', async () => {
+    const result = await runBuildGate(deadSandbox, 'javascript');
+    // skipped_no_runner is the dangerous answer: computeTier accepts it as
+    // buildOk, so a vanished machine would satisfy the build gate.
+    expect(result.outcome).not.toBe('skipped_no_runner');
+    expect(result.outcome).toBe('infra_error');
+  });
+
+  it('reports infra_error when the sandbox dies AFTER package.json is read', async () => {
+    // Without this case the suite passes even if fileExists still swallows
+    // sandbox death: the package.json read throws first and short-circuits.
+    let reads = 0;
+    const diesLater: SandboxRuntime = {
+      ...deadSandbox,
+      files: {
+        read: async (path: string) => {
+          reads++;
+          if (path.endsWith('package.json')) return JSON.stringify({ scripts: {} });
+          throw new SandboxUnavailableError('Sandbox is probably not running anymore');
+        },
+        write: async () => undefined,
+      },
+    };
+
+    const result = await runBuildGate(diesLater, 'javascript');
+    expect(reads).toBeGreaterThan(1);
+    expect(result.outcome).toBe('infra_error');
+  });
+
+  it('reports infra_error for the python syntax gate too', async () => {
+    const result = await runBuildGate(deadSandbox, 'python');
+    expect(result.outcome).toBe('infra_error');
   });
 });

--- a/packages/worker/src/harness/__tests__/sandbox-repo.test.ts
+++ b/packages/worker/src/harness/__tests__/sandbox-repo.test.ts
@@ -7,6 +7,10 @@ function buildSandbox(opts: {
   run?: (command: string) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
 }): SandboxRuntime {
   return {
+    id: 'fake-sandbox',
+    createdAt: 0,
+    lifetimeMs: 1_800_000,
+    unavailable: false,
     files: {
       read: async (path) => {
         const content = opts.files?.[path];

--- a/packages/worker/src/harness/__tests__/sandbox-runtime.test.ts
+++ b/packages/worker/src/harness/__tests__/sandbox-runtime.test.ts
@@ -107,6 +107,58 @@ describe('createSandboxRuntime', () => {
     expect(runtime.unavailable).toBe(false);
   });
 
+  it('provisions the JavaScript sandbox with an explicit lifetime, not the SDK default', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    delete process.env['SANDBOX_LIFETIME_MS'];
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-life', commands: { run: vi.fn() },
+      files: { read: vi.fn(), write: vi.fn() }, kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime('javascript');
+    expect(runtime.lifetimeMs).toBe(1_800_000);
+    expect(createE2BSandbox).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 1_800_000 }));
+  });
+
+  it('clamps a lifetime below the floor back to the default', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    process.env['SANDBOX_LIFETIME_MS'] = '60000';
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-low', commands: { run: vi.fn() },
+      files: { read: vi.fn(), write: vi.fn() }, kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime('javascript');
+    expect(runtime.lifetimeMs).toBe(1_800_000);
+  });
+
+  it('honours a lifetime at or above the floor', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    process.env['SANDBOX_LIFETIME_MS'] = '900000';
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-ok', commands: { run: vi.fn() },
+      files: { read: vi.fn(), write: vi.fn() }, kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime('javascript');
+    expect(runtime.lifetimeMs).toBe(900_000);
+    // Assert the provisioning argument, not just the metadata: the two could
+    // disagree and the sandbox would still be created with the wrong ceiling.
+    expect(createE2BSandbox).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 900_000 }));
+  });
+
+  it('clamps a lifetime above the account ceiling', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    process.env['SANDBOX_LIFETIME_MS'] = '999999999';
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-high', commands: { run: vi.fn() },
+      files: { read: vi.fn(), write: vi.fn() }, kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime('javascript');
+    expect(runtime.lifetimeMs).toBe(1_800_000);
+  });
+
   it('raises SandboxUnavailableError from the local backend after kill', async () => {
     process.env['OPSLANE_SANDBOX_BACKEND'] = 'local';
     process.env['OPSLANE_RELIABILITY_HARNESS'] = '1';

--- a/packages/worker/src/harness/__tests__/sandbox-runtime.test.ts
+++ b/packages/worker/src/harness/__tests__/sandbox-runtime.test.ts
@@ -159,6 +159,25 @@ describe('createSandboxRuntime', () => {
     expect(runtime.lifetimeMs).toBe(1_800_000);
   });
 
+  it('provisions the Python sandbox with its template AND the resolved lifetime', async () => {
+    // The Python path moved off a hardcoded PYTHON_SANDBOX_LIFETIME_MS onto the
+    // shared resolver. Without this, a regression there is invisible: every
+    // other lifetime test drives the JavaScript branch.
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    process.env['SANDBOX_LIFETIME_MS'] = '900000';
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-py', commands: { run: vi.fn() },
+      files: { read: vi.fn(), write: vi.fn() }, kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime('python');
+    expect(runtime.lifetimeMs).toBe(900_000);
+    expect(createE2BSandbox).toHaveBeenCalledWith(
+      'opslane-python',
+      expect.objectContaining({ timeoutMs: 900_000 }),
+    );
+  });
+
   it('raises SandboxUnavailableError from the local backend after kill', async () => {
     process.env['OPSLANE_SANDBOX_BACKEND'] = 'local';
     process.env['OPSLANE_RELIABILITY_HARNESS'] = '1';

--- a/packages/worker/src/harness/__tests__/sandbox-runtime.test.ts
+++ b/packages/worker/src/harness/__tests__/sandbox-runtime.test.ts
@@ -7,15 +7,28 @@ const { createE2BSandbox } = vi.hoisted(() => ({
   createE2BSandbox: vi.fn(),
 }));
 
-vi.mock('e2b', () => ({
+vi.mock('e2b', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('e2b')>()),
   Sandbox: { create: createE2BSandbox },
 }));
 
-import { createSandboxRuntime } from '../sandbox-runtime.js';
+import { createSandboxRuntime, SandboxUnavailableError } from '../sandbox-runtime.js';
 
 const ENV_KEYS = [
   'OPSLANE_SANDBOX_BACKEND',
   'OPSLANE_RELIABILITY_HARNESS',
+  'SANDBOX_LIFETIME_MS',
+  'ANTHROPIC_API_KEY',
+  'GITHUB_TOKEN',
+  'DATABASE_URL',
+  'MINIO_SECRET_KEY',
+  'E2B_API_KEY',
+  'LANGFUSE_PUBLIC_KEY',
+  'LANGFUSE_SECRET_KEY',
+] as const;
+
+/** Worker secrets that must never reach a sandbox command environment. */
+const SECRET_ENV_KEYS = [
   'ANTHROPIC_API_KEY',
   'GITHUB_TOKEN',
   'DATABASE_URL',
@@ -44,11 +57,63 @@ afterEach(() => {
 describe('createSandboxRuntime', () => {
   it('uses E2B by default', async () => {
     delete process.env['OPSLANE_SANDBOX_BACKEND'];
-    const e2bRuntime = { marker: 'e2b' };
-    createE2BSandbox.mockResolvedValue(e2bRuntime);
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-default',
+      commands: { run: vi.fn() },
+      files: { read: vi.fn(), write: vi.fn() },
+      kill: vi.fn(),
+    });
 
-    await expect(createSandboxRuntime()).resolves.toBe(e2bRuntime);
+    const runtime = await createSandboxRuntime();
+    expect(runtime.id).toBe('sbx-default');
     expect(createE2BSandbox).toHaveBeenCalledOnce();
+  });
+
+  it('exports SandboxNotFoundError from the installed E2B version', async () => {
+    const e2b = await vi.importActual<typeof import('e2b')>('e2b');
+    expect(typeof e2b.SandboxNotFoundError).toBe('function');
+  });
+
+  it('latches unavailable and throws SandboxUnavailableError when E2B reports the sandbox is gone', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    const { SandboxNotFoundError } = await vi.importActual<typeof import('e2b')>('e2b');
+    const dead = new SandboxNotFoundError('Sandbox is probably not running anymore');
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-test-1',
+      commands: { run: vi.fn().mockRejectedValue(dead) },
+      files: { read: vi.fn().mockRejectedValue(dead), write: vi.fn() },
+      kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime();
+    expect(runtime.id).toBe('sbx-test-1');
+    expect(runtime.unavailable).toBe(false);
+
+    await expect(runtime.commands.run('echo hi')).rejects.toBeInstanceOf(SandboxUnavailableError);
+    expect(runtime.unavailable).toBe(true);
+  });
+
+  it('does not latch unavailable for an ordinary command failure', async () => {
+    delete process.env['OPSLANE_SANDBOX_BACKEND'];
+    createE2BSandbox.mockResolvedValue({
+      sandboxId: 'sbx-test-2',
+      commands: { run: vi.fn().mockRejectedValue(new Error('Command exited with code 1')) },
+      files: { read: vi.fn(), write: vi.fn() },
+      kill: vi.fn(),
+    });
+
+    const runtime = await createSandboxRuntime();
+    await expect(runtime.commands.run('false')).rejects.toThrow('Command exited with code 1');
+    expect(runtime.unavailable).toBe(false);
+  });
+
+  it('raises SandboxUnavailableError from the local backend after kill', async () => {
+    process.env['OPSLANE_SANDBOX_BACKEND'] = 'local';
+    process.env['OPSLANE_RELIABILITY_HARNESS'] = '1';
+    const sandbox = await createSandboxRuntime();
+    await sandbox.kill();
+    await expect(sandbox.commands.run('echo hi')).rejects.toBeInstanceOf(SandboxUnavailableError);
+    expect(sandbox.unavailable).toBe(true);
   });
 
   it('maps virtual paths and commands into a disposable local filesystem', async () => {
@@ -72,7 +137,7 @@ describe('createSandboxRuntime', () => {
   it('isolates temporary files and removes worker secrets from command environments', async () => {
     process.env['OPSLANE_SANDBOX_BACKEND'] = 'local';
     process.env['OPSLANE_RELIABILITY_HARNESS'] = '1';
-    for (const key of ENV_KEYS.slice(2)) process.env[key] = `secret-${key}`;
+    for (const key of SECRET_ENV_KEYS) process.env[key] = `secret-${key}`;
     const sandbox = await createSandboxRuntime();
 
     await sandbox.files.write('/tmp/provider.patch', 'fixture');

--- a/packages/worker/src/harness/__tests__/test-runner.test.ts
+++ b/packages/worker/src/harness/__tests__/test-runner.test.ts
@@ -8,7 +8,7 @@ import {
   selectTestCommand,
   type SuiteRun,
 } from '../test-runner.js';
-import type { SandboxRuntime } from '../sandbox-runtime.js';
+import { SandboxUnavailableError, type SandboxRuntime } from '../sandbox-runtime.js';
 
 describe('selectTestCommand', () => {
   it('prefers repo-local vitest with an explicit JSON reporter and never uses npx', () => {
@@ -276,5 +276,54 @@ describe('runSuite taxonomy', () => {
   it('skips a none plan without claiming evidence', async () => {
     const result = await runSuite(fakeSandbox({}), { kind: 'none', command: null });
     expect(result.outcome).toBe('skipped_no_runner');
+  });
+
+  it('classifies a vanished sandbox during the SUITE COMMAND as infra_error', async () => {
+    // Cleanup succeeds; only the suite command hits the dead machine.
+    // Deliberately an npm-script plan: a vitest plan reaches infra_error anyway
+    // because the results file is missing, so it cannot tell the new typed
+    // branch apart from the pre-existing unparseable-report path.
+    const run = await runSuite(
+      fakeSandbox({
+        onRun: (command) => {
+          if (command.startsWith('rm -f')) return { exitCode: 0 };
+          throw new SandboxUnavailableError('Sandbox is probably not running anymore');
+        },
+      }),
+      { kind: 'npm-script', command: 'npm test' },
+    );
+    expect(run.outcome).toBe('infra_error');
+  });
+
+  it('classifies a vanished sandbox during PRE-RUN CLEANUP as infra_error', async () => {
+    // `rm -f <results path>` used to sit outside the try, so a dead sandbox
+    // threw straight past every classifier and out of runSuite entirely.
+    const run = await runSuite(
+      fakeSandbox({
+        onRun: (command) => {
+          if (command.startsWith('rm -f')) {
+            throw new SandboxUnavailableError('Sandbox is probably not running anymore');
+          }
+          return { exitCode: 0 };
+        },
+      }),
+      { kind: 'vitest', command: './node_modules/.bin/vitest run' },
+    );
+    expect(run.outcome).toBe('infra_error');
+  });
+
+  it('treats an ordinary cleanup failure as infra_error, never a failed suite', async () => {
+    // A failed `rm` must never read as the customer's tests failing, and must
+    // not continue — a stale results file would be parsed as this run's result.
+    const run = await runSuite(
+      fakeSandbox({
+        onRun: (command) => {
+          if (command.startsWith('rm -f')) throw new Error('rm: permission denied');
+          return { exitCode: 0, stdout: '{"testResults":[],"numTotalTests":0}' };
+        },
+      }),
+      { kind: 'npm-script', command: 'npm test' },
+    );
+    expect(run.outcome).toBe('infra_error');
   });
 });

--- a/packages/worker/src/harness/__tests__/test-runner.test.ts
+++ b/packages/worker/src/harness/__tests__/test-runner.test.ts
@@ -128,6 +128,10 @@ function fakeSandbox(opts: {
   onRun?: (command: string) => { exitCode?: number; stdout?: string; stderr?: string; throwMsg?: string };
 }): SandboxRuntime {
   return {
+    id: 'fake-sandbox',
+    createdAt: 0,
+    lifetimeMs: 1_800_000,
+    unavailable: false,
     commands: {
       run: async (command: string) => {
         const behavior = opts.onRun?.(command);

--- a/packages/worker/src/harness/__tests__/test-runner.test.ts
+++ b/packages/worker/src/harness/__tests__/test-runner.test.ts
@@ -327,3 +327,45 @@ describe('runSuite taxonomy', () => {
     expect(run.outcome).toBe('infra_error');
   });
 });
+
+describe('planTests against an unavailable sandbox', () => {
+  it('propagates sandbox death instead of reporting no test runner', async () => {
+    // fileExists returning false for a dead machine makes the repo look like it
+    // has no runner, and the suite gate then records skipped_no_runner — the
+    // same silent misclassification as the build gate's path D.
+    const dead: SandboxRuntime = {
+      id: 'dead', createdAt: 0, lifetimeMs: 1_800_000, unavailable: true,
+      commands: { run: async () => ({ exitCode: 0, stdout: '', stderr: '' }) },
+      files: {
+        read: async () => { throw new SandboxUnavailableError('Sandbox is probably not running anymore'); },
+        write: async () => undefined,
+      },
+      kill: async () => undefined,
+    };
+
+    await expect(planTests(dead, 'javascript')).rejects.toBeInstanceOf(SandboxUnavailableError);
+  });
+
+  it('propagates a death that happens AFTER package.json is read', async () => {
+    // Without this case the suite passes even if fileExists still swallows
+    // sandbox death: the package.json read throws first and short-circuits.
+    // Mirrors the equivalent guard in sandbox-repo.test.ts.
+    let reads = 0;
+    const diesLater: SandboxRuntime = {
+      id: 'dies-later', createdAt: 0, lifetimeMs: 1_800_000, unavailable: true,
+      commands: { run: async () => ({ exitCode: 0, stdout: '', stderr: '' }) },
+      files: {
+        read: async (path: string) => {
+          reads++;
+          if (path.endsWith('package.json')) return JSON.stringify({ scripts: {} });
+          throw new SandboxUnavailableError('Sandbox is probably not running anymore');
+        },
+        write: async () => undefined,
+      },
+      kill: async () => undefined,
+    };
+
+    await expect(planTests(diesLater, 'javascript')).rejects.toBeInstanceOf(SandboxUnavailableError);
+    expect(reads).toBeGreaterThan(1);
+  });
+});

--- a/packages/worker/src/harness/sandbox-repo.ts
+++ b/packages/worker/src/harness/sandbox-repo.ts
@@ -143,6 +143,11 @@ export async function createRepoSandbox(opts: {
           exitCode: 0,
         };
       } catch (err: unknown) {
+        // A dead sandbox is not "git exited 1". Synthesizing a failed git result
+        // here erases the class before the catch below can preserve it: the
+        // failure resurfaces as CloneResolutionError and terminalizes as a
+        // customer-facing clone failure with no infra retry.
+        if (err instanceof SandboxUnavailableError) throw err;
         const detail = err as { message?: string; stdout?: string; stderr?: string };
         return {
           stdout: String(detail.stdout ?? ''),
@@ -162,7 +167,12 @@ export async function createRepoSandbox(opts: {
       // the PR-base authority.
       await resolveClonedBranch(runner, opts.githubRepo ?? 'repo');
     } catch (err: unknown) {
-      if (err instanceof CloneResolutionError) throw err;
+      // Preserve both typed classes. Wrapping a dead sandbox in `clone failed:`
+      // erases the class, and agent-fix.ts matches that string and RETURNS a
+      // needs_human clone failure — so it never reaches the outer catch that
+      // raises VerificationInfraError. The customer would see "we couldn't
+      // clone your repo" for a provider outage, with no infra retry.
+      if (err instanceof CloneResolutionError || err instanceof SandboxUnavailableError) throw err;
       const detail = err as { message?: string; stderr?: string };
       const message = [
         detail.message ?? String(err),

--- a/packages/worker/src/harness/sandbox-repo.ts
+++ b/packages/worker/src/harness/sandbox-repo.ts
@@ -7,7 +7,7 @@ import {
   type GitRunner,
 } from '../repo-clone.js';
 import { redactCloneDetail, scrubSecrets } from './redact.js';
-import { createSandboxRuntime, type SandboxRuntime } from './sandbox-runtime.js';
+import { createSandboxRuntime, SandboxUnavailableError, type SandboxRuntime } from './sandbox-runtime.js';
 import type { Platform } from '../platform.js';
 import { sanitizeRuntimeValue, type RuntimeInfo } from '../runtime-info.js';
 import { TRAVERSAL_EXCLUSIONS } from './traversal-exclusions.js';
@@ -314,6 +314,9 @@ async function runPythonSyntaxGate(sandbox: SandboxRuntime): Promise<BuildGateRe
       ? { outcome: 'passed', exitCode: 0, output }
       : { outcome: 'failed', exitCode: res.exitCode, output };
   } catch (err: unknown) {
+    if (err instanceof SandboxUnavailableError) {
+      return { outcome: 'infra_error', output: scrubSecrets(err.message) };
+    }
     const failure = err as BuildFailureLike;
     const rawMessage = err instanceof Error ? err.message : String(err);
     const detail = [failure.stderr, failure.stdout]
@@ -341,15 +344,26 @@ export async function runBuildGate(
   try {
     const raw = await sandbox.files.read(`${SANDBOX_REPO}/package.json`);
     pkg = JSON.parse(raw) as PackageJsonLike;
-  } catch {
+  } catch (err: unknown) {
+    if (err instanceof SandboxUnavailableError) {
+      return { outcome: 'infra_error', output: scrubSecrets(err.message) };
+    }
     // no package.json
   }
 
-  const tsconfigExists = await fileExists(sandbox, `${SANDBOX_REPO}/tsconfig.json`);
-  const pm: 'npm' | 'pnpm' | 'yarn' =
-    (await fileExists(sandbox, `${SANDBOX_REPO}/pnpm-lock.yaml`)) ? 'pnpm'
+  let tsconfigExists: boolean;
+  let pm: 'npm' | 'pnpm' | 'yarn';
+  try {
+    tsconfigExists = await fileExists(sandbox, `${SANDBOX_REPO}/tsconfig.json`);
+    pm = (await fileExists(sandbox, `${SANDBOX_REPO}/pnpm-lock.yaml`)) ? 'pnpm'
       : (await fileExists(sandbox, `${SANDBOX_REPO}/yarn.lock`)) ? 'yarn'
         : 'npm';
+  } catch (err: unknown) {
+    if (err instanceof SandboxUnavailableError) {
+      return { outcome: 'infra_error', output: scrubSecrets(err.message) };
+    }
+    throw err;
+  }
 
   const cmd = selectBuildCommand(pkg, tsconfigExists, pm);
   if (!cmd) return { outcome: 'skipped_no_runner', output: 'no build script or tsconfig' };
@@ -361,6 +375,9 @@ export async function runBuildGate(
       ? { outcome: 'passed', exitCode: 0, output }
       : { outcome: 'failed', exitCode: res.exitCode, output };
   } catch (err: unknown) {
+    if (err instanceof SandboxUnavailableError) {
+      return { outcome: 'infra_error', output: scrubSecrets(err.message) };
+    }
     const failure = err as BuildFailureLike;
     const rawMessage = err instanceof Error ? err.message : String(err);
     const detail = [failure.stderr, failure.stdout]
@@ -375,11 +392,19 @@ export async function runBuildGate(
   }
 }
 
+/**
+ * Note the deliberate asymmetry: a vanished sandbox must not read as "file
+ * absent", because runBuildGate would then report skipped_no_runner and
+ * computeTier accepts that as a satisfied build gate. Other read failures
+ * (permissions, transport) still return false — this narrows the hole, it does
+ * not close it.
+ */
 async function fileExists(sandbox: SandboxRuntime, path: string): Promise<boolean> {
   try {
     await sandbox.files.read(path);
     return true;
-  } catch {
+  } catch (err: unknown) {
+    if (err instanceof SandboxUnavailableError) throw err;
     return false;
   }
 }

--- a/packages/worker/src/harness/sandbox-runtime.ts
+++ b/packages/worker/src/harness/sandbox-runtime.ts
@@ -10,8 +10,33 @@ const execFile = promisify(execFileCallback);
 const VIRTUAL_HOME = '/home/user';
 /** Must match the template name in packages/worker/e2b-python/e2b.toml. */
 const DEFAULT_PYTHON_TEMPLATE = 'opslane-python';
-const PYTHON_SANDBOX_LIFETIME_MS = 1_800_000;
 const VIRTUAL_TMP = '/tmp';
+
+/**
+ * Measured worst-case run is ~606s (Langfuse agent-loop p100 x4 attempts plus
+ * gates, opslane-oss#255). The floor guards against gross misconfiguration; it
+ * is not a proof of sufficiency, because the phase timeout caps are not all
+ * simultaneously reachable and their sum exceeds this. The default matches the
+ * Python path, which already runs 1_800_000 in production and therefore proves
+ * this account's tier accepts it.
+ */
+const SANDBOX_LIFETIME_FLOOR_MS = 900_000;
+const SANDBOX_LIFETIME_DEFAULT_MS = 1_800_000;
+/**
+ * E2B enforces account-tier maximums and rejects creation above them. 1_800_000
+ * is the only value proven acceptable on this account (the Python path has run
+ * it in production). Anything higher is clamped rather than risking a creation
+ * failure that would look like an unrelated outage.
+ */
+const SANDBOX_LIFETIME_CEILING_MS = 1_800_000;
+
+function resolveSandboxLifetimeMs(): number {
+  const raw = parseInt(process.env['SANDBOX_LIFETIME_MS'] ?? String(SANDBOX_LIFETIME_DEFAULT_MS), 10);
+  if (!Number.isInteger(raw)) return SANDBOX_LIFETIME_DEFAULT_MS;
+  if (raw < SANDBOX_LIFETIME_FLOOR_MS) return SANDBOX_LIFETIME_DEFAULT_MS;
+  if (raw > SANDBOX_LIFETIME_CEILING_MS) return SANDBOX_LIFETIME_CEILING_MS;
+  return raw;
+}
 
 export interface SandboxCommandResult {
   exitCode: number;
@@ -109,20 +134,20 @@ function adaptE2BSandbox(sbx: E2BSandboxLike, lifetimeMs: number, createdAt: num
 export async function createSandboxRuntime(platform: Platform = 'javascript'): Promise<SandboxRuntime> {
   const backend = process.env['OPSLANE_SANDBOX_BACKEND']?.trim().toLowerCase() || 'e2b';
   if (backend === 'e2b') {
+    // The lifetime is a ceiling, not a reservation: agent-fix.ts kills the
+    // sandbox in a finally and E2B bills actual uptime, so a job finishing in
+    // 60s costs 60s regardless. The accepted cost is crash exposure — if the
+    // worker process dies, finally never runs and the orphan leaks for up to
+    // the ceiling rather than 5 minutes. The Python path already carries this.
+    const lifetimeMs = resolveSandboxLifetimeMs();
     // Captured BEFORE the await: creation takes real time, and age-at-error must
     // measure from when provisioning started, not when the promise resolved.
     const createdAt = Date.now();
     if (platform !== 'python') {
-      // 300_000 is E2B's default. `Sandbox.defaultSandboxTimeoutMs` is
-      // `protected static` in v2.35 and will not compile. Task 2 deletes this line.
-      return adaptE2BSandbox(await Sandbox.create(), 300_000, createdAt);
+      return adaptE2BSandbox(await Sandbox.create({ timeoutMs: lifetimeMs }), lifetimeMs, createdAt);
     }
     const template = process.env['OPSLANE_E2B_PYTHON_TEMPLATE']?.trim() || DEFAULT_PYTHON_TEMPLATE;
-    return adaptE2BSandbox(
-      await Sandbox.create(template, { timeoutMs: PYTHON_SANDBOX_LIFETIME_MS }),
-      PYTHON_SANDBOX_LIFETIME_MS,
-      createdAt,
-    );
+    return adaptE2BSandbox(await Sandbox.create(template, { timeoutMs: lifetimeMs }), lifetimeMs, createdAt);
   }
   if (backend === 'local') {
     if (process.env['OPSLANE_RELIABILITY_HARNESS'] !== '1') {

--- a/packages/worker/src/harness/sandbox-runtime.ts
+++ b/packages/worker/src/harness/sandbox-runtime.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
-import { Sandbox } from 'e2b';
+import { Sandbox, SandboxNotFoundError } from 'e2b';
 import type { Platform } from '../platform.js';
 
 const execFile = promisify(execFileCallback);
@@ -19,8 +19,32 @@ export interface SandboxCommandResult {
   stderr: string;
 }
 
+/**
+ * The verification machine is gone — expired, evicted, or never existed.
+ * Distinct from a command that ran and failed: no verdict about the patch is
+ * possible once this is raised. Callers must classify it as infra_error.
+ */
+export class SandboxUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SandboxUnavailableError';
+  }
+}
+
 /** The small portion of the E2B API used by the agent and verification harness. */
 export interface SandboxRuntime {
+  /** Provider's sandbox identifier, for correlating an incident to the machine. */
+  readonly id: string;
+  /** Epoch ms at creation. Required: id and lifetimeMs alone cannot yield age-at-error. */
+  readonly createdAt: number;
+  /** Wall-clock ceiling this sandbox was provisioned with. */
+  readonly lifetimeMs: number;
+  /**
+   * Latched once the provider reports the machine is gone. Never resets.
+   * Exists because agent-core/tool-loop.ts converts every tool exception into
+   * model-visible text, so no exception can escape runAgentLoop. State can.
+   */
+  readonly unavailable: boolean;
   commands: {
     run(command: string, options?: { timeoutMs?: number }): Promise<SandboxCommandResult>;
   };
@@ -29,6 +53,51 @@ export interface SandboxRuntime {
     write(path: string, data: string): Promise<unknown>;
   };
   kill(): Promise<unknown>;
+}
+
+/** The E2B object shape this adapter needs. Avoids importing SDK types wholesale. */
+interface E2BSandboxLike {
+  sandboxId: string;
+  commands: { run(command: string, options?: { timeoutMs?: number }): Promise<SandboxCommandResult> };
+  files: { read(path: string): Promise<string>; write(path: string, data: string): Promise<unknown> };
+  kill(): Promise<unknown>;
+}
+
+/**
+ * Wrap the provider so a vanished sandbox becomes a typed, latched signal.
+ * Only SandboxNotFoundError is mapped: E2B's TimeoutError also covers ordinary
+ * per-command deadlines, and mapping it would turn an agent command timeout
+ * into a whole-job retry.
+ */
+function adaptE2BSandbox(sbx: E2BSandboxLike, lifetimeMs: number, createdAt: number): SandboxRuntime {
+  let unavailable = false;
+
+  const guard = async <T>(operation: () => Promise<T>): Promise<T> => {
+    try {
+      return await operation();
+    } catch (err: unknown) {
+      if (err instanceof SandboxNotFoundError) {
+        unavailable = true;
+        throw new SandboxUnavailableError(err.message);
+      }
+      throw err;
+    }
+  };
+
+  return {
+    id: sbx.sandboxId,
+    createdAt,
+    lifetimeMs,
+    get unavailable() { return unavailable; },
+    commands: {
+      run: (command, options) => guard(() => sbx.commands.run(command, options)),
+    },
+    files: {
+      read: (path) => guard(() => sbx.files.read(path)),
+      write: (path, data) => guard(() => sbx.files.write(path, data)),
+    },
+    kill: () => sbx.kill(),
+  };
 }
 
 /**
@@ -40,13 +109,20 @@ export interface SandboxRuntime {
 export async function createSandboxRuntime(platform: Platform = 'javascript'): Promise<SandboxRuntime> {
   const backend = process.env['OPSLANE_SANDBOX_BACKEND']?.trim().toLowerCase() || 'e2b';
   if (backend === 'e2b') {
-    // Python installs (pip build backends, compiled wheels) run far longer than
-    // npm, so the Python path gets an extended lifetime. The JavaScript path
-    // keeps the E2B default: raising it there would multiply billed sandbox
-    // time and leak duration on a worker crash for no benefit.
-    if (platform !== 'python') return Sandbox.create();
+    // Captured BEFORE the await: creation takes real time, and age-at-error must
+    // measure from when provisioning started, not when the promise resolved.
+    const createdAt = Date.now();
+    if (platform !== 'python') {
+      // 300_000 is E2B's default. `Sandbox.defaultSandboxTimeoutMs` is
+      // `protected static` in v2.35 and will not compile. Task 2 deletes this line.
+      return adaptE2BSandbox(await Sandbox.create(), 300_000, createdAt);
+    }
     const template = process.env['OPSLANE_E2B_PYTHON_TEMPLATE']?.trim() || DEFAULT_PYTHON_TEMPLATE;
-    return Sandbox.create(template, { timeoutMs: PYTHON_SANDBOX_LIFETIME_MS });
+    return adaptE2BSandbox(
+      await Sandbox.create(template, { timeoutMs: PYTHON_SANDBOX_LIFETIME_MS }),
+      PYTHON_SANDBOX_LIFETIME_MS,
+      createdAt,
+    );
   }
   if (backend === 'local') {
     if (process.env['OPSLANE_RELIABILITY_HARNESS'] !== '1') {
@@ -91,7 +167,7 @@ async function createLocalSandboxRuntime(): Promise<SandboxRuntime> {
   let killed = false;
 
   const ensureRunning = (): void => {
-    if (killed) throw new Error('Sandbox has been killed');
+    if (killed) throw new SandboxUnavailableError('Sandbox has been killed');
   };
 
   const mapPath = (path: string): string => {
@@ -145,7 +221,16 @@ async function createLocalSandboxRuntime(): Promise<SandboxRuntime> {
     return env;
   };
 
+  const createdAt = Date.now();
+
   return {
+    id: `local-${createdAt}`,
+    createdAt,
+    // 0 means "no provider-imposed ceiling" — it lives until killed. Do NOT use
+    // Number.POSITIVE_INFINITY: OpenTelemetry attributes must be finite and JSON
+    // logging serializes it as null.
+    lifetimeMs: 0,
+    get unavailable() { return killed; },
     commands: {
       async run(command, options) {
         ensureRunning();

--- a/packages/worker/src/harness/test-runner.ts
+++ b/packages/worker/src/harness/test-runner.ts
@@ -123,11 +123,18 @@ export function compareSuiteRuns(
   };
 }
 
+/**
+ * Mirrors the guard in sandbox-repo.ts: a vanished sandbox must not read as
+ * "file absent". Otherwise planTests finds no runner, returns `{kind:'none'}`,
+ * and the suite gate records skipped_no_runner for a machine that is simply
+ * gone. Other read failures (permissions, transport) still return false.
+ */
 async function fileExists(sandbox: SandboxRuntime, path: string): Promise<boolean> {
   try {
     await sandbox.files.read(path);
     return true;
-  } catch {
+  } catch (err: unknown) {
+    if (err instanceof SandboxUnavailableError) throw err;
     return false;
   }
 }
@@ -142,7 +149,10 @@ export async function planTests(
   let pkg: PackageJsonLike = {};
   try {
     pkg = JSON.parse(await sandbox.files.read(`${SANDBOX_REPO}/package.json`)) as PackageJsonLike;
-  } catch {
+  } catch (err: unknown) {
+    // Same asymmetry as runBuildGate: a dead machine must not read as a repo
+    // that simply has no package.json.
+    if (err instanceof SandboxUnavailableError) throw err;
     // A repository without a root package.json has no supported Phase-1 runner.
   }
   if (pkg.workspaces || await fileExists(sandbox, `${SANDBOX_REPO}/pnpm-workspace.yaml`)) {
@@ -205,19 +215,20 @@ export async function runSuite(
   // ordinary `rm` failure be reported as the customer's tests failing; leaving
   // it uncaught (the previous code) let a dead sandbox throw past every
   // classifier and surface as worker_runtime_error.
+  const cleanupCommand = `rm -f ${plan.kind === 'pytest' ? PYTEST_RESULTS_PATH : SUITE_RESULTS_PATH}`;
   try {
-    await sandbox.commands.run(
-      `rm -f ${plan.kind === 'pytest' ? PYTEST_RESULTS_PATH : SUITE_RESULTS_PATH}`,
-      { timeoutMs: 10_000 },
-    );
+    await sandbox.commands.run(cleanupCommand, { timeoutMs: 10_000 });
   } catch (error: unknown) {
     // EVERY cleanup failure is infrastructure, not a verdict. Continuing would
     // let the parser read a results file left by a previous run and report it
     // as this patch's outcome — a stale-evidence false positive.
+    //
+    // Report the cleanup command, not plan.command: evidence is customer-facing,
+    // and pairing "npm test" with an `rm` failure reads as the suite failing.
     const detail = error instanceof Error ? error.message : String(error);
     return {
       outcome: 'infra_error',
-      command: plan.command,
+      command: cleanupCommand,
       tests: null,
       total: null,
       output: bound(scrubSecrets(detail)),

--- a/packages/worker/src/harness/test-runner.ts
+++ b/packages/worker/src/harness/test-runner.ts
@@ -1,5 +1,5 @@
 import type { CheckOutcome } from '@opslane/shared';
-import type { SandboxRuntime } from './sandbox-runtime.js';
+import { SandboxUnavailableError, type SandboxRuntime } from './sandbox-runtime.js';
 import { scrubSecrets } from './redact.js';
 import type { Platform } from '../platform.js';
 import { parseJUnitXml } from './junit.js';
@@ -201,7 +201,29 @@ export async function runSuite(
     };
   }
 
-  await sandbox.commands.run(`rm -f ${plan.kind === 'pytest' ? PYTEST_RESULTS_PATH : SUITE_RESULTS_PATH}`, { timeoutMs: 10_000 });
+  // Cleanup gets its OWN catch. Folding it into the suite try would let an
+  // ordinary `rm` failure be reported as the customer's tests failing; leaving
+  // it uncaught (the previous code) let a dead sandbox throw past every
+  // classifier and surface as worker_runtime_error.
+  try {
+    await sandbox.commands.run(
+      `rm -f ${plan.kind === 'pytest' ? PYTEST_RESULTS_PATH : SUITE_RESULTS_PATH}`,
+      { timeoutMs: 10_000 },
+    );
+  } catch (error: unknown) {
+    // EVERY cleanup failure is infrastructure, not a verdict. Continuing would
+    // let the parser read a results file left by a previous run and report it
+    // as this patch's outcome — a stale-evidence false positive.
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      outcome: 'infra_error',
+      command: plan.command,
+      tests: null,
+      total: null,
+      output: bound(scrubSecrets(detail)),
+    };
+  }
+
   let rawOutput = '';
   let exitCode = 0;
   try {
@@ -212,6 +234,15 @@ export async function runSuite(
     exitCode = result.exitCode;
     rawOutput = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
   } catch (error: unknown) {
+    if (error instanceof SandboxUnavailableError) {
+      return {
+        outcome: 'infra_error',
+        command: plan.command,
+        tests: null,
+        total: null,
+        output: bound(scrubSecrets(error.message)),
+      };
+    }
     const errorMessage = error instanceof Error ? error.message : String(error);
     const output = failureOutput(error);
     if (/timed out|timeout/i.test(errorMessage)) {


### PR DESCRIPTION
## Summary

The JavaScript verification sandbox was killed 300s after creation and **no code path treated that as an infrastructure failure**. Seven production incidents burned a full fix budget against a machine that was already gone, then terminalized as if the customer's patch had failed. Live E2B probes on 2026-08-04 confirmed both halves: tool calls succeeded through T+298.7s and failed at T+313.8s with `SandboxNotFoundError: "Sandbox is probably not running anymore"`, a string no classifier matched.

**Boundary typing** — `sandbox-runtime.ts` is now a real adapter over the E2B SDK. `SandboxNotFoundError` becomes a typed `SandboxUnavailableError` and latches `unavailable` on the runtime object. The latch exists because `agent-core/tool-loop.ts` converts every tool exception into model-visible text, so no exception can escape `runAgentLoop` — state can. Only `SandboxNotFoundError` is mapped; mapping E2B's `TimeoutError` would turn ordinary agent command timeouts into whole-job retries.

**Classification** — a vanished sandbox now yields `infra_error` at the suite runner and the build gate instead of `skipped_no_runner`. That last one was the dangerous case: `computeTier` accepts `skipped_no_runner` as a satisfied build gate, so a dead machine was indistinguishable from a repo that legitimately has no build script.

**Class preservation** — two wrappers erased the typed class before anything could classify it, and both ended at the same place: `agent-fix.ts` matches the string `clone failed` and *returns* a needs_human clone failure, so the job never reached the outer catch and never requeued. An E2B outage was reported to the customer as "we couldn't clone your repo". The `GitRunner` adapter synthesized `{exitCode: 1}` from any thrown error (death during branch resolution → `CloneResolutionError`), and the clone catch rewrapped everything. Both now rethrow.

**Budget** — the latch is read before the model cascade starts, not only after `runAgentLoop` returns, so a death during setup / `planTests` / the baseline suite no longer burns a full agent budget against a corpse.

**Lifetime** — `SANDBOX_LIFETIME_MS`, default `1_800_000`, floor `900_000`, ceiling `1_800_000`, both platforms. The floor guards against gross misconfiguration; it is not a proof of sufficiency, since the phase timeout caps sum past it. The ceiling is the only value proven acceptable on this account.

**Observability** — `sandbox.id`, `created_at`, `lifetime_ms`, `age_at_error_ms`, `error.class`, and `error.phase` are recorded at the point of failure, via both the active span and `logger.error` (Langfuse export is a no-op when its keys are unset).

Accepted tradeoff, stated deliberately: the ceiling is not a reservation (E2B bills actual uptime and the sandbox is killed in a `finally`), but a worker crash skips that `finally`, so an orphan now leaks up to 30 minutes instead of 5. The Python path already carried this.

## Live verification

Driving the built adapter against real E2B, since every unit test here uses a fake and that is exactly how the original bug shipped (the old infra regex was written against the local backend's message format and only ever worked there):

| Assumption | Result |
|---|---|
| Account tier accepts `timeoutMs: 1_800_000` on the **JS** path | **Confirmed.** Provider reported `startedAt 21:20:47 → endAt 21:50:47`, a window of exactly 1,800,000 ms. |
| The hand-written `E2BSandboxLike` subset works against the real SDK | **Confirmed.** Real command returned `42`; file write+read round-tripped. |
| The real SDK raises `SandboxNotFoundError`, the one class mapped | **Confirmed.** After `kill()`, the next command surfaced as `SandboxUnavailableError` with message `"Sandbox is probably not running anymore"`, and `unavailable` latched. |

Limit: this proves the *killed* path. Expiry needs a 30-minute wait; the plan's live probe already showed expiry produces the same class and message.

Pipeline smoke on ports 8092/5444/9022: migrations + seed applied, ingestion healthy, event → `202`, worker claimed the job, group reached a terminal state with a correct actionable reason. It stopped at `missing_github_token` (empty `GITHUB_TOKEN`, zero rows in `github_app_installations`), so it did not reach a sandbox — hence the direct adapter probe above.

## Test Coverage

```
CODE PATHS (this diff)                                       STATUS
[+] harness/sandbox-runtime.ts
  ├── resolveSandboxLifetimeMs  default/floor/ceiling        [TESTED] 4 tests
  │   └── non-integer env value → default                    [GAP]
  ├── guard()  SandboxNotFoundError → latch + throw          [TESTED]
  │   └── ordinary error → passthrough, no latch             [TESTED]
  ├── createSandboxRuntime  JS path + timeoutMs              [TESTED]
  │   └── Python path + template + timeoutMs                 [TESTED]
  ├── files.write guard                                      [GAP]
  └── local backend  ensureRunning after kill                [TESTED]
[+] harness/sandbox-repo.ts
  ├── runBuildGate  pkg.json / tsconfig / build-cmd death    [TESTED] 3 tests
  ├── runPythonSyntaxGate death                              [TESTED]
  ├── fileExists rethrow (dies AFTER pkg.json)               [TESTED]
  ├── GitRunner preserves class (branch resolution)          [TESTED]
  └── clone catch preserves SandboxUnavailableError          [TESTED]
[+] harness/test-runner.ts
  ├── cleanup  death / ordinary failure                      [TESTED] 2 tests
  ├── suite command death                                    [TESTED]
  ├── planTests  pkg.json rethrow                            [TESTED]
  └── planTests  fileExists rethrow (dies AFTER pkg.json)    [TESTED]
[+] agent-fix.ts
  ├── pre-agent-loop latch check                             [TESTED]
  ├── agent-loop check (success / gaveUp / budget)           [TESTED] 3 tests
  ├── outer catch  typed error / setup death + evidence      [TESTED]
  ├── outer catch  sandbox?.unavailable + plain error        [GAP]
  └── verification-gate phase logging                        [GAP]

COVERAGE: 29/33 paths (88%)   GAPS: 4
```

Coverage gate: PASS (88%), above the 80% target. Worker tests 585 → 606.

The branch-resolution regression test was verified to actually guard its fix: with the `GitRunner` rethrow reverted it fails with `promise resolved "{ status: 'needs_human' }" instead of rejecting` — the precise customer-blaming outcome.

## Pre-Landing Review

5 findings, all fixed.

| Severity | Finding | Resolution |
|---|---|---|
| CRITICAL | `sandbox-repo.ts` clone catch erased `SandboxUnavailableError`; `agent-fix.ts:655` string-matches `clone failed` and returns, bypassing the outer catch | Rethrow the typed class at the boundary |
| CRITICAL | `GitRunner` synthesized `{exitCode: 1}` from any error, so death during branch resolution became `CloneResolutionError` (found by Codex) | Rethrow before synthesizing a git result |
| INFO | `test-runner.ts` `fileExists` still swallowed death — the untouched twin of the hardened `sandbox-repo.ts` copy | Both readers rethrow |
| INFO | Latch only read after `runAgentLoop`, so a setup-phase death burned the full agent budget | Pre-cascade check, sharing one `raiseSandboxGone` helper |
| INFO | Cleanup-failure evidence reported `command: plan.command`, pairing `"npm test"` with an `rm` failure in customer-visible evidence | Report the actual cleanup command |

## Adversarial Review

Two Codex passes. The second found the `GitRunner` class erasure above — a real bug, now fixed with a regression test.

One `[P1]` from the structured review is **refuted**: it claims a death during an agent tool call leaves `verificationInfraError` false and reaches `budget_exhausted`, and recommends recording unavailability "through a side channel". That side channel is the `sandbox.unavailable` latch, which already exists. `runAgentLoop` returns at `agent-fix.ts:880` and the latch check is at `:909`, before every budget / `gaveUp` / success branch. The cited lines `1012-1016` are the build gate's `installFailed` ternary, not a terminal guard. `agent-fix.test.ts` has a passing test that mimics `tool-loop.ts` swallowing the exception and reporting success, asserting `VerificationInfraError`; it would fail if the finding were correct.

An earlier pass raised three findings against pre-change code and the plan's superseded revision (`setup-pr.ts`, the `installFailed` promotion, and a 600000 floor that is `900_000` in code) — all outside this diff, all scoped out by the plan.

## Scope Drift

Scope Check: CLEAN. 12 source files, all under `packages/worker`, plus one docs row and the plan/decision records.

## Plan Completion

Plan: `docs/plans/2026-08-04-sandbox-death-misclassification.md` (opslane-oss#255). **6/6 items DONE, 9/9 verification items DONE.**

Two items were PARTIAL until review caught them: item 3 (outer-catch translation) was bypassed on the clone path, and item 4 (`fileExists` rethrow) had only one of the function's two copies. The plan's one unwritten test, "a setup-time death constructs a valid `VerificationInfraError`", is now written and is what exposed the clone gap.

Explicitly out of scope per the plan: backfilling the seven existing incidents (terminal in the database, they stay `needs_human`), `CommandFailedError` cleanup (#274), redacting internal faults from customer evidence (#273).

## TODOS

No TODO items in `TODOS.md` relate to this change.

## Documentation

`SANDBOX_LIFETIME_MS` documented in `docs/reference/environment-variables.md`. `scripts/check-docs-drift.mjs` passes: 69 env vars consistent.

## Test plan

- [x] `pnpm --filter @opslane/worker test` — 606 passed, 0 failed
- [x] `pnpm -r build` — clean
- [x] `pnpm test:repo` — 146 passed, 0 failed, 0 skipped
- [x] `go build ./... && go test ./...` — all packages ok, **0 skips** (DB + MinIO wired, per AGENTS.md)
- [x] `docker compose config --quiet` — clean
- [x] `node scripts/check-docs-drift.mjs` — clean
- [ ] `packages/sdk` browser matrix — cannot run in this container (Playwright missing `libgtk-4.so.1` et al). Fails identically with this branch's changes stashed; CI installs the deps at `.github/workflows/ci.yml:245`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
