### PR TITLE
fix: archived issues no longer appear in incident lists or account counts

### DIFF
--- a/docs/superpowers/plans/2026-08-05-hide-archived-issues.md
+++ b/docs/superpowers/plans/2026-08-05-hide-archived-issues.md
@@ -15,8 +15,8 @@
 - The rule, verbatim: **archived issues are excluded from every incident list unless the caller explicitly filters for `status=archived`.** An explicit status filter always wins.
 - No `include_archived` / `exclude_status` compatibility parameter. `AGENTS.md` forbids legacy shims by default; this is an explicit contract change.
 - `ListAccountIncidents` gains **no** `status` passthrough. There is no account-scoped archived view.
-- Account `incident_count` means *visible* incidents — it must match the length of the list rendered beneath it.
-- Go DB tests require `DATABASE_URL`. They `t.Skip` without it and the suite still prints `ok`. Confirm **zero skips** before believing a green run.
+- Account `incident_count` means *visible* incidents. It equals the length of the list rendered beneath it **only below 100** — `ListErrorGroups` caps at `LIMIT 100` while the count is unbounded, so an account with 101 visible incidents shows "101 incidents" over a 100-row list. That residual mismatch is out of scope and deliberately left alone; it is a far milder symptom than the "3 incidents / No incidents for this account" contradiction this change fixes.
+- Go DB tests `t.Skip` when Postgres is unreachable, and the suite still prints `ok`. Note `testPool` (`testhelper_test.go:17`) falls back to `defaultTestDSN` = `postgres://opslane:opslane_dev@localhost:5434/opslane?sslmode=disable` when `DATABASE_URL` is unset, so exporting that exact DSN changes nothing — a skip means Postgres is not reachable at all, not that the variable is missing. Confirm **zero skips** before believing a green run.
 - Dashboard verification requires both `build` and `test` (`packages/dashboard/AGENTS.md:13`).
 - Every query below aliases `error_groups` as `eg`.
 
@@ -197,7 +197,8 @@ func TestListErrorGroupsArchivedFloodDoesNotEvictLiveGroups(t *testing.T) {
 	}{
 		{name: "error arm environment filtered", kind: "error", filterByEnv: true},
 		{name: "friction arm environment filtered", kind: "friction", filterByEnv: true},
-		{name: "unfiltered branch", kind: "error", filterByEnv: false},
+		{name: "unfiltered branch error", kind: "error", filterByEnv: false},
+		{name: "unfiltered branch friction", kind: "friction", filterByEnv: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			pool := testPool(t)
@@ -269,13 +270,12 @@ func TestListErrorGroupsArchivedFloodDoesNotEvictLiveGroups(t *testing.T) {
 - [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
-export DATABASE_URL="postgres://opslane:opslane_dev@localhost:5434/opslane?sslmode=disable"
 (cd packages/ingestion && go test ./db/ -run 'TestListErrorGroups(HidesArchived|ArchivedFlood)' -v)
 ```
 
-Expected: all three FAIL. `HidesArchivedUnlessRequested` and `HidesArchivedInEnvironmentFilteredArms` report the archived group appearing where it should not; `ArchivedFloodDoesNotEvictLiveGroups` reports the live group evicted in all three subtests.
+Expected: all three FAIL. `HidesArchivedUnlessRequested` and `HidesArchivedInEnvironmentFilteredArms` report the archived group appearing where it should not; `ArchivedFloodDoesNotEvictLiveGroups` reports the live group evicted in all four subtests.
 
-If instead they SKIP, `DATABASE_URL` is not reaching the suite — fix that before continuing. A skip is not a failing test.
+If instead they SKIP, Postgres is unreachable — start it (`docker compose up -d postgres`) and re-run. A skip is not a failing test, and no amount of `DATABASE_URL` juggling fixes it: `testPool` already defaults to the local dev DSN.
 
 - [ ] **Step 3: Promote the predicates to package-level constants**
 
@@ -332,7 +332,7 @@ Both arms already have `eg` in scope: the error arm joins `error_groups eg ON eg
 (cd packages/ingestion && go test ./db/ -run 'TestListErrorGroups(HidesArchived|ArchivedFlood)' -v)
 ```
 
-Expected: PASS, five test cases total (two top-level plus three subtests), zero skips.
+Expected: PASS, six test cases total (two top-level plus four subtests), zero skips.
 
 - [ ] **Step 6: Run the full ingestion suite for regressions**
 
@@ -434,6 +434,8 @@ func TestAccountIncidentCountExcludesArchivedAndMatchesTheList(t *testing.T) {
 	}
 
 	// The count must equal the list rendered beneath it in AccountDetail.vue.
+	// This equality only holds below ListErrorGroups' LIMIT 100; the fixture is
+	// deliberately one incident, so the cap is not in play here.
 	incidents, err := q.ListErrorGroups(ctx, projID, &db.ErrorGroupFilters{AccountID: "acct-archived"})
 	if err != nil {
 		t.Fatalf("ListErrorGroups by account: %v", err)
@@ -486,7 +488,22 @@ func TestAccountIncidentCountExcludesOrdinaryCandidates(t *testing.T) {
 		t.Fatal("GetAccountByID returned nil for an account whose only incident is a candidate")
 	}
 	if account.IncidentCount != 0 {
-		t.Errorf("IncidentCount = %d, want 0 (ordinary candidates are hidden workflow records)", account.IncidentCount)
+		t.Errorf("GetAccountByID IncidentCount = %d, want 0 (ordinary candidates are hidden workflow records)", account.IncidentCount)
+	}
+
+	// Assert ListAccounts separately: the two queries are edited independently,
+	// so covering only GetAccountByID would let a missing visibleCandidateSQL
+	// in ListAccounts ship green.
+	accounts, err := q.ListAccounts(ctx, projID, nil)
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	listed := accountByID(accounts, "acct-candidate")
+	if listed == nil {
+		t.Fatal("account with only a candidate incident vanished from ListAccounts")
+	}
+	if listed.IncidentCount != 0 {
+		t.Errorf("ListAccounts IncidentCount = %d, want 0", listed.IncidentCount)
 	}
 }
 ```
@@ -713,10 +730,22 @@ the URL sync are preserved, and it hides when already viewing archived."
 
 ## Final verification
 
-Run the full repository gate before opening a PR:
+Run the full repository gate before opening a PR. `DATABASE_URL` alone is not enough for a zero-skip run — the Go storage tests `t.Skip` without the MinIO variables, so export the whole block from `AGENTS.md` as a unit and start the services first:
 
 ```bash
-export DATABASE_URL="postgres://opslane:opslane_dev@localhost:5434/opslane?sslmode=disable"
+docker compose up -d postgres minio
+
+export INGESTION_PORT=8082
+export OPSLANE_POSTGRES_HOST_PORT=5434
+export OPSLANE_MINIO_HOST_PORT=9012
+export INGESTION_URL="http://localhost:$INGESTION_PORT"
+export DATABASE_URL="postgres://opslane:opslane_dev@localhost:$OPSLANE_POSTGRES_HOST_PORT/opslane?sslmode=disable"
+export MINIO_ENDPOINT="http://localhost:$OPSLANE_MINIO_HOST_PORT"
+export REPLAY_STORE_ENDPOINT="$MINIO_ENDPOINT"
+export REPLAY_STORE_PUBLIC_ENDPOINT="$MINIO_ENDPOINT"
+export MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=minio12345 MINIO_BUCKET=opslane-replays
+export REPLAY_STORE_ACCESS_KEY=minio REPLAY_STORE_SECRET_KEY=minio12345 REPLAY_STORE_BUCKET=opslane-replays
+
 pnpm install --frozen-lockfile
 pnpm -r build
 pnpm test
@@ -724,4 +753,6 @@ pnpm test
 docker compose config --quiet
 ```
 
-Read the **skip count**, not the pass count. `go test ./...` printing `ok` while ~30 DB tests silently skipped is the documented failure mode of this gate.
+If this runs from a worktree where another stack already holds the default ports, pick a free triple and re-export the whole block — the URLs do not follow the ports on their own.
+
+Read the **skip count**, not the pass count. `go test ./...` printing `ok` while ~30 storage tests silently skipped is the documented failure mode of this gate.

--- a/docs/superpowers/plans/2026-08-05-hide-archived-issues.md
+++ b/docs/superpowers/plans/2026-08-05-hide-archived-issues.md
@@ -702,7 +702,7 @@ Then add this block inside **both** `<EmptyState>` elements — the `v-if="hasAc
           class="mx-auto mt-3 block text-sm text-muted underline underline-offset-4 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           @click="viewArchived"
         >
-          Archived issues are hidden — view archived
+          View archived issues
         </button>
 ```
 

--- a/docs/superpowers/plans/2026-08-05-hide-archived-issues.md
+++ b/docs/superpowers/plans/2026-08-05-hide-archived-issues.md
@@ -1,0 +1,727 @@
+# Hide Archived Issues Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Archived incidents disappear from every incident list and account incident count unless the caller explicitly asks for `status=archived`.
+
+**Architecture:** The exclusion lives in SQL inside `packages/ingestion/db/queries.go`, not in the Vue layer, because `ListErrorGroups` caps at `LIMIT 100` and archived rows currently evict live ones from the response. Two shared predicate constants are applied at four query sites: the three `ListErrorGroups` WHERE-clause builders and the two account aggregate queries. The dashboard adds no filtering logic — only an escape-hatch link in its empty states.
+
+**Tech Stack:** Go 1.24 + pgx (ingestion), Vue 3 + Vitest + `@vue/test-utils` (dashboard), Postgres.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-hide-archived-issues-design.md`
+
+## Global Constraints
+
+- The rule, verbatim: **archived issues are excluded from every incident list unless the caller explicitly filters for `status=archived`.** An explicit status filter always wins.
+- No `include_archived` / `exclude_status` compatibility parameter. `AGENTS.md` forbids legacy shims by default; this is an explicit contract change.
+- `ListAccountIncidents` gains **no** `status` passthrough. There is no account-scoped archived view.
+- Account `incident_count` means *visible* incidents — it must match the length of the list rendered beneath it.
+- Go DB tests require `DATABASE_URL`. They `t.Skip` without it and the suite still prints `ok`. Confirm **zero skips** before believing a green run.
+- Dashboard verification requires both `build` and `test` (`packages/dashboard/AGENTS.md:13`).
+- Every query below aliases `error_groups` as `eg`.
+
+## File Structure
+
+| File | Change | Responsibility |
+| --- | --- | --- |
+| `packages/ingestion/db/queries.go` | Modify | Owns both predicate constants and applies them at all four query sites |
+| `packages/ingestion/db/archived_visibility_test.go` | Create | All Go coverage for this change — list visibility, per-arm eviction, account counts |
+| `packages/dashboard/src/components/FilterBar.vue` | Modify | Exposes `showArchived()` so callers switch status without duplicating URL-sync logic |
+| `packages/dashboard/src/views/IssuesList.vue` | Modify | Renders the escape-hatch link in both empty states |
+| `packages/dashboard/src/views/__tests__/issues-list-filters.test.ts` | Modify | Extend the existing suite — do not create a second one |
+
+A new Go test file rather than appending to `queries_test.go` (which the spec named): that file is over 1000 lines and covers unrelated concerns, and `environment_filters_test.go` is the established precedent for a focused per-concern test file. The new file shares package `db_test`, so it reuses `testPool`, `seedGroup`, `cleanupTenant`, and `insertFrictionGroupForEnvironment` with no imports beyond stdlib and pgxpool.
+
+---
+
+### Task 1: Exclude archived from incident lists
+
+**Files:**
+- Modify: `packages/ingestion/db/queries.go:770-771` (predicate constants), `:774`, `:806`, `:812` (three application sites)
+- Test: `packages/ingestion/db/archived_visibility_test.go` (create)
+
+**Interfaces:**
+- Consumes: existing `db.Queries.ListErrorGroups(ctx, projectID string, filters *db.ErrorGroupFilters) ([]db.ErrorGroup, error)`; existing test helpers `testPool(t) *pgxpool.Pool`, `seedGroup(t, pool, q, name) (orgID, projectID, envID, groupID string)`, `cleanupTenant(t, pool, orgID)`, `insertFrictionGroupForEnvironment(t, pool, projectID, environmentID, fingerprint string, firstSeen, lastSeen time.Time, occurrences int) string`
+- Produces: package-level constants `visibleCandidateSQL` and `notArchivedSQL` in package `db` (Task 2 reuses both); test helpers `containsGroup([]db.ErrorGroup, string) bool` and `insertArchivedFlood(t, pool, projectID, environmentID, kind, prefix string, count int, newerThan time.Time)` in package `db_test` (Task 2 reuses `containsGroup`)
+
+**Background for the implementer:** `ListErrorGroups` builds one of two SQL shapes. When no environment filter is passed it is a single flat `SELECT ... WHERE ... LIMIT 100`. When an environment *is* passed it becomes a CTE with two `UNION ALL` arms — an error arm reading `error_group_environments` and a friction arm reading `error_groups` directly — **and each arm carries its own `LIMIT 100`**. That is why the predicate must be appended to the arms' WHERE builders rather than the outer select: an outer filter would let 100 archived rows fill an arm and starve the live rows before the outer query ever sees them.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/ingestion/db/archived_visibility_test.go`:
+
+```go
+package db_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/opslane/opslane/packages/ingestion/db"
+)
+
+func containsGroup(groups []db.ErrorGroup, groupID string) bool {
+	for _, g := range groups {
+		if g.ID == groupID {
+			return true
+		}
+	}
+	return false
+}
+
+// insertArchivedFlood inserts count archived groups of the given kind into the
+// given environment, each with last_seen newer than newerThan so they sort
+// ahead of any live fixture. Error groups also get the per-environment rollup
+// row that the environment-filtered error arm reads from; friction groups are
+// matched on error_groups.environment_id directly and need no rollup.
+func insertArchivedFlood(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	projectID, environmentID, kind, prefix string,
+	count int,
+	newerThan time.Time,
+) {
+	t.Helper()
+	ctx := context.Background()
+	for i := 0; i < count; i++ {
+		seen := newerThan.Add(time.Duration(i+1) * time.Minute)
+		fingerprint := fmt.Sprintf("%s-%d", prefix, i)
+		var id string
+		if err := pool.QueryRow(ctx, `
+			INSERT INTO error_groups
+			  (project_id, fingerprint, title, first_seen, last_seen, occurrence_count,
+			   status, kind, environment_id)
+			VALUES ($1, $2, $2, $3, $3, 1, 'archived', $4, $5)
+			RETURNING id`,
+			projectID, fingerprint, seen, kind, environmentID,
+		).Scan(&id); err != nil {
+			t.Fatalf("insert archived %s group: %v", kind, err)
+		}
+		if kind != "error" {
+			continue
+		}
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO error_group_environments
+			  (error_group_id, environment_id, first_seen, last_seen, occurrence_count)
+			VALUES ($1, $2, $3, $3, 1)`, id, environmentID, seen,
+		); err != nil {
+			t.Fatalf("insert archived rollup: %v", err)
+		}
+	}
+}
+
+func TestListErrorGroupsHidesArchivedUnlessRequested(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	_, projID, _, groupID := seedGroup(t, pool, q, "archived-hidden")
+
+	if err := q.ArchiveErrorGroup(ctx, projID, groupID); err != nil {
+		t.Fatalf("ArchiveErrorGroup: %v", err)
+	}
+
+	unfiltered, err := q.ListErrorGroups(ctx, projID, nil)
+	if err != nil {
+		t.Fatalf("ListErrorGroups unfiltered: %v", err)
+	}
+	if containsGroup(unfiltered, groupID) {
+		t.Errorf("archived group %s appeared in the unfiltered list", groupID)
+	}
+
+	requested, err := q.ListErrorGroups(ctx, projID, &db.ErrorGroupFilters{Status: "archived"})
+	if err != nil {
+		t.Fatalf("ListErrorGroups status=archived: %v", err)
+	}
+	if !containsGroup(requested, groupID) {
+		t.Errorf("archived group %s missing from the status=archived list", groupID)
+	}
+}
+
+func TestListErrorGroupsHidesArchivedInEnvironmentFilteredArms(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	_, projID, envID, errorGroupID := seedGroup(t, pool, q, "archived-env-arms")
+
+	base := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	frictionGroupID := insertFrictionGroupForEnvironment(
+		t, pool, projID, envID, "friction-archived-env", base, base, 1,
+	)
+
+	for _, id := range []string{errorGroupID, frictionGroupID} {
+		if err := q.ArchiveErrorGroup(ctx, projID, id); err != nil {
+			t.Fatalf("ArchiveErrorGroup %s: %v", id, err)
+		}
+	}
+
+	visible, err := q.ListErrorGroups(ctx, projID, &db.ErrorGroupFilters{EnvironmentID: &envID})
+	if err != nil {
+		t.Fatalf("ListErrorGroups environment-filtered: %v", err)
+	}
+	if containsGroup(visible, errorGroupID) {
+		t.Error("archived error group appeared in the environment-filtered error arm")
+	}
+	if containsGroup(visible, frictionGroupID) {
+		t.Error("archived friction group appeared in the environment-filtered friction arm")
+	}
+
+	requested, err := q.ListErrorGroups(ctx, projID, &db.ErrorGroupFilters{
+		EnvironmentID: &envID,
+		Status:        "archived",
+	})
+	if err != nil {
+		t.Fatalf("ListErrorGroups environment-filtered status=archived: %v", err)
+	}
+	if !containsGroup(requested, errorGroupID) {
+		t.Error("archived error group missing from the explicit environment-filtered archived list")
+	}
+	if !containsGroup(requested, frictionGroupID) {
+		t.Error("archived friction group missing from the explicit environment-filtered archived list")
+	}
+}
+
+// A flood of archived rows must not consume the LIMIT 100 that lives inside
+// each CTE arm. This is the case that separates a correct per-arm predicate
+// from an outer-select filter, which would pass every other test here.
+func TestListErrorGroupsArchivedFloodDoesNotEvictLiveGroups(t *testing.T) {
+	const floodSize = 101
+
+	for _, tc := range []struct {
+		name        string
+		kind        string
+		filterByEnv bool
+	}{
+		{name: "error arm environment filtered", kind: "error", filterByEnv: true},
+		{name: "friction arm environment filtered", kind: "friction", filterByEnv: true},
+		{name: "unfiltered branch", kind: "error", filterByEnv: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := testPool(t)
+			ctx := context.Background()
+			q := db.New(pool)
+
+			org, err := q.CreateOrg(ctx, "archived-flood-"+tc.name)
+			if err != nil {
+				t.Fatalf("CreateOrg: %v", err)
+			}
+			t.Cleanup(func() { cleanupTenant(t, pool, org.ID) })
+			project, err := q.CreateProject(ctx, org.ID, "archived-flood", nil)
+			if err != nil {
+				t.Fatalf("CreateProject: %v", err)
+			}
+			environment, err := q.CreateEnvironment(ctx, project.ID, "production")
+			if err != nil {
+				t.Fatalf("CreateEnvironment: %v", err)
+			}
+
+			// The live group is deliberately the OLDEST row, so ordering by
+			// last_seen DESC places it behind the entire flood.
+			base := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+			var liveGroupID string
+			if tc.kind == "friction" {
+				liveGroupID = insertFrictionGroupForEnvironment(
+					t, pool, project.ID, environment.ID, "friction-live-under-flood", base, base, 1,
+				)
+			} else {
+				result, err := q.InsertErrorEventAndGroup(ctx, db.IngestParams{
+					ProjectID:     project.ID,
+					EnvironmentID: environment.ID,
+					ErrorType:     "TypeError",
+					ErrorMessage:  "live under flood",
+					StackTraceRaw: "at live.js:1:1",
+					Fingerprint:   "fp-live-under-flood",
+					Title:         "TypeError: live under flood",
+					EventTime:     base,
+				})
+				if err != nil {
+					t.Fatalf("InsertErrorEventAndGroup: %v", err)
+				}
+				liveGroupID = result.GroupID
+			}
+
+			insertArchivedFlood(
+				t, pool, project.ID, environment.ID, tc.kind, "flood-"+tc.kind, floodSize, base,
+			)
+
+			var filters *db.ErrorGroupFilters
+			if tc.filterByEnv {
+				filters = &db.ErrorGroupFilters{EnvironmentID: &environment.ID}
+			}
+			groups, err := q.ListErrorGroups(ctx, project.ID, filters)
+			if err != nil {
+				t.Fatalf("ListErrorGroups: %v", err)
+			}
+			if !containsGroup(groups, liveGroupID) {
+				t.Fatalf(
+					"live group %s was evicted by %d archived rows (got %d groups)",
+					liveGroupID, floodSize, len(groups),
+				)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+export DATABASE_URL="postgres://opslane:opslane_dev@localhost:5434/opslane?sslmode=disable"
+(cd packages/ingestion && go test ./db/ -run 'TestListErrorGroups(HidesArchived|ArchivedFlood)' -v)
+```
+
+Expected: all three FAIL. `HidesArchivedUnlessRequested` and `HidesArchivedInEnvironmentFilteredArms` report the archived group appearing where it should not; `ArchivedFloodDoesNotEvictLiveGroups` reports the live group evicted in all three subtests.
+
+If instead they SKIP, `DATABASE_URL` is not reaching the suite — fix that before continuing. A skip is not a failing test.
+
+- [ ] **Step 3: Promote the predicates to package-level constants**
+
+In `packages/ingestion/db/queries.go`, delete the local `visibleCandidate` declaration and its comment (currently lines 770-771, immediately above `var query string`) and add this block near the top of the file, next to the existing `requeueStatuses` var around line 325:
+
+```go
+const (
+	// Ordinary candidates are hidden workflow records (issue #56); the only
+	// visible candidate is an exhausted 'unchecked' adjudication diagnostic.
+	visibleCandidateSQL = "(eg.status <> 'candidate' OR eg.adjudication_status = 'unchecked')"
+
+	// Archived groups are permanently dismissed by the user (see
+	// requeueStatuses); they are excluded from every incident list and every
+	// account incident count unless explicitly requested by status.
+	notArchivedSQL = "eg.status <> 'archived'"
+)
+```
+
+Then replace the three remaining bare `visibleCandidate` references inside `ListErrorGroups` with `visibleCandidateSQL`.
+
+- [ ] **Step 4: Apply the archived predicate at all three sites**
+
+Still in `ListErrorGroups`, immediately after the `var query string` declaration, add:
+
+```go
+	// Applied only when the caller passed no status: an explicit status filter
+	// already scopes the query, and appending this would break status=archived.
+	hideArchived := statusArg == 0
+```
+
+In the `environmentArg == 0` branch, extend the initial `wheres` build:
+
+```go
+		wheres := []string{"eg.project_id = $1", visibleCandidateSQL}
+		if hideArchived {
+			wheres = append(wheres, notArchivedSQL)
+		}
+```
+
+In the `else` branch, after `errorWheres` and `frictionWheres` are declared and before the `if statusArg != 0` block:
+
+```go
+		if hideArchived {
+			errorWheres = append(errorWheres, notArchivedSQL)
+			frictionWheres = append(frictionWheres, notArchivedSQL)
+		}
+```
+
+Both arms already have `eg` in scope: the error arm joins `error_groups eg ON eg.id = ege.error_group_id`, the friction arm selects `FROM error_groups eg`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+(cd packages/ingestion && go test ./db/ -run 'TestListErrorGroups(HidesArchived|ArchivedFlood)' -v)
+```
+
+Expected: PASS, five test cases total (two top-level plus three subtests), zero skips.
+
+- [ ] **Step 6: Run the full ingestion suite for regressions**
+
+```bash
+(cd packages/ingestion && go build ./... && go test ./...)
+```
+
+Expected: PASS with zero skips. Existing tests that assert an archived group is listed without a status filter would now legitimately fail — if any do, fix the *test* to pass `Status: "archived"`, since the new default is the intended behavior.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ingestion/db/queries.go packages/ingestion/db/archived_visibility_test.go
+git commit -m "feat(ingestion): exclude archived groups from incident lists by default
+
+Archived rows shared the LIMIT 100 with live ones and evicted them from
+the response. The predicate goes inside each environment CTE arm, which
+carries its own limit, not on the outer select."
+```
+
+---
+
+### Task 2: Count only visible incidents in account aggregates
+
+**Files:**
+- Modify: `packages/ingestion/db/queries.go:974-982` (`ListAccounts`), `:1013-1021` (`GetAccountByID`)
+- Test: `packages/ingestion/db/archived_visibility_test.go` (append)
+
+**Interfaces:**
+- Consumes: `visibleCandidateSQL` and `notArchivedSQL` from Task 1; `containsGroup` from Task 1; `db.Queries.ListAccounts(ctx, projectID string, query *string) ([]db.Account, error)`; `db.Queries.GetAccountByID(ctx, projectID, externalAccountID string) (*db.Account, error)`; `db.Account.IncidentCount`
+- Produces: nothing consumed by later tasks
+
+**Background for the implementer:** After Task 1, `ListAccountIncidents` no longer returns archived groups, but `Account.IncidentCount` still counts them — so `AccountDetail.vue` can render "3 incidents" directly above "No incidents for this account." The same divergence already exists for `candidate` groups, which `visibleCandidateSQL` hides from the list while the count includes them. Both queries share one join shape, so one fix closes both.
+
+Two traps:
+1. The predicates go in the **`ON` clause**. In `WHERE` they demote the `LEFT JOIN` to an inner join, and accounts with zero visible incidents drop out of the accounts list entirely.
+2. Count `eg.id`, not `eau.error_group_id`. Filtered-out rows must contribute `NULL` so they fall out of `COUNT(DISTINCT ...)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/ingestion/db/archived_visibility_test.go`:
+
+```go
+// linkAccountUser attaches a new end user carrying externalAccountID to the
+// given group, which is how both account aggregates discover incidents.
+func linkAccountUser(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	projectID, groupID, externalUserID, externalAccountID string,
+) {
+	t.Helper()
+	ctx := context.Background()
+	var userID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO end_users (project_id, external_user_id, external_account_id, account_name)
+		VALUES ($1, $2, $3, $3)
+		RETURNING id`,
+		projectID, externalUserID, externalAccountID,
+	).Scan(&userID); err != nil {
+		t.Fatalf("insert end user: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO error_group_affected_users (error_group_id, end_user_id)
+		VALUES ($1, $2)`, groupID, userID,
+	); err != nil {
+		t.Fatalf("link affected user: %v", err)
+	}
+}
+
+func accountByID(accounts []db.Account, externalAccountID string) *db.Account {
+	for i := range accounts {
+		if accounts[i].ExternalAccountID == externalAccountID {
+			return &accounts[i]
+		}
+	}
+	return nil
+}
+
+func TestAccountIncidentCountExcludesArchivedAndMatchesTheList(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	_, projID, _, groupID := seedGroup(t, pool, q, "account-archived-count")
+
+	linkAccountUser(t, pool, projID, groupID, "user-archived", "acct-archived")
+	if err := q.ArchiveErrorGroup(ctx, projID, groupID); err != nil {
+		t.Fatalf("ArchiveErrorGroup: %v", err)
+	}
+
+	account, err := q.GetAccountByID(ctx, projID, "acct-archived")
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if account == nil {
+		t.Fatal("GetAccountByID returned nil for an account whose only incident is archived")
+	}
+	if account.IncidentCount != 0 {
+		t.Errorf("IncidentCount = %d, want 0 (archived incidents are not visible)", account.IncidentCount)
+	}
+
+	// The count must equal the list rendered beneath it in AccountDetail.vue.
+	incidents, err := q.ListErrorGroups(ctx, projID, &db.ErrorGroupFilters{AccountID: "acct-archived"})
+	if err != nil {
+		t.Fatalf("ListErrorGroups by account: %v", err)
+	}
+	if len(incidents) != account.IncidentCount {
+		t.Errorf("list length %d does not match IncidentCount %d", len(incidents), account.IncidentCount)
+	}
+
+	// The LEFT JOIN must survive: an account with zero visible incidents is
+	// still an account and must keep appearing in the accounts list.
+	accounts, err := q.ListAccounts(ctx, projID, nil)
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	listed := accountByID(accounts, "acct-archived")
+	if listed == nil {
+		t.Fatal("account with only archived incidents vanished from ListAccounts")
+	}
+	if listed.IncidentCount != 0 {
+		t.Errorf("ListAccounts IncidentCount = %d, want 0", listed.IncidentCount)
+	}
+}
+
+func TestAccountIncidentCountExcludesOrdinaryCandidates(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	_, projID, envID, _ := seedGroup(t, pool, q, "account-candidate-count")
+
+	// adjudication_status stays NULL: its CHECK admits only 'unchecked', and an
+	// 'unchecked' candidate is the one variety that is deliberately visible.
+	var candidateID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO error_groups
+		  (project_id, fingerprint, title, first_seen, last_seen, occurrence_count,
+		   status, kind, environment_id)
+		VALUES ($1, 'fp-ordinary-candidate', 'ordinary candidate', now(), now(), 1,
+		        'candidate', 'friction', $2)
+		RETURNING id`, projID, envID,
+	).Scan(&candidateID); err != nil {
+		t.Fatalf("insert candidate group: %v", err)
+	}
+	linkAccountUser(t, pool, projID, candidateID, "user-candidate", "acct-candidate")
+
+	account, err := q.GetAccountByID(ctx, projID, "acct-candidate")
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if account == nil {
+		t.Fatal("GetAccountByID returned nil for an account whose only incident is a candidate")
+	}
+	if account.IncidentCount != 0 {
+		t.Errorf("IncidentCount = %d, want 0 (ordinary candidates are hidden workflow records)", account.IncidentCount)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+(cd packages/ingestion && go test ./db/ -run 'TestAccountIncidentCount' -v)
+```
+
+Expected: both FAIL with `IncidentCount = 1, want 0`.
+
+`db.Account.IncidentCount` is a plain `int` (`queries.go:939`), so `len(incidents)` compares directly with no conversion.
+
+- [ ] **Step 3: Apply the predicates to both account queries**
+
+In `ListAccounts` (`packages/ingestion/db/queries.go:974`), change the opening of `sql` from `COUNT(DISTINCT eau.error_group_id)` and add the group join:
+
+```go
+	sql := `SELECT eu.external_account_id,
+	               MAX(eu.account_name) AS account_name,
+	               COUNT(DISTINCT eu.id) AS user_count,
+	               COUNT(DISTINCT eg.id) AS incident_count,
+	               MAX(eu.last_seen) AS last_seen
+	        FROM end_users eu
+	        LEFT JOIN error_group_affected_users eau ON eau.end_user_id = eu.id
+	        LEFT JOIN error_groups eg ON eg.id = eau.error_group_id
+	             AND ` + notArchivedSQL + `
+	             AND ` + visibleCandidateSQL + `
+	        WHERE eu.project_id = $1 AND eu.external_account_id IS NOT NULL`
+```
+
+Apply the identical join and count change to `GetAccountByID` (`:1013`), keeping its own `WHERE eu.project_id = $1 AND eu.external_account_id = $2`.
+
+Unlike `ListErrorGroups`, `notArchivedSQL` is applied unconditionally here — neither endpoint accepts a status filter.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+(cd packages/ingestion && go test ./db/ -run 'TestAccountIncidentCount' -v)
+```
+
+Expected: PASS, zero skips.
+
+- [ ] **Step 5: Run the full ingestion suite**
+
+```bash
+(cd packages/ingestion && go build ./... && go test ./...)
+```
+
+Expected: PASS with zero skips.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ingestion/db/queries.go packages/ingestion/db/archived_visibility_test.go
+git commit -m "fix(ingestion): account incident counts count only visible incidents
+
+Archived and ordinary-candidate groups inflated the account header count
+above the list beneath it. Predicates go in the ON clause so accounts
+with zero visible incidents survive the LEFT JOIN."
+```
+
+---
+
+### Task 3: Archived escape-hatch link in the issues empty states
+
+**Files:**
+- Modify: `packages/dashboard/src/components/FilterBar.vue:88-95` (add `showArchived`, extend `defineExpose`)
+- Modify: `packages/dashboard/src/views/IssuesList.vue:65` (add computed), `:213-234` (both empty states)
+- Test: `packages/dashboard/src/views/__tests__/issues-list-filters.test.ts` (append a `describe` block)
+
+**Interfaces:**
+- Consumes: `FilterBar` exposed instance methods via the existing `filterBar` template ref in `IssuesList.vue`; existing `currentFilters` ref and `hasActiveFilters` computed
+- Produces: `FilterBar.showArchived(): void` on the exposed instance; `[data-testid="view-archived"]` on the link
+
+**Background for the implementer:** `FilterBar` already watches `selectedStatus` and calls `onFilterChange` on every change, which syncs the URL query and re-emits filters. So `showArchived()` only needs to assign the ref — the watcher does the rest, and every other filter is left untouched, which is exactly the "preserve other filters, replace only status" requirement. Do not build a `router.push` in `IssuesList.vue`; that would duplicate the URL-sync logic and drift.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/dashboard/src/views/__tests__/issues-list-filters.test.ts`, after the existing `describe` block:
+
+```ts
+describe('IssuesList archived escape hatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listAccounts.mockResolvedValue([]);
+    mocks.listEnvironments.mockResolvedValue({ environments: [], rollup_ready: false });
+    mocks.route.query = {};
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('offers the archived view from an empty filtered feed and keeps the other filters', async () => {
+    mocks.route.query = { project_id: 'p1', platform: 'python' };
+    window.history.replaceState({}, '', '/?project_id=p1&platform=python');
+    mocks.listIncidents.mockResolvedValue([]);
+
+    const wrapper = mountFeed();
+    await flushPromises();
+
+    expect(mocks.listIncidents).toHaveBeenCalledWith('p1', { platform: 'python' });
+
+    await wrapper.get('[data-testid="view-archived"]').trigger('click');
+    await flushPromises();
+
+    // Assert on the request, not the rendered text: the point of the link is
+    // the filter it applies, and it must not discard the platform filter.
+    expect(mocks.listIncidents).toHaveBeenLastCalledWith('p1', {
+      platform: 'python',
+      status: 'archived',
+    });
+
+    wrapper.unmount();
+  });
+
+  it('offers the archived view from a wholly empty feed', async () => {
+    mocks.route.query = { project_id: 'p1' };
+    window.history.replaceState({}, '', '/?project_id=p1');
+    mocks.listIncidents.mockResolvedValue([]);
+
+    const wrapper = mountFeed();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="view-archived"]').exists()).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it('does not offer the archived view when already viewing archived', async () => {
+    mocks.route.query = { project_id: 'p1', status: 'archived' };
+    window.history.replaceState({}, '', '/?project_id=p1&status=archived');
+    mocks.listIncidents.mockResolvedValue([]);
+
+    const wrapper = mountFeed();
+    await flushPromises();
+
+    expect(mocks.listIncidents).toHaveBeenCalledWith('p1', { status: 'archived' });
+    expect(wrapper.find('[data-testid="view-archived"]').exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pnpm --filter @opslane/dashboard test -- issues-list-filters
+```
+
+Expected: the first two FAIL on the missing `[data-testid="view-archived"]` element. The third may pass vacuously (nothing renders the element yet) — that is fine; it becomes meaningful after Step 3.
+
+- [ ] **Step 3: Expose `showArchived` from FilterBar**
+
+In `packages/dashboard/src/components/FilterBar.vue`, add after the `reset` function and update the expose:
+
+```ts
+function showArchived() {
+  // The watcher on selectedStatus performs the URL sync and re-emit, so every
+  // other active filter is preserved and only status changes.
+  selectedStatus.value = 'archived';
+}
+
+defineExpose({ reset, showArchived });
+```
+
+- [ ] **Step 4: Render the link in both empty states**
+
+In `packages/dashboard/src/views/IssuesList.vue`, add next to `hasActiveFilters` (line 65):
+
+```ts
+const viewingArchived = computed(() => currentFilters.value.status === 'archived');
+
+function viewArchived() {
+  filterBar.value?.showArchived();
+}
+```
+
+Then add this block inside **both** `<EmptyState>` elements — the `v-if="hasActiveFilters"` one and the `v-else` one — as a sibling of the existing slot content:
+
+```html
+        <button
+          v-if="!viewingArchived"
+          type="button"
+          data-testid="view-archived"
+          class="mt-3 text-sm text-muted underline underline-offset-4 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          @click="viewArchived"
+        >
+          Archived issues are hidden — view archived
+        </button>
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+pnpm --filter @opslane/dashboard test -- issues-list-filters
+```
+
+Expected: all three new tests PASS, and the pre-existing tests in the file still PASS.
+
+- [ ] **Step 6: Run the dashboard gate**
+
+```bash
+pnpm --filter @opslane/dashboard build
+pnpm --filter @opslane/dashboard test
+```
+
+Expected: both succeed. `build` runs `vue-tsc`, so a type error on the `showArchived` expose surfaces here rather than at runtime.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/dashboard/src/components/FilterBar.vue \
+        packages/dashboard/src/views/IssuesList.vue \
+        packages/dashboard/src/views/__tests__/issues-list-filters.test.ts
+git commit -m "feat(dashboard): offer the archived view from empty issue states
+
+Archived issues no longer appear by default, so an empty feed links to
+them. The link routes through FilterBar so the other active filters and
+the URL sync are preserved, and it hides when already viewing archived."
+```
+
+---
+
+## Final verification
+
+Run the full repository gate before opening a PR:
+
+```bash
+export DATABASE_URL="postgres://opslane:opslane_dev@localhost:5434/opslane?sslmode=disable"
+pnpm install --frozen-lockfile
+pnpm -r build
+pnpm test
+(cd packages/ingestion && go build ./... && go test ./...)
+docker compose config --quiet
+```
+
+Read the **skip count**, not the pass count. `go test ./...` printing `ok` while ~30 DB tests silently skipped is the documented failure mode of this gate.

--- a/docs/superpowers/plans/2026-08-05-hide-archived-issues.md
+++ b/docs/superpowers/plans/2026-08-05-hide-archived-issues.md
@@ -4,7 +4,7 @@
 
 **Goal:** Archived incidents disappear from every incident list and account incident count unless the caller explicitly asks for `status=archived`.
 
-**Architecture:** The exclusion lives in SQL inside `packages/ingestion/db/queries.go`, not in the Vue layer, because `ListErrorGroups` caps at `LIMIT 100` and archived rows currently evict live ones from the response. Two shared predicate constants are applied at four query sites: the three `ListErrorGroups` WHERE-clause builders and the two account aggregate queries. The dashboard adds no filtering logic — only an escape-hatch link in its empty states.
+**Architecture:** The exclusion lives in SQL inside `packages/ingestion/db/queries.go`, not in the Vue layer, because `ListErrorGroups` caps at `LIMIT 100` and archived rows currently evict live ones from the response. Two shared predicate constants are applied at five query sites: the three `ListErrorGroups` WHERE-clause builders and the two account aggregate queries. The dashboard adds no filtering logic — only an escape-hatch link in its empty states.
 
 **Tech Stack:** Go 1.24 + pgx (ingestion), Vue 3 + Vitest + `@vue/test-utils` (dashboard), Postgres.
 
@@ -616,6 +616,16 @@ describe('IssuesList archived escape hatch', () => {
       status: 'archived',
     });
 
+    // The URL must follow too, or a reload drops the user back to the
+    // default view with no way to tell what happened.
+    expect(mocks.replace).toHaveBeenCalledWith({
+      query: {
+        project_id: 'p1',
+        platform: 'python',
+        status: 'archived',
+      },
+    });
+
     wrapper.unmount();
   });
 
@@ -689,12 +699,17 @@ Then add this block inside **both** `<EmptyState>` elements — the `v-if="hasAc
           v-if="!viewingArchived"
           type="button"
           data-testid="view-archived"
-          class="mt-3 text-sm text-muted underline underline-offset-4 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          class="mx-auto mt-3 block text-sm text-muted underline underline-offset-4 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           @click="viewArchived"
         >
           Archived issues are hidden — view archived
         </button>
 ```
+
+`block mx-auto` is load-bearing, not decoration. `EmptyState.vue` wraps its
+default slot in a single `text-center` div, and the existing primary action is
+`inline-flex` — a second inline element would sit beside it on the same line.
+`block` forces its own row and `mx-auto` re-centers it.
 
 - [ ] **Step 5: Run the tests to verify they pass**
 
@@ -733,7 +748,9 @@ the URL sync are preserved, and it hides when already viewing archived."
 Run the full repository gate before opening a PR. `DATABASE_URL` alone is not enough for a zero-skip run — the Go storage tests `t.Skip` without the MinIO variables, so export the whole block from `AGENTS.md` as a unit and start the services first:
 
 ```bash
-docker compose up -d postgres minio
+# --wait blocks until both report healthy. Without it the first test can race
+# container startup and t.Skip, which reads as a green run.
+docker compose up -d --wait postgres minio
 
 export INGESTION_PORT=8082
 export OPSLANE_POSTGRES_HOST_PORT=5434

--- a/docs/superpowers/specs/2026-08-05-hide-archived-issues-design.md
+++ b/docs/superpowers/specs/2026-08-05-hide-archived-issues-design.md
@@ -29,8 +29,11 @@ An explicit status filter always wins over the default. There is no third state
 and no separate include-archived flag to keep in sync with the status filter.
 
 Account incident **counts** are brought in line with the same rule: a count
-means *visible incidents*, matching the list rendered beneath it. See
-"Account views" below.
+means *visible incidents*. It matches the list rendered beneath it up to
+`ListErrorGroups`' `LIMIT 100`; past that the count keeps climbing while the
+list stops at 100. That residual gap is left alone — "101 incidents" over 100
+rows is a far milder lie than "3 incidents" over an empty list. See "Account
+views" below.
 
 ## Shared visibility predicates
 
@@ -169,9 +172,13 @@ it here. So the copy is unconditional in the other direction: a brand-new
 project with no events shows a link to an empty archived list. Accepted
 tradeoff.
 
-`packages/dashboard/src/components/FilterBar.vue` is untouched. The existing
-"Archived" option (line 158) already sends exactly the request that reveals
-them.
+`packages/dashboard/src/components/FilterBar.vue` gains one method,
+`showArchived()`, added to its existing `defineExpose`. Its status dropdown and
+options are unchanged — the existing "Archived" option (line 158) already sends
+exactly the request that reveals them. The link routes through this method
+rather than pushing a route itself, because `FilterBar` already owns the
+watcher that syncs status to the URL and re-emits the filter set; duplicating
+that in `IssuesList.vue` would drift.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-08-05-hide-archived-issues-design.md
+++ b/docs/superpowers/specs/2026-08-05-hide-archived-issues-design.md
@@ -3,8 +3,8 @@
 ## Problem
 
 The dashboard issue list shows archived incidents mixed in with live ones. In
-practice a burst of auto-archived friction incidents can dominate the entire
-first page.
+practice a batch of archived friction incidents can dominate the entire first
+page.
 
 This is worse than visual noise. `ListErrorGroups` caps results at `LIMIT 100`,
 so archived rows **evict live issues from the response**. A user with 100+
@@ -14,7 +14,11 @@ fix that filters in the Vue component would leave that eviction in place.
 The codebase already treats archived as terminal everywhere else.
 `packages/ingestion/db/queries.go:326` excludes archived from `requeueStatuses`
 with the comment that archived groups are "permanently dismissed by the user."
-The list query is the one place that does not honor that.
+The incident lists are the one place that does not honor that.
+
+Archival is always explicit: `ArchiveIncident`
+(`packages/ingestion/handler/read_api.go:917`) is the only writer of
+`status = 'archived'`. Nothing archives automatically.
 
 ## The rule
 
@@ -24,22 +28,41 @@ The list query is the one place that does not honor that.
 An explicit status filter always wins over the default. There is no third state
 and no separate include-archived flag to keep in sync with the status filter.
 
-## Server
+Account incident **counts** are brought in line with the same rule: a count
+means *visible incidents*, matching the list rendered beneath it. See
+"Account views" below.
+
+## Shared visibility predicates
+
+`ListErrorGroups` currently inlines its candidate predicate as a local
+`visibleCandidate` string. Promote both predicates to package-level constants in
+`packages/ingestion/db/queries.go` so the incident list and the account counts
+cannot drift apart:
+
+```go
+const (
+	// Ordinary candidates are hidden workflow records (issue #56); the only
+	// visible candidate is an exhausted 'unchecked' adjudication diagnostic.
+	visibleCandidateSQL = "(eg.status <> 'candidate' OR eg.adjudication_status = 'unchecked')"
+
+	// Archived groups are permanently dismissed by the user (see
+	// requeueStatuses); they are excluded from every list and count unless
+	// explicitly requested by status.
+	notArchivedSQL = "eg.status <> 'archived'"
+)
+```
+
+Every query below aliases `error_groups` as `eg`, so the constants drop in
+unchanged.
+
+## Server: incident lists
 
 **File:** `packages/ingestion/db/queries.go`, `ListErrorGroups`
 
-Add a predicate alongside the existing `visibleCandidate` one, applied **only
-when no status filter was passed** (`statusArg == 0`):
-
-```go
-// Archived groups are permanently dismissed by the user (see requeueStatuses);
-// they are excluded from every list unless explicitly requested by status.
-notArchived := "eg.status <> 'archived'"
-```
-
-When `statusArg != 0` the existing `eg.status = $n` predicate already scopes the
-query, and appending `notArchived` would break the archived view. So the append
-is conditional.
+Append `notArchivedSQL` **only when no status filter was passed**
+(`statusArg == 0`). When `statusArg != 0` the existing `eg.status = $n`
+predicate already scopes the query, and appending `notArchivedSQL` would break
+the archived view.
 
 The query has two shapes, and the predicate is needed in three places:
 
@@ -49,7 +72,7 @@ The query has two shapes, and the predicate is needed in three places:
 
 It must go **inside** the environment branch's CTE arms, not on the outer
 select. Each arm carries its own `LIMIT 100`, so filtering after the union would
-still let archived rows evict live ones inside an arm.
+still let archived rows evict live ones within an arm.
 
 `eg` is in scope in both arms: the error arm joins `error_groups eg ON eg.id =
 ege.error_group_id`, and the friction arm selects `FROM error_groups eg`.
@@ -64,12 +87,61 @@ No handler changes. Both callers of `ListErrorGroups` inherit the new default:
 `cli/src/errors.ts` needs no change; it passes `--status` straight through, so
 `opslane errors --status archived` remains the way to see them.
 
-### Contract note
+## Server: account views
+
+`ListAccountIncidents` (`read_api.go:553`) hardcodes
+`&db.ErrorGroupFilters{AccountID: accountID}` and never reads `status`, so the
+account incident list has no archived escape hatch and gains none here. That is
+intentional: the account view answers "what is this customer hitting," and an
+archived incident has been dismissed.
+
+That makes the header count wrong. `GetAccountByID` (`queries.go:1013`) and
+`ListAccounts` (`queries.go:974`) both compute:
+
+```sql
+COUNT(DISTINCT eau.error_group_id) AS incident_count
+FROM end_users eu
+LEFT JOIN error_group_affected_users eau ON eau.end_user_id = eu.id
+```
+
+with no status predicate at all. Without a fix, an account whose incidents are
+all archived renders "3 incidents" directly above "No incidents for this
+account" (`packages/dashboard/src/views/AccountDetail.vue:69`).
+
+Note this divergence **already exists** for `candidate` groups, which
+`visibleCandidate` hides from the list while the count still includes them. The
+fix closes both.
+
+In both queries, add a join to `error_groups` carrying the visibility
+predicates, and count the joined group rather than the join-table column:
+
+```sql
+COUNT(DISTINCT eg.id) AS incident_count
+FROM end_users eu
+LEFT JOIN error_group_affected_users eau ON eau.end_user_id = eu.id
+LEFT JOIN error_groups eg ON eg.id = eau.error_group_id
+     AND <notArchivedSQL>
+     AND <visibleCandidateSQL>
+```
+
+Two constraints that are easy to get wrong:
+
+- The predicates must live in the **`ON` clause**, not `WHERE`. In `WHERE` they
+  demote the LEFT JOIN to an inner join, and accounts with zero visible
+  incidents vanish from the accounts list entirely.
+- Count `eg.id`, not `eau.error_group_id`. Filtered-out rows must contribute
+  `NULL` so they fall out of the `COUNT(DISTINCT ...)`.
+
+Unlike `ListErrorGroups`, the account counts apply `notArchivedSQL`
+unconditionally — these endpoints take no status filter.
+
+## Contract note
 
 This is a deliberate, explicit behavior change to
-`GET /api/v1/projects/{id}/incidents`, not a shim. No `include_archived=true`
+`GET /api/v1/projects/{id}/incidents`, its account-scoped sibling, and the
+account `incident_count` field. It is not a shim: no `include_archived=true`
 compatibility parameter is added, per the "do not add legacy shims by default"
-guardrail in `AGENTS.md`. The endpoint is not a frozen contract — only
+guardrail in `AGENTS.md`. The endpoints are not frozen contracts — only
 `POST /api/v1/events` is append-only.
 
 ## Dashboard
@@ -79,15 +151,23 @@ guardrail in `AGENTS.md`. The endpoint is not a frozen contract — only
 No filtering logic in the component. It keeps rendering whatever the API
 returns.
 
-The only change is the empty state. Both existing variants — "No issues match
-these filters" and "No issues yet" — get a quiet secondary link to the archived
-view (`?status=archived`), so a user who archived everything is not told their
-issues simply vanished.
+The only change is the empty state: a quiet secondary link to the archived view,
+with defined semantics.
+
+**When it renders.** Only when the current status filter is not already
+`archived`. `hasActiveFilters` is true when `status=archived` returns nothing,
+so an unconditional link would point at the view the user is already on.
+
+**Where it points.** It preserves every other active filter (environment,
+platform, account) and replaces only `status` with `archived`. Jumping to a
+bare `?status=archived` would silently discard the user's environment
+selection.
 
 The link deliberately carries **no count**. Rendering "3 archived issues hidden"
 would require a count the API does not expose, and a new endpoint is not worth
-it here. The copy is therefore unconditional: a brand-new project with no events
-shows a link to an empty archived list. Accepted tradeoff.
+it here. So the copy is unconditional in the other direction: a brand-new
+project with no events shows a link to an empty archived list. Accepted
+tradeoff.
 
 `packages/dashboard/src/components/FilterBar.vue` is untouched. The existing
 "Archived" option (line 158) already sends exactly the request that reveals
@@ -101,31 +181,58 @@ them.
   `archived: 10` entry, which still applies inside the explicit archived view.
 - No change to what causes an incident to be archived. The near-duplicate
   friction incidents that motivated this are a separate grouping concern.
+- No account-scoped archived view. `ListAccountIncidents` gains no `status`
+  passthrough; no UI asks for one.
 
 ## Verification
 
 **Go — `packages/ingestion/db/queries_test.go`:**
 
+Incident lists:
+
 - an archived group is absent from an unfiltered list
 - the same group is present when `status=archived` is passed
 - both hold in the environment-filtered query shape as well as the unfiltered
-  one, for both `kind='error'` and `kind='friction'`
-- eviction regression: with more than 100 archived rows and one live row, the
-  live row is still returned
+  one, for `kind='error'` and `kind='friction'`
 
-**Vitest — new file `packages/dashboard/src/views/IssuesList.test.ts`:**
+Eviction regression, table-driven over the environment-filtered arms — this is
+the case that distinguishes a correct per-arm filter from an outer-select
+filter that would otherwise pass every other test:
 
-`IssuesList.vue` has no test today. Add one colocated in `views/`, following
-the existing `SessionsList.test.ts` / `Settings.test.ts` siblings.
+| case | fixture |
+| --- | --- |
+| error arm | 101 archived `kind='error'` groups with `last_seen` newer than one older live error group, all in the selected environment |
+| friction arm | same shape for `kind='friction'` |
+| no environment filter | same shape against the unfiltered branch |
 
-- the empty state renders the archived link
+In each case the older live group must still be returned.
+
+Account counts:
+
+- an account whose only incidents are archived reports `incident_count = 0` and
+  still appears in `ListAccounts` (the LEFT JOIN regression)
+- `GetAccountByID` count matches the length of `ListAccountIncidents` for the
+  same account
+- an ordinary `candidate` group is excluded from the count (the pre-existing
+  divergence)
+
+**Vitest — extend `packages/dashboard/src/views/__tests__/issues-list-filters.test.ts`:**
+
+This suite already exists; add to it rather than creating a second one.
+
+- the archived link is absent when the active status filter is `archived`
+- activating the link issues a request with `status: 'archived'` and retains the
+  other active filters — assert on the request, not merely that the text
+  rendered
 
 **Gate:**
 
 ```bash
 (cd packages/ingestion && go build ./... && go test ./...)
+pnpm --filter @opslane/dashboard build
 pnpm --filter @opslane/dashboard test
 ```
 
-Go DB tests require `DATABASE_URL`; confirm the run reports **zero** skips
-rather than trusting an `ok`.
+Both dashboard commands are required by `packages/dashboard/AGENTS.md:13`. Go DB
+tests require `DATABASE_URL`; confirm the run reports **zero** skips rather than
+trusting an `ok`.

--- a/docs/superpowers/specs/2026-08-05-hide-archived-issues-design.md
+++ b/docs/superpowers/specs/2026-08-05-hide-archived-issues-design.md
@@ -193,7 +193,11 @@ that in `IssuesList.vue` would drift.
 
 ## Verification
 
-**Go — `packages/ingestion/db/queries_test.go`:**
+**Go — new file `packages/ingestion/db/archived_visibility_test.go`:**
+
+A focused per-concern file in package `db_test`, following the
+`environment_filters_test.go` precedent, rather than appending to the
+1000-line `queries_test.go`. It reuses that package's existing helpers.
 
 Incident lists:
 
@@ -208,9 +212,10 @@ filter that would otherwise pass every other test:
 
 | case | fixture |
 | --- | --- |
-| error arm | 101 archived `kind='error'` groups with `last_seen` newer than one older live error group, all in the selected environment |
-| friction arm | same shape for `kind='friction'` |
-| no environment filter | same shape against the unfiltered branch |
+| error arm, environment filtered | 101 archived `kind='error'` groups with `last_seen` newer than one older live error group, all in the selected environment |
+| friction arm, environment filtered | same shape for `kind='friction'` |
+| unfiltered branch, error | same shape for `kind='error'` with no environment filter |
+| unfiltered branch, friction | same shape for `kind='friction'` with no environment filter |
 
 In each case the older live group must still be returned.
 
@@ -240,6 +245,11 @@ pnpm --filter @opslane/dashboard build
 pnpm --filter @opslane/dashboard test
 ```
 
-Both dashboard commands are required by `packages/dashboard/AGENTS.md:13`. Go DB
-tests require `DATABASE_URL`; confirm the run reports **zero** skips rather than
-trusting an `ok`.
+Both dashboard commands are required by `packages/dashboard/AGENTS.md:13`.
+
+Go DB tests do **not** require `DATABASE_URL` — `testPool`
+(`testhelper_test.go:17`) falls back to the local dev DSN — so a skip means
+Postgres is unreachable, not that a variable is missing. The storage tests are
+the ones that need environment: they `t.Skip` without the MinIO block. Start
+the services and export that block as a unit, then confirm the run reports
+**zero** skips rather than trusting an `ok`.

--- a/docs/superpowers/specs/2026-08-05-hide-archived-issues-design.md
+++ b/docs/superpowers/specs/2026-08-05-hide-archived-issues-design.md
@@ -1,0 +1,131 @@
+# Hide archived issues from incident lists by default
+
+## Problem
+
+The dashboard issue list shows archived incidents mixed in with live ones. In
+practice a burst of auto-archived friction incidents can dominate the entire
+first page.
+
+This is worse than visual noise. `ListErrorGroups` caps results at `LIMIT 100`,
+so archived rows **evict live issues from the response**. A user with 100+
+archived incidents can lose real work off the bottom of the list entirely. Any
+fix that filters in the Vue component would leave that eviction in place.
+
+The codebase already treats archived as terminal everywhere else.
+`packages/ingestion/db/queries.go:326` excludes archived from `requeueStatuses`
+with the comment that archived groups are "permanently dismissed by the user."
+The list query is the one place that does not honor that.
+
+## The rule
+
+> Archived issues are excluded from every incident list unless the caller
+> explicitly filters for `status=archived`.
+
+An explicit status filter always wins over the default. There is no third state
+and no separate include-archived flag to keep in sync with the status filter.
+
+## Server
+
+**File:** `packages/ingestion/db/queries.go`, `ListErrorGroups`
+
+Add a predicate alongside the existing `visibleCandidate` one, applied **only
+when no status filter was passed** (`statusArg == 0`):
+
+```go
+// Archived groups are permanently dismissed by the user (see requeueStatuses);
+// they are excluded from every list unless explicitly requested by status.
+notArchived := "eg.status <> 'archived'"
+```
+
+When `statusArg != 0` the existing `eg.status = $n` predicate already scopes the
+query, and appending `notArchived` would break the archived view. So the append
+is conditional.
+
+The query has two shapes, and the predicate is needed in three places:
+
+1. the no-environment branch's `wheres`
+2. the environment branch's `errorWheres`
+3. the environment branch's `frictionWheres`
+
+It must go **inside** the environment branch's CTE arms, not on the outer
+select. Each arm carries its own `LIMIT 100`, so filtering after the union would
+still let archived rows evict live ones inside an arm.
+
+`eg` is in scope in both arms: the error arm joins `error_groups eg ON eg.id =
+ege.error_group_id`, and the friction arm selects `FROM error_groups eg`.
+
+### Consumers
+
+No handler changes. Both callers of `ListErrorGroups` inherit the new default:
+
+- `packages/ingestion/handler/read_api.go:262` — project incidents list
+- `packages/ingestion/handler/read_api.go:562` — account-scoped incidents list
+
+`cli/src/errors.ts` needs no change; it passes `--status` straight through, so
+`opslane errors --status archived` remains the way to see them.
+
+### Contract note
+
+This is a deliberate, explicit behavior change to
+`GET /api/v1/projects/{id}/incidents`, not a shim. No `include_archived=true`
+compatibility parameter is added, per the "do not add legacy shims by default"
+guardrail in `AGENTS.md`. The endpoint is not a frozen contract — only
+`POST /api/v1/events` is append-only.
+
+## Dashboard
+
+**File:** `packages/dashboard/src/views/IssuesList.vue`
+
+No filtering logic in the component. It keeps rendering whatever the API
+returns.
+
+The only change is the empty state. Both existing variants — "No issues match
+these filters" and "No issues yet" — get a quiet secondary link to the archived
+view (`?status=archived`), so a user who archived everything is not told their
+issues simply vanished.
+
+The link deliberately carries **no count**. Rendering "3 archived issues hidden"
+would require a count the API does not expose, and a new endpoint is not worth
+it here. The copy is therefore unconditional: a brand-new project with no events
+shows a link to an empty archived list. Accepted tradeoff.
+
+`packages/dashboard/src/components/FilterBar.vue` is untouched. The existing
+"Archived" option (line 158) already sends exactly the request that reveals
+them.
+
+## Out of scope
+
+- `resolved` and `merged` still appear in the default list. Only `archived` is
+  hidden.
+- No change to sort order. `statusOrder` in `IssuesList.vue` keeps its
+  `archived: 10` entry, which still applies inside the explicit archived view.
+- No change to what causes an incident to be archived. The near-duplicate
+  friction incidents that motivated this are a separate grouping concern.
+
+## Verification
+
+**Go — `packages/ingestion/db/queries_test.go`:**
+
+- an archived group is absent from an unfiltered list
+- the same group is present when `status=archived` is passed
+- both hold in the environment-filtered query shape as well as the unfiltered
+  one, for both `kind='error'` and `kind='friction'`
+- eviction regression: with more than 100 archived rows and one live row, the
+  live row is still returned
+
+**Vitest — new file `packages/dashboard/src/views/IssuesList.test.ts`:**
+
+`IssuesList.vue` has no test today. Add one colocated in `views/`, following
+the existing `SessionsList.test.ts` / `Settings.test.ts` siblings.
+
+- the empty state renders the archived link
+
+**Gate:**
+
+```bash
+(cd packages/ingestion && go build ./... && go test ./...)
+pnpm --filter @opslane/dashboard test
+```
+
+Go DB tests require `DATABASE_URL`; confirm the run reports **zero** skips
+rather than trusting an `ok`.

--- a/packages/dashboard/src/components/FilterBar.vue
+++ b/packages/dashboard/src/components/FilterBar.vue
@@ -93,7 +93,13 @@ function reset() {
   selectedEnvironmentId.value = '';
 }
 
-defineExpose({ reset });
+function showArchived() {
+  // The watcher on selectedStatus performs the URL sync and re-emit, so every
+  // other active filter is preserved and only status changes.
+  selectedStatus.value = 'archived';
+}
+
+defineExpose({ reset, showArchived });
 
 watch(
   [selectedAccountId, selectedStatus, selectedPlatform, selectedEnvironmentId, rollupReady],

--- a/packages/dashboard/src/views/IssuesList.vue
+++ b/packages/dashboard/src/views/IssuesList.vue
@@ -63,6 +63,11 @@ const platformsVary = computed(
   () => new Set(incidents.value.map((incident) => incident.platform).filter(Boolean)).size > 1,
 );
 const hasActiveFilters = computed(() => Object.keys(currentFilters.value).length > 0);
+const viewingArchived = computed(() => currentFilters.value.status === 'archived');
+
+function viewArchived() {
+  filterBar.value?.showArchived();
+}
 
 const newIncidentCount = ref(0);
 let pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -223,6 +228,15 @@ onUnmounted(() => stopPolling());
         >
           Clear filters
         </button>
+        <button
+          v-if="!viewingArchived"
+          type="button"
+          data-testid="view-archived"
+          class="mx-auto mt-3 block text-sm text-muted underline underline-offset-4 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          @click="viewArchived"
+        >
+          Archived issues are hidden — view archived
+        </button>
       </EmptyState>
       <EmptyState
         v-else
@@ -235,6 +249,15 @@ onUnmounted(() => stopPolling());
         >
           Setup guide
         </router-link>
+        <button
+          v-if="!viewingArchived"
+          type="button"
+          data-testid="view-archived"
+          class="mx-auto mt-3 block text-sm text-muted underline underline-offset-4 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          @click="viewArchived"
+        >
+          Archived issues are hidden — view archived
+        </button>
       </EmptyState>
     </template>
 

--- a/packages/dashboard/src/views/IssuesList.vue
+++ b/packages/dashboard/src/views/IssuesList.vue
@@ -93,9 +93,12 @@ async function fetchIncidents(filters?: IncidentFilters) {
 async function pollForNew() {
   try {
     const latest = await listIncidents(projectId.value, currentFilters.value);
-    if (latest.length > incidents.value.length) {
-      newIncidentCount.value = latest.length - incidents.value.length;
-    }
+    // Count unseen ids rather than a length delta. Archiving removes rows from
+    // the default feed, so a shrink can cancel out an arrival: 3 archived plus
+    // 2 new reads as a net -1, the banner stays hidden, and since the banner is
+    // the only thing that refetches, the feed freezes on stale rows.
+    const known = new Set(incidents.value.map((incident) => incident.id));
+    newIncidentCount.value = latest.filter((incident) => !known.has(incident.id)).length;
   } catch {
     // Silent — polling failure is non-fatal
   }
@@ -235,7 +238,7 @@ onUnmounted(() => stopPolling());
           class="mx-auto mt-3 block text-sm text-muted underline underline-offset-4 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           @click="viewArchived"
         >
-          Archived issues are hidden — view archived
+          View archived issues
         </button>
       </EmptyState>
       <EmptyState
@@ -256,7 +259,7 @@ onUnmounted(() => stopPolling());
           class="mx-auto mt-3 block text-sm text-muted underline underline-offset-4 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           @click="viewArchived"
         >
-          Archived issues are hidden — view archived
+          View archived issues
         </button>
       </EmptyState>
     </template>

--- a/packages/dashboard/src/views/__tests__/issues-list-filters.test.ts
+++ b/packages/dashboard/src/views/__tests__/issues-list-filters.test.ts
@@ -481,7 +481,11 @@ describe('IssuesList archived escape hatch', () => {
     wrapper.unmount();
   });
 
-  it('offers the archived view from a wholly empty feed', async () => {
+  // The button is rendered twice — once per EmptyState variant — so this
+  // exercises the "No issues yet" copy's own click wiring. Asserting only that
+  // it exists would let a broken handler on this copy ship green, and this is
+  // the likelier path: a fresh project, or one whose issues are all archived.
+  it('offers a working archived view from a wholly empty feed', async () => {
     mocks.route.query = { project_id: 'p1' };
     window.history.replaceState({}, '', '/?project_id=p1');
     mocks.listIncidents.mockResolvedValue([]);
@@ -490,6 +494,17 @@ describe('IssuesList archived escape hatch', () => {
     await flushPromises();
 
     expect(wrapper.find('[data-testid="view-archived"]').exists()).toBe(true);
+
+    await wrapper.get('[data-testid="view-archived"]').trigger('click');
+    await flushPromises();
+
+    expect(mocks.listIncidents).toHaveBeenLastCalledWith('p1', { status: 'archived' });
+    expect(mocks.replace).toHaveBeenCalledWith({
+      query: {
+        project_id: 'p1',
+        status: 'archived',
+      },
+    });
 
     wrapper.unmount();
   });

--- a/packages/dashboard/src/views/__tests__/issues-list-filters.test.ts
+++ b/packages/dashboard/src/views/__tests__/issues-list-filters.test.ts
@@ -438,3 +438,73 @@ describe('IssuesList URL filters', () => {
     wrapper.unmount();
   });
 });
+
+describe('IssuesList archived escape hatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listAccounts.mockResolvedValue([]);
+    mocks.listEnvironments.mockResolvedValue({ environments: [], rollup_ready: false });
+    mocks.route.query = {};
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('offers the archived view from an empty filtered feed and keeps the other filters', async () => {
+    mocks.route.query = { project_id: 'p1', platform: 'python' };
+    window.history.replaceState({}, '', '/?project_id=p1&platform=python');
+    mocks.listIncidents.mockResolvedValue([]);
+
+    const wrapper = mountFeed();
+    await flushPromises();
+
+    expect(mocks.listIncidents).toHaveBeenCalledWith('p1', { platform: 'python' });
+
+    await wrapper.get('[data-testid="view-archived"]').trigger('click');
+    await flushPromises();
+
+    // Assert on the request, not the rendered text: the point of the link is
+    // the filter it applies, and it must not discard the platform filter.
+    expect(mocks.listIncidents).toHaveBeenLastCalledWith('p1', {
+      platform: 'python',
+      status: 'archived',
+    });
+
+    // The URL must follow too, or a reload drops the user back to the
+    // default view with no way to tell what happened.
+    expect(mocks.replace).toHaveBeenCalledWith({
+      query: {
+        project_id: 'p1',
+        platform: 'python',
+        status: 'archived',
+      },
+    });
+
+    wrapper.unmount();
+  });
+
+  it('offers the archived view from a wholly empty feed', async () => {
+    mocks.route.query = { project_id: 'p1' };
+    window.history.replaceState({}, '', '/?project_id=p1');
+    mocks.listIncidents.mockResolvedValue([]);
+
+    const wrapper = mountFeed();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="view-archived"]').exists()).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it('does not offer the archived view when already viewing archived', async () => {
+    mocks.route.query = { project_id: 'p1', status: 'archived' };
+    window.history.replaceState({}, '', '/?project_id=p1&status=archived');
+    mocks.listIncidents.mockResolvedValue([]);
+
+    const wrapper = mountFeed();
+    await flushPromises();
+
+    expect(mocks.listIncidents).toHaveBeenCalledWith('p1', { status: 'archived' });
+    expect(wrapper.find('[data-testid="view-archived"]').exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+});

--- a/packages/ingestion/db/archived_visibility_test.go
+++ b/packages/ingestion/db/archived_visibility_test.go
@@ -176,14 +176,14 @@ func TestListErrorGroupsArchivedFloodDoesNotEvictLiveGroups(t *testing.T) {
 				)
 			} else {
 				result, err := q.InsertErrorEventAndGroup(ctx, db.IngestParams{
-					ProjectID:     project.ID,
-					EnvironmentID: environment.ID,
-					ErrorType:     "TypeError",
-					ErrorMessage:  "live under flood",
-					StackTraceRaw: "at live.js:1:1",
-					Fingerprint:   "fp-live-under-flood",
-					Title:         "TypeError: live under flood",
-					EventTime:     base,
+					ProjectID:            project.ID,
+					DefaultEnvironmentID: environment.ID,
+					ErrorType:            "TypeError",
+					ErrorMessage:         "live under flood",
+					StackTraceRaw:        "at live.js:1:1",
+					Fingerprint:          "fp-live-under-flood",
+					Title:                "TypeError: live under flood",
+					EventTime:            base,
 				})
 				if err != nil {
 					t.Fatalf("InsertErrorEventAndGroup: %v", err)

--- a/packages/ingestion/db/archived_visibility_test.go
+++ b/packages/ingestion/db/archived_visibility_test.go
@@ -1,0 +1,214 @@
+package db_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/opslane/opslane/packages/ingestion/db"
+)
+
+func containsGroup(groups []db.ErrorGroup, groupID string) bool {
+	for _, g := range groups {
+		if g.ID == groupID {
+			return true
+		}
+	}
+	return false
+}
+
+// insertArchivedFlood inserts count archived groups of the given kind into the
+// given environment, each with last_seen newer than newerThan so they sort
+// ahead of any live fixture. Error groups also get the per-environment rollup
+// row that the environment-filtered error arm reads from; friction groups are
+// matched on error_groups.environment_id directly and need no rollup.
+func insertArchivedFlood(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	projectID, environmentID, kind, prefix string,
+	count int,
+	newerThan time.Time,
+) {
+	t.Helper()
+	ctx := context.Background()
+	for i := 0; i < count; i++ {
+		seen := newerThan.Add(time.Duration(i+1) * time.Minute)
+		fingerprint := fmt.Sprintf("%s-%d", prefix, i)
+		var id string
+		if err := pool.QueryRow(ctx, `
+			INSERT INTO error_groups
+			  (project_id, fingerprint, title, first_seen, last_seen, occurrence_count,
+			   status, kind, environment_id)
+			VALUES ($1, $2, $2, $3, $3, 1, 'archived', $4, $5)
+			RETURNING id`,
+			projectID, fingerprint, seen, kind, environmentID,
+		).Scan(&id); err != nil {
+			t.Fatalf("insert archived %s group: %v", kind, err)
+		}
+		if kind != "error" {
+			continue
+		}
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO error_group_environments
+			  (error_group_id, environment_id, first_seen, last_seen, occurrence_count)
+			VALUES ($1, $2, $3, $3, 1)`, id, environmentID, seen,
+		); err != nil {
+			t.Fatalf("insert archived rollup: %v", err)
+		}
+	}
+}
+
+func TestListErrorGroupsHidesArchivedUnlessRequested(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	_, projID, _, groupID := seedGroup(t, pool, q, "archived-hidden")
+
+	if err := q.ArchiveErrorGroup(ctx, projID, groupID); err != nil {
+		t.Fatalf("ArchiveErrorGroup: %v", err)
+	}
+
+	unfiltered, err := q.ListErrorGroups(ctx, projID, nil)
+	if err != nil {
+		t.Fatalf("ListErrorGroups unfiltered: %v", err)
+	}
+	if containsGroup(unfiltered, groupID) {
+		t.Errorf("archived group %s appeared in the unfiltered list", groupID)
+	}
+
+	requested, err := q.ListErrorGroups(ctx, projID, &db.ErrorGroupFilters{Status: "archived"})
+	if err != nil {
+		t.Fatalf("ListErrorGroups status=archived: %v", err)
+	}
+	if !containsGroup(requested, groupID) {
+		t.Errorf("archived group %s missing from the status=archived list", groupID)
+	}
+}
+
+func TestListErrorGroupsHidesArchivedInEnvironmentFilteredArms(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	_, projID, envID, errorGroupID := seedGroup(t, pool, q, "archived-env-arms")
+
+	base := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	frictionGroupID := insertFrictionGroupForEnvironment(
+		t, pool, projID, envID, "friction-archived-env", base, base, 1,
+	)
+
+	for _, id := range []string{errorGroupID, frictionGroupID} {
+		if err := q.ArchiveErrorGroup(ctx, projID, id); err != nil {
+			t.Fatalf("ArchiveErrorGroup %s: %v", id, err)
+		}
+	}
+
+	visible, err := q.ListErrorGroups(ctx, projID, &db.ErrorGroupFilters{EnvironmentID: &envID})
+	if err != nil {
+		t.Fatalf("ListErrorGroups environment-filtered: %v", err)
+	}
+	if containsGroup(visible, errorGroupID) {
+		t.Error("archived error group appeared in the environment-filtered error arm")
+	}
+	if containsGroup(visible, frictionGroupID) {
+		t.Error("archived friction group appeared in the environment-filtered friction arm")
+	}
+
+	requested, err := q.ListErrorGroups(ctx, projID, &db.ErrorGroupFilters{
+		EnvironmentID: &envID,
+		Status:        "archived",
+	})
+	if err != nil {
+		t.Fatalf("ListErrorGroups environment-filtered status=archived: %v", err)
+	}
+	if !containsGroup(requested, errorGroupID) {
+		t.Error("archived error group missing from the explicit environment-filtered archived list")
+	}
+	if !containsGroup(requested, frictionGroupID) {
+		t.Error("archived friction group missing from the explicit environment-filtered archived list")
+	}
+}
+
+// A flood of archived rows must not consume the LIMIT 100 that lives inside
+// each CTE arm. This is the case that separates a correct per-arm predicate
+// from an outer-select filter, which would pass every other test here.
+func TestListErrorGroupsArchivedFloodDoesNotEvictLiveGroups(t *testing.T) {
+	const floodSize = 101
+
+	for _, tc := range []struct {
+		name        string
+		kind        string
+		filterByEnv bool
+	}{
+		{name: "error arm environment filtered", kind: "error", filterByEnv: true},
+		{name: "friction arm environment filtered", kind: "friction", filterByEnv: true},
+		{name: "unfiltered branch error", kind: "error", filterByEnv: false},
+		{name: "unfiltered branch friction", kind: "friction", filterByEnv: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := testPool(t)
+			ctx := context.Background()
+			q := db.New(pool)
+
+			org, err := q.CreateOrg(ctx, "archived-flood-"+tc.name)
+			if err != nil {
+				t.Fatalf("CreateOrg: %v", err)
+			}
+			t.Cleanup(func() { cleanupTenant(t, pool, org.ID) })
+			project, err := q.CreateProject(ctx, org.ID, "archived-flood", nil)
+			if err != nil {
+				t.Fatalf("CreateProject: %v", err)
+			}
+			environment, err := q.CreateEnvironment(ctx, project.ID, "production")
+			if err != nil {
+				t.Fatalf("CreateEnvironment: %v", err)
+			}
+
+			// The live group is deliberately the OLDEST row, so ordering by
+			// last_seen DESC places it behind the entire flood.
+			base := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+			var liveGroupID string
+			if tc.kind == "friction" {
+				liveGroupID = insertFrictionGroupForEnvironment(
+					t, pool, project.ID, environment.ID, "friction-live-under-flood", base, base, 1,
+				)
+			} else {
+				result, err := q.InsertErrorEventAndGroup(ctx, db.IngestParams{
+					ProjectID:     project.ID,
+					EnvironmentID: environment.ID,
+					ErrorType:     "TypeError",
+					ErrorMessage:  "live under flood",
+					StackTraceRaw: "at live.js:1:1",
+					Fingerprint:   "fp-live-under-flood",
+					Title:         "TypeError: live under flood",
+					EventTime:     base,
+				})
+				if err != nil {
+					t.Fatalf("InsertErrorEventAndGroup: %v", err)
+				}
+				liveGroupID = result.GroupID
+			}
+
+			insertArchivedFlood(
+				t, pool, project.ID, environment.ID, tc.kind, "flood-"+tc.kind, floodSize, base,
+			)
+
+			var filters *db.ErrorGroupFilters
+			if tc.filterByEnv {
+				filters = &db.ErrorGroupFilters{EnvironmentID: &environment.ID}
+			}
+			groups, err := q.ListErrorGroups(ctx, project.ID, filters)
+			if err != nil {
+				t.Fatalf("ListErrorGroups: %v", err)
+			}
+			if !containsGroup(groups, liveGroupID) {
+				t.Fatalf(
+					"live group %s was evicted by %d archived rows (got %d groups)",
+					liveGroupID, floodSize, len(groups),
+				)
+			}
+		})
+	}
+}

--- a/packages/ingestion/db/archived_visibility_test.go
+++ b/packages/ingestion/db/archived_visibility_test.go
@@ -212,3 +212,134 @@ func TestListErrorGroupsArchivedFloodDoesNotEvictLiveGroups(t *testing.T) {
 		})
 	}
 }
+
+// linkAccountUser attaches a new end user carrying externalAccountID to the
+// given group, which is how both account aggregates discover incidents.
+func linkAccountUser(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	projectID, groupID, externalUserID, externalAccountID string,
+) {
+	t.Helper()
+	ctx := context.Background()
+	var userID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO end_users (project_id, external_user_id, external_account_id, account_name)
+		VALUES ($1, $2, $3, $3)
+		RETURNING id`,
+		projectID, externalUserID, externalAccountID,
+	).Scan(&userID); err != nil {
+		t.Fatalf("insert end user: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO error_group_affected_users (error_group_id, end_user_id)
+		VALUES ($1, $2)`, groupID, userID,
+	); err != nil {
+		t.Fatalf("link affected user: %v", err)
+	}
+}
+
+func accountByID(accounts []db.Account, externalAccountID string) *db.Account {
+	for i := range accounts {
+		if accounts[i].ExternalAccountID == externalAccountID {
+			return &accounts[i]
+		}
+	}
+	return nil
+}
+
+func TestAccountIncidentCountExcludesArchivedAndMatchesTheList(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	_, projID, _, groupID := seedGroup(t, pool, q, "account-archived-count")
+
+	linkAccountUser(t, pool, projID, groupID, "user-archived", "acct-archived")
+	if err := q.ArchiveErrorGroup(ctx, projID, groupID); err != nil {
+		t.Fatalf("ArchiveErrorGroup: %v", err)
+	}
+
+	account, err := q.GetAccountByID(ctx, projID, "acct-archived")
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if account == nil {
+		t.Fatal("GetAccountByID returned nil for an account whose only incident is archived")
+	}
+	if account.IncidentCount != 0 {
+		t.Errorf("IncidentCount = %d, want 0 (archived incidents are not visible)", account.IncidentCount)
+	}
+
+	// The count must equal the list rendered beneath it in AccountDetail.vue.
+	// This equality only holds below ListErrorGroups' LIMIT 100; the fixture is
+	// deliberately one incident, so the cap is not in play here.
+	incidents, err := q.ListErrorGroups(ctx, projID, &db.ErrorGroupFilters{AccountID: "acct-archived"})
+	if err != nil {
+		t.Fatalf("ListErrorGroups by account: %v", err)
+	}
+	if len(incidents) != account.IncidentCount {
+		t.Errorf("list length %d does not match IncidentCount %d", len(incidents), account.IncidentCount)
+	}
+
+	// The LEFT JOIN must survive: an account with zero visible incidents is
+	// still an account and must keep appearing in the accounts list.
+	accounts, err := q.ListAccounts(ctx, projID, nil)
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	listed := accountByID(accounts, "acct-archived")
+	if listed == nil {
+		t.Fatal("account with only archived incidents vanished from ListAccounts")
+	}
+	if listed.IncidentCount != 0 {
+		t.Errorf("ListAccounts IncidentCount = %d, want 0", listed.IncidentCount)
+	}
+}
+
+func TestAccountIncidentCountExcludesOrdinaryCandidates(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	_, projID, envID, _ := seedGroup(t, pool, q, "account-candidate-count")
+
+	// adjudication_status stays NULL: its CHECK admits only 'unchecked', and an
+	// 'unchecked' candidate is the one variety that is deliberately visible.
+	var candidateID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO error_groups
+		  (project_id, fingerprint, title, first_seen, last_seen, occurrence_count,
+		   status, kind, environment_id)
+		VALUES ($1, 'fp-ordinary-candidate', 'ordinary candidate', now(), now(), 1,
+		        'candidate', 'friction', $2)
+		RETURNING id`, projID, envID,
+	).Scan(&candidateID); err != nil {
+		t.Fatalf("insert candidate group: %v", err)
+	}
+	linkAccountUser(t, pool, projID, candidateID, "user-candidate", "acct-candidate")
+
+	account, err := q.GetAccountByID(ctx, projID, "acct-candidate")
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if account == nil {
+		t.Fatal("GetAccountByID returned nil for an account whose only incident is a candidate")
+	}
+	if account.IncidentCount != 0 {
+		t.Errorf("GetAccountByID IncidentCount = %d, want 0 (ordinary candidates are hidden workflow records)", account.IncidentCount)
+	}
+
+	// Assert ListAccounts separately: the two queries are edited independently,
+	// so covering only GetAccountByID would let a missing visibleCandidateSQL
+	// in ListAccounts ship green.
+	accounts, err := q.ListAccounts(ctx, projID, nil)
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	listed := accountByID(accounts, "acct-candidate")
+	if listed == nil {
+		t.Fatal("account with only a candidate incident vanished from ListAccounts")
+	}
+	if listed.IncidentCount != 0 {
+		t.Errorf("ListAccounts IncidentCount = %d, want 0", listed.IncidentCount)
+	}
+}

--- a/packages/ingestion/db/archived_visibility_test.go
+++ b/packages/ingestion/db/archived_visibility_test.go
@@ -239,6 +239,31 @@ func linkAccountUser(
 	}
 }
 
+// insertGroupWithStatus inserts one group with an explicit status and
+// adjudication_status so the visibility predicates can be exercised directly.
+// adjudicationStatus is nil for everything except an exhausted 'unchecked'
+// candidate — the column's CHECK admits no other value.
+func insertGroupWithStatus(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	projectID, environmentID, fingerprint, status string,
+	adjudicationStatus *string,
+) string {
+	t.Helper()
+	var id string
+	if err := pool.QueryRow(context.Background(), `
+		INSERT INTO error_groups
+		  (project_id, fingerprint, title, first_seen, last_seen, occurrence_count,
+		   status, kind, environment_id, adjudication_status)
+		VALUES ($1, $2, $2, now(), now(), 1, $3::error_group_status, 'friction', $4, $5)
+		RETURNING id`,
+		projectID, fingerprint, status, environmentID, adjudicationStatus,
+	).Scan(&id); err != nil {
+		t.Fatalf("insert %s group %s: %v", status, fingerprint, err)
+	}
+	return id
+}
+
 func accountByID(accounts []db.Account, externalAccountID string) *db.Account {
 	for i := range accounts {
 		if accounts[i].ExternalAccountID == externalAccountID {
@@ -246,6 +271,74 @@ func accountByID(accounts []db.Account, externalAccountID string) *db.Account {
 		}
 	}
 	return nil
+}
+
+// Every other account assertion in this file expects zero, which a join that
+// never matches would also satisfy — mutating the ON clause to an impossible
+// condition leaves those tests green. This one pins a non-zero count, so the
+// join has to actually match, and it covers the visible half of
+// visibleCandidateSQL: an exhausted 'unchecked' candidate still counts.
+func TestAccountIncidentCountCountsVisibleIncidents(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	_, projID, envID, liveErrorGroupID := seedGroup(t, pool, q, "account-visible-count")
+
+	const externalAccountID = "acct-mixed"
+	unchecked := "unchecked"
+
+	visible := []string{
+		liveErrorGroupID, // seeded kind='error', status='new'
+		insertGroupWithStatus(t, pool, projID, envID, "fp-mixed-insight", "insight", nil),
+		insertGroupWithStatus(t, pool, projID, envID, "fp-mixed-unchecked", "candidate", &unchecked),
+	}
+	hidden := []string{
+		insertGroupWithStatus(t, pool, projID, envID, "fp-mixed-archived", "archived", nil),
+		insertGroupWithStatus(t, pool, projID, envID, "fp-mixed-candidate", "candidate", nil),
+	}
+
+	for i, groupID := range append(append([]string{}, visible...), hidden...) {
+		linkAccountUser(t, pool, projID, groupID, fmt.Sprintf("user-mixed-%d", i), externalAccountID)
+	}
+
+	want := len(visible)
+
+	account, err := q.GetAccountByID(ctx, projID, externalAccountID)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if account == nil {
+		t.Fatal("GetAccountByID returned nil for an account with visible incidents")
+	}
+	if account.IncidentCount != want {
+		t.Errorf("GetAccountByID IncidentCount = %d, want %d", account.IncidentCount, want)
+	}
+
+	accounts, err := q.ListAccounts(ctx, projID, nil)
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	listed := accountByID(accounts, externalAccountID)
+	if listed == nil {
+		t.Fatalf("account %s missing from ListAccounts", externalAccountID)
+	}
+	if listed.IncidentCount != want {
+		t.Errorf("ListAccounts IncidentCount = %d, want %d", listed.IncidentCount, want)
+	}
+
+	// The header count and the list beneath it must agree on the same fixture.
+	incidents, err := q.ListErrorGroups(ctx, projID, &db.ErrorGroupFilters{AccountID: externalAccountID})
+	if err != nil {
+		t.Fatalf("ListErrorGroups by account: %v", err)
+	}
+	if len(incidents) != want {
+		t.Errorf("list length %d, want %d", len(incidents), want)
+	}
+	for _, groupID := range hidden {
+		if containsGroup(incidents, groupID) {
+			t.Errorf("hidden group %s appeared in the account incident list", groupID)
+		}
+	}
 }
 
 func TestAccountIncidentCountExcludesArchivedAndMatchesTheList(t *testing.T) {

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -1016,6 +1016,7 @@ func (q *Queries) ListAccounts(ctx context.Context, projectID string, query *str
 	        FROM end_users eu
 	        LEFT JOIN error_group_affected_users eau ON eau.end_user_id = eu.id
 	        LEFT JOIN error_groups eg ON eg.id = eau.error_group_id
+	             AND eg.project_id = eu.project_id
 	             AND ` + notArchivedSQL + `
 	             AND ` + visibleCandidateSQL + `
 	        WHERE eu.project_id = $1 AND eu.external_account_id IS NOT NULL`
@@ -1059,6 +1060,7 @@ func (q *Queries) GetAccountByID(ctx context.Context, projectID, externalAccount
 		 FROM end_users eu
 		 LEFT JOIN error_group_affected_users eau ON eau.end_user_id = eu.id
 		 LEFT JOIN error_groups eg ON eg.id = eau.error_group_id
+		      AND eg.project_id = eu.project_id
 		      AND `+notArchivedSQL+`
 		      AND `+visibleCandidateSQL+`
 		 WHERE eu.project_id = $1 AND eu.external_account_id = $2

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -311,6 +311,17 @@ var nonRetriableReasonCodes = map[string]struct{}{
 	// make a later investigation actionable.
 }
 
+const (
+	// Ordinary candidates are hidden workflow records (issue #56); the only
+	// visible candidate is an exhausted 'unchecked' adjudication diagnostic.
+	visibleCandidateSQL = "(eg.status <> 'candidate' OR eg.adjudication_status = 'unchecked')"
+
+	// Archived groups are permanently dismissed by the user (see
+	// requeueStatuses); they are excluded from every incident list and every
+	// account incident count unless explicitly requested by status.
+	notArchivedSQL = "eg.status <> 'archived'"
+)
+
 // requeueStatuses defines error group statuses eligible for re-queuing when a new
 // occurrence arrives. Active states (queued, analyzing) are excluded to prevent double-queuing.
 // Note: "archived" is intentionally excluded — archived groups are considered permanently
@@ -780,12 +791,15 @@ func (q *Queries) ListErrorGroups(ctx context.Context, projectID string, filters
 		return strings.Join(predicates, " AND ")
 	}
 
-	// Ordinary candidates are hidden workflow records (issue #56); the only
-	// visible candidate is an exhausted 'unchecked' adjudication diagnostic.
-	visibleCandidate := "(eg.status <> 'candidate' OR eg.adjudication_status = 'unchecked')"
 	var query string
+	// Applied only when the caller passed no status: an explicit status filter
+	// already scopes the query, and appending this would break status=archived.
+	hideArchived := statusArg == 0
 	if environmentArg == 0 {
-		wheres := []string{"eg.project_id = $1", visibleCandidate}
+		wheres := []string{"eg.project_id = $1", visibleCandidateSQL}
+		if hideArchived {
+			wheres = append(wheres, notArchivedSQL)
+		}
 		if statusArg != 0 {
 			wheres = append(wheres, fmt.Sprintf("eg.status = $%d", statusArg))
 		}
@@ -817,13 +831,17 @@ func (q *Queries) ListErrorGroups(ctx context.Context, projectID string, filters
 			fmt.Sprintf("ege.environment_id = $%d", environmentArg),
 			"eg.project_id = $1",
 			"eg.kind = 'error'",
-			visibleCandidate,
+			visibleCandidateSQL,
 		}
 		frictionWheres := []string{
 			"eg.project_id = $1",
 			"eg.kind = 'friction'",
 			fmt.Sprintf("eg.environment_id = $%d", environmentArg),
-			visibleCandidate,
+			visibleCandidateSQL,
+		}
+		if hideArchived {
+			errorWheres = append(errorWheres, notArchivedSQL)
+			frictionWheres = append(frictionWheres, notArchivedSQL)
 		}
 		if statusArg != 0 {
 			statusClause := fmt.Sprintf("eg.status = $%d", statusArg)

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -1004,13 +1004,20 @@ func (q *Queries) ListAffectedUsers(ctx context.Context, projectID, errorGroupID
 
 // ListAccounts returns aggregated accounts for a project. Tenant-scoped.
 func (q *Queries) ListAccounts(ctx context.Context, projectID string, query *string) ([]Account, error) {
+	// The visibility predicates live in the ON clause, not WHERE: in WHERE they
+	// would demote the LEFT JOIN to an inner join and drop accounts with zero
+	// visible incidents out of the list entirely. Counting eg.id rather than
+	// eau.error_group_id lets filtered-out rows contribute NULL.
 	sql := `SELECT eu.external_account_id,
 	               MAX(eu.account_name) AS account_name,
 	               COUNT(DISTINCT eu.id) AS user_count,
-	               COUNT(DISTINCT eau.error_group_id) AS incident_count,
+	               COUNT(DISTINCT eg.id) AS incident_count,
 	               MAX(eu.last_seen) AS last_seen
 	        FROM end_users eu
 	        LEFT JOIN error_group_affected_users eau ON eau.end_user_id = eu.id
+	        LEFT JOIN error_groups eg ON eg.id = eau.error_group_id
+	             AND ` + notArchivedSQL + `
+	             AND ` + visibleCandidateSQL + `
 	        WHERE eu.project_id = $1 AND eu.external_account_id IS NOT NULL`
 
 	args := []interface{}{projectID}
@@ -1042,13 +1049,18 @@ func (q *Queries) ListAccounts(ctx context.Context, projectID string, query *str
 func (q *Queries) GetAccountByID(ctx context.Context, projectID, externalAccountID string) (*Account, error) {
 	var a Account
 	err := q.pool.QueryRow(ctx,
+		// Same ON-clause / COUNT(eg.id) shape as ListAccounts; see the comment
+		// there for why the predicates cannot move into WHERE.
 		`SELECT eu.external_account_id,
 		        MAX(eu.account_name) AS account_name,
 		        COUNT(DISTINCT eu.id) AS user_count,
-		        COUNT(DISTINCT eau.error_group_id) AS incident_count,
+		        COUNT(DISTINCT eg.id) AS incident_count,
 		        MAX(eu.last_seen) AS last_seen
 		 FROM end_users eu
 		 LEFT JOIN error_group_affected_users eau ON eau.end_user_id = eu.id
+		 LEFT JOIN error_groups eg ON eg.id = eau.error_group_id
+		      AND `+notArchivedSQL+`
+		      AND `+visibleCandidateSQL+`
 		 WHERE eu.project_id = $1 AND eu.external_account_id = $2
 		 GROUP BY eu.external_account_id`,
 		projectID, externalAccountID,


### PR DESCRIPTION
Archived incidents no longer appear in incident lists, and account incident counts now count only what the list beneath them shows.

## Why

Archived incidents shared the `LIMIT 100` with live ones in `ListErrorGroups`, so they didn't just add noise — they **evicted real work from the response**. A project with 100+ archived incidents could lose live issues off the bottom of the list entirely. Filtering in the Vue layer would have left that eviction in place, so the exclusion lives in SQL.

The codebase already treated archived as terminal everywhere else: `queries.go` excludes it from `requeueStatuses` with the note that archived groups are "permanently dismissed by the user." The incident lists were the one place that didn't honour that.

## The rule

> Archived issues are excluded from every incident list unless the caller explicitly filters for `status=archived`.

An explicit status filter always wins. No third state, no `include_archived` flag to keep in sync.

## What changed

**`packages/ingestion/db/queries.go`** — two shared predicate constants (`visibleCandidateSQL`, `notArchivedSQL`) applied at five sites: the three `ListErrorGroups` WHERE builders and the two account aggregates. The archived predicate goes **inside** each environment CTE arm, not on the outer select — each arm carries its own `LIMIT 100`, so an outer filter would still let archived rows starve live ones within an arm.

**Account counts** — `ListAccounts` and `GetAccountByID` join `error_groups` with the visibility predicates so `incident_count` means *visible* incidents. Without this, an account whose incidents were all archived rendered "3 incidents" directly above "No incidents for this account." The predicates sit in the `ON` clause, not `WHERE`: in `WHERE` they demote the LEFT JOIN and drop zero-incident accounts out of the accounts list. This also closes a pre-existing version of the same bug for `candidate` groups.

**`packages/dashboard`** — the issues empty state offers "View archived issues", routed through a new `FilterBar.showArchived()` so the URL sync and other active filters are preserved. Hidden when already viewing archived.

**Poll fix** — `pollForNew` counted a length *delta*, which archiving silently defeats: 3 archived + 2 new reads as net −1, the banner stays hidden, and since the banner is the only refetch trigger the feed freezes on stale rows while real errors go unannounced. It now counts unseen ids. Archiving is the first routine action that shrinks the default feed, so this regression is one this branch introduced.

## Contract change

This deliberately changes `GET /api/v1/projects/{id}/incidents`, its account-scoped sibling, and the account `incident_count` field. No compatibility parameter, per the "no legacy shims by default" guardrail. Only `POST /api/v1/events` is frozen. `opslane errors` inherits the new default; `--status archived` still works.

Note `incident_count` will drop for any account with archived or candidate incidents. That's a correction, but it will look like data loss to anyone watching the number.

## Out of scope

`resolved` and `merged` still appear by default. `AccountDetail.vue` gets no archived escape hatch — the account view answers "what is this customer hitting," and archived means dismissed. The count/list equality holds only below `LIMIT 100`; past that the count keeps climbing while the list stops at 100, which is a far milder mismatch than the one this fixes.

## Verification

Go and Vitest suites pass (`db`, `handler`, 300 dashboard tests). The two critical test findings below were each confirmed by mutating the implementation and watching the test fail.

Beyond the suites, all ten acceptance criteria were driven against a real stack — Compose Postgres + MinIO + an ingestion image built from this branch — via the HTTP API, the `opslane` CLI, and a real browser:

- Archiving removes an incident from the default list; `?status=archived` returns it
- 102 archived rows newer than a backdated live issue: the live issue still comes back (before, it would have sat at position 103 behind the cap)
- Account with 2 visible + 1 archived + 1 candidate reports `incident_count` 2 over a 2-row list; an all-archived account stays in the accounts list at 0
- `opslane errors list` → 0 archived rows; `--status archived` → 100 archived rows, both exit 0
- Empty state offers the link, it preserves an active platform filter, and it disappears once already on the archived view
- With the page open, archiving 3 and ingesting 2 (net 8 → 7) still raised the "2 new issues" banner

Not covered: the GitHub OAuth handshake (this build has password signup disabled, so a session was minted with the stack's own signing key and then accepted by the real auth middleware), and the worker package, which this change doesn't touch.

## Review

Two `/codex` review iterations on the plan, then a pre-landing review with testing, security, and adversarial passes. Findings fixed:

- Account count tests were vacuous — every assertion expected `0`, which a join that never matches also satisfies. Mutating the ON clause to an impossible condition left the whole suite green. Added a positive-count case.
- The empty-state button renders twice; only one copy's click was tested. Replacing the other handler with a no-op passed 297 tests.
- The poll regression above.
- Account joins gained `eg.project_id = eu.project_id`, making `idx_error_groups_project_status` usable and self-scoping the count instead of leaning on a write-path invariant the schema doesn't enforce.
- Empty-state copy no longer claims "Archived issues are hidden" on a brand-new project that has never received an event.

Flagged, not fixed (both pre-existing / out of scope): `FilterBar.vue` omits `selectedEndUserId` from its watch array, so "Clear filters" is a dead click on an `end_user_id`-scoped feed; and `AccountDetail.vue` shows an all-archived account as "0 incidents / No incidents for this account", which reads as "never had an error."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
