### PR TITLE
feat(sdk): attach observed network timing to error events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ eval/results/
 
 # Real-repo Detect eval corpus (cloned on demand by cli/scripts/onboard-eval-corpus.mjs)
 .eval-corpus/
+.verify/
+.playwright-mcp/

--- a/docs/architecture/life-of-an-error.md
+++ b/docs/architecture/life-of-an-error.md
@@ -10,7 +10,7 @@ What happens between an exception in a user's browser and a ready pull request, 
 
 ## 1. Capture (browser)
 
-The SDK catches the error via global handlers (or a framework hook), attaches breadcrumbs (console, fetch/XHR, navigation), scrubs tokens and credentials from text and URLs, and POSTs to `/api/v1/events`. Session recording is enabled by default; when browser support, storage, and the project's server-side switch allow it, the SDK uploads a continuous stream of masked-input chunks and the error points into that session.
+The SDK catches the error via global handlers (or a framework hook), attaches breadcrumbs (console, fetch/XHR, navigation) and network timings, scrubs tokens and credentials from text and URLs, and POSTs to `/api/v1/events`. Session recording is enabled by default; when browser support, storage, and the project's server-side switch allow it, the SDK uploads a continuous stream of masked-input chunks and the error points into that session.
 
 ## 2. Ingest and group (ingestion API)
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -42,7 +42,7 @@ flowchart LR
 
 | Component | Runtime | Role |
 | --- | --- | --- |
-| **Browser SDK** (`packages/sdk`) | Your users' browsers | Captures errors, breadcrumbs, and default-on session recordings; masks in the browser before upload, with a server-side scrub gate before reads. MIT licensed — it runs in *your* product. |
+| **Browser SDK** (`packages/sdk`) | Your users' browsers | Captures errors, breadcrumbs, network timings, and default-on session recordings; masks in the browser before upload, with a server-side scrub gate before reads. MIT licensed — it runs in *your* product. |
 | **Ingestion API** (`packages/ingestion`) | Go service | Receives events, drops known noise, groups errors by fingerprint (family-based or platform + error type + message + stack), enqueues investigation jobs, delivers notifications, serves the dashboard SPA, and exposes the read/write API. |
 | **Worker** (`packages/worker`) | Node service | Claims jobs from Postgres, investigates with Claude, writes candidate fixes, verifies them in an E2B sandbox, and opens GitHub PRs. |
 | **Dashboard** (`packages/dashboard`) | Vue SPA, served by ingestion | Issues, replays, project and GitHub settings. |
@@ -60,3 +60,4 @@ flowchart LR
 - [Life of an error](life-of-an-error.md) — the pipeline stage by stage
 - [Precision](precision.md) — what "verified" guarantees and what it does not
 - [Trust](trust.md) — permissions, data flow, token handling, retention
+

--- a/docs/architecture/trust.md
+++ b/docs/architecture/trust.md
@@ -67,7 +67,7 @@ object at completion, so an upload interrupted before completion leaves the raw
 recording in storage. That path is retired once error replays resolve to chunk
 pointers.
 
-For error events, ingestion redacts breadcrumbs and context (sensitive headers, API-key prefixes, URL-embedded credentials) before persistence. Events matching known-noise patterns (browser-internal errors like ResizeObserver loop warnings) are suppressed before persistence. Error messages and stack traces are stored verbatim to preserve grouping fingerprints, then redacted when served.
+For error events, ingestion redacts breadcrumbs, context (sensitive headers, API-key prefixes, URL-embedded credentials), and network timings (query strings, URL-embedded credentials) before persistence. Events matching known-noise patterns (browser-internal errors like ResizeObserver loop warnings) are suppressed before persistence. Error messages and stack traces are stored verbatim to preserve grouping fingerprints, then redacted when served.
 
 See [replay privacy and masking](../guides/replay-privacy.md) for what replay data may contain.
 

--- a/docs/contracts/events.md
+++ b/docs/contracts/events.md
@@ -84,3 +84,35 @@ Ingestion sanitizes it before storage:
 
 An invalid `commit_sha` is discarded independently of otherwise valid debug
 images. Unknown fields remain tolerated under the append-only event contract.
+
+## Network timings
+
+Browser SDK 4.1.0 adds the optional top-level `network_timings` array. Each entry
+describes one observed browser request:
+
+- `transport` — `fetch` or `xhr`
+- `method` — a 1–16-byte uppercase HTTP token
+- `url` — 1–2048 bytes, no control characters
+- `started_at_ms` — epoch milliseconds
+- `duration_ms` — start to terminal event, 0–600000
+- `ttfb_ms` — optional; time to response headers, 0–600000
+- `outcome` — `ok`, `http_error`, `timeout`, `abort`, `network_error`, or `in_flight`
+- `status` — optional integer, 100–599
+
+The corresponding frozen fixtures are `v4.1.0-minimal.json` (field omitted) and
+`v4.1.0-full.json` (field populated). Older payloads remain valid.
+
+`duration_ms` is transport-dependent: `fetch` resolves when response headers
+arrive, while XHR `loadend` fires after the transfer completes. `ttfb_ms` is the
+comparable field across both. A fetch entry never reflects response-body time.
+
+The array is not chronological. The browser SDK emits still-running requests
+first, oldest start first, each with `outcome: "in_flight"`; the remaining slots
+hold settled requests, most recently settled first. Sort on `started_at_ms` if a
+consumer needs time order.
+
+Timing data is advisory and must never make event ingestion fail. Ingestion
+sanitizes it before storage: a non-array container becomes `[]`; entries failing
+any constraint above are dropped individually; at most 20 entries are retained in
+first-seen order. URLs are redacted server-side — userinfo, the full query string,
+and token-bearing fragments are stripped regardless of what the client sent.

--- a/docs/design/2026-08-06-sdk-network-timing.md
+++ b/docs/design/2026-08-06-sdk-network-timing.md
@@ -1,0 +1,342 @@
+# Browser SDK network timing capture
+
+Date: 2026-08-06
+Status: designed, not implemented
+Spec: `docs/superpowers/specs/2026-08-06-sdk-network-timing-design.md`
+Plan: `docs/superpowers/plans/2026-08-06-sdk-network-timing.md`
+
+## Problem
+
+Opslane opened [PR #1297 on `conelike/asset-management-jira`][pr] to fix a
+`TimeoutError: signal timed out`. The fix raised `FETCH_TIMEOUT` from 10000 to
+30000 in three files, and the PR was closed unmerged.
+
+The agent was not reasoning badly. It had a minified stack, breadcrumbs, and
+nothing else. The PR body records `Visual replay analysis not available` and
+`Signals not available`. The SDK reports what threw; it has never reported how
+long anything took.
+
+Concretely: `network.ts:96-107` writes a breadcrumb on fetch rejection carrying
+method, URL, and the error message, but no elapsed time. So the payload did not
+establish even that the request ran to its full deadline, let alone which of the
+plausible causes applied. Given that input, changing the constant was the only
+action the evidence supported.
+
+There is timing in the system already. `telemetry.ts:7-8` emits `request_start`
+and `request_end` with timestamps, but they ride inside the rrweb replay stream
+(`shared/src/types.ts:353-357`) and reach the agent only when replay analysis
+succeeds. On this error it did not. **Timing stored somewhere the error event
+does not reach is equivalent to timing not stored**, and that is the specific
+failure this design targets.
+
+[pr]: https://github.com/conelike/asset-management-jira/pull/1297
+
+## Goals and non-goals
+
+**Goal.** Attach observed request timing to the error event, so a later slice can
+put it in front of the investigation agent.
+
+Non-goals, each of which scopes the work:
+
+- **No `traceparent` propagation.** Adding a header to a cross-origin request
+  forces a CORS preflight, so an SDK upgrade could start failing requests that
+  worked the day before. For an error monitor that is the worst available failure
+  mode. It also returns nothing unless the customer already runs backend tracing.
+- **No continuous performance capture.** Timing leaves the browser only inside an
+  error event. No new always-on upload path, no new storage volume.
+- **No main-thread profiling.** Longtask observers and the JS Self-Profiling API
+  answer "why did the UI freeze", a different question from the one PR #1297
+  asked.
+- **No worker or agent changes in this slice.** The column is written by
+  ingestion and read by nothing. That split is deliberate; see Milestones.
+
+## What this can and cannot establish
+
+It can establish which request failed, how long it ran, whether response headers ever
+arrived, and what else was in flight beside it.
+
+It cannot establish whether the server received the request. Patch-point instrumentation
+sees only what the browser sees, and once a timeout aborts a request the browser
+cannot observe a later response. Sibling requests returning quickly is
+circumstantial evidence for one slow endpoint, not proof. Service workers, cache
+hits, CORS preflights, client-side cancellation, connection-pool contention, and
+per-request payload size all remain live alternatives.
+
+So the payoff is bounded: enough to rule out an unsupported timeout-constant
+change and to raise a more precise `needs_human` incident. Not enough to prove a
+backend fault.
+
+## Requirements
+
+| | Requirement | Verified by |
+| --- | --- | --- |
+| R1 | Every fetch and XHR that completes or fails records its elapsed time | `network-timing.test.ts`, `network.test.ts` |
+| R2 | A request still running when the error fires is recorded with elapsed-so-far | `network-timing.test.ts` in-flight case |
+| R3 | A timeout is classified from the rejection, not inferred from duration | `network.test.ts` `TimeoutError` case |
+| R4 | A long-running request survives a burst of shorter ones | `network-timing.test.ts` "20 later completions" case |
+| R5 | Timing reaches Postgres intact through ingestion | `queries_test.go`, `wire_compat_test.go` |
+| R6 | Malformed timing never fails an event | `network_timings_internal_test.go`, per-field cases |
+| R7 | URLs are redacted server-side regardless of what the client sent | `masking_test.go`, live smoke asserting `token=leak` is absent |
+| R8 | A real browser produces this on a real timeout | `browser-contract.test.ts` against a hanging server |
+
+Everything above R8 can pass while the feature does nothing in a browser, which
+is why R8 exists.
+
+## System overview
+
+```mermaid
+sequenceDiagram
+    participant App as Customer app
+    participant Patch as network.ts patches
+    participant Store as network-timing.ts
+    participant Core as core.ts buildPayload
+    participant Ing as ingestion handler
+    participant PG as Postgres
+
+    App->>Patch: fetch('/api/assets/search')
+    Patch->>Store: startTiming('fetch', 'POST', url)
+    Note over Store: active registry (max 20)
+    App->>Patch: fetch('/api/user')
+    Patch->>Store: startTiming(...)
+    Patch->>Store: markHeaders() then finalizeTiming('ok', 200)
+    Note over Store: completion ring (max 20)
+    Patch-->>App: TimeoutError after 10002ms
+    Patch->>Store: finalizeTiming('timeout')
+    App->>Core: unhandledrejection
+    Core->>Store: snapshotNetworkTimings()
+    Store-->>Core: actives longest-running first, then newest completions
+    Core->>Ing: POST /api/v1/events with network_timings
+    Ing->>Ing: sanitize, redact URLs
+    Ing->>PG: INSERT ... network_timings JSONB
+```
+
+## Component design
+
+### The timing store (`packages/sdk/src/network-timing.ts`, new)
+
+Its own module rather than growing `network.ts` (218 lines): retention policy is
+a different responsibility from patching globals, and both the fetch and XHR
+patches consume the same seam.
+
+```ts
+export interface NetworkTiming {
+  transport: 'fetch' | 'xhr';
+  method: string;
+  url: string;
+  started_at_ms: number;
+  duration_ms: number;
+  ttfb_ms?: number;
+  outcome: 'ok' | 'http_error' | 'timeout' | 'abort' | 'network_error' | 'in_flight';
+  status?: number;
+}
+```
+
+Two collections rather than one buffer, because a single FIFO ring evicts the
+record the feature exists to capture. A request open for 30 seconds becomes the oldest entry
+while shorter requests start and finish around it, so twenty subsequent requests
+drop it before its timeout ever fires. Instead: an active registry plus a ring of
+recent completions, with the snapshot taking actives first, ordered
+longest-running first.
+
+At capacity the store refuses the new request rather than evicting an existing
+one. The obvious version, evicting the newest and inserting the newer, always keeps
+the arrival that just displaced its predecessor. That inverts the policy. Refusing
+keeps the oldest twenty, which are the long-running requests being diagnosed.
+This one was caught in review after shipping into the plan with a passing test;
+the test asserted only length and the first element.
+
+Handles are never reissued, including across `clearNetworkTimings()`.
+`unpatchFetch` cannot cancel a request already awaiting (`network.ts:70`) or
+detach listeners already registered, so a callback from before `destroy()` can
+fire after re-init. Were handles to restart at zero, that stale callback would
+finalize an unrelated new request holding the reused handle.
+
+Elapsed values come from `performance.now()` while `started_at_ms` comes from
+`Date.now()`. `Date.now()` can jump backwards on NTP correction or when a laptop wakes from
+sleep, producing negative or inflated durations on exactly the long-running
+requests that matter. `started_at_ms` still needs to be an absolute timestamp so
+it correlates with breadcrumbs. Existing telemetry uses `Date.now()` for both;
+this does not change that, only declines to copy it.
+
+### Two timing milestones, one of them comparable
+
+`fetch()` resolves when response **headers** arrive. XHR `loadend` fires after the
+transfer completes. Recording one number from both compares unlike things, and the
+concurrency comparison is the main signal this feature produces.
+
+- `ttfb_ms` is time to response headers, and **it is the field that compares
+  across transports.** Fetch: promise resolution. XHR: `readystatechange` at
+  `readyState === 2`. Absent when the request ended before any headers arrived.
+- `duration_ms` is start to terminal event. Transport-dependent by construction,
+  which is why `transport` is on the wire.
+
+This recovers diagnostic power that dropping Resource Timing cost. `ttfb_ms`
+absent on a `timeout` means no headers ever arrived. Present means the server
+responded and the body stalled.
+
+**Known limitation:** for fetch, `duration_ms` never includes the body phase. A
+response whose headers arrive in 200ms and whose body hangs for 10s records as
+`ok` with `duration_ms: 200`, and a later `response.json()` abort is invisible.
+Instrumenting it means wrapping `response.body`, which risks altering stream
+semantics in customer code.
+
+### Outcome classification
+
+Fetch reads `name` structurally rather than through `instanceof Error`. In real
+browsers `AbortSignal.timeout` rejects with a `DOMException`, and that does
+inherit from `Error`. Verified: `new DOMException('x','TimeoutError') instanceof
+Error` is `true`. Polyfilled or cross-realm reasons need not, though, and
+misclassifying a timeout as `network_error` loses the one field this feature
+exists to record.
+
+A resolved fetch whose `response.type` is `opaque` or `opaqueredirect` reports
+`status: 0` with `ok === false`. Classifying on `ok` would report a working
+cross-origin request as an HTTP error, and `0` is not a storable status, so it is
+recorded as `ok` with `status` omitted.
+
+XHR has four mutually exclusive terminal events that `loadend` alone cannot
+distinguish, so each gets a listener and the first wins. `loadend` still
+registers as a fallback, so a request reaching it with no terminal event is
+recorded rather than leaking as permanently in-flight. Listeners bind once per
+XHR object, because an XHR can be reused and `once: true` removes only the
+listener that actually fired.
+
+### Ingestion (`packages/ingestion`)
+
+Follows the `debug_meta` precedent exactly (`error_event.go:304`,
+`028_event_debug_meta.sql`): a JSONB column defaulting to `'[]'`, per-entry
+validation, discards counted by reason, and **no malformed input ever fails an
+event**.
+
+The server redacts URLs independently of the SDK. The official SDK scrubs them,
+but ingestion accepts payloads from arbitrary and older clients, so shape
+validation alone would persist whatever arrived. `masking.RedactURL`
+(`masking.go:100`) already exists but deliberately preserves non-sensitive query
+parameters, leaving it weaker than the SDK's `scrubUrl`. So a stricter
+`masking.RedactRequestURL` goes in that same package.
+
+The caps are duplicated on both sides rather than trusted once. If the
+SDK's rule is looser than the sanitizer's, the SDK emits entries the server
+silently drops, and the failure is invisible. Every pair is pinned:
+
+| Limit | SDK | Ingestion |
+| --- | --- | --- |
+| Entry count | 20 | 20 |
+| URL | 2048 UTF-8 bytes | 2048 UTF-8 bytes |
+| Method | upper, 16 bytes, RFC 7230 token | upper, same token set |
+| Elapsed | clamped to 600000 | rejected above 600000 |
+| Status | omitted unless 100–599 | rejected outside 100–599 |
+| Empty URL | never recorded | rejected |
+
+The URL row is subtler than it looks: a UTF-16 `.length` cap in TypeScript
+against a byte-length check in Go lets a Unicode URL pass one and fail the other.
+
+## Milestones
+
+**M1, capture and storage (this slice).** SDK store, both patches, payload
+attachment, teardown, wire fixtures, ingestion migration and sanitizer, contract
+docs.
+
+*Exit:* the `v4.1.0` fixture pair replays through
+`TestWireFixtures_AcceptedAndStored` with `network_timings` round-tripping. The
+live smoke stores a timed-out entry and proves `token=leak` was stripped. The
+browser contract test captures a real timeout and **executes rather than
+skips**.
+
+**M2, agent consumption (separate PR).** `db.ts` select, `pipeline.ts`
+threading, a prompt section with its own truncation budget, rendered as a table
+sorted by duration descending so the outlier is the first line.
+
+*Exit:* the assembled prompt provably contains the failing request's duration.
+
+M2 is gated on M1 landing, not on a date. The split is deliberate: **M1 changes
+no diagnosis behavior**, and the PR description has to say so or it reads as a fix
+for PR #1297.
+
+The likely payoff at M2 is narrower than better fixes. Given siblings returning in
+200ms while one hangs at 10s, the right verdict for that error class is
+`unfixable_infra`: an incident naming the slow endpoint rather than a PR raising
+a constant. That reason code already exists with a remediation string. It remains
+a confidence-weighted inference, not something the data proves.
+
+## Testing and validation
+
+In CI, deterministically: SDK unit tests for retention, classification, caps, and
+teardown. Go tests for each malformed sanitizer shape and for
+`RedactRequestURL`. Wire fixtures replayed by both `wire-shape.test.ts` and
+`wire_compat_test.go`.
+
+In CI, in a browser: `browser-contract.test.ts` drives Playwright against a second
+HTTP server that accepts connections and never responds, so `AbortSignal.timeout`
+is the only thing that ends the request. It must report passed, not skipped.
+
+Live and by hand: the pipeline smoke from the root `AGENTS.md`: migrate, seed,
+rebuild, POST an event, assert the stored row.
+
+Two ways this reports success without having run, both explicitly guarded in the
+plan:
+
+- `pnpm --filter @opslane/sdk test -- <name>` does not filter. pnpm forwards
+  the `--`, vitest reads it as a separator, and the whole suite runs. Verified by
+  running it: 36 files, 311 tests, for a one-file filter.
+- `go test ./... | grep -c SKIP` prints `0` while DB tests are skipping, because
+  `go test` suppresses per-test skip lines without `-v`. The skip check also has
+  to run *after* Postgres is up, or it measures nothing.
+
+Separately, `src/__tests__/debug-id-browser.test.ts` already fails on a clean
+checkout at the base commit. It is not a regression from this work.
+
+## Risks
+
+| Risk | Blast radius | What stops it |
+| --- | --- | --- |
+| SDK throws into a customer app | Their app breaks, our fault | Every new call site wrapped in `try {} catch {}`, matching every sibling in `network.ts` |
+| Unbounded memory in a long-lived SPA | Browser tab degrades | Hard cap of 20 per collection, enforced on insert |
+| A URL leaks a credential | Persisted secret | `scrubUrl` client-side, `RedactRequestURL` server-side, independently |
+| SDK emits what ingestion drops | Silent data loss, looks like it works | Caps pinned pairwise in the table above, with the test that proves it |
+| Event grows past the 1 MiB read limit | Event rejected outright | SDK enforces the same caps ingestion does, so oversized values never leave the browser (`error_event.go:51`) |
+| **Timing lands and still doesn't help** | Wasted slice | **Unmitigated.** M2 has to actually render it into the prompt, and its value there is an inference, not a proof |
+
+The last row has no mitigation because there isn't one. This slice buys
+evidence, not conclusions.
+
+## Alternatives considered
+
+**PerformanceObserver on `resource` entries, instead of patch points.** Rejected.
+For cross-origin requests without `Timing-Allow-Origin`, `PerformanceResourceTiming`
+zeroes `domainLookupStart`, `connectStart`, `secureConnectionStart`,
+`requestStart`, and `responseStart` ([MDN][mdn]). Those are precisely the fields that would
+separate a slow server from a connection that never established, and precisely
+the requests Opslane sees are cross-origin. The phase breakdown Sentry advertises
+via `enableHTTPTimings` is mostly zeros for B2B SaaS traffic. Available later as a
+merge on top of the patch-point spine.
+
+**Enriching the existing breadcrumbs instead of a new field.** Cheaper, since
+`Breadcrumb.data` is already `Record<string, unknown>`, so no wire-contract
+change is needed. Rejected because it inherits both existing traps: the agent prompt
+truncates breadcrumbs at 1000 chars, and breadcrumbs evict after 30s
+(`breadcrumbs.ts:5`), so a 30s timeout loses its own start record. It also does
+not extend to aggregate rollups.
+
+**Continuous capture with queryable storage.** Strictly better diagnosis:
+"this endpoint's p95 went 800ms to 12s at commit X" is an answer rather than
+an inference. Rejected for now as a new ingest path, new storage, and a new cost
+profile. The wire shape is designed so it can be added without a contract break.
+
+**Client-side URL templating** (`/api/assets/:id`). Rejected: templating rules
+baked into a released SDK cannot be corrected, since customers upgrade on their
+own schedule, while server-side templating can be fixed on any deploy.
+
+**How the comparable tools do it.** Sentry patches fetch and XHR into
+`http.client` spans on a pageload transaction. PostHog wraps them into session
+replay blobs, which its own docs say are not queryable. Highlight uses
+OpenTelemetry browser auto-instrumentation feeding a traces product.
+
+All three put timing somewhere separate from the error. That is correct for
+their consumer, a human who can open the error and click across to the
+performance view. Opslane's consumer is an agent with one prompt and no ability
+to pivot. That difference is why this design puts timing on the error event, and
+it is why PostHog's "in the replay blob, not queryable" describes our current
+state rather than our target.
+
+[mdn]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming

--- a/docs/superpowers/plans/2026-08-06-sdk-network-timing.md
+++ b/docs/superpowers/plans/2026-08-06-sdk-network-timing.md
@@ -1,0 +1,1482 @@
+# Browser SDK Network Timing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture per-request network timing in the browser SDK and persist it on the error event, so a later slice can give the investigation agent evidence about timeout-class failures.
+
+**Architecture:** A new SDK module owns a bounded timing store with two internal collections — an active-request registry and a completion ring — behind a single `snapshotNetworkTimings()` seam. The existing fetch and XHR patches in `network.ts` call into it; `core.ts` attaches a snapshot to the outgoing payload. Ingestion validates and redacts the array independently of the SDK, then stores it in a new JSONB column that nothing reads yet.
+
+**Tech Stack:** TypeScript (strict, ESM), Vitest, Go 1.24 with pgx, Postgres.
+
+Spec: `docs/superpowers/specs/2026-08-06-sdk-network-timing-design.md`
+
+## Global Constraints
+
+- The SDK must never throw into customer code. Every new call site in `network.ts` is wrapped in `try {} catch {}`, matching existing siblings.
+- `POST /api/v1/events` is append-only. Add optional fields only; never edit or delete a frozen fixture under `test-fixtures/wire/`.
+- Malformed timing data must never fail ingestion.
+- Caps, identical in the SDK and in ingestion: 20 entries, `url` 2048 bytes, `method` 16 bytes, elapsed values 600000 ms.
+- Use `unknown` plus narrowing instead of `any`. Keep Vitest tests colocated in `__tests__`.
+- This PR changes no diagnosis behavior. The `network_timings` column is written by ingestion and read by nothing.
+
+---
+
+### Task 1: Shared type and the timing store
+
+**Files:**
+- Modify: `shared/src/types.ts`
+- Create: `packages/sdk/src/network-timing.ts`
+- Test: `packages/sdk/src/__tests__/network-timing.test.ts`
+
+**Interfaces:**
+- Consumes: `scrubUrl` from `packages/sdk/src/scrub.ts`
+- Produces: `NetworkTiming` (shared); `startTiming(transport, method, url): number`, `markHeaders(handle): void`, `finalizeTiming(handle, outcome, status?): void`, `discardTiming(handle): void`, `snapshotNetworkTimings(): NetworkTiming[]`, `clearNetworkTimings(): void`
+
+Kept in its own module rather than growing `network.ts` (218 lines): retention policy and outcome shaping are a separate responsibility from patching globals, and Tasks 2 and 3 both consume this one seam.
+
+- [ ] **Step 1: Add the shared type**
+
+In `shared/src/types.ts`, immediately after the `Breadcrumb` interface and its `BreadcrumbType` union:
+
+```ts
+/**
+ * One observed browser request, attached to an error event.
+ *
+ * `ttfb_ms` is the cross-transport comparable field: fetch resolves at
+ * response headers while XHR `loadend` fires after the transfer completes,
+ * so `duration_ms` means different things per transport and `transport`
+ * records which. `ttfb_ms` absent on a `timeout` means no headers ever
+ * arrived; present means the server responded and the body stalled.
+ */
+export interface NetworkTiming {
+  transport: 'fetch' | 'xhr';
+  method: string;
+  url: string;
+  started_at_ms: number;
+  duration_ms: number;
+  ttfb_ms?: number;
+  outcome: 'ok' | 'http_error' | 'timeout' | 'abort' | 'network_error' | 'in_flight';
+  status?: number;
+}
+```
+
+Add to `ErrorEventPayload`, directly below `debug_meta?: DebugMeta;`:
+
+```ts
+  network_timings?: NetworkTiming[];  // observed request timing; omitted when empty
+```
+
+- [ ] **Step 2: Build shared so the SDK can import the type**
+
+Run: `pnpm --filter @opslane/shared build`
+Expected: PASS
+
+- [ ] **Step 3: Write the failing retention tests**
+
+Create `packages/sdk/src/__tests__/network-timing.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearNetworkTimings,
+  discardTiming,
+  finalizeTiming,
+  markHeaders,
+  snapshotNetworkTimings,
+  startTiming,
+} from '../network-timing';
+
+describe('network timing store', () => {
+  beforeEach(() => clearNetworkTimings());
+
+  it('records a completed request', () => {
+    const handle = startTiming('fetch', 'GET', 'https://api.test/a');
+    markHeaders(handle);
+    finalizeTiming(handle, 'ok', 200);
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.transport).toBe('fetch');
+    expect(entry.method).toBe('GET');
+    expect(entry.url).toBe('https://api.test/a');
+    expect(entry.outcome).toBe('ok');
+    expect(entry.status).toBe(200);
+    expect(entry.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(entry.ttfb_ms).toBeGreaterThanOrEqual(0);
+    expect(entry.started_at_ms).toBeGreaterThan(0);
+  });
+
+  it('omits ttfb_ms and status when never observed', () => {
+    const handle = startTiming('fetch', 'POST', 'https://api.test/b');
+    finalizeTiming(handle, 'timeout');
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.outcome).toBe('timeout');
+    expect(entry).not.toHaveProperty('ttfb_ms');
+    expect(entry).not.toHaveProperty('status');
+  });
+
+  it('scrubs the query string and truncates oversized values', () => {
+    const handle = startTiming('fetch', 'GET', `https://api.test/c?token=secret#x`);
+    finalizeTiming(handle, 'ok', 200);
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.url).not.toContain('secret');
+
+    clearNetworkTimings();
+    const long = startTiming('xhr', 'PROPFIND-VERY-LONG-METHOD', `https://api.test/${'a'.repeat(4000)}`);
+    finalizeTiming(long, 'ok', 200);
+
+    const [big] = snapshotNetworkTimings();
+    expect(big.url.length).toBe(2048);
+    expect(big.method.length).toBe(16);
+  });
+
+  // The regression the two-collection design exists to prevent: a single FIFO
+  // buffer would evict the long-running request being diagnosed.
+  it('keeps one long-running active request across 20 later completions', () => {
+    const slow = startTiming('fetch', 'POST', 'https://api.test/slow');
+    for (let i = 0; i < 20; i += 1) {
+      const fast = startTiming('fetch', 'GET', `https://api.test/fast-${i}`);
+      finalizeTiming(fast, 'ok', 200);
+    }
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot[0].url).toBe('https://api.test/slow');
+    expect(snapshot[0].outcome).toBe('in_flight');
+    expect(snapshot).toHaveLength(20);
+    expect(slow).toBeGreaterThanOrEqual(0);
+  });
+
+  it('fills the snapshot with actives longest-running first when over the cap', () => {
+    for (let i = 0; i < 25; i += 1) startTiming('fetch', 'GET', `https://api.test/active-${i}`);
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(20);
+    expect(snapshot.every((e) => e.outcome === 'in_flight')).toBe(true);
+    expect(snapshot[0].url).toBe('https://api.test/active-0');
+  });
+
+  it('finalizes at most once', () => {
+    const handle = startTiming('xhr', 'GET', 'https://api.test/d');
+    finalizeTiming(handle, 'timeout');
+    finalizeTiming(handle, 'ok', 200);
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].outcome).toBe('timeout');
+  });
+
+  it('discards a record without recording it', () => {
+    const handle = startTiming('xhr', 'GET', 'https://api.test/e');
+    discardTiming(handle);
+    expect(snapshotNetworkTimings()).toHaveLength(0);
+  });
+
+  it('clears both collections', () => {
+    startTiming('fetch', 'GET', 'https://api.test/f');
+    const done = startTiming('fetch', 'GET', 'https://api.test/g');
+    finalizeTiming(done, 'ok', 200);
+
+    clearNetworkTimings();
+    expect(snapshotNetworkTimings()).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `pnpm --filter @opslane/sdk test -- network-timing`
+Expected: FAIL — cannot resolve `../network-timing`
+
+- [ ] **Step 5: Implement the store**
+
+Create `packages/sdk/src/network-timing.ts`:
+
+```ts
+import type { NetworkTiming } from '@opslane/shared';
+import { scrubUrl } from './scrub';
+
+/** Shared with ingestion's sanitizer; both must agree or events get rejected upstream. */
+const MAX_ENTRIES = 20;
+const MAX_URL_BYTES = 2048;
+const MAX_METHOD_BYTES = 16;
+
+export type Transport = NetworkTiming['transport'];
+export type Outcome = NetworkTiming['outcome'];
+
+interface ActiveRecord {
+  transport: Transport;
+  method: string;
+  url: string;
+  startedAtMs: number;
+  startMark: number;
+  ttfbMs?: number;
+}
+
+let active = new Map<number, ActiveRecord>();
+let completed: NetworkTiming[] = [];
+let nextHandle = 0;
+
+/**
+ * Monotonic clock. `Date.now()` can jump backwards on NTP correction or on a
+ * laptop waking from sleep, producing negative or inflated durations on
+ * exactly the long-running requests this feature exists to capture.
+ */
+function mark(): number {
+  return typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+}
+
+function cap(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+function elapsed(from: number, to: number): number {
+  return Math.max(0, Math.round(to - from));
+}
+
+export function startTiming(transport: Transport, method: string, url: string): number {
+  const handle = nextHandle;
+  nextHandle += 1;
+
+  // Evict the NEWEST active record when full, so a burst of short requests
+  // cannot displace a long-running one.
+  if (active.size >= MAX_ENTRIES) {
+    let newestKey = -1;
+    let newestMark = -Infinity;
+    for (const [key, record] of active) {
+      if (record.startMark > newestMark) {
+        newestMark = record.startMark;
+        newestKey = key;
+      }
+    }
+    if (newestKey >= 0) active.delete(newestKey);
+  }
+
+  active.set(handle, {
+    transport,
+    method: cap(method, MAX_METHOD_BYTES),
+    url: cap(scrubUrl(url), MAX_URL_BYTES),
+    startedAtMs: Date.now(),
+    startMark: mark(),
+  });
+  return handle;
+}
+
+/** Records time-to-response-headers. First call wins. */
+export function markHeaders(handle: number): void {
+  const record = active.get(handle);
+  if (!record || record.ttfbMs !== undefined) return;
+  record.ttfbMs = elapsed(record.startMark, mark());
+}
+
+/**
+ * Moves a record from active to completed. Deleting from the registry is what
+ * makes this finalize-once: XHR's `loadend` fires after every terminal event,
+ * and a second call finds nothing.
+ */
+export function finalizeTiming(handle: number, outcome: Outcome, status?: number): void {
+  const record = active.get(handle);
+  if (!record) return;
+  active.delete(handle);
+
+  const entry: NetworkTiming = {
+    transport: record.transport,
+    method: record.method,
+    url: record.url,
+    started_at_ms: record.startedAtMs,
+    duration_ms: elapsed(record.startMark, mark()),
+    outcome,
+  };
+  if (record.ttfbMs !== undefined) entry.ttfb_ms = record.ttfbMs;
+  if (status !== undefined) entry.status = status;
+
+  completed.push(entry);
+  if (completed.length > MAX_ENTRIES) completed = completed.slice(completed.length - MAX_ENTRIES);
+}
+
+/** Drops a record entirely — used when `send()` throws synchronously. */
+export function discardTiming(handle: number): void {
+  active.delete(handle);
+}
+
+export function snapshotNetworkTimings(): NetworkTiming[] {
+  const at = mark();
+  const inFlight: NetworkTiming[] = [...active.values()]
+    .sort((a, b) => a.startMark - b.startMark)
+    .slice(0, MAX_ENTRIES)
+    .map((record) => {
+      const entry: NetworkTiming = {
+        transport: record.transport,
+        method: record.method,
+        url: record.url,
+        started_at_ms: record.startedAtMs,
+        duration_ms: elapsed(record.startMark, at),
+        outcome: 'in_flight',
+      };
+      if (record.ttfbMs !== undefined) entry.ttfb_ms = record.ttfbMs;
+      return entry;
+    });
+
+  const remaining = MAX_ENTRIES - inFlight.length;
+  if (remaining <= 0) return inFlight;
+  return [...inFlight, ...completed.slice(-remaining).reverse()];
+}
+
+export function clearNetworkTimings(): void {
+  active = new Map();
+  completed = [];
+  nextHandle = 0;
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm --filter @opslane/sdk test -- network-timing`
+Expected: PASS (9 tests)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add shared/src/types.ts packages/sdk/src/network-timing.ts packages/sdk/src/__tests__/network-timing.test.ts
+git commit -m "feat(sdk): add bounded network timing store"
+```
+
+---
+
+### Task 2: Fetch instrumentation
+
+**Files:**
+- Modify: `packages/sdk/src/network.ts:43-116`
+- Test: `packages/sdk/src/__tests__/network.test.ts`
+
+**Interfaces:**
+- Consumes: `startTiming`, `markHeaders`, `finalizeTiming`, `snapshotNetworkTimings`, `clearNetworkTimings` from Task 1
+- Produces: nothing new; `patchFetch` gains timing as a side effect
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/sdk/src/__tests__/network.test.ts` (keep the file's existing imports; add the timing imports alongside them):
+
+```ts
+describe('fetch timing capture', () => {
+  beforeEach(() => {
+    clearNetworkTimings();
+    loadConfig({ apiKey: TEST_PK, endpoint: 'https://api.test', errorThrottleMs: 0 });
+  });
+  afterEach(() => unpatchFetch());
+
+  it('records ok with status and ttfb', async () => {
+    vi.stubGlobal('fetch', async () => ({ status: 200, ok: true, type: 'basic' }) as Response);
+    patchFetch();
+    await fetch('https://app.example.com/api/items');
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.transport).toBe('fetch');
+    expect(entry.outcome).toBe('ok');
+    expect(entry.status).toBe(200);
+    expect(entry.ttfb_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('records http_error for a 4xx/5xx response', async () => {
+    vi.stubGlobal('fetch', async () => ({ status: 503, ok: false, type: 'basic' }) as Response);
+    patchFetch();
+    await fetch('https://app.example.com/api/items');
+
+    expect(snapshotNetworkTimings()[0].outcome).toBe('http_error');
+  });
+
+  // An opaque response resolves successfully but reports status 0 and
+  // ok === false. Classifying on `ok` would report a working cross-origin
+  // request as an HTTP error, and status 0 fails ingestion's 100-599 check.
+  it('records an opaque response as ok with no status', async () => {
+    vi.stubGlobal('fetch', async () => ({ status: 0, ok: false, type: 'opaque' }) as Response);
+    patchFetch();
+    await fetch('https://cdn.example.com/pixel.gif');
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.outcome).toBe('ok');
+    expect(entry).not.toHaveProperty('status');
+  });
+
+  it.each([
+    ['TimeoutError', 'timeout'],
+    ['AbortError', 'abort'],
+    ['TypeError', 'network_error'],
+  ])('classifies a %s rejection as %s with no ttfb', async (name, expected) => {
+    vi.stubGlobal('fetch', async () => {
+      const error = new Error('boom');
+      error.name = name;
+      throw error;
+    });
+    patchFetch();
+    await expect(fetch('https://app.example.com/api/items')).rejects.toThrow('boom');
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.outcome).toBe(expected);
+    expect(entry).not.toHaveProperty('ttfb_ms');
+  });
+
+  it('does not time the SDK\'s own endpoint', async () => {
+    vi.stubGlobal('fetch', async () => ({ status: 200, ok: true, type: 'basic' }) as Response);
+    patchFetch();
+    await fetch('https://api.test/api/v1/events');
+
+    expect(snapshotNetworkTimings()).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @opslane/sdk test -- network`
+Expected: FAIL — `snapshotNetworkTimings()` returns `[]`
+
+- [ ] **Step 3: Wire timing into `patchFetch`**
+
+In `packages/sdk/src/network.ts`, extend the existing import block:
+
+```ts
+import { finalizeTiming, markHeaders, startTiming } from './network-timing';
+```
+
+Inside the `globalThis.fetch` replacement, directly after the existing `emitTelemetry({ kind: 'request_start', ... })` call:
+
+```ts
+    let timingHandle = -1;
+    try {
+      timingHandle = startTiming('fetch', method, url);
+    } catch {
+      // SDK must never throw
+    }
+```
+
+In the success branch, immediately after `const response = await orig.call(globalThis, input, init);`:
+
+```ts
+      try {
+        markHeaders(timingHandle);
+        // An opaque or opaque-redirect response resolves successfully but
+        // reports status 0 with ok === false. It is not an HTTP error, and
+        // 0 is not a storable status.
+        if (response.type === 'opaque' || response.type === 'opaqueredirect') {
+          finalizeTiming(timingHandle, 'ok');
+        } else {
+          finalizeTiming(timingHandle, response.status >= 400 ? 'http_error' : 'ok', response.status);
+        }
+      } catch {
+        // SDK must never throw
+      }
+```
+
+In the `catch (error: unknown)` branch, immediately after the existing `emitTelemetry({ kind: 'request_end', ... })` call:
+
+```ts
+      try {
+        const name = error instanceof Error ? error.name : '';
+        finalizeTiming(
+          timingHandle,
+          name === 'TimeoutError' ? 'timeout' : name === 'AbortError' ? 'abort' : 'network_error',
+        );
+      } catch {
+        // SDK must never throw
+      }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @opslane/sdk test -- network`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src/network.ts packages/sdk/src/__tests__/network.test.ts
+git commit -m "feat(sdk): time fetch requests, classifying opaque responses as ok"
+```
+
+---
+
+### Task 3: XHR instrumentation
+
+**Files:**
+- Modify: `packages/sdk/src/network.ts:135-207`
+- Test: `packages/sdk/src/__tests__/network.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1's store, plus `discardTiming`
+- Produces: `_opslaneTimingHandle` on the `XHRWithOpslane` interface
+
+XHR's `load`, `timeout`, `abort`, and `error` events are mutually exclusive, and `loadend` — the only event the current patch observes (`network.ts:150`) — does not say which occurred. Each gets its own listener; `finalizeTiming` deleting from the registry makes the subsequent `loadend` a no-op.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/sdk/src/__tests__/network.test.ts`. This uses the file's existing XHR mocking approach; if the file has no XHR harness yet, add this minimal fake:
+
+```ts
+class FakeXHR {
+  static instances: FakeXHR[] = [];
+  readyState = 0;
+  status = 0;
+  private listeners = new Map<string, Array<() => void>>();
+  open(_method: string, _url: string): void {}
+  send(): void {}
+  addEventListener(type: string, fn: () => void): void {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(fn);
+    this.listeners.set(type, existing);
+  }
+  emit(type: string): void {
+    for (const fn of this.listeners.get(type) ?? []) fn();
+  }
+  setReadyState(state: number): void {
+    this.readyState = state;
+    this.emit('readystatechange');
+  }
+}
+
+describe('xhr timing capture', () => {
+  beforeEach(() => {
+    clearNetworkTimings();
+    loadConfig({ apiKey: TEST_PK, endpoint: 'https://api.test', errorThrottleMs: 0 });
+    vi.stubGlobal('XMLHttpRequest', FakeXHR);
+    patchXHR();
+  });
+  afterEach(() => {
+    unpatchXHR();
+    vi.unstubAllGlobals();
+  });
+
+  function drive(terminal: string, status: number, withHeaders: boolean): void {
+    const xhr = new (globalThis.XMLHttpRequest as unknown as typeof FakeXHR)();
+    xhr.open('GET', 'https://app.example.com/api/items');
+    xhr.send();
+    if (withHeaders) xhr.setReadyState(2);
+    xhr.status = status;
+    xhr.emit(terminal);
+    xhr.emit('loadend');
+  }
+
+  it.each([
+    ['load', 200, 'ok'],
+    ['load', 500, 'http_error'],
+    ['timeout', 0, 'timeout'],
+    ['abort', 0, 'abort'],
+    ['error', 0, 'network_error'],
+  ])('maps %s/%i to %s', (terminal, status, expected) => {
+    drive(terminal, status, false);
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].transport).toBe('xhr');
+    expect(snapshot[0].outcome).toBe(expected);
+  });
+
+  it('records ttfb from HEADERS_RECEIVED, so a body-phase timeout is distinguishable', () => {
+    drive('timeout', 0, true);
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.outcome).toBe('timeout');
+    expect(entry.ttfb_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not double-finalize when loadend follows a terminal event', () => {
+    drive('timeout', 0, false);
+    expect(snapshotNetworkTimings()).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @opslane/sdk test -- network`
+Expected: FAIL — snapshot is empty
+
+- [ ] **Step 3: Extend the XHR patch**
+
+In `packages/sdk/src/network.ts`, add `discardTiming` to the `./network-timing` import.
+
+Add a field to the existing `XHRWithOpslane` interface:
+
+```ts
+  _opslaneTimingHandle?: number;
+```
+
+Inside `XMLHttpRequest.prototype.send`, replace the existing `try { ... }` telemetry block's tail so that after `this.addEventListener('loadend', ...)` for telemetry, the timing listeners are registered:
+
+```ts
+        const timingHandle = startTiming('xhr', this._opslaneMethod || 'GET', url);
+        this._opslaneTimingHandle = timingHandle;
+
+        this.addEventListener('readystatechange', () => {
+          // 2 === HEADERS_RECEIVED. This is the cross-transport comparable
+          // milestone: fetch resolves here, XHR's loadend does not.
+          if (this.readyState === 2) {
+            try { markHeaders(timingHandle); } catch { /* SDK must never throw */ }
+          }
+        });
+
+        // load/timeout/abort/error are mutually exclusive; loadend follows all
+        // of them and cannot distinguish them. finalizeTiming is idempotent.
+        const finalize = (outcome: Outcome, withStatus: boolean): void => {
+          try {
+            finalizeTiming(timingHandle, outcome, withStatus ? this.status : undefined);
+          } catch {
+            // SDK must never throw
+          }
+        };
+        this.addEventListener('load', () => finalize(this.status >= 400 ? 'http_error' : 'ok', true), { once: true });
+        this.addEventListener('timeout', () => finalize('timeout', false), { once: true });
+        this.addEventListener('abort', () => finalize('abort', false), { once: true });
+        this.addEventListener('error', () => finalize('network_error', false), { once: true });
+```
+
+Import the `Outcome` type alongside the functions:
+
+```ts
+import { discardTiming, finalizeTiming, markHeaders, startTiming, type Outcome } from './network-timing';
+```
+
+Replace the final `return origSend.apply(this, args);` so a synchronous throw removes the record rather than leaving it in flight forever:
+
+```ts
+    try {
+      return origSend.apply(this, args);
+    } catch (error) {
+      try {
+        if (this._opslaneTimingHandle !== undefined) discardTiming(this._opslaneTimingHandle);
+      } catch {
+        // SDK must never throw
+      }
+      throw error; // rethrow unchanged
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @opslane/sdk test -- network`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src/network.ts packages/sdk/src/__tests__/network.test.ts
+git commit -m "feat(sdk): time XHR requests with an explicit terminal-event matrix"
+```
+
+---
+
+### Task 4: Payload attachment and teardown
+
+**Files:**
+- Modify: `packages/sdk/src/core.ts:65-99`
+- Modify: `packages/sdk/src/index.ts:53-69`
+- Test: `packages/sdk/src/__tests__/core.test.ts`
+
+**Interfaces:**
+- Consumes: `snapshotNetworkTimings`, `clearNetworkTimings` from Task 1
+- Produces: `ErrorEventPayload.network_timings` populated on real payloads
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/sdk/src/__tests__/core.test.ts`:
+
+```ts
+describe('network timings on the payload', () => {
+  beforeEach(() => clearNetworkTimings());
+
+  it('omits the field entirely when nothing was captured', () => {
+    const payload = buildPayload('TypeError', 'boom', '', {
+      type: 'error', timestamp: new Date().toISOString(), category: 'exception', message: 'boom',
+    });
+    expect(payload).not.toHaveProperty('network_timings');
+  });
+
+  it('attaches captured timings', () => {
+    const handle = startTiming('fetch', 'GET', 'https://app.example.com/api/items');
+    finalizeTiming(handle, 'timeout');
+
+    const payload = buildPayload('TypeError', 'boom', '', {
+      type: 'error', timestamp: new Date().toISOString(), category: 'exception', message: 'boom',
+    });
+    expect(payload.network_timings).toHaveLength(1);
+    expect(payload.network_timings?.[0].outcome).toBe('timeout');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @opslane/sdk test -- core`
+Expected: FAIL — `network_timings` is undefined in the second test
+
+- [ ] **Step 3: Attach the snapshot in `buildPayload`**
+
+In `packages/sdk/src/core.ts`, add to the import block:
+
+```ts
+import { snapshotNetworkTimings } from './network-timing';
+```
+
+Replace the `return { ... }` at the end of `buildPayload` with a named object so the field can be added conditionally:
+
+```ts
+  const payload: ErrorEventPayload = {
+    timestamp: new Date().toISOString(),
+    error: {
+      type: errorType,
+      message: errorMessage,
+      stack,
+    },
+    breadcrumbs: getBreadcrumbs(),
+    context,
+    sdk_version: SDK_VERSION,
+    release: config.release || undefined,
+    commit_sha: readCommitSha(),
+    session_id: getSessionId() || undefined,
+    environment: config.environment || undefined,
+  };
+
+  // Omitted rather than sent as [], so the minimal wire fixture stays minimal.
+  const timings = snapshotNetworkTimings();
+  if (timings.length > 0) payload.network_timings = timings;
+
+  return payload;
+```
+
+- [ ] **Step 4: Clear timings on teardown**
+
+In `packages/sdk/src/index.ts`, add to the `./network` import line's neighbours:
+
+```ts
+import { clearNetworkTimings } from './network-timing';
+```
+
+In `destroy()`, directly after `safeCall(clearBreadcrumbs);`:
+
+```ts
+  safeCall(clearNetworkTimings);
+```
+
+Without this, request history survives reinitialization and can carry requests captured under one project configuration into an event sent under another.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @opslane/sdk test`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/sdk/src/core.ts packages/sdk/src/index.ts packages/sdk/src/__tests__/core.test.ts
+git commit -m "feat(sdk): attach network timings to the error payload and clear on destroy"
+```
+
+---
+
+### Task 5: Wire contract — version bump and frozen fixtures
+
+**Files:**
+- Modify: `packages/sdk/package.json:3`
+- Create: `test-fixtures/wire/events/v4.1.0-minimal.json`
+- Create: `test-fixtures/wire/events/v4.1.0-full.json`
+- Modify: `packages/sdk/src/__tests__/wire-shape.test.ts:20,33-56,120-176`
+
+**Interfaces:**
+- Consumes: Task 4's payload attachment
+- Produces: frozen fixtures replayed by `wire_compat_test.go` in Task 7
+
+`WIRE_FIXTURE_VERSION` currently reads `3.0.0` against a `4.0.0` package. `docs/contracts/events.md:17` requires a pair for every released SDK version, so that gap is pre-existing repository debt — add the `4.1.0` pair this change introduces and do not backfill `4.0.0`.
+
+- [ ] **Step 1: Bump the package version**
+
+In `packages/sdk/package.json`, change `"version": "4.0.0"` to `"version": "4.1.0"`. Adding an optional field is a minor bump.
+
+- [ ] **Step 2: Create the minimal fixture**
+
+Create `test-fixtures/wire/events/v4.1.0-minimal.json` — identical to `v3.0.0-minimal.json` with the version changed, and **no** `network_timings` key, encoding that the field is omitted when empty:
+
+```json
+{
+  "timestamp": "2026-07-16T00:00:00.000Z",
+  "error": {
+    "type": "TypeError",
+    "message": "Cannot read properties of null (reading 'name')",
+    "stack": "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)"
+  },
+  "breadcrumbs": [],
+  "context": {
+    "url": "https://app.example.com/dashboard",
+    "user_agent": "Mozilla/5.0"
+  },
+  "sdk_version": "4.1.0"
+}
+```
+
+- [ ] **Step 3: Create the full fixture**
+
+Copy the existing full fixture and edit it, rather than retyping fields:
+
+```bash
+cp test-fixtures/wire/events/v3.0.0-full.json test-fixtures/wire/events/v4.1.0-full.json
+```
+
+Then in `v4.1.0-full.json`: change `"sdk_version"` to `"4.1.0"`, and add a top-level `network_timings` key:
+
+```json
+  "network_timings": [
+    {
+      "transport": "fetch",
+      "method": "POST",
+      "url": "https://api.example.com/v1/assets/search",
+      "started_at_ms": 1784160000000,
+      "duration_ms": 10002,
+      "outcome": "timeout"
+    }
+  ]
+```
+
+`ttfb_ms` is deliberately absent — this fixture encodes the PR #1297 shape, where no response headers ever arrived.
+
+- [ ] **Step 4: Update the wire-shape test**
+
+In `packages/sdk/src/__tests__/wire-shape.test.ts`:
+
+Change line 20 to:
+
+```ts
+const WIRE_FIXTURE_VERSION = '4.1.0';
+```
+
+Add to the import block:
+
+```ts
+import { clearNetworkTimings, finalizeTiming, startTiming } from '../network-timing';
+```
+
+Inside `normalize()`, before the closing `return value;`, sentinel the volatile timing values — durations and wall-clock starts vary per run, exactly like `timestamp`:
+
+```ts
+  if (Array.isArray(value.network_timings)) {
+    for (const timing of value.network_timings as Array<Record<string, unknown>>) {
+      if (!timing) continue;
+      if (typeof timing.started_at_ms === 'number') timing.started_at_ms = SENTINEL;
+      if (typeof timing.duration_ms === 'number') timing.duration_ms = SENTINEL;
+      if (typeof timing.ttfb_ms === 'number') timing.ttfb_ms = SENTINEL;
+    }
+  }
+```
+
+In the top-level `beforeEach`, add alongside `clearBreadcrumbs()`:
+
+```ts
+    clearNetworkTimings();
+```
+
+In the `'full payload matches the frozen fixture'` test, directly before the `const wire = await captureWire(...)` line, seed one timing matching the fixture:
+
+```ts
+    const timingHandle = startTiming('fetch', 'POST', 'https://api.example.com/v1/assets/search');
+    finalizeTiming(timingHandle, 'timeout');
+```
+
+- [ ] **Step 5: Run the wire-shape test**
+
+Run: `pnpm --filter @opslane/sdk build && pnpm --filter @opslane/sdk test -- wire-shape`
+Expected: PASS. The build is required because `sdk_version` is injected at build time.
+
+- [ ] **Step 6: Verify no frozen fixture was modified**
+
+Run: `git status --porcelain test-fixtures/wire/`
+Expected: only two lines, both `??` (untracked new files). Any ` M` line is a contract violation — revert it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/sdk/package.json test-fixtures/wire/events/v4.1.0-minimal.json test-fixtures/wire/events/v4.1.0-full.json packages/sdk/src/__tests__/wire-shape.test.ts
+git commit -m "test(sdk): freeze the v4.1.0 wire shape with network_timings"
+```
+
+---
+
+### Task 6: Strict request-URL redaction in the masking package
+
+**Files:**
+- Modify: `packages/ingestion/masking/masking.go`
+- Test: `packages/ingestion/masking/masking_test.go`
+
+**Interfaces:**
+- Consumes: existing `RedactURL`
+- Produces: `masking.RedactRequestURL(raw string) string`, consumed by Task 7
+
+Ingestion accepts payloads from arbitrary and older clients, so shape validation alone would persist unsanitized URLs. `RedactURL` exists but deliberately preserves non-sensitive query parameters, leaving it weaker than the SDK's `scrubUrl`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/ingestion/masking/masking_test.go`:
+
+```go
+func TestRedactRequestURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"drops the whole query string", "https://api.example.com/v1/search?q=hi&token=abc", "https://api.example.com/v1/search"},
+		{"drops userinfo", "https://user:pw@api.example.com/v1/search", "https://api.example.com/v1/search"},
+		{"drops a token-bearing fragment", "https://api.example.com/cb#access_token=abc", "https://api.example.com/cb"},
+		{"keeps a route fragment", "https://app.example.com/x#/dashboard", "https://app.example.com/x#/dashboard"},
+		{"leaves a clean URL alone", "https://api.example.com/v1/items", "https://api.example.com/v1/items"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RedactRequestURL(tc.in); got != tc.want {
+				t.Fatalf("RedactRequestURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRedactRequestURLUnparseable(t *testing.T) {
+	// Falls back to RedactURL rather than returning the raw value.
+	got := RedactRequestURL("://not a url?token=abc")
+	if strings.Contains(got, "abc") {
+		t.Fatalf("RedactRequestURL leaked a token: %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/ingestion && go test ./masking/ -run RedactRequestURL`
+Expected: FAIL — undefined: RedactRequestURL
+
+- [ ] **Step 3: Implement it**
+
+In `packages/ingestion/masking/masking.go`, add `"net/url"` to the import block, then add below `RedactURL`:
+
+```go
+// tokenFragmentRe matches fragments carrying an OAuth-style credential.
+var tokenFragmentRe = regexp.MustCompile(`(?i)\b(access_token|id_token|refresh_token|token|code)=`)
+
+// RedactRequestURL strips userinfo, the entire query string, and token-bearing
+// fragments from a single request URL. It is deliberately stricter than
+// RedactURL, which preserves non-sensitive query parameters: request URLs
+// captured from a customer's browser must retain no query data at all, and
+// ingestion cannot assume the client already scrubbed them.
+func RedactRequestURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return RedactURL(raw)
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.ForceQuery = false
+	if u.Fragment != "" && tokenFragmentRe.MatchString(u.Fragment) {
+		u.Fragment = ""
+	}
+	return u.String()
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/ingestion && go test ./masking/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/masking/
+git commit -m "feat(ingestion): add strict request-URL redaction"
+```
+
+---
+
+### Task 7: Ingestion sanitizer
+
+**Files:**
+- Modify: `packages/ingestion/handler/error_event.go:90-145`
+- Modify: `packages/ingestion/handler/metrics.go`
+- Test: `packages/ingestion/handler/error_event_test.go`
+
+**Interfaces:**
+- Consumes: `masking.RedactRequestURL` from Task 6
+- Produces: `sanitizeNetworkTimings(raw json.RawMessage) string` returning JSON, defaulting to `"[]"`; `RecordNetworkTimingDiscard(reason string)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/ingestion/handler/error_event_test.go`:
+
+```go
+func TestSanitizeNetworkTimings(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"absent", ``, `[]`},
+		{"non-array container", `{"a":1}`, `[]`},
+		{"non-object entry", `["x"]`, `[]`},
+		{"bad transport", `[{"transport":"grpc","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok"}]`, `[]`},
+		{"bad method", `[{"transport":"fetch","method":"get!","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok"}]`, `[]`},
+		{"bad outcome", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"weird"}]`, `[]`},
+		{"negative duration", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":-2,"outcome":"ok"}]`, `[]`},
+		{"duration over cap", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":600001,"outcome":"ok"}]`, `[]`},
+		{"control chars in url", "[{\"transport\":\"fetch\",\"method\":\"GET\",\"url\":\"https://a.test/\\u0000\",\"started_at_ms\":1,\"duration_ms\":2,\"outcome\":\"ok\"}]", `[]`},
+		{"status out of range", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok","status":0}]`, `[]`},
+		{
+			"valid entry is retained and its query stripped",
+			`[{"transport":"fetch","method":"get","url":"https://a.test/x?token=abc","started_at_ms":1,"duration_ms":2,"outcome":"timeout"}]`,
+			`[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"timeout"}]`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeNetworkTimings(json.RawMessage(tc.in))
+			if got != tc.want {
+				t.Fatalf("sanitizeNetworkTimings(%s) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeNetworkTimingsCapsAtTwenty(t *testing.T) {
+	var entries []string
+	for i := 0; i < 30; i++ {
+		entries = append(entries, `{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok","status":200}`)
+	}
+	raw := "[" + strings.Join(entries, ",") + "]"
+
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(sanitizeNetworkTimings(json.RawMessage(raw))), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 20 {
+		t.Fatalf("retained %d entries, want 20", len(got))
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ingestion && go test ./handler/ -run NetworkTimings`
+Expected: FAIL — undefined: sanitizeNetworkTimings
+
+- [ ] **Step 3: Implement the sanitizer**
+
+In `packages/ingestion/handler/error_event.go`, add the import for the masking package if absent, then add near `sanitizeDebugMeta`:
+
+```go
+const (
+	maxNetworkTimings   = 20
+	maxTimingURLBytes   = 2048
+	maxTimingElapsedMs  = 600000
+)
+
+var (
+	reTimingMethod    = regexp.MustCompile(`^[A-Z]{1,16}$`)
+	validTransports   = map[string]struct{}{"fetch": {}, "xhr": {}}
+	validTimingOutcome = map[string]struct{}{
+		"ok": {}, "http_error": {}, "timeout": {},
+		"abort": {}, "network_error": {}, "in_flight": {},
+	}
+)
+
+type validatedNetworkTiming struct {
+	Transport   string `json:"transport"`
+	Method      string `json:"method"`
+	URL         string `json:"url"`
+	StartedAtMs int64  `json:"started_at_ms"`
+	DurationMs  int64  `json:"duration_ms"`
+	TTFBMs      *int64 `json:"ttfb_ms,omitempty"`
+	Outcome     string `json:"outcome"`
+	Status      *int   `json:"status,omitempty"`
+}
+
+func validTimingURL(value string) bool {
+	if len(value) == 0 || len(value) > maxTimingURLBytes {
+		return false
+	}
+	return strings.IndexFunc(value, func(r rune) bool { return r < 0x20 || r == 0x7f }) < 0
+}
+
+func validElapsed(value int64) bool {
+	return value >= 0 && value <= maxTimingElapsedMs
+}
+
+// sanitizeNetworkTimings validates advisory request timing. Like debug_meta,
+// malformed data is discarded rather than failing the event. URLs are redacted
+// here independently of the SDK, because ingestion accepts payloads from
+// arbitrary and older clients.
+func sanitizeNetworkTimings(raw json.RawMessage) string {
+	const empty = `[]`
+	if len(raw) == 0 {
+		return empty
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		RecordNetworkTimingDiscard("malformed_container")
+		return empty
+	}
+
+	var entries []json.RawMessage
+	if err := json.Unmarshal(trimmed, &entries); err != nil || entries == nil {
+		RecordNetworkTimingDiscard("malformed_container")
+		return empty
+	}
+
+	retained := make([]validatedNetworkTiming, 0, min(len(entries), maxNetworkTimings))
+	for _, entry := range entries {
+		if len(retained) == maxNetworkTimings {
+			RecordNetworkTimingDiscard("over_limit")
+			continue
+		}
+
+		var candidate validatedNetworkTiming
+		trimmedEntry := bytes.TrimSpace(entry)
+		if len(trimmedEntry) == 0 || trimmedEntry[0] != '{' || json.Unmarshal(trimmedEntry, &candidate) != nil {
+			RecordNetworkTimingDiscard("non_object_entry")
+			continue
+		}
+		if _, ok := validTransports[candidate.Transport]; !ok {
+			RecordNetworkTimingDiscard("bad_transport")
+			continue
+		}
+		candidate.Method = strings.ToUpper(candidate.Method)
+		if !reTimingMethod.MatchString(candidate.Method) {
+			RecordNetworkTimingDiscard("bad_method")
+			continue
+		}
+		if !validTimingURL(candidate.URL) {
+			RecordNetworkTimingDiscard("bad_url")
+			continue
+		}
+		if _, ok := validTimingOutcome[candidate.Outcome]; !ok {
+			RecordNetworkTimingDiscard("bad_outcome")
+			continue
+		}
+		// An epoch value, so only checked for non-negativity — the elapsed cap
+		// does not apply to it.
+		if candidate.StartedAtMs < 0 {
+			RecordNetworkTimingDiscard("bad_started_at")
+			continue
+		}
+		if !validElapsed(candidate.DurationMs) {
+			RecordNetworkTimingDiscard("bad_duration")
+			continue
+		}
+		if candidate.TTFBMs != nil && !validElapsed(*candidate.TTFBMs) {
+			RecordNetworkTimingDiscard("bad_ttfb")
+			continue
+		}
+		if candidate.Status != nil && (*candidate.Status < 100 || *candidate.Status > 599) {
+			RecordNetworkTimingDiscard("bad_status")
+			continue
+		}
+
+		candidate.URL = masking.RedactRequestURL(candidate.URL)
+		if !validTimingURL(candidate.URL) {
+			RecordNetworkTimingDiscard("bad_url")
+			continue
+		}
+		retained = append(retained, candidate)
+	}
+
+	encoded, err := json.Marshal(retained)
+	if err != nil {
+		return empty
+	}
+	return string(encoded)
+}
+```
+
+- [ ] **Step 4: Add the metric**
+
+In `packages/ingestion/handler/metrics.go`, mirror `RecordDebugMetaDiscard` and its `/metrics` output block, using the name `opslane_network_timings_discarded_total` with a `reason` label and the help text `Network timing entries discarded during validation`.
+
+- [ ] **Step 5: Call it from the ingest path**
+
+In `error_event.go`, add to the anonymous `payload` struct after `DebugMeta`:
+
+```go
+		NetworkTimings json.RawMessage `json:"network_timings"`
+```
+
+and next to the existing `debugMeta := sanitizeDebugMeta(...)` line:
+
+```go
+	networkTimings := sanitizeNetworkTimings(payload.NetworkTimings)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd packages/ingestion && go test ./handler/ -run NetworkTimings && go build ./...`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ingestion/handler/
+git commit -m "feat(ingestion): validate and redact network timings"
+```
+
+---
+
+### Task 8: Migration and storage
+
+**Files:**
+- Create: `packages/ingestion/db/migrations/033_event_network_timings.sql`
+- Modify: `packages/ingestion/db/queries.go:415-470,519-523`
+- Modify: `packages/ingestion/handler/error_event.go:230-250`
+- Test: `packages/ingestion/db/queries_test.go`
+
+**Interfaces:**
+- Consumes: `sanitizeNetworkTimings` from Task 7
+- Produces: `IngestParams.NetworkTimings string`; `error_events.network_timings` JSONB column
+
+- [ ] **Step 1: Write the migration**
+
+Create `packages/ingestion/db/migrations/033_event_network_timings.sql`:
+
+```sql
+SET lock_timeout = '3s';
+
+-- Written by ingestion, read by nothing. The worker slice that renders these
+-- into the investigation prompt lands separately; an unread column here is
+-- intentional, not dead schema.
+ALTER TABLE error_events
+  ADD COLUMN IF NOT EXISTS network_timings JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE error_events DROP CONSTRAINT IF EXISTS error_events_network_timings_array;
+ALTER TABLE error_events ADD CONSTRAINT error_events_network_timings_array
+  CHECK (jsonb_typeof(network_timings) = 'array') NOT VALID;
+
+ALTER TABLE error_events VALIDATE CONSTRAINT error_events_network_timings_array;
+```
+
+Note the existing duplicate `028_` prefix in this directory is pre-existing debt; `033` is the next free number.
+
+- [ ] **Step 2: Thread the field through `IngestParams`**
+
+In `packages/ingestion/db/queries.go`, add below `DebugMeta`:
+
+```go
+	NetworkTimings string // JSON array, defaults to "[]"
+```
+
+In `InsertErrorEventAndGroup`, below the existing `DebugMeta` default:
+
+```go
+	if p.NetworkTimings == "" {
+		p.NetworkTimings = "[]"
+	}
+```
+
+Extend the INSERT at line 519 — add `network_timings` to the column list, `$14::jsonb` to VALUES, and `p.NetworkTimings` as the final argument.
+
+- [ ] **Step 3: Pass it from the handler**
+
+In `error_event.go`, add to the `IngestParams` literal after `DebugMeta:`:
+
+```go
+		NetworkTimings:       networkTimings,
+```
+
+- [ ] **Step 4: Write the failing round-trip test**
+
+Append to `packages/ingestion/db/queries_test.go`, following the file's existing DB-test setup helpers:
+
+```go
+func TestInsertErrorEventStoresNetworkTimings(t *testing.T) {
+	q, projectID := setupTestProject(t)
+	timings := `[{"transport":"fetch","method":"POST","url":"https://api.test/search","started_at_ms":1,"duration_ms":10002,"outcome":"timeout"}]`
+
+	result, err := q.InsertErrorEventAndGroup(context.Background(), IngestParams{
+		ProjectID:      projectID,
+		ErrorType:      "TimeoutError",
+		ErrorMessage:   "signal timed out",
+		Fingerprint:    "fp-timing",
+		Title:          "TimeoutError: signal timed out",
+		NetworkTimings: timings,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	var stored string
+	if err := q.pool.QueryRow(context.Background(),
+		`SELECT network_timings::text FROM error_events WHERE id = $1`, result.EventID,
+	).Scan(&stored); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if !strings.Contains(stored, `"outcome": "timeout"`) && !strings.Contains(stored, `"outcome":"timeout"`) {
+		t.Fatalf("stored timings missing outcome: %s", stored)
+	}
+}
+```
+
+Adapt `setupTestProject` to whatever the file's existing helper is named — do not introduce a second one.
+
+- [ ] **Step 5: Apply migrations and run the tests**
+
+```bash
+export DATABASE_URL="postgres://opslane:opslane_dev@localhost:${OPSLANE_POSTGRES_HOST_PORT:-5434}/opslane?sslmode=disable"
+cd packages/ingestion && go test ./db/ -run NetworkTimings -v
+```
+
+Expected: PASS, and **not** `SKIP`. A skip means `DATABASE_URL` is unset and the test never ran.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ingestion/db/ packages/ingestion/handler/error_event.go
+git commit -m "feat(ingestion): store network timings on error events"
+```
+
+---
+
+### Task 9: Wire-compat replay and contract documentation
+
+**Files:**
+- Modify: `docs/contracts/events.md`
+- Test: `packages/ingestion/handler/wire_compat_test.go`
+
+**Interfaces:**
+- Consumes: fixtures from Task 5, sanitizer from Task 7, column from Task 8
+
+- [ ] **Step 1: Run the existing wire-compat suite against the new fixtures**
+
+Run: `cd packages/ingestion && go test ./handler/ -run WireCompat -v`
+Expected: PASS, including the two new `v4.1.0` files. The suite discovers fixtures from the directory, so no test change should be needed — if it hardcodes a version list, add `4.1.0` to it.
+
+- [ ] **Step 2: Document the field**
+
+Append a section to `docs/contracts/events.md`, after the existing "Build provenance and debug images" section:
+
+```markdown
+## Network timings
+
+Browser SDK 4.1.0 adds the optional top-level `network_timings` array. Each entry
+describes one observed browser request:
+
+- `transport` — `fetch` or `xhr`
+- `method` — 1–16 uppercase letters
+- `url` — 1–2048 bytes, no control characters
+- `started_at_ms` — epoch milliseconds
+- `duration_ms` — start to terminal event, 0–600000
+- `ttfb_ms` — optional; time to response headers, 0–600000
+- `outcome` — `ok`, `http_error`, `timeout`, `abort`, `network_error`, or `in_flight`
+- `status` — optional integer, 100–599
+
+The corresponding frozen fixtures are `v4.1.0-minimal.json` (field omitted) and
+`v4.1.0-full.json` (field populated). Older payloads remain valid.
+
+`duration_ms` is transport-dependent: `fetch` resolves when response headers
+arrive, while XHR `loadend` fires after the transfer completes. `ttfb_ms` is the
+comparable field across both. A fetch entry never reflects response-body time.
+
+Timing data is advisory and must never make event ingestion fail. Ingestion
+sanitizes it before storage: a non-array container becomes `[]`; entries failing
+any constraint above are dropped individually; at most 20 entries are retained in
+first-seen order. URLs are redacted server-side — userinfo, the full query string,
+and token-bearing fragments are stripped regardless of what the client sent.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/contracts/events.md packages/ingestion/handler/wire_compat_test.go
+git commit -m "docs: document the network_timings wire field"
+```
+
+---
+
+### Task 10: Full gate and live smoke
+
+**Files:** none modified — this task proves the previous nine.
+
+- [ ] **Step 1: Run the full repository gate**
+
+```bash
+pnpm install --frozen-lockfile
+pnpm -r build
+pnpm test
+(cd packages/ingestion && go build ./... && go test ./...)
+docker compose config --quiet
+```
+
+Expected: all pass. Read the **skip count**, not the pass count — database-gated suites report skipped rather than failed when `DATABASE_URL` is unset.
+
+- [ ] **Step 2: Export the worktree port block as a unit**
+
+```bash
+export INGESTION_PORT=8092
+export OPSLANE_POSTGRES_HOST_PORT=5444
+export OPSLANE_MINIO_HOST_PORT=9022
+export INGESTION_URL="http://localhost:$INGESTION_PORT"
+export DATABASE_URL="postgres://opslane:opslane_dev@localhost:$OPSLANE_POSTGRES_HOST_PORT/opslane?sslmode=disable"
+export MINIO_ENDPOINT="http://localhost:$OPSLANE_MINIO_HOST_PORT"
+export REPLAY_STORE_ENDPOINT="$MINIO_ENDPOINT"
+export REPLAY_STORE_PUBLIC_ENDPOINT="$MINIO_ENDPOINT"
+export MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=minio12345 MINIO_BUCKET=opslane-replays
+export REPLAY_STORE_ACCESS_KEY=minio REPLAY_STORE_SECRET_KEY=minio12345 REPLAY_STORE_BUCKET=opslane-replays
+```
+
+Setting a port without its URL is the silent failure mode: Go DB tests fall back to the hardcoded `localhost:5434` DSN and skip instead of failing.
+
+- [ ] **Step 3: Confirm Go tests run with zero skips**
+
+Run: `cd packages/ingestion && go test ./... 2>&1 | grep -c SKIP`
+Expected: `0`. A storage misconfiguration reports `ok` while roughly 30 tests never run.
+
+- [ ] **Step 4: Bring the stack up and apply migrations**
+
+```bash
+docker compose up -d postgres minio
+docker compose build ingestion && docker compose up -d ingestion
+psql "$DATABASE_URL" -f scripts/seed-e2e.sql
+```
+
+- [ ] **Step 5: Post an event carrying timings and assert it stored**
+
+```bash
+curl -sS -X POST "$INGESTION_URL/api/v1/events" \
+  -H 'Content-Type: application/json' \
+  -H "X-Opslane-Key: $(psql "$DATABASE_URL" -tAc "SELECT public_key FROM project_api_keys LIMIT 1")" \
+  -d '{
+    "timestamp": "2026-08-06T00:00:00.000Z",
+    "error": {"type":"TimeoutError","message":"signal timed out","stack":""},
+    "breadcrumbs": [],
+    "context": {"url":"https://app.example.com/assets"},
+    "sdk_version": "4.1.0",
+    "network_timings": [
+      {"transport":"fetch","method":"POST","url":"https://api.example.com/v1/assets/search?token=leak","started_at_ms":1784160000000,"duration_ms":10002,"outcome":"timeout"},
+      {"transport":"fetch","method":"GET","url":"https://api.example.com/v1/user","started_at_ms":1784160000100,"duration_ms":184,"ttfb_ms":170,"outcome":"ok","status":200}
+    ]
+  }'
+
+psql "$DATABASE_URL" -c \
+  "SELECT jsonb_pretty(network_timings) FROM error_events ORDER BY created_at DESC LIMIT 1;"
+```
+
+Expected: both entries stored; the first has `"outcome": "timeout"` with no `ttfb_ms` key; **neither URL contains `token=leak`**, proving server-side redaction ran independently of the SDK.
+
+- [ ] **Step 6: Confirm the auth header name**
+
+If the `curl` returns 401, read the key header name from `packages/ingestion/handler/routes.go` and correct the command rather than disabling auth.
+
+- [ ] **Step 7: Commit any fixes and open the PR**
+
+The PR description must state that this changes no diagnosis behavior and that the column is read by nothing until the worker slice lands, or it will be misread as a fix for the timeout-diagnosis problem.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Wire shape → Task 1. Timing milestones and `ttfb_ms` → Tasks 1–3. Fetch outcome matrix including opaque → Task 2. XHR matrix, finalize-once, sync-throw → Task 3. Retention with active registry and completion ring → Task 1. `destroy()` clearing → Task 4. Field omitted when empty → Tasks 4 and 5. SDK caps → Task 1. Migration and storage → Task 8. Ingestion validation → Task 7. Independent server-side redaction → Tasks 6 and 7. Fixtures and the version-debt note → Task 5. Contract docs → Task 9. Live smoke with zero skips → Task 10.
+
+**Not covered by any task, by design:** the spec's "what this does not deliver" items — worker consumption, backend correlation, fetch body-phase timing, aggregates.
+
+**Type consistency.** `snapshotNetworkTimings`, `startTiming`, `markHeaders`, `finalizeTiming`, `discardTiming`, `clearNetworkTimings` are named identically in Tasks 1–5. `NetworkTiming` field names match between `shared/src/types.ts` (Task 1), the fixtures (Task 5), and `validatedNetworkTiming`'s JSON tags (Task 7). The cap of 20 appears in Task 1 (`MAX_ENTRIES`) and Task 7 (`maxNetworkTimings`) and must stay equal.

--- a/docs/superpowers/plans/2026-08-06-sdk-network-timing.md
+++ b/docs/superpowers/plans/2026-08-06-sdk-network-timing.md
@@ -76,7 +76,7 @@ Expected: PASS
 Create `packages/sdk/src/__tests__/network-timing.test.ts`:
 
 ```ts
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearNetworkTimings,
   discardTiming,
@@ -123,12 +123,23 @@ describe('network timing store', () => {
     expect(entry.url).not.toContain('secret');
 
     clearNetworkTimings();
-    const long = startTiming('xhr', 'PROPFIND-VERY-LONG-METHOD', `https://api.test/${'a'.repeat(4000)}`);
+    const long = startTiming('xhr', 'propfind-very-long-method', `https://api.test/${'a'.repeat(4000)}`);
     finalizeTiming(long, 'ok', 200);
 
     const [big] = snapshotNetworkTimings();
     expect(big.url.length).toBe(2048);
-    expect(big.method.length).toBe(16);
+    expect(big.method).toBe('PROPFIND-VERY-LO');
+  });
+
+  // Ingestion measures the URL in UTF-8 bytes. A UTF-16 `.length` cap would
+  // emit a value the SDK considers legal and the Go sanitizer drops.
+  it('truncates the url by utf-8 bytes, not utf-16 units', () => {
+    const handle = startTiming('fetch', 'GET', `https://api.test/${'é'.repeat(2000)}`);
+    finalizeTiming(handle, 'ok', 200);
+
+    const [entry] = snapshotNetworkTimings();
+    expect(new TextEncoder().encode(entry.url).length).toBeLessThanOrEqual(2048);
+    expect(entry.url).not.toMatch(/�$/);
   });
 
   // The regression the two-collection design exists to prevent: a single FIFO
@@ -147,13 +158,77 @@ describe('network timing store', () => {
     expect(slow).toBeGreaterThanOrEqual(0);
   });
 
-  it('fills the snapshot with actives longest-running first when over the cap', () => {
-    for (let i = 0; i < 25; i += 1) startTiming('fetch', 'GET', `https://api.test/active-${i}`);
+  // Locks the retention policy end to end: the OLDEST 20 are kept and the
+  // arrivals that came after them are refused, not the reverse.
+  it('refuses new requests at capacity and keeps the oldest twenty', () => {
+    const handles = [];
+    for (let i = 0; i < 25; i += 1) handles.push(startTiming('fetch', 'GET', `https://api.test/active-${i}`));
+
+    expect(handles[19]).not.toBe(-1);
+    expect(handles[20]).toBe(-1);
+    expect(handles[24]).toBe(-1);
 
     const snapshot = snapshotNetworkTimings();
     expect(snapshot).toHaveLength(20);
     expect(snapshot.every((e) => e.outcome === 'in_flight')).toBe(true);
     expect(snapshot[0].url).toBe('https://api.test/active-0');
+    expect(snapshot[19].url).toBe('https://api.test/active-19');
+    expect(snapshot.some((e) => e.url === 'https://api.test/active-20')).toBe(false);
+  });
+
+  it('no-ops on the untracked handle', () => {
+    for (let i = 0; i < 20; i += 1) startTiming('fetch', 'GET', `https://api.test/a-${i}`);
+    const untracked = startTiming('fetch', 'GET', 'https://api.test/refused');
+    expect(untracked).toBe(-1);
+
+    markHeaders(untracked);
+    finalizeTiming(untracked, 'ok', 200);
+    discardTiming(untracked);
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(20);
+    expect(snapshot.some((e) => e.url === 'https://api.test/refused')).toBe(false);
+  });
+
+  it('snapshots in-flight elapsed time from the monotonic clock', () => {
+    const nowSpy = vi.spyOn(performance, 'now');
+    nowSpy.mockReturnValue(1000);
+    startTiming('fetch', 'POST', 'https://api.test/slow');
+    nowSpy.mockReturnValue(11002);
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.outcome).toBe('in_flight');
+    expect(entry.duration_ms).toBe(10002);
+    nowSpy.mockRestore();
+  });
+
+  // Ingestion drops entries above 600000, so the SDK must clamp rather than
+  // emit a value that will be discarded server-side.
+  it('clamps elapsed values at the ingestion ceiling', () => {
+    const nowSpy = vi.spyOn(performance, 'now');
+    nowSpy.mockReturnValue(0);
+    const handle = startTiming('fetch', 'GET', 'https://api.test/forever');
+    nowSpy.mockReturnValue(900000);
+    finalizeTiming(handle, 'timeout');
+
+    expect(snapshotNetworkTimings()[0].duration_ms).toBe(600000);
+    nowSpy.mockRestore();
+  });
+
+  // unpatchFetch cannot cancel an awaiting request, so a callback from before
+  // destroy() can fire after re-init. Handles must never be reissued.
+  it('does not reuse handles after clearing', () => {
+    const stale = startTiming('fetch', 'GET', 'https://api.test/old');
+    clearNetworkTimings();
+    const fresh = startTiming('fetch', 'GET', 'https://api.test/new');
+    expect(fresh).not.toBe(stale);
+
+    finalizeTiming(stale, 'ok', 200); // the stale callback fires late
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].url).toBe('https://api.test/new');
+    expect(snapshot[0].outcome).toBe('in_flight');
   });
 
   it('finalizes at most once', () => {
@@ -200,6 +275,13 @@ import { scrubUrl } from './scrub';
 const MAX_ENTRIES = 20;
 const MAX_URL_BYTES = 2048;
 const MAX_METHOD_BYTES = 16;
+const MAX_ELAPSED_MS = 600000;
+
+/** Returned by startTiming when the active registry is full. All other exports no-op on it. */
+const UNTRACKED = -1;
+
+const encoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+const decoder = typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8') : null;
 
 export type Transport = NetworkTiming['transport'];
 export type Outcome = NetworkTiming['outcome'];
@@ -228,36 +310,39 @@ function mark(): number {
     : Date.now();
 }
 
-function cap(value: string, max: number): string {
-  return value.length > max ? value.slice(0, max) : value;
+/**
+ * Truncate to at most `maxBytes` UTF-8 bytes. Ingestion measures bytes; a
+ * UTF-16 `.length` cap would let a Unicode URL pass here and be dropped there.
+ */
+function capBytes(value: string, maxBytes: number): string {
+  if (!encoder || !decoder) return value.length > maxBytes ? value.slice(0, maxBytes) : value;
+  const bytes = encoder.encode(value);
+  if (bytes.length <= maxBytes) return value;
+  // A cut mid-sequence decodes to U+FFFD; strip it so no stored URL ends in a
+  // replacement character.
+  return decoder.decode(bytes.subarray(0, maxBytes)).replace(/�+$/, '');
 }
 
+/** Clamped, not just floored: ingestion drops entries above MAX_ELAPSED_MS. */
 function elapsed(from: number, to: number): number {
-  return Math.max(0, Math.round(to - from));
+  return Math.min(MAX_ELAPSED_MS, Math.max(0, Math.round(to - from)));
 }
 
 export function startTiming(transport: Transport, method: string, url: string): number {
+  // At capacity, refuse the NEW request rather than evicting an existing one.
+  // Evicting the newest-and-then-inserting an even newer record would keep the
+  // arrival that just displaced its predecessor, defeating the whole point:
+  // the registry must retain the OLDEST requests, which are the long-running
+  // ones being diagnosed.
+  if (active.size >= MAX_ENTRIES) return UNTRACKED;
+
   const handle = nextHandle;
   nextHandle += 1;
 
-  // Evict the NEWEST active record when full, so a burst of short requests
-  // cannot displace a long-running one.
-  if (active.size >= MAX_ENTRIES) {
-    let newestKey = -1;
-    let newestMark = -Infinity;
-    for (const [key, record] of active) {
-      if (record.startMark > newestMark) {
-        newestMark = record.startMark;
-        newestKey = key;
-      }
-    }
-    if (newestKey >= 0) active.delete(newestKey);
-  }
-
   active.set(handle, {
     transport,
-    method: cap(method, MAX_METHOD_BYTES),
-    url: cap(scrubUrl(url), MAX_URL_BYTES),
+    method: capBytes(method.toUpperCase(), MAX_METHOD_BYTES),
+    url: capBytes(scrubUrl(url), MAX_URL_BYTES),
     startedAtMs: Date.now(),
     startMark: mark(),
   });
@@ -327,14 +412,18 @@ export function snapshotNetworkTimings(): NetworkTiming[] {
 export function clearNetworkTimings(): void {
   active = new Map();
   completed = [];
-  nextHandle = 0;
+  // nextHandle is deliberately NOT reset. `unpatchFetch`/`unpatchXHR` cannot
+  // cancel a request that is already awaiting (network.ts:70) or detach
+  // listeners already registered, so a callback from before destroy() can fire
+  // after re-init. If handles restarted at zero, that stale callback would
+  // finalize an unrelated new request that had been issued the same handle.
 }
 ```
 
 - [ ] **Step 6: Run tests to verify they pass**
 
 Run: `pnpm --filter @opslane/sdk test -- network-timing`
-Expected: PASS (9 tests)
+Expected: PASS (14 tests)
 
 - [ ] **Step 7: Commit**
 
@@ -418,6 +507,9 @@ describe('fetch timing capture', () => {
     expect(entry).not.toHaveProperty('ttfb_ms');
   });
 
+  // isSdkEndpoint is a raw prefix match (network.ts:16), so this asserts only
+  // that the SDK's own traffic is excluded. It does not characterise the
+  // helper's prefix behaviour, which is pre-existing and out of scope here.
   it('does not time the SDK\'s own endpoint', async () => {
     vi.stubGlobal('fetch', async () => ({ status: 200, ok: true, type: 'basic' }) as Response);
     patchFetch();
@@ -489,10 +581,41 @@ In the `catch (error: unknown)` branch, immediately after the existing `emitTele
 Run: `pnpm --filter @opslane/sdk test -- network`
 Expected: PASS
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Add real-browser capture coverage**
+
+The spec requires a real-browser test that executes rather than skips. Append to `packages/sdk/src/__tests__/browser-contract.test.ts`, inside the existing describe that already holds `page`/`vitePort` (`browser-contract.test.ts:136`), following its established `page.goto` / `page.click` / `waitForTimeout` shape:
+
+```ts
+  it('captures fetch timing on the event, including a request that never responds', async () => {
+    receivedEvents = [];
+
+    await page.goto(`http://localhost:${vitePort}`);
+    // The fixture route issues a fetch to a route the mock server never
+    // answers, aborted by AbortSignal.timeout, then throws.
+    await page.click('[data-testid="nav-usercard"]');
+    await page.click('[data-testid="edit-profile-btn"]');
+    await page.waitForTimeout(2000);
+
+    const event = receivedEvents[0] as Record<string, unknown>;
+    const timings = event.network_timings as Array<Record<string, unknown>> | undefined;
+    expect(timings).toBeInstanceOf(Array);
+    expect(timings?.length).toBeGreaterThanOrEqual(1);
+    expect(timings?.[0]).toHaveProperty('transport', 'fetch');
+    expect(typeof timings?.[0].duration_ms).toBe('number');
+  }, 15_000);
+```
+
+If the existing fixture app issues no fetch on that route, add a hanging-fetch trigger to `test-fixtures/vue-app` rather than weakening the assertion — an event with no `network_timings` must fail this test, not pass it vacuously.
+
+- [ ] **Step 6: Confirm the browser test executed rather than skipped**
+
+Run: `pnpm --filter @opslane/sdk test -- browser-contract --reporter=verbose`
+Expected: the new test reports as **passed**, not skipped. A skip means Playwright browsers are unavailable (`browser-contract.test.ts:8-16`); install them rather than accepting the skip.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add packages/sdk/src/network.ts packages/sdk/src/__tests__/network.test.ts
+git add packages/sdk/src/network.ts packages/sdk/src/__tests__/network.test.ts packages/sdk/src/__tests__/browser-contract.test.ts
 git commit -m "feat(sdk): time fetch requests, classifying opaque responses as ok"
 ```
 
@@ -585,6 +708,44 @@ describe('xhr timing capture', () => {
     drive('timeout', 0, false);
     expect(snapshotNetworkTimings()).toHaveLength(1);
   });
+
+  it('falls back to network_error when loadend fires with no terminal event', () => {
+    const xhr = new (globalThis.XMLHttpRequest as unknown as typeof FakeXHR)();
+    xhr.open('GET', 'https://app.example.com/api/items');
+    xhr.send();
+    xhr.emit('loadend');
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].outcome).toBe('network_error');
+  });
+
+  // A successful file:// or extension-scheme XHR reports status 0, which
+  // ingestion rejects as out of range.
+  it('omits status 0 on load', () => {
+    drive('load', 0, false);
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.outcome).toBe('ok');
+    expect(entry).not.toHaveProperty('status');
+  });
+
+  it('discards the record and rethrows when send() throws synchronously', () => {
+    class ThrowingXHR extends FakeXHR {
+      send(): void {
+        throw new Error('InvalidStateError');
+      }
+    }
+    vi.stubGlobal('XMLHttpRequest', ThrowingXHR);
+    unpatchXHR();
+    patchXHR();
+
+    const xhr = new (globalThis.XMLHttpRequest as unknown as typeof ThrowingXHR)();
+    xhr.open('GET', 'https://app.example.com/api/items');
+    expect(() => xhr.send()).toThrow('InvalidStateError');
+
+    expect(snapshotNetworkTimings()).toHaveLength(0);
+  });
 });
 ```
 
@@ -626,10 +787,21 @@ Inside `XMLHttpRequest.prototype.send`, replace the existing `try { ... }` telem
             // SDK must never throw
           }
         };
-        this.addEventListener('load', () => finalize(this.status >= 400 ? 'http_error' : 'ok', true), { once: true });
+        this.addEventListener('load', () => {
+          // A successful non-HTTP XHR (file://, some extension schemes) reports
+          // status 0, which ingestion rejects as outside 100-599. Omit it
+          // rather than emitting an entry that will be discarded server-side.
+          const storable = this.status >= 100 && this.status <= 599;
+          finalize(this.status >= 400 ? 'http_error' : 'ok', storable);
+        }, { once: true });
         this.addEventListener('timeout', () => finalize('timeout', false), { once: true });
         this.addEventListener('abort', () => finalize('abort', false), { once: true });
         this.addEventListener('error', () => finalize('network_error', false), { once: true });
+        // Fallback only. loadend follows every terminal event above and
+        // finalizeTiming is idempotent, so this is a no-op in the normal case.
+        // It exists so a request that somehow reaches loadend with no terminal
+        // event is still recorded instead of leaking as permanently in-flight.
+        this.addEventListener('loadend', () => finalize('network_error', false), { once: true });
 ```
 
 Import the `Outcome` type alongside the functions:
@@ -680,11 +852,20 @@ git commit -m "feat(sdk): time XHR requests with an explicit terminal-event matr
 
 - [ ] **Step 1: Write the failing tests**
 
-Append to `packages/sdk/src/__tests__/core.test.ts`:
+Append to `packages/sdk/src/__tests__/core.test.ts`. `buildPayload` calls `getConfig()` (`core.ts:71`), which throws when no config is loaded, so this block needs its own `loadConfig` — do not rely on another describe's setup. Add these to the file's existing import block if absent:
+
+```ts
+import { loadConfig } from '../config';
+import { TEST_PK } from './test-keys';
+import { clearNetworkTimings, finalizeTiming, startTiming } from '../network-timing';
+```
 
 ```ts
 describe('network timings on the payload', () => {
-  beforeEach(() => clearNetworkTimings());
+  beforeEach(() => {
+    clearNetworkTimings();
+    loadConfig({ apiKey: TEST_PK, endpoint: 'https://api.test', errorThrottleMs: 0 });
+  });
 
   it('omits the field entirely when nothing was captured', () => {
     const payload = buildPayload('TypeError', 'boom', '', {
@@ -703,8 +884,25 @@ describe('network timings on the payload', () => {
     expect(payload.network_timings).toHaveLength(1);
     expect(payload.network_timings?.[0].outcome).toBe('timeout');
   });
+
+  // Request history must not survive reinitialization: it could carry requests
+  // captured under one project configuration into an event sent under another.
+  it('carries no history across destroy() and re-init()', () => {
+    const handle = startTiming('fetch', 'GET', 'https://app.example.com/api/before');
+    finalizeTiming(handle, 'ok', 200);
+
+    destroy();
+    init({ apiKey: TEST_PK, endpoint: 'https://api.test', errorThrottleMs: 0 });
+
+    const payload = buildPayload('TypeError', 'boom', '', {
+      type: 'error', timestamp: new Date().toISOString(), category: 'exception', message: 'boom',
+    });
+    expect(payload).not.toHaveProperty('network_timings');
+  });
 });
 ```
+
+The re-init test needs `import { destroy, init } from '../index';` in the same import block.
 
 - [ ] **Step 2: Run tests to verify they fail**
 
@@ -781,11 +979,11 @@ git commit -m "feat(sdk): attach network timings to the error payload and clear 
 - Modify: `packages/sdk/package.json:3`
 - Create: `test-fixtures/wire/events/v4.1.0-minimal.json`
 - Create: `test-fixtures/wire/events/v4.1.0-full.json`
-- Modify: `packages/sdk/src/__tests__/wire-shape.test.ts:20,33-56,120-176`
+- Modify: `packages/sdk/src/__tests__/wire-shape.test.ts:21,34-56,121-176`
 
 **Interfaces:**
 - Consumes: Task 4's payload attachment
-- Produces: frozen fixtures replayed by `wire_compat_test.go` in Task 7
+- Produces: frozen fixtures replayed by `wire_compat_test.go` in Task 9
 
 `WIRE_FIXTURE_VERSION` currently reads `3.0.0` against a `4.0.0` package. `docs/contracts/events.md:17` requires a pair for every released SDK version, so that gap is pre-existing repository debt — add the `4.1.0` pair this change introduces and do not backfill `4.0.0`.
 
@@ -843,7 +1041,7 @@ Then in `v4.1.0-full.json`: change `"sdk_version"` to `"4.1.0"`, and add a top-l
 
 In `packages/sdk/src/__tests__/wire-shape.test.ts`:
 
-Change line 20 to:
+Change line 21 to:
 
 ```ts
 const WIRE_FIXTURE_VERSION = '4.1.0';
@@ -914,7 +1112,7 @@ Ingestion accepts payloads from arbitrary and older clients, so shape validation
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `packages/ingestion/masking/masking_test.go`:
+Append to `packages/ingestion/masking/masking_test.go`. That file is `package masking_test` (an external test package), so every call must be qualified `masking.` and the file must already import `strings` — add it if absent.
 
 ```go
 func TestRedactRequestURL(t *testing.T) {
@@ -926,12 +1124,13 @@ func TestRedactRequestURL(t *testing.T) {
 		{"drops the whole query string", "https://api.example.com/v1/search?q=hi&token=abc", "https://api.example.com/v1/search"},
 		{"drops userinfo", "https://user:pw@api.example.com/v1/search", "https://api.example.com/v1/search"},
 		{"drops a token-bearing fragment", "https://api.example.com/cb#access_token=abc", "https://api.example.com/cb"},
+		{"drops a prefixed token fragment", "https://api.example.com/cb#oauth_access_token=abc", "https://api.example.com/cb"},
 		{"keeps a route fragment", "https://app.example.com/x#/dashboard", "https://app.example.com/x#/dashboard"},
 		{"leaves a clean URL alone", "https://api.example.com/v1/items", "https://api.example.com/v1/items"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := RedactRequestURL(tc.in); got != tc.want {
+			if got := masking.RedactRequestURL(tc.in); got != tc.want {
 				t.Fatalf("RedactRequestURL(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
@@ -940,7 +1139,7 @@ func TestRedactRequestURL(t *testing.T) {
 
 func TestRedactRequestURLUnparseable(t *testing.T) {
 	// Falls back to RedactURL rather than returning the raw value.
-	got := RedactRequestURL("://not a url?token=abc")
+	got := masking.RedactRequestURL("://not a url?token=abc")
 	if strings.Contains(got, "abc") {
 		t.Fatalf("RedactRequestURL leaked a token: %q", got)
 	}
@@ -958,7 +1157,11 @@ In `packages/ingestion/masking/masking.go`, add `"net/url"` to the import block,
 
 ```go
 // tokenFragmentRe matches fragments carrying an OAuth-style credential.
-var tokenFragmentRe = regexp.MustCompile(`(?i)\b(access_token|id_token|refresh_token|token|code)=`)
+// Deliberately NO \b prefix: `_` is a word character, so `\baccess_token`
+// would not match `#oauth_access_token=...`. The SDK's TOKEN_HASH
+// (scrub.ts:3) has no boundary either, and server-side redaction must never
+// be weaker than the client's.
+var tokenFragmentRe = regexp.MustCompile(`(?i)(access_token|id_token|refresh_token|token|code)=`)
 
 // RedactRequestURL strips userinfo, the entire query string, and token-bearing
 // fragments from a single request URL. It is deliberately stricter than
@@ -997,7 +1200,7 @@ git commit -m "feat(ingestion): add strict request-URL redaction"
 ### Task 7: Ingestion sanitizer
 
 **Files:**
-- Modify: `packages/ingestion/handler/error_event.go:90-145`
+- Modify: `packages/ingestion/handler/error_event.go:90-145` (payload struct and call site) and near `:304` (the sanitizer, beside `sanitizeDebugMeta`)
 - Modify: `packages/ingestion/handler/metrics.go`
 - Test: `packages/ingestion/handler/error_event_test.go`
 
@@ -1007,7 +1210,21 @@ git commit -m "feat(ingestion): add strict request-URL redaction"
 
 - [ ] **Step 1: Write the failing tests**
 
-Append to `packages/ingestion/handler/error_event_test.go`:
+`error_event_test.go` is `package handler_test` (external), so it cannot reach the unexported `sanitizeNetworkTimings`. Create a new **internal** test file instead — Go permits `handler` and `handler_test` packages side by side in one directory.
+
+Create `packages/ingestion/handler/network_timings_internal_test.go`:
+
+```go
+package handler
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+```
+
+then append:
 
 ```go
 func TestSanitizeNetworkTimings(t *testing.T) {
@@ -1026,6 +1243,9 @@ func TestSanitizeNetworkTimings(t *testing.T) {
 		{"duration over cap", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":600001,"outcome":"ok"}]`, `[]`},
 		{"control chars in url", "[{\"transport\":\"fetch\",\"method\":\"GET\",\"url\":\"https://a.test/\\u0000\",\"started_at_ms\":1,\"duration_ms\":2,\"outcome\":\"ok\"}]", `[]`},
 		{"status out of range", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok","status":0}]`, `[]`},
+		{"missing duration", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"outcome":"ok"}]`, `[]`},
+		{"null started_at", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":null,"duration_ms":2,"outcome":"ok"}]`, `[]`},
+		{"hyphenated method the SDK can emit is accepted", `[{"transport":"xhr","method":"PROPFIND-VERY-LO","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok"}]`, `[{"transport":"xhr","method":"PROPFIND-VERY-LO","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok"}]`},
 		{
 			"valid entry is retained and its query stripped",
 			`[{"transport":"fetch","method":"get","url":"https://a.test/x?token=abc","started_at_ms":1,"duration_ms":2,"outcome":"timeout"}]`,
@@ -1066,7 +1286,7 @@ Expected: FAIL — undefined: sanitizeNetworkTimings
 
 - [ ] **Step 3: Implement the sanitizer**
 
-In `packages/ingestion/handler/error_event.go`, add the import for the masking package if absent, then add near `sanitizeDebugMeta`:
+In `packages/ingestion/handler/error_event.go`, confirm `bytes`, `encoding/json`, `regexp`, and `strings` are imported and add the `masking` package import if absent, then add near `sanitizeDebugMeta` (`:304`):
 
 ```go
 const (
@@ -1076,7 +1296,10 @@ const (
 )
 
 var (
-	reTimingMethod    = regexp.MustCompile(`^[A-Z]{1,16}$`)
+	// Applied after ToUpper. Permits the punctuation real methods and
+	// SDK-truncated methods carry (e.g. a clipped `PROPFIND-VERY-LO`); a
+	// letters-only rule would reject values the SDK legitimately emits.
+	reTimingMethod    = regexp.MustCompile(`^[A-Z0-9._-]{1,16}$`)
 	validTransports   = map[string]struct{}{"fetch": {}, "xhr": {}}
 	validTimingOutcome = map[string]struct{}{
 		"ok": {}, "http_error": {}, "timeout": {},
@@ -1088,8 +1311,10 @@ type validatedNetworkTiming struct {
 	Transport   string `json:"transport"`
 	Method      string `json:"method"`
 	URL         string `json:"url"`
-	StartedAtMs int64  `json:"started_at_ms"`
-	DurationMs  int64  `json:"duration_ms"`
+	// Pointers because both are REQUIRED: a plain int64 makes an absent or
+	// null field decode to 0, which then passes the non-negative check.
+	StartedAtMs *int64 `json:"started_at_ms"`
+	DurationMs  *int64 `json:"duration_ms"`
 	TTFBMs      *int64 `json:"ttfb_ms,omitempty"`
 	Outcome     string `json:"outcome"`
 	Status      *int   `json:"status,omitempty"`
@@ -1157,13 +1382,13 @@ func sanitizeNetworkTimings(raw json.RawMessage) string {
 			RecordNetworkTimingDiscard("bad_outcome")
 			continue
 		}
-		// An epoch value, so only checked for non-negativity — the elapsed cap
-		// does not apply to it.
-		if candidate.StartedAtMs < 0 {
+		// An epoch value, so only checked for presence and non-negativity —
+		// the elapsed cap does not apply to it.
+		if candidate.StartedAtMs == nil || *candidate.StartedAtMs < 0 {
 			RecordNetworkTimingDiscard("bad_started_at")
 			continue
 		}
-		if !validElapsed(candidate.DurationMs) {
+		if candidate.DurationMs == nil || !validElapsed(*candidate.DurationMs) {
 			RecordNetworkTimingDiscard("bad_duration")
 			continue
 		}
@@ -1286,38 +1511,60 @@ In `error_event.go`, add to the `IngestParams` literal after `DebugMeta:`:
 
 - [ ] **Step 4: Write the failing round-trip test**
 
-Append to `packages/ingestion/db/queries_test.go`, following the file's existing DB-test setup helpers:
+Append to `packages/ingestion/db/queries_test.go`. That file is `package db_test`, so types are qualified `db.` and the private `q.pool` is unreachable — query through the `pool` returned by `testPool`. This mirrors `error_group_ingestion_test.go:13-46` exactly; `DefaultEnvironmentID` is required, and omitting it fails environment resolution (`environments.go:46`).
 
 ```go
 func TestInsertErrorEventStoresNetworkTimings(t *testing.T) {
-	q, projectID := setupTestProject(t)
-	timings := `[{"transport":"fetch","method":"POST","url":"https://api.test/search","started_at_ms":1,"duration_ms":10002,"outcome":"timeout"}]`
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
 
-	result, err := q.InsertErrorEventAndGroup(context.Background(), IngestParams{
-		ProjectID:      projectID,
-		ErrorType:      "TimeoutError",
-		ErrorMessage:   "signal timed out",
-		Fingerprint:    "fp-timing",
-		Title:          "TimeoutError: signal timed out",
-		NetworkTimings: timings,
+	org, err := q.CreateOrg(ctx, "test-network-timings")
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	t.Cleanup(func() { cleanupTenant(t, pool, org.ID) })
+
+	proj, err := q.CreateProject(ctx, org.ID, "proj-network-timings", ptrStr("org/repo"))
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	env, err := q.CreateEnvironment(ctx, proj.ID, "production")
+	if err != nil {
+		t.Fatalf("CreateEnvironment: %v", err)
+	}
+
+	timings := `[{"transport":"fetch","method":"POST","url":"https://api.test/search","started_at_ms":1,"duration_ms":10002,"outcome":"timeout"}]`
+	result, err := q.InsertErrorEventAndGroup(ctx, db.IngestParams{
+		ProjectID:            proj.ID,
+		DefaultEnvironmentID: env.ID,
+		ErrorType:            "TimeoutError",
+		ErrorMessage:         "signal timed out",
+		Fingerprint:          "fp-network-timings",
+		Title:                "TimeoutError: signal timed out",
+		NetworkTimings:       timings,
 	})
 	if err != nil {
-		t.Fatalf("insert: %v", err)
+		t.Fatalf("InsertErrorEventAndGroup: %v", err)
 	}
 
 	var stored string
-	if err := q.pool.QueryRow(context.Background(),
+	if err := pool.QueryRow(ctx,
 		`SELECT network_timings::text FROM error_events WHERE id = $1`, result.EventID,
 	).Scan(&stored); err != nil {
 		t.Fatalf("select: %v", err)
 	}
-	if !strings.Contains(stored, `"outcome": "timeout"`) && !strings.Contains(stored, `"outcome":"timeout"`) {
-		t.Fatalf("stored timings missing outcome: %s", stored)
+	var decoded []map[string]any
+	if err := json.Unmarshal([]byte(stored), &decoded); err != nil {
+		t.Fatalf("unmarshal stored timings: %v", err)
+	}
+	if len(decoded) != 1 || decoded[0]["outcome"] != "timeout" {
+		t.Fatalf("stored timings unexpected: %s", stored)
 	}
 }
 ```
 
-Adapt `setupTestProject` to whatever the file's existing helper is named — do not introduce a second one.
+Decoding rather than substring-matching the JSON avoids a false pass on `jsonb`'s whitespace normalization.
 
 - [ ] **Step 5: Apply migrations and run the tests**
 
@@ -1346,12 +1593,41 @@ git commit -m "feat(ingestion): store network timings on error events"
 **Interfaces:**
 - Consumes: fixtures from Task 5, sanitizer from Task 7, column from Task 8
 
-- [ ] **Step 1: Run the existing wire-compat suite against the new fixtures**
+- [ ] **Step 1: Extend the wire-compat suite to actually cover the new field**
 
-Run: `cd packages/ingestion && go test ./handler/ -run WireCompat -v`
-Expected: PASS, including the two new `v4.1.0` files. The suite discovers fixtures from the directory, so no test change should be needed — if it hardcodes a version list, add `4.1.0` to it.
+The suite is `TestWireFixtures_AcceptedAndStored` (`wire_compat_test.go:154`) — there is no test matching `-run WireCompat`. More importantly its `wireFixture` struct (`wire_compat_test.go:22`) and its round-trip query (`wire_compat_test.go:172`) both omit `network_timings`, so the handler could discard the field entirely and the suite would still pass.
 
-- [ ] **Step 2: Document the field**
+Add to the `wireFixture` struct:
+
+```go
+	NetworkTimings json.RawMessage `json:"network_timings"`
+```
+
+Add `network_timings::text` to the round-trip `SELECT` and scan it into a new `networkTimingsText` variable alongside `debugMetaText`. Then assert the round trip, treating an omitted fixture field as the stored default:
+
+```go
+			wantTimings := "[]"
+			if len(fixture.NetworkTimings) > 0 {
+				wantTimings = string(fixture.NetworkTimings)
+			}
+			var gotTimings, expectTimings []map[string]any
+			if err := json.Unmarshal([]byte(networkTimingsText), &gotTimings); err != nil {
+				t.Fatalf("stored network_timings is not an array: %v", err)
+			}
+			if err := json.Unmarshal([]byte(wantTimings), &expectTimings); err != nil {
+				t.Fatalf("fixture network_timings is not an array: %v", err)
+			}
+			if len(gotTimings) != len(expectTimings) {
+				t.Errorf("network_timings round trip: got %d entries, want %d", len(gotTimings), len(expectTimings))
+			}
+```
+
+- [ ] **Step 2: Run the suite under its real name**
+
+Run: `cd packages/ingestion && go test ./handler/ -run TestWireFixtures -v`
+Expected: PASS across every fixture including the two new `v4.1.0` files, with the new assertion executing rather than being skipped.
+
+- [ ] **Step 3: Document the field**
 
 Append a section to `docs/contracts/events.md`, after the existing "Build provenance and debug images" section:
 
@@ -1384,7 +1660,7 @@ first-seen order. URLs are redacted server-side — userinfo, the full query str
 and token-bearing fragments are stripped regardless of what the client sent.
 ```
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
 git add docs/contracts/events.md packages/ingestion/handler/wire_compat_test.go
@@ -1428,8 +1704,8 @@ Setting a port without its URL is the silent failure mode: Go DB tests fall back
 
 - [ ] **Step 3: Confirm Go tests run with zero skips**
 
-Run: `cd packages/ingestion && go test ./... 2>&1 | grep -c SKIP`
-Expected: `0`. A storage misconfiguration reports `ok` while roughly 30 tests never run.
+Run: `cd packages/ingestion && go test ./... -v 2>&1 | grep -c -- "--- SKIP"`
+Expected: `0`. The `-v` is load-bearing: without it `go test` suppresses per-test skip lines, so the grep prints `0` while DB tests are calling `t.Skip` (`db/testhelper_test.go:21`). A storage misconfiguration otherwise reports `ok` while roughly 30 tests never run.
 
 - [ ] **Step 4: Bring the stack up and apply migrations**
 
@@ -1441,10 +1717,14 @@ psql "$DATABASE_URL" -f scripts/seed-e2e.sql
 
 - [ ] **Step 5: Post an event carrying timings and assert it stored**
 
+The route reads `X-API-Key` (`handler/project_keys.go:18`), and `project_api_keys` stores only key IDs and hashes — the raw key is not recoverable by query. Use the seeded raw key, which `scripts/seed-e2e.sql:7` records in a comment:
+
 ```bash
+export OPSLANE_TEST_KEY='opslane_pk_mzxw6ytboi3damrrgi3tknzxgq_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq'
+
 curl -sS -X POST "$INGESTION_URL/api/v1/events" \
   -H 'Content-Type: application/json' \
-  -H "X-Opslane-Key: $(psql "$DATABASE_URL" -tAc "SELECT public_key FROM project_api_keys LIMIT 1")" \
+  -H "X-API-Key: $OPSLANE_TEST_KEY" \
   -d '{
     "timestamp": "2026-08-06T00:00:00.000Z",
     "error": {"type":"TimeoutError","message":"signal timed out","stack":""},
@@ -1463,11 +1743,9 @@ psql "$DATABASE_URL" -c \
 
 Expected: both entries stored; the first has `"outcome": "timeout"` with no `ttfb_ms` key; **neither URL contains `token=leak`**, proving server-side redaction ran independently of the SDK.
 
-- [ ] **Step 6: Confirm the auth header name**
+If this returns 401, the seed did not run or the seeded key rotated — re-run `scripts/seed-e2e.sql` and re-read the raw key from its header comment. Do not disable auth to get a green smoke.
 
-If the `curl` returns 401, read the key header name from `packages/ingestion/handler/routes.go` and correct the command rather than disabling auth.
-
-- [ ] **Step 7: Commit any fixes and open the PR**
+- [ ] **Step 6: Commit any fixes and open the PR**
 
 The PR description must state that this changes no diagnosis behavior and that the column is read by nothing until the worker slice lands, or it will be misread as a fix for the timeout-diagnosis problem.
 
@@ -1479,4 +1757,16 @@ The PR description must state that this changes no diagnosis behavior and that t
 
 **Not covered by any task, by design:** the spec's "what this does not deliver" items — worker consumption, backend correlation, fetch body-phase timing, aggregates.
 
-**Type consistency.** `snapshotNetworkTimings`, `startTiming`, `markHeaders`, `finalizeTiming`, `discardTiming`, `clearNetworkTimings` are named identically in Tasks 1–5. `NetworkTiming` field names match between `shared/src/types.ts` (Task 1), the fixtures (Task 5), and `validatedNetworkTiming`'s JSON tags (Task 7). The cap of 20 appears in Task 1 (`MAX_ENTRIES`) and Task 7 (`maxNetworkTimings`) and must stay equal.
+**Type consistency.** `snapshotNetworkTimings`, `startTiming`, `markHeaders`, `finalizeTiming`, `discardTiming`, `clearNetworkTimings` are named identically in Tasks 1–5. `NetworkTiming` field names match between `shared/src/types.ts` (Task 1), the fixtures (Task 5), and `validatedNetworkTiming`'s JSON tags (Task 7).
+
+**SDK and ingestion limits must agree**, or the SDK emits entries ingestion silently drops. Every pair:
+
+| Limit | SDK (Task 1) | Ingestion (Task 7) |
+| --- | --- | --- |
+| Entry count | `MAX_ENTRIES = 20` | `maxNetworkTimings = 20` |
+| URL length | `capBytes(..., 2048)`, UTF-8 bytes | `len(value) > 2048`, UTF-8 bytes |
+| Method | `toUpperCase()` then 16 bytes | `ToUpper` then `^[A-Z0-9._-]{1,16}$` |
+| Elapsed | clamped to `MAX_ELAPSED_MS = 600000` | dropped above `600000` |
+| Status | omitted unless 100–599 | rejected outside 100–599 |
+
+**Go test packages.** `error_event_test.go`, `queries_test.go`, and `masking_test.go` are all external (`*_test` packages). Task 7's sanitizer tests therefore go in a new internal file; Tasks 6 and 8 qualify every call and type with its package name.

--- a/docs/superpowers/plans/2026-08-06-sdk-network-timing.md
+++ b/docs/superpowers/plans/2026-08-06-sdk-network-timing.md
@@ -18,6 +18,8 @@ Spec: `docs/superpowers/specs/2026-08-06-sdk-network-timing-design.md`
 - Caps, identical in the SDK and in ingestion: 20 entries, `url` 2048 bytes, `method` 16 bytes, elapsed values 600000 ms.
 - Use `unknown` plus narrowing instead of `any`. Keep Vitest tests colocated in `__tests__`.
 - This PR changes no diagnosis behavior. The `network_timings` column is written by ingestion and read by nothing.
+- **`pnpm --filter @opslane/sdk test -- <name>` does not filter.** pnpm forwards the `--`, vitest sees it as a separator, and the whole suite runs. Every focused command below uses `pnpm --filter @opslane/sdk exec vitest run <path>` instead.
+- **`src/__tests__/debug-id-browser.test.ts` already fails on a clean checkout** at the base commit, unrelated to this work. Do not treat it as a regression and do not fix it here; compare against that baseline when reading full-suite output.
 
 ---
 
@@ -260,7 +262,7 @@ describe('network timing store', () => {
 
 - [ ] **Step 4: Run tests to verify they fail**
 
-Run: `pnpm --filter @opslane/sdk test -- network-timing`
+Run: `pnpm --filter @opslane/sdk exec vitest run src/__tests__/network-timing.test.ts`
 Expected: FAIL — cannot resolve `../network-timing`
 
 - [ ] **Step 5: Implement the store**
@@ -279,6 +281,9 @@ const MAX_ELAPSED_MS = 600000;
 
 /** Returned by startTiming when the active registry is full. All other exports no-op on it. */
 const UNTRACKED = -1;
+
+/** RFC 7230 token, the same set ingestion accepts. Kept in sync deliberately. */
+const TOKEN = /^[A-Z0-9!#$%&'*+.^_`|~-]{1,16}$/;
 
 const encoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
 const decoder = typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8') : null;
@@ -315,7 +320,9 @@ function mark(): number {
  * UTF-16 `.length` cap would let a Unicode URL pass here and be dropped there.
  */
 function capBytes(value: string, maxBytes: number): string {
-  if (!encoder || !decoder) return value.length > maxBytes ? value.slice(0, maxBytes) : value;
+  // Without TextEncoder, one UTF-16 unit can reach 3 UTF-8 bytes, so divide
+  // rather than slicing at maxBytes and overshooting the server's limit.
+  if (!encoder || !decoder) return value.slice(0, Math.floor(maxBytes / 3));
   const bytes = encoder.encode(value);
   if (bytes.length <= maxBytes) return value;
   // A cut mid-sequence decodes to U+FFFD; strip it so no stored URL ends in a
@@ -329,6 +336,14 @@ function elapsed(from: number, to: number): number {
 }
 
 export function startTiming(transport: Transport, method: string, url: string): number {
+  // `scrubUrl` returns '' for a query-only relative URL such as fetch('?q=1')
+  // (scrub.ts:16). Ingestion drops a zero-length url, so never record one.
+  const scrubbed = capBytes(scrubUrl(url), MAX_URL_BYTES);
+  if (!scrubbed) return UNTRACKED;
+
+  const safeMethod = capBytes(method.toUpperCase(), MAX_METHOD_BYTES);
+  if (!TOKEN.test(safeMethod)) return UNTRACKED;
+
   // At capacity, refuse the NEW request rather than evicting an existing one.
   // Evicting the newest-and-then-inserting an even newer record would keep the
   // arrival that just displaced its predecessor, defeating the whole point:
@@ -341,8 +356,8 @@ export function startTiming(transport: Transport, method: string, url: string): 
 
   active.set(handle, {
     transport,
-    method: capBytes(method.toUpperCase(), MAX_METHOD_BYTES),
-    url: capBytes(scrubUrl(url), MAX_URL_BYTES),
+    method: safeMethod,
+    url: scrubbed,
     startedAtMs: Date.now(),
     startMark: mark(),
   });
@@ -422,7 +437,7 @@ export function clearNetworkTimings(): void {
 
 - [ ] **Step 6: Run tests to verify they pass**
 
-Run: `pnpm --filter @opslane/sdk test -- network-timing`
+Run: `pnpm --filter @opslane/sdk exec vitest run src/__tests__/network-timing.test.ts`
 Expected: PASS (14 tests)
 
 - [ ] **Step 7: Commit**
@@ -522,7 +537,7 @@ describe('fetch timing capture', () => {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `pnpm --filter @opslane/sdk test -- network`
+Run: `pnpm --filter @opslane/sdk exec vitest run src/__tests__/network.test.ts`
 Expected: FAIL — `snapshotNetworkTimings()` returns `[]`
 
 - [ ] **Step 3: Wire timing into `patchFetch`**
@@ -566,7 +581,15 @@ In the `catch (error: unknown)` branch, immediately after the existing `emitTele
 
 ```ts
       try {
-        const name = error instanceof Error ? error.name : '';
+        // Read `name` structurally rather than via `instanceof Error`. Real
+        // browsers reject AbortSignal.timeout with a DOMException that does
+        // inherit from Error, but polyfilled or cross-realm rejection reasons
+        // need not, and misclassifying a timeout as network_error would lose
+        // the single field this feature exists to record.
+        const name =
+          typeof error === 'object' && error !== null && typeof (error as { name?: unknown }).name === 'string'
+            ? (error as { name: string }).name
+            : '';
         finalizeTiming(
           timingHandle,
           name === 'TimeoutError' ? 'timeout' : name === 'AbortError' ? 'abort' : 'network_error',
@@ -578,44 +601,106 @@ In the `catch (error: unknown)` branch, immediately after the existing `emitTele
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `pnpm --filter @opslane/sdk test -- network`
+Run: `pnpm --filter @opslane/sdk exec vitest run src/__tests__/network.test.ts`
 Expected: PASS
 
-- [ ] **Step 5: Add real-browser capture coverage**
+- [ ] **Step 5: Give the fixture app a request that never answers**
 
-The spec requires a real-browser test that executes rather than skips. Append to `packages/sdk/src/__tests__/browser-contract.test.ts`, inside the existing describe that already holds `page`/`vitePort` (`browser-contract.test.ts:136`), following its established `page.goto` / `page.click` / `waitForTimeout` shape:
+The spec requires real-browser capture, and nothing in the repo can currently produce it: `UserCard.vue` issues no fetch, and the contract test's mock server answers *every* request with 202 (`browser-contract.test.ts:62-78`). Both sides need a hanging path.
+
+In `test-fixtures/vue-app/src/components/FetchUser.vue`, add to the `<script setup>` block:
 
 ```ts
-  it('captures fetch timing on the event, including a request that never responds', async () => {
+async function loadSlow() {
+  // Points at a server that accepts the connection and never responds, so
+  // AbortSignal.timeout is the only thing that ends this request.
+  const url = import.meta.env['VITE_OPSLANE_HANG_URL'] ?? 'http://localhost:1/hang';
+  await fetch(url, { signal: AbortSignal.timeout(1000) });
+}
+```
+
+and to its `<template>`, beside the existing load button:
+
+```html
+    <button data-testid="load-slow-btn" @click="loadSlow">Load Slow</button>
+```
+
+The URL must not start with the SDK's configured endpoint, or `isSdkEndpoint` (`network.ts:16`) excludes it from timing and the test silently measures nothing.
+
+- [ ] **Step 6: Serve that hanging endpoint from the contract test**
+
+In `packages/sdk/src/__tests__/browser-contract.test.ts`, alongside the existing `mockServer`, add a second server whose handler never responds, and pass its URL to the fixture through the same define mechanism that already injects `endpoint` (`browser-contract.test.ts:107`):
+
+```ts
+let hangServer: http.Server;
+let hangPort: number;
+```
+
+In the same `beforeAll` that starts `mockServer`:
+
+```ts
+    hangServer = http.createServer(() => {
+      // Deliberately never responds: the socket stays open until the client
+      // aborts. Do not call res.end().
+    });
+    await new Promise<void>(r => hangServer.listen(0, () => {
+      hangPort = (hangServer.address() as { port: number }).port;
+      r();
+    }));
+```
+
+Add `'import.meta.env.VITE_OPSLANE_HANG_URL': JSON.stringify(\`http://localhost:${hangPort}/hang\`)` to the existing define object, and close it in `afterAll` beside the other teardown:
+
+```ts
+    await new Promise<void>(r => hangServer?.close(() => r()));
+```
+
+`hangServer.close()` waits for open connections, so also call `hangServer.closeAllConnections()` first — the aborted request's socket may still be open and would hang the suite's teardown.
+
+- [ ] **Step 7: Write the real-browser timing test**
+
+Append inside the describe that already holds `page` and `vitePort`:
+
+```ts
+  it('captures a timed-out fetch with its duration in a real browser', async () => {
     receivedEvents = [];
 
     await page.goto(`http://localhost:${vitePort}`);
-    // The fixture route issues a fetch to a route the mock server never
-    // answers, aborted by AbortSignal.timeout, then throws.
-    await page.click('[data-testid="nav-usercard"]');
-    await page.click('[data-testid="edit-profile-btn"]');
-    await page.waitForTimeout(2000);
+    await page.click('[data-testid="nav-fetch"]');
+    await page.click('[data-testid="load-slow-btn"]');
+    // 1s AbortSignal.timeout, then the SDK flush interval.
+    await page.waitForTimeout(4000);
 
-    const event = receivedEvents[0] as Record<string, unknown>;
-    const timings = event.network_timings as Array<Record<string, unknown>> | undefined;
-    expect(timings).toBeInstanceOf(Array);
-    expect(timings?.length).toBeGreaterThanOrEqual(1);
-    expect(timings?.[0]).toHaveProperty('transport', 'fetch');
-    expect(typeof timings?.[0].duration_ms).toBe('number');
-  }, 15_000);
+    expect(receivedEvents.length).toBeGreaterThanOrEqual(1);
+    const event = receivedEvents.find(
+      (e) => Array.isArray((e as Record<string, unknown>).network_timings),
+    ) as Record<string, unknown> | undefined;
+    expect(event).toBeDefined();
+
+    const timings = event!.network_timings as Array<Record<string, unknown>>;
+    const hung = timings.find((t) => String(t.url).includes('/hang'));
+    expect(hung).toBeDefined();
+    expect(hung!.transport).toBe('fetch');
+    expect(hung!.outcome).toBe('timeout');
+    // Aborted before any headers arrived, which is the PR #1297 shape.
+    expect(hung).not.toHaveProperty('ttfb_ms');
+    expect(hung!.duration_ms as number).toBeGreaterThanOrEqual(900);
+  }, 20_000);
 ```
 
-If the existing fixture app issues no fetch on that route, add a hanging-fetch trigger to `test-fixtures/vue-app` rather than weakening the assertion — an event with no `network_timings` must fail this test, not pass it vacuously.
+An event without `network_timings` must fail this test, not pass it — hence the explicit `toBeDefined()` rather than optional chaining on the lookup.
 
-- [ ] **Step 6: Confirm the browser test executed rather than skipped**
+- [ ] **Step 8: Confirm the browser test executed rather than skipped**
 
-Run: `pnpm --filter @opslane/sdk test -- browser-contract --reporter=verbose`
+Run: `pnpm --filter @opslane/sdk exec vitest run src/__tests__/browser-contract.test.ts --reporter=verbose`
 Expected: the new test reports as **passed**, not skipped. A skip means Playwright browsers are unavailable (`browser-contract.test.ts:8-16`); install them rather than accepting the skip.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 9: Commit**
 
 ```bash
-git add packages/sdk/src/network.ts packages/sdk/src/__tests__/network.test.ts packages/sdk/src/__tests__/browser-contract.test.ts
+git add packages/sdk/src/network.ts packages/sdk/src/__tests__/network.test.ts \
+        packages/sdk/src/__tests__/browser-contract.test.ts \
+        test-fixtures/vue-app/src/components/FetchUser.vue
 git commit -m "feat(sdk): time fetch requests, classifying opaque responses as ok"
 ```
 
@@ -751,7 +836,7 @@ describe('xhr timing capture', () => {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `pnpm --filter @opslane/sdk test -- network`
+Run: `pnpm --filter @opslane/sdk exec vitest run src/__tests__/network.test.ts`
 Expected: FAIL — snapshot is empty
 
 - [ ] **Step 3: Extend the XHR patch**
@@ -762,6 +847,7 @@ Add a field to the existing `XHRWithOpslane` interface:
 
 ```ts
   _opslaneTimingHandle?: number;
+  _opslaneTimingBound?: boolean;
 ```
 
 Inside `XMLHttpRequest.prototype.send`, replace the existing `try { ... }` telemetry block's tail so that after `this.addEventListener('loadend', ...)` for telemetry, the timing listeners are registered:
@@ -770,11 +856,19 @@ Inside `XMLHttpRequest.prototype.send`, replace the existing `try { ... }` telem
         const timingHandle = startTiming('xhr', this._opslaneMethod || 'GET', url);
         this._opslaneTimingHandle = timingHandle;
 
+        // An XHR object can be reused: open()/send() may run many times on one
+        // instance. `once: true` removes only the listener that actually
+        // fired, so re-registering per send would accumulate the other four
+        // every time. Register once per instance and read the handle off
+        // `this` inside the callbacks.
+        if (!this._opslaneTimingBound) {
+          this._opslaneTimingBound = true;
+
         this.addEventListener('readystatechange', () => {
           // 2 === HEADERS_RECEIVED. This is the cross-transport comparable
           // milestone: fetch resolves here, XHR's loadend does not.
-          if (this.readyState === 2) {
-            try { markHeaders(timingHandle); } catch { /* SDK must never throw */ }
+          if (this.readyState === 2 && this._opslaneTimingHandle !== undefined) {
+            try { markHeaders(this._opslaneTimingHandle); } catch { /* SDK must never throw */ }
           }
         });
 
@@ -782,7 +876,9 @@ Inside `XMLHttpRequest.prototype.send`, replace the existing `try { ... }` telem
         // of them and cannot distinguish them. finalizeTiming is idempotent.
         const finalize = (outcome: Outcome, withStatus: boolean): void => {
           try {
-            finalizeTiming(timingHandle, outcome, withStatus ? this.status : undefined);
+            const handle = this._opslaneTimingHandle;
+            if (handle === undefined) return;
+            finalizeTiming(handle, outcome, withStatus ? this.status : undefined);
           } catch {
             // SDK must never throw
           }
@@ -802,6 +898,7 @@ Inside `XMLHttpRequest.prototype.send`, replace the existing `try { ... }` telem
         // It exists so a request that somehow reaches loadend with no terminal
         // event is still recorded instead of leaking as permanently in-flight.
         this.addEventListener('loadend', () => finalize('network_error', false), { once: true });
+        }
 ```
 
 Import the `Outcome` type alongside the functions:
@@ -827,7 +924,7 @@ Replace the final `return origSend.apply(this, args);` so a synchronous throw re
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `pnpm --filter @opslane/sdk test -- network`
+Run: `pnpm --filter @opslane/sdk exec vitest run src/__tests__/network.test.ts`
 Expected: PASS
 
 - [ ] **Step 5: Commit**
@@ -885,28 +982,60 @@ describe('network timings on the payload', () => {
     expect(payload.network_timings?.[0].outcome).toBe('timeout');
   });
 
+});
+```
+
+- [ ] **Step 3a: Test teardown in its own file**
+
+This cannot live in `core.test.ts`: that file mocks `../transport` (`core.test.ts:9`), and `destroy()` returns immediately unless `init()` ran first (`index.ts:54`), so a `destroy()` call after a bare `loadConfig` would clear nothing and the test would pass vacuously.
+
+Create `packages/sdk/src/__tests__/network-timing-teardown.test.ts`:
+
+```ts
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { destroy, init } from '../index';
+import { buildPayload } from '../core';
+import { clearNetworkTimings, finalizeTiming, snapshotNetworkTimings, startTiming } from '../network-timing';
+import { TEST_PK } from './test-keys';
+
+vi.mock('../transport', () => ({
+  enqueueEvent: vi.fn(),
+  flushEvents: vi.fn(),
+  startTransport: vi.fn(),
+  stopTransport: vi.fn(),
+}));
+
+describe('network timing teardown', () => {
+  beforeEach(() => clearNetworkTimings());
+
   // Request history must not survive reinitialization: it could carry requests
   // captured under one project configuration into an event sent under another.
   it('carries no history across destroy() and re-init()', () => {
+    init({ apiKey: TEST_PK, endpoint: 'https://api.test', errorThrottleMs: 0 });
     const handle = startTiming('fetch', 'GET', 'https://app.example.com/api/before');
     finalizeTiming(handle, 'ok', 200);
+    expect(snapshotNetworkTimings()).toHaveLength(1);
 
     destroy();
-    init({ apiKey: TEST_PK, endpoint: 'https://api.test', errorThrottleMs: 0 });
+    expect(snapshotNetworkTimings()).toHaveLength(0);
 
+    init({ apiKey: TEST_PK, endpoint: 'https://api.test', errorThrottleMs: 0 });
     const payload = buildPayload('TypeError', 'boom', '', {
       type: 'error', timestamp: new Date().toISOString(), category: 'exception', message: 'boom',
     });
     expect(payload).not.toHaveProperty('network_timings');
+    destroy();
   });
 });
 ```
 
-The re-init test needs `import { destroy, init } from '../index';` in the same import block.
+Run: `pnpm --filter @opslane/sdk exec vitest run src/__tests__/network-timing-teardown.test.ts`
+Expected: FAIL before Step 4's `destroy()` wiring, PASS after.
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `pnpm --filter @opslane/sdk test -- core`
+Run: `pnpm --filter @opslane/sdk exec vitest run src/__tests__/core.test.ts`
 Expected: FAIL — `network_timings` is undefined in the second test
 
 - [ ] **Step 3: Attach the snapshot in `buildPayload`**
@@ -1081,7 +1210,7 @@ In the `'full payload matches the frozen fixture'` test, directly before the `co
 
 - [ ] **Step 5: Run the wire-shape test**
 
-Run: `pnpm --filter @opslane/sdk build && pnpm --filter @opslane/sdk test -- wire-shape`
+Run: `pnpm --filter @opslane/sdk build && pnpm --filter @opslane/sdk exec vitest run src/__tests__/wire-shape.test.ts`
 Expected: PASS. The build is required because `sdk_version` is injected at build time.
 
 - [ ] **Step 6: Verify no frozen fixture was modified**
@@ -1286,7 +1415,7 @@ Expected: FAIL — undefined: sanitizeNetworkTimings
 
 - [ ] **Step 3: Implement the sanitizer**
 
-In `packages/ingestion/handler/error_event.go`, confirm `bytes`, `encoding/json`, `regexp`, and `strings` are imported and add the `masking` package import if absent, then add near `sanitizeDebugMeta` (`:304`):
+In `packages/ingestion/handler/error_event.go`, confirm `bytes`, `encoding/json`, `math`, and `strings` are imported and add the `masking` package import if absent, then add near `sanitizeDebugMeta` (`:304`):
 
 ```go
 const (
@@ -1296,10 +1425,11 @@ const (
 )
 
 var (
-	// Applied after ToUpper. Permits the punctuation real methods and
-	// SDK-truncated methods carry (e.g. a clipped `PROPFIND-VERY-LO`); a
-	// letters-only rule would reject values the SDK legitimately emits.
-	reTimingMethod    = regexp.MustCompile(`^[A-Z0-9._-]{1,16}$`)
+	// RFC 7230 token, upper-cased. Must stay identical to the SDK's TOKEN
+	// regex: any narrower rule here silently drops entries the SDK emits.
+	// Written as a byte set rather than a regexp because a Go raw string
+	// literal cannot contain the backtick the token grammar allows.
+	timingMethodBytes = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+.^_`|~-"
 	validTransports   = map[string]struct{}{"fetch": {}, "xhr": {}}
 	validTimingOutcome = map[string]struct{}{
 		"ok": {}, "http_error": {}, "timeout": {},
@@ -1311,13 +1441,28 @@ type validatedNetworkTiming struct {
 	Transport   string `json:"transport"`
 	Method      string `json:"method"`
 	URL         string `json:"url"`
-	// Pointers because both are REQUIRED: a plain int64 makes an absent or
+	// Pointers because both are REQUIRED: a plain numeric makes an absent or
 	// null field decode to 0, which then passes the non-negative check.
-	StartedAtMs *int64 `json:"started_at_ms"`
-	DurationMs  *int64 `json:"duration_ms"`
-	TTFBMs      *int64 `json:"ttfb_ms,omitempty"`
+	// float64, not int64, so a client sending 10.0 or 1e3 — legal JSON numbers
+	// the wire contract does not forbid — is accepted rather than rejected as
+	// malformed. Values are rounded on the way out.
+	StartedAtMs *float64 `json:"started_at_ms"`
+	DurationMs  *float64 `json:"duration_ms"`
+	TTFBMs      *float64 `json:"ttfb_ms,omitempty"`
 	Outcome     string `json:"outcome"`
 	Status      *int   `json:"status,omitempty"`
+}
+
+func validTimingMethod(value string) bool {
+	if len(value) == 0 || len(value) > 16 {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if !strings.ContainsRune(timingMethodBytes, rune(value[i])) {
+			return false
+		}
+	}
+	return true
 }
 
 func validTimingURL(value string) bool {
@@ -1327,8 +1472,8 @@ func validTimingURL(value string) bool {
 	return strings.IndexFunc(value, func(r rune) bool { return r < 0x20 || r == 0x7f }) < 0
 }
 
-func validElapsed(value int64) bool {
-	return value >= 0 && value <= maxTimingElapsedMs
+func validElapsed(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0) && value >= 0 && value <= maxTimingElapsedMs
 }
 
 // sanitizeNetworkTimings validates advisory request timing. Like debug_meta,
@@ -1370,7 +1515,7 @@ func sanitizeNetworkTimings(raw json.RawMessage) string {
 			continue
 		}
 		candidate.Method = strings.ToUpper(candidate.Method)
-		if !reTimingMethod.MatchString(candidate.Method) {
+		if !validTimingMethod(candidate.Method) {
 			RecordNetworkTimingDiscard("bad_method")
 			continue
 		}
@@ -1405,6 +1550,14 @@ func sanitizeNetworkTimings(raw json.RawMessage) string {
 		if !validTimingURL(candidate.URL) {
 			RecordNetworkTimingDiscard("bad_url")
 			continue
+		}
+
+		// Normalize to whole milliseconds so stored rows are uniform whatever
+		// numeric form the client sent.
+		*candidate.StartedAtMs = math.Round(*candidate.StartedAtMs)
+		*candidate.DurationMs = math.Round(*candidate.DurationMs)
+		if candidate.TTFBMs != nil {
+			*candidate.TTFBMs = math.Round(*candidate.TTFBMs)
 		}
 		retained = append(retained, candidate)
 	}
@@ -1511,7 +1664,7 @@ In `error_event.go`, add to the `IngestParams` literal after `DebugMeta:`:
 
 - [ ] **Step 4: Write the failing round-trip test**
 
-Append to `packages/ingestion/db/queries_test.go`. That file is `package db_test`, so types are qualified `db.` and the private `q.pool` is unreachable — query through the `pool` returned by `testPool`. This mirrors `error_group_ingestion_test.go:13-46` exactly; `DefaultEnvironmentID` is required, and omitting it fails environment resolution (`environments.go:46`).
+Append to `packages/ingestion/db/queries_test.go`. That file is `package db_test`, so types are qualified `db.` and the private `q.pool` is unreachable — query through the `pool` returned by `testPool`. Add `encoding/json` to its import block; the file does not currently import it (`queries_test.go:3-12`). This mirrors `error_group_ingestion_test.go:13-46` exactly; `DefaultEnvironmentID` is required, and omitting it fails environment resolution (`environments.go:46`).
 
 ```go
 func TestInsertErrorEventStoresNetworkTimings(t *testing.T) {
@@ -1566,14 +1719,17 @@ func TestInsertErrorEventStoresNetworkTimings(t *testing.T) {
 
 Decoding rather than substring-matching the JSON avoids a false pass on `jsonb`'s whitespace normalization.
 
-- [ ] **Step 5: Apply migrations and run the tests**
+- [ ] **Step 5: Actually apply the migration, then run the tests**
+
+`testPool` only opens a connection (`db/testhelper_test.go:13`); it runs no migrations, so without this the new column does not exist and the test fails on a missing relation.
 
 ```bash
 export DATABASE_URL="postgres://opslane:opslane_dev@localhost:${OPSLANE_POSTGRES_HOST_PORT:-5434}/opslane?sslmode=disable"
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f packages/ingestion/db/migrations/033_event_network_timings.sql
 cd packages/ingestion && go test ./db/ -run NetworkTimings -v
 ```
 
-Expected: PASS, and **not** `SKIP`. A skip means `DATABASE_URL` is unset and the test never ran.
+Expected: PASS, and **not** `SKIP`. A skip means `DATABASE_URL` is unset or Postgres is unreachable, and the test never ran.
 
 - [ ] **Step 6: Commit**
 
@@ -1603,23 +1759,14 @@ Add to the `wireFixture` struct:
 	NetworkTimings json.RawMessage `json:"network_timings"`
 ```
 
-Add `network_timings::text` to the round-trip `SELECT` and scan it into a new `networkTimingsText` variable alongside `debugMetaText`. Then assert the round trip, treating an omitted fixture field as the stored default:
+Add `network_timings::text` to the round-trip `SELECT` and scan it into a new `networkTimingsText` variable alongside `debugMetaText`. Then assert the round trip with the file's existing comparator (`wire_compat_test.go:133`), which ignores JSONB key order and whitespace — a length check would pass on same-cardinality field corruption:
 
 ```go
-			wantTimings := "[]"
-			if len(fixture.NetworkTimings) > 0 {
-				wantTimings = string(fixture.NetworkTimings)
+			wantTimings := fixture.NetworkTimings
+			if len(wantTimings) == 0 {
+				wantTimings = json.RawMessage(`[]`)
 			}
-			var gotTimings, expectTimings []map[string]any
-			if err := json.Unmarshal([]byte(networkTimingsText), &gotTimings); err != nil {
-				t.Fatalf("stored network_timings is not an array: %v", err)
-			}
-			if err := json.Unmarshal([]byte(wantTimings), &expectTimings); err != nil {
-				t.Fatalf("fixture network_timings is not an array: %v", err)
-			}
-			if len(gotTimings) != len(expectTimings) {
-				t.Errorf("network_timings round trip: got %d entries, want %d", len(gotTimings), len(expectTimings))
-			}
+			semanticJSONEqual(t, "network_timings", networkTimingsText, wantTimings)
 ```
 
 - [ ] **Step 2: Run the suite under its real name**
@@ -1702,18 +1849,20 @@ export REPLAY_STORE_ACCESS_KEY=minio REPLAY_STORE_SECRET_KEY=minio12345 REPLAY_S
 
 Setting a port without its URL is the silent failure mode: Go DB tests fall back to the hardcoded `localhost:5434` DSN and skip instead of failing.
 
-- [ ] **Step 3: Confirm Go tests run with zero skips**
-
-Run: `cd packages/ingestion && go test ./... -v 2>&1 | grep -c -- "--- SKIP"`
-Expected: `0`. The `-v` is load-bearing: without it `go test` suppresses per-test skip lines, so the grep prints `0` while DB tests are calling `t.Skip` (`db/testhelper_test.go:21`). A storage misconfiguration otherwise reports `ok` while roughly 30 tests never run.
-
-- [ ] **Step 4: Bring the stack up and apply migrations**
+- [ ] **Step 3: Bring the stack up and apply migrations**
 
 ```bash
 docker compose up -d postgres minio
 docker compose build ingestion && docker compose up -d ingestion
 psql "$DATABASE_URL" -f scripts/seed-e2e.sql
 ```
+
+- [ ] **Step 4: Confirm Go tests run with zero skips**
+
+This runs **after** the stack is up, deliberately: with Postgres down every DB test skips, and a skip check run first would be measuring the wrong thing.
+
+Run: `cd packages/ingestion && go test ./... -v 2>&1 | grep -c -- "--- SKIP"`
+Expected: `0`. The `-v` is load-bearing: without it `go test` suppresses per-test skip lines, so the grep prints `0` while DB tests are calling `t.Skip` (`db/testhelper_test.go:21`). A storage misconfiguration otherwise reports `ok` while roughly 30 tests never run.
 
 - [ ] **Step 5: Post an event carrying timings and assert it stored**
 
@@ -1722,7 +1871,7 @@ The route reads `X-API-Key` (`handler/project_keys.go:18`), and `project_api_key
 ```bash
 export OPSLANE_TEST_KEY='opslane_pk_mzxw6ytboi3damrrgi3tknzxgq_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq'
 
-curl -sS -X POST "$INGESTION_URL/api/v1/events" \
+EVENT=$(curl -sS --fail-with-body -X POST "$INGESTION_URL/api/v1/events" \
   -H 'Content-Type: application/json' \
   -H "X-API-Key: $OPSLANE_TEST_KEY" \
   -d '{
@@ -1735,11 +1884,16 @@ curl -sS -X POST "$INGESTION_URL/api/v1/events" \
       {"transport":"fetch","method":"POST","url":"https://api.example.com/v1/assets/search?token=leak","started_at_ms":1784160000000,"duration_ms":10002,"outcome":"timeout"},
       {"transport":"fetch","method":"GET","url":"https://api.example.com/v1/user","started_at_ms":1784160000100,"duration_ms":184,"ttfb_ms":170,"outcome":"ok","status":200}
     ]
-  }'
+  }') || { echo "ingest failed: $EVENT"; exit 1; }
 
+# Assert against THIS event, not whatever happens to be newest — a stale row
+# from an earlier run would otherwise produce a green smoke.
+EVENT_ID=$(printf '%s' "$EVENT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["event_id"])')
 psql "$DATABASE_URL" -c \
-  "SELECT jsonb_pretty(network_timings) FROM error_events ORDER BY created_at DESC LIMIT 1;"
+  "SELECT jsonb_pretty(network_timings) FROM error_events WHERE id = '$EVENT_ID';"
 ```
+
+If `event_id` is not the field name in the 202 body, read the response key from `handler/error_event.go` rather than falling back to `ORDER BY created_at`.
 
 Expected: both entries stored; the first has `"outcome": "timeout"` with no `ttfb_ms` key; **neither URL contains `token=leak`**, proving server-side redaction ran independently of the SDK.
 
@@ -1765,8 +1919,11 @@ The PR description must state that this changes no diagnosis behavior and that t
 | --- | --- | --- |
 | Entry count | `MAX_ENTRIES = 20` | `maxNetworkTimings = 20` |
 | URL length | `capBytes(..., 2048)`, UTF-8 bytes | `len(value) > 2048`, UTF-8 bytes |
-| Method | `toUpperCase()` then 16 bytes | `ToUpper` then `^[A-Z0-9._-]{1,16}$` |
+| Method | `toUpperCase()`, 16 bytes, then the `TOKEN` regex | `ToUpper` then `validTimingMethod`, same RFC 7230 token set |
+| Empty URL | not recorded (`scrubUrl` can return `''`) | rejected as `bad_url` |
 | Elapsed | clamped to `MAX_ELAPSED_MS = 600000` | dropped above `600000` |
 | Status | omitted unless 100–599 | rejected outside 100–599 |
+
+**Numeric decoding.** The Go sanitizer decodes timing numbers as `*float64`: pointers so a missing or null required field is detected rather than defaulting to 0, and floats so a legal JSON number such as `10.0` or `1e3` is accepted rather than rejected as malformed. Values are rounded to whole milliseconds before storage.
 
 **Go test packages.** `error_event_test.go`, `queries_test.go`, and `masking_test.go` are all external (`*_test` packages). Task 7's sanitizer tests therefore go in a new internal file; Tasks 6 and 8 qualify every call and type with its package name.

--- a/docs/superpowers/specs/2026-08-06-sdk-network-timing-design.md
+++ b/docs/superpowers/specs/2026-08-06-sdk-network-timing-design.md
@@ -6,7 +6,8 @@ Status: approved, not implemented
 ## Problem
 
 The SDK reports what threw, never how long anything took. For timeout-class errors
-that leaves the investigation agent with no way to reach a root cause.
+that leaves the investigation agent unable to say anything about the request that
+failed beyond its existence.
 
 [PR #1297 on `conelike/asset-management-jira`][pr] is the worked example. A
 `TimeoutError: signal timed out` from an `AbortSignal.timeout(FETCH_TIMEOUT)`
@@ -14,31 +15,42 @@ produced a fix that raised the constant from 10s to 30s in three files. The PR w
 closed unmerged.
 
 The agent had a minified stack, breadcrumbs, and nothing else. The PR body records
-`Visual replay analysis not available` and `Signals not available`. Nothing in the
-payload distinguished:
-
-- the server replied, just past the deadline;
-- the server received the request and never replied;
-- the request never left the browser.
-
-Those have different fixes and only one of them is a timeout constant. Raising the
-constant was the only action the available evidence supported.
+`Visual replay analysis not available` and `Signals not available`. The fetch
+breadcrumb carries method, URL, and the error message, but no elapsed time
+(`network.ts:96-107`), so nothing in the payload established even that the request
+ran to the full deadline. Raising the constant was the only action the available
+evidence supported.
 
 [pr]: https://github.com/conelike/asset-management-jira/pull/1297
 
+## What this can and cannot establish
+
+**Can:** which request failed, how long it actually ran, whether response headers
+were ever received, and what else was in flight alongside it.
+
+**Cannot:** whether the server received the request. Patch-point instrumentation
+observes only what the browser observes, and once a timeout aborts a request the
+browser cannot see a later response. Sibling requests completing quickly is
+circumstantial evidence for a single slow endpoint, not proof — service workers,
+cache hits, CORS preflights, client-side cancellation, connection-pool contention,
+and per-request payload size all remain live alternatives.
+
+The payoff is therefore bounded and worth stating as such: it supplies the failing
+URL, its observed duration, whether headers arrived, and overlapping request
+context — enough to rule out unsupported timeout-constant changes and to raise a
+more precise `needs_human` incident. Any downstream `unfixable_infra` verdict is a
+confidence-weighted inference from that evidence, not a verdict the data proves.
+
 ## What exists today
 
-`packages/sdk/src/network.ts` already brackets every fetch and XHR. On rejection it
-writes a breadcrumb carrying method, URL, and the error message — but no elapsed
-time (`network.ts:96-107`).
+`packages/sdk/src/network.ts` already brackets every fetch and XHR, but records no
+timing on the error path.
 
 `request_start` / `request_end` telemetry with timestamps does exist
 (`telemetry.ts:7-8`), but it rides inside the rrweb replay stream
 (`shared/src/types.ts:353-357`) and reaches the agent only when replay analysis
-succeeds. On PR #1297 it did not.
-
-So the timing was arguably collected and still could not be read. Storing it
-somewhere the error event does not reach is equivalent to not storing it.
+succeeds. On PR #1297 it did not. Timing stored somewhere the error event does not
+reach is equivalent to timing not stored.
 
 ## Prior art
 
@@ -50,12 +62,8 @@ somewhere the error event does not reach is equivalent to not storing it.
 
 All three separate timing from the error, because their consumer is a human who can
 open the error and click across to the performance view. Opslane's consumer is an
-agent with one prompt and no ability to pivot. That difference is the whole reason
-this design puts timing on the error event.
-
-Worth copying: Sentry's explicit origin allowlist for trace headers, and its
-documented requirement that the customer's server send
-`Access-Control-Allow-Headers` or the request breaks.
+agent with one prompt and no ability to pivot. That difference is the reason this
+design puts timing on the error event.
 
 ## Decisions
 
@@ -67,99 +75,48 @@ later without a contract break.
 **No `traceparent` propagation in v1.** Adding a header to a cross-origin request
 forces a CORS preflight, so an SDK upgrade could start failing requests that worked
 the day before — the worst available failure mode for an error monitor. It also
-requires the customer to have backend tracing before it returns anything. Its value
-is real but it lands on a subset of customers and carries the largest blast radius
-in the SDK. Separate slice, separately justified.
+requires the customer to have backend tracing before it returns anything. Separate
+slice, separately justified.
 
-**Network timing only.** No longtask observer, no JS self-profiling. One capture
-mechanism, at patch points that already exist.
+**Network timing only.** No longtask observer, no JS self-profiling.
 
 **Patch-point wall clock is the spine; Resource Timing is not used in v1.** For
 cross-origin requests without `Timing-Allow-Origin`, `PerformanceResourceTiming`
 zeroes `domainLookupStart`, `connectStart`, `secureConnectionStart`, `requestStart`,
-and `responseStart` ([MDN][mdn]). Those are precisely the fields that would
-otherwise separate "slow server" from "never connected", and precisely the requests
-Opslane cares about are cross-origin. The phase breakdown Sentry advertises is
-mostly zeros for B2B SaaS traffic. Merging it stays available as a later seam.
-
-The discriminator that does survive cross-origin is **concurrency**: sibling
-requests to the same origin completing in ~200ms while one sits at 10,002ms
-identifies a single slow endpoint without any header cooperation. That signal is
-free, and it is what the buffer is shaped to produce.
+and `responseStart` ([MDN][mdn]) — precisely the fields that would otherwise
+separate a slow server from a connection that never established, and precisely the
+requests Opslane sees are cross-origin. Merging it stays available as a later seam.
 
 [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming
 
 ## Scope
 
-In scope:
+In scope: `packages/sdk/src/network.ts` capture and retention, `core.ts` payload
+attachment, `index.ts` teardown, `shared/src/types.ts`, ingestion migration and
+sanitization, `packages/ingestion/masking`, `docs/contracts/events.md`, fixtures.
 
-- `packages/sdk/src/network.ts` — timing capture and rolling buffer
-- `packages/sdk/src/core.ts` — attach buffer snapshot to the payload
-- `shared/src/types.ts` — `NetworkTiming` type, optional payload field
-- `packages/ingestion` — migration, sanitization, storage
-- `docs/contracts/events.md`, frozen fixture pair
+Out of scope, deferred to a follow-up PR: `worker/src/db.ts` event select,
+`pipeline.ts` threading, prompt sections in `investigate.ts` and `agent-fix.ts`, and
+any triage behavior change.
 
-Out of scope, deferred to a follow-up PR:
+**This PR changes no diagnosis behavior.** The column is written and read by nothing
+until the follow-up lands. The migration carries a comment saying so, and the PR
+description must say so, or it will be misread as a fix for the PR #1297 class.
 
-- `packages/worker/src/db.ts` event select
-- `packages/worker/src/pipeline.ts` threading
-- Prompt sections in `investigate.ts` and `agent-fix.ts`
-- Any triage behavior change
-
-**This PR changes no diagnosis behavior.** The column is written and read by
-nothing until the follow-up lands. The migration carries a comment saying so, and
-the PR description must say so, or it will be misread as a fix for the PR #1297
-class of error.
-
-## SDK capture
-
-A module-local buffer in `network.ts`, hard-capped at 20 entries, **with no age
-eviction**. This differs deliberately from breadcrumbs, whose 30s window
-(`breadcrumbs.ts:5`) would discard a 30s timeout's own start record.
+## Wire shape
 
 ```ts
 export interface NetworkTiming {
+  transport: 'fetch' | 'xhr';
   method: string;
   url: string;
-  start: number;
+  started_at_ms: number;
   duration_ms: number;
+  ttfb_ms?: number;
   outcome: 'ok' | 'http_error' | 'timeout' | 'abort' | 'network_error' | 'in_flight';
   status?: number;
 }
 ```
-
-`url` is passed through the existing `scrubUrl` (`scrub.ts:6`), which already strips
-query strings, userinfo, and token-bearing fragments. Requests to the SDK's own
-endpoint are excluded by the existing `isSdkEndpoint` check.
-
-`outcome` is classified at the patch point from the rejection's `name`
-(`TimeoutError` / `AbortError`), never inferred from duration. This is the field
-that would have flipped PR #1297.
-
-`in_flight` entries are snapshotted when the error fires, with `duration_ms` set to
-elapsed-so-far. Without them the buffer records only completions, and the
-concurrency signal — the main discriminator available cross-origin — is lost.
-
-`start` is `Date.now()`, an absolute timestamp correlatable with breadcrumbs.
-`duration_ms` is computed from `performance.now()` deltas, because `Date.now()` can
-jump backwards on NTP correction or on a laptop waking from sleep, producing
-negative or inflated durations on exactly the long-running requests that matter.
-Existing telemetry uses `Date.now()` for both; that is not changed here, only not
-copied.
-
-No request headers and no bodies. PostHog captures both and needs a header
-deny-list plus payload redaction to do it safely. Capturing neither means this
-slice adds no new privacy surface beyond URLs, which are already captured and
-already scrubbed.
-
-`buildPayload` (`core.ts:65`) takes a copy of the buffer at error time. The buffer
-is **not** cleared afterwards, so a second error in the same session still carries
-the preceding request history; the count cap alone bounds it.
-
-Every buffer write is wrapped in `try {} catch {}`, matching every sibling in
-`network.ts`. The SDK must never throw into a customer's app.
-
-## Wire and storage
 
 New optional top-level field on `ErrorEventPayload`:
 
@@ -167,14 +124,144 @@ New optional top-level field on `ErrorEventPayload`:
 network_timings?: NetworkTiming[];
 ```
 
-Append-only per `docs/contracts/events.md`: optional server-side, existing fixtures
-unaffected, decoding stays tolerant of unknown fields.
+`buildPayload` **omits the field entirely when the buffer is empty**, rather than
+emitting `[]`. The minimal fixture encodes that.
 
 The SDK sends the scrubbed raw URL, not a templated route. `/api/assets/12345`
 aggregates badly, but baking templating rules into a released SDK makes them
-unfixable — customers upgrade on their own schedule. Server-side templating can be
-corrected on any deploy. The cost is that grouping for the future aggregate slice is
+unfixable — customers upgrade on their own schedule, while server-side templating
+can be corrected on any deploy. Grouping for a future aggregate slice is therefore
 deferred work rather than free.
+
+### Timing milestones
+
+`fetch()` resolves when response **headers** arrive; XHR `loadend` fires after the
+transfer completes or fails. Recording one number from both would compare unlike
+things, and the concurrency comparison is the main signal this feature produces.
+
+So two milestones are recorded, and only one of them is comparable:
+
+- **`ttfb_ms` — time to response headers. This is the cross-transport comparable
+  field.** For fetch, the moment the promise resolves. For XHR, a `readystatechange`
+  listener firing at `readyState === 2` (`HEADERS_RECEIVED`). Absent when the
+  request terminated before any headers arrived.
+- **`duration_ms` — start to terminal event.** For fetch, promise settle. For XHR,
+  `loadend`. Transport-dependent by construction, which is why `transport` is on
+  the wire.
+
+`ttfb_ms` absent on a `timeout` means no headers ever arrived. `ttfb_ms` present on
+a `timeout` means the server responded and the body stalled. That distinction is the
+one piece of phase information that survives cross-origin without
+`Timing-Allow-Origin`.
+
+**Known limitation:** for fetch, `duration_ms` never includes the body phase.
+A response whose headers arrive in 200ms and whose body hangs for 10s records as
+`ok` with `duration_ms: 200`, and a later `response.json()` abort is invisible to
+this patch. Instrumenting it means wrapping `response.body`, which risks altering
+stream semantics in customer code. Out of scope for v1 and documented as such.
+
+`started_at_ms` is `Date.now()`, an absolute timestamp correlatable with
+breadcrumbs. All elapsed values are computed from `performance.now()` deltas,
+because `Date.now()` can jump backwards on NTP correction or on a laptop waking
+from sleep, producing negative or inflated durations on exactly the long-running
+requests that matter. Existing telemetry uses `Date.now()` for both; that is not
+changed here, only not copied.
+
+### Outcome matrix
+
+Fetch:
+
+| Condition | `outcome` | `status` |
+| --- | --- | --- |
+| resolves, `response.type` is `opaque` or `opaqueredirect` | `ok` | omitted |
+| resolves, `status >= 400` | `http_error` | recorded |
+| resolves otherwise | `ok` | recorded |
+| rejects, `err.name === 'TimeoutError'` | `timeout` | omitted |
+| rejects, `err.name === 'AbortError'` | `abort` | omitted |
+| rejects otherwise | `network_error` | omitted |
+
+The opaque row matters: a successfully-resolved opaque response reports `status: 0`
+and `response.ok === false`, so classifying on `ok` alone would report a working
+cross-origin request as an HTTP error, and storing `0` would fail the status
+validation below.
+
+XHR, which has mutually exclusive terminal events that `loadend` alone does not
+distinguish:
+
+| Event | `outcome` | `status` |
+| --- | --- | --- |
+| `load`, `status >= 400` | `http_error` | recorded |
+| `load` otherwise | `ok` | recorded |
+| `timeout` | `timeout` | omitted |
+| `abort` | `abort` | omitted |
+| `error` | `network_error` | omitted |
+
+`loadend` fires after every one of those, so finalization is guarded to **run at
+most once per request**; the first terminal event wins and `loadend` is used only to
+close out a record that somehow has none. A synchronous throw from `send()` removes
+the in-flight record entirely and rethrows unchanged.
+
+`in_flight` is not produced by either matrix. It is assigned at snapshot time to
+records that have not finalized, with `duration_ms` set to elapsed-so-far. Without
+those entries the buffer records only completions and the concurrency signal is
+lost.
+
+## Retention
+
+A single FIFO buffer would evict the record this feature exists to capture: a
+request open for 30s becomes the oldest entry while shorter requests start and
+finish around it, so twenty subsequent requests drop it before its timeout ever
+fires.
+
+Two internal collections instead, behind one exported `snapshotNetworkTimings()`:
+
+- an **active registry** of in-flight requests, keyed per request;
+- a **ring of the 20 most recent completions**.
+
+Snapshot policy, capped at 20 entries total:
+
+1. Take active requests first, **longest-running first** (ascending
+   `started_at_ms`). The request open for 10s is the one being diagnosed; newest-first
+   would discard it.
+2. Fill the remaining allowance with the newest completions.
+
+If more than 20 requests are concurrently active, step 1 consumes the whole
+allowance and no completions are included. That is the correct trade for this
+feature, and the resulting snapshot is still ordered longest-running first.
+
+The active registry is bounded by the same cap on insert, evicting the *newest*
+active record when full, so a burst of short requests cannot displace a long-running
+one. Entries are removed from the registry on finalization.
+
+`buildPayload` (`core.ts:65`) takes a snapshot; neither collection is cleared
+afterwards, so a second error in the same session still carries preceding request
+history.
+
+`destroy()` (`index.ts:53`) clears both collections via a `safeCall`, alongside the
+existing `clearBreadcrumbs`. Without it, request history survives across
+reinitialization and can leak requests captured under one project configuration into
+an event sent under another.
+
+## SDK safety
+
+`url` is passed through the existing `scrubUrl` (`scrub.ts:6`), which strips query
+strings, userinfo, and token-bearing fragments. Requests to the SDK's own endpoint
+are excluded by the existing `isSdkEndpoint` check.
+
+The SDK applies the same caps as ingestion — `url` truncated to 2048 bytes, `method`
+to 16 — because ingestion reads the body under a 1 MiB `MaxBytesReader`
+(`error_event.go:51`). An oversized value would push the event past that limit and
+be rejected before the sanitizer ever ran, contradicting the guarantee that
+malformed timing data never fails an event.
+
+No request headers and no bodies. PostHog captures both and needs a header deny-list
+plus payload redaction to do it safely. Capturing neither means this slice adds no
+new privacy surface beyond URLs, which are already captured and already scrubbed.
+
+Every buffer write is wrapped in `try {} catch {}`, matching every sibling in
+`network.ts`. The SDK must never throw into a customer's app.
+
+## Ingestion
 
 Migration `033_event_network_timings.sql` follows `028_event_debug_meta.sql`: a
 JSONB column defaulting to `'[]'::jsonb`, with a `NOT VALID` type check validated in
@@ -186,51 +273,82 @@ Sanitization in `handler/error_event.go` mirrors `sanitizeDebugMeta`
 - a non-array container becomes `[]`;
 - non-object entries are dropped;
 - at most 20 entries retained, in first-seen order;
+- `transport` must be `fetch` or `xhr`;
+- `method` must be 1–16 bytes of `A-Z` after upper-casing;
 - `url` must be 1–2048 bytes and free of control characters;
-- `start` and `duration_ms` must be finite and non-negative, and `duration_ms` at
-  most 600000 (ten minutes), above which the entry is dropped rather than clamped;
+- `started_at_ms`, `duration_ms`, and `ttfb_ms` must be finite and non-negative,
+  with elapsed values at most 600000 (ten minutes), above which the entry is
+  dropped rather than clamped;
 - `status`, when present, must be an integer in 100–599;
 - `outcome` must be one of the six known values;
-- discards increment a counter with a reason label, as `RecordDebugMetaDiscard` does.
+- discards increment a counter with a reason label, as `RecordDebugMetaDiscard`
+  does.
 
-Malformed timing data never fails an event. This is the same guarantee that already
-governs `debug_meta`, and it matters more here because the data is advisory.
+Malformed timing data never fails an event — the guarantee that already governs
+`debug_meta`.
+
+**Server-side redaction is independent of the SDK.** The official SDK scrubs URLs,
+but ingestion accepts payloads from arbitrary and older clients, so shape validation
+alone would persist unsanitized URLs. `masking.RedactURL` (`masking.go:100`) exists
+but deliberately preserves non-sensitive query parameters, leaving it weaker than
+the SDK's `scrubUrl`. Add a stricter `masking.RedactRequestURL` in that package: drop
+userinfo, drop the query string entirely, drop token-bearing fragments, and fall
+back to `RedactURL` when the value does not parse. Applied to every retained entry.
 
 ## Testing
 
-SDK unit tests: duration is recorded on success and failure; a `TimeoutError`
-classifies as `timeout`; in-flight requests are snapshotted with elapsed time; the
-buffer caps at 20 and drops oldest; `scrubUrl` is applied; the SDK's own endpoint is
-excluded.
+SDK unit tests:
+
+- duration and `ttfb_ms` recorded on fetch success;
+- `TimeoutError` classifies `timeout` with `ttfb_ms` absent;
+- `AbortError` classifies `abort`; other rejections classify `network_error`;
+- opaque fetch response classifies `ok` with `status` omitted, not `http_error`;
+- every XHR terminal event maps per the matrix, and `loadend` after each does not
+  double-finalize;
+- XHR `ttfb_ms` recorded from `readyState === 2`;
+- a synchronous `send()` throw removes the record and rethrows unchanged;
+- in-flight requests snapshot with elapsed time;
+- **one long-running active request survives 20 subsequent completions**, the
+  regression the retention design exists to prevent;
+- more than 20 concurrently-active requests fill the snapshot with actives, ordered
+  longest-running first;
+- `scrubUrl` applied; URL and method truncated at the caps; SDK endpoint excluded;
+- `destroy()` clears history, and a re-`init()` event carries none of it;
+- the field is omitted, not `[]`, when the buffer is empty.
 
 Real-browser contract test covering capture, confirmed to **execute rather than
 skip** per `packages/sdk/AGENTS.md`.
 
 Wire contract: add `test-fixtures/wire/events/v4.1.0-minimal.json` (field omitted)
-and `v4.1.0-full.json` (field populated), and bump `WIRE_FIXTURE_VERSION` at
-`packages/sdk/src/__tests__/wire-shape.test.ts:20` from `3.0.0` to `4.1.0`. That
-constant tracks wire-shape changes rather than releases, which is why it currently
-lags the package version. Bump `packages/sdk/package.json` from `4.0.0` to `4.1.0`.
+and `v4.1.0-full.json` (field populated), bump `packages/sdk/package.json` from
+`4.0.0` to `4.1.0`, and bump `WIRE_FIXTURE_VERSION` at
+`packages/sdk/src/__tests__/wire-shape.test.ts:20` to `4.1.0`.
 `wire_compat_test.go` replays every fixture including the new pair. No existing
 fixture is edited or deleted.
 
-Go sanitizer tests for each malformed shape above.
+That constant currently reads `3.0.0` against a `4.0.0` package. `docs/contracts/
+events.md:17` requires a fixture pair for **every** released SDK version, so that
+gap is pre-existing repository debt, not an intended invariant — this spec adds the
+`4.1.0` pair it introduces and does not attempt to backfill `4.0.0`.
+
+Go tests: sanitizer rejection for each malformed shape above, and
+`RedactRequestURL` stripping userinfo, query strings, and token fragments from
+URLs an unofficial client could send.
 
 Live smoke per root `AGENTS.md`: apply migrations, seed, rebuild ingestion, drive a
 browser fixture that issues a request which times out, POST the event to
 `$INGESTION_URL/api/v1/events`, and assert the stored `network_timings` contains the
-timed-out entry with a plausible duration and `outcome: "timeout"`. Export the
-worktree port block as a unit, and confirm `go test ./...` reports **zero** skips —
-a storage misconfiguration reports `ok` while ~30 tests never run.
+timed-out entry with a plausible duration, `outcome: "timeout"`, and `ttfb_ms`
+absent. Export the worktree port block as a unit, and confirm `go test ./...`
+reports **zero** skips — a storage misconfiguration reports `ok` while ~30 tests
+never run.
 
 ## What this does not deliver
 
-No improvement in diagnosis quality. That arrives only when the follow-up PR reads
-the column into the agent prompt. The likely payoff there is narrower than better
-fixes: given sibling requests returning in 200ms while one hangs at 10s, the correct
-triage verdict for the PR #1297 class is `unfixable_infra` — an incident naming the
-slow endpoint, rather than a PR raising a constant. The reason code already exists
-and already carries a remediation string.
+No improvement in diagnosis quality; that arrives only when the follow-up PR reads
+the column into the agent prompt, and even then as better-evidenced inference rather
+than proof.
 
-Also not delivered: backend correlation, aggregate latency history, main-thread
-blocking, and page load timing.
+Also not delivered: whether the server received a request, fetch body-phase timing,
+backend correlation, aggregate latency history, main-thread blocking, and page load
+timing.

--- a/docs/superpowers/specs/2026-08-06-sdk-network-timing-design.md
+++ b/docs/superpowers/specs/2026-08-06-sdk-network-timing-design.md
@@ -146,8 +146,12 @@ So two milestones are recorded, and only one of them is comparable:
   listener firing at `readyState === 2` (`HEADERS_RECEIVED`). Absent when the
   request terminated before any headers arrived.
 - **`duration_ms` — start to terminal event.** For fetch, promise settle. For XHR,
-  `loadend`. Transport-dependent by construction, which is why `transport` is on
-  the wire.
+  the first of `load`/`timeout`/`abort`/`error`. Transport-dependent by
+  construction, which is why `transport` is on the wire.
+
+Both elapsed values are clamped in the SDK to the same 600000 ms ceiling ingestion
+enforces, so the SDK never emits a value the server will drop. A stored 600000
+therefore means "at least ten minutes", not "exactly ten minutes".
 
 `ttfb_ms` absent on a `timeout` means no headers ever arrived. `ttfb_ms` present on
 a `timeout` means the server responded and the body stalled. That distinction is the
@@ -197,9 +201,15 @@ distinguish:
 | `error` | `network_error` | omitted |
 
 `loadend` fires after every one of those, so finalization is guarded to **run at
-most once per request**; the first terminal event wins and `loadend` is used only to
-close out a record that somehow has none. A synchronous throw from `send()` removes
-the in-flight record entirely and rethrows unchanged.
+most once per request**; the first terminal event wins. A `loadend` listener is
+still registered as a fallback classifying `network_error`, so a request reaching
+`loadend` with no terminal event is recorded rather than leaking as permanently
+in-flight; in the normal case it is a no-op. A synchronous throw from `send()`
+removes the in-flight record entirely and rethrows unchanged.
+
+A successful non-HTTP XHR (`file://`, some extension schemes) reports `status 0`,
+which falls outside the storable range, so `status` is omitted rather than sent and
+discarded.
 
 `in_flight` is not produced by either matrix. It is assigned at snapshot time to
 records that have not finalized, with `duration_ms` set to elapsed-so-far. Without
@@ -229,13 +239,22 @@ If more than 20 requests are concurrently active, step 1 consumes the whole
 allowance and no completions are included. That is the correct trade for this
 feature, and the resulting snapshot is still ordered longest-running first.
 
-The active registry is bounded by the same cap on insert, evicting the *newest*
-active record when full, so a burst of short requests cannot displace a long-running
-one. Entries are removed from the registry on finalization.
+The active registry is bounded by the same cap, and at capacity it **refuses the
+new request** rather than evicting an existing one. Evicting the newest and then
+inserting an even newer record would keep the arrival that just displaced its
+predecessor — the exact inversion of the policy. Refusing keeps the oldest 20,
+which are the long-running requests being diagnosed. Entries are removed from the
+registry on finalization.
 
 `buildPayload` (`core.ts:65`) takes a snapshot; neither collection is cleared
 afterwards, so a second error in the same session still carries preceding request
 history.
+
+Request handles are never reissued, including across `clearNetworkTimings()`.
+`unpatchFetch`/`unpatchXHR` cannot cancel a request that is already awaiting
+(`network.ts:70`) or detach listeners already registered, so a callback from before
+`destroy()` can fire after re-init. Were handles to restart at zero, that stale
+callback would finalize an unrelated new request holding the reused handle.
 
 `destroy()` (`index.ts:53`) clears both collections via a `safeCall`, alongside the
 existing `clearBreadcrumbs`. Without it, request history survives across
@@ -274,7 +293,9 @@ Sanitization in `handler/error_event.go` mirrors `sanitizeDebugMeta`
 - non-object entries are dropped;
 - at most 20 entries retained, in first-seen order;
 - `transport` must be `fetch` or `xhr`;
-- `method` must be 1–16 bytes of `A-Z` after upper-casing;
+- `method` must match `^[A-Z0-9._-]{1,16}$` after upper-casing — punctuation is
+  permitted because real methods carry it and because a 16-byte SDK truncation can
+  clip one mid-token;
 - `url` must be 1–2048 bytes and free of control characters;
 - `started_at_ms`, `duration_ms`, and `ttfb_ms` must be finite and non-negative,
   with elapsed values at most 600000 (ten minutes), above which the entry is

--- a/docs/superpowers/specs/2026-08-06-sdk-network-timing-design.md
+++ b/docs/superpowers/specs/2026-08-06-sdk-network-timing-design.md
@@ -1,0 +1,236 @@
+# Browser SDK network timing capture
+
+Date: 2026-08-06
+Status: approved, not implemented
+
+## Problem
+
+The SDK reports what threw, never how long anything took. For timeout-class errors
+that leaves the investigation agent with no way to reach a root cause.
+
+[PR #1297 on `conelike/asset-management-jira`][pr] is the worked example. A
+`TimeoutError: signal timed out` from an `AbortSignal.timeout(FETCH_TIMEOUT)`
+produced a fix that raised the constant from 10s to 30s in three files. The PR was
+closed unmerged.
+
+The agent had a minified stack, breadcrumbs, and nothing else. The PR body records
+`Visual replay analysis not available` and `Signals not available`. Nothing in the
+payload distinguished:
+
+- the server replied, just past the deadline;
+- the server received the request and never replied;
+- the request never left the browser.
+
+Those have different fixes and only one of them is a timeout constant. Raising the
+constant was the only action the available evidence supported.
+
+[pr]: https://github.com/conelike/asset-management-jira/pull/1297
+
+## What exists today
+
+`packages/sdk/src/network.ts` already brackets every fetch and XHR. On rejection it
+writes a breadcrumb carrying method, URL, and the error message — but no elapsed
+time (`network.ts:96-107`).
+
+`request_start` / `request_end` telemetry with timestamps does exist
+(`telemetry.ts:7-8`), but it rides inside the rrweb replay stream
+(`shared/src/types.ts:353-357`) and reaches the agent only when replay analysis
+succeeds. On PR #1297 it did not.
+
+So the timing was arguably collected and still could not be read. Storing it
+somewhere the error event does not reach is equivalent to not storing it.
+
+## Prior art
+
+| | Capture | Where it lands |
+| --- | --- | --- |
+| Sentry | Patches fetch/XHR into `http.client` spans; `enableHTTPTimings` merges Resource Timing | Performance product. Error breadcrumbs carry only method/url/status |
+| PostHog | Wraps fetch/XHR plus `PerformanceObserver` | Session replay blobs; their docs state it is not queryable |
+| Highlight | OpenTelemetry browser auto-instrumentation | Traces product, linked to sessions |
+
+All three separate timing from the error, because their consumer is a human who can
+open the error and click across to the performance view. Opslane's consumer is an
+agent with one prompt and no ability to pivot. That difference is the whole reason
+this design puts timing on the error event.
+
+Worth copying: Sentry's explicit origin allowlist for trace headers, and its
+documented requirement that the customer's server send
+`Access-Control-Allow-Headers` or the request breaks.
+
+## Decisions
+
+**Capture is error-attached, not continuous.** A bounded in-memory buffer that
+leaves the browser only as part of an error event. No new always-on upload path, no
+new ingest volume. The wire shape is designed so aggregate rollups can be added
+later without a contract break.
+
+**No `traceparent` propagation in v1.** Adding a header to a cross-origin request
+forces a CORS preflight, so an SDK upgrade could start failing requests that worked
+the day before — the worst available failure mode for an error monitor. It also
+requires the customer to have backend tracing before it returns anything. Its value
+is real but it lands on a subset of customers and carries the largest blast radius
+in the SDK. Separate slice, separately justified.
+
+**Network timing only.** No longtask observer, no JS self-profiling. One capture
+mechanism, at patch points that already exist.
+
+**Patch-point wall clock is the spine; Resource Timing is not used in v1.** For
+cross-origin requests without `Timing-Allow-Origin`, `PerformanceResourceTiming`
+zeroes `domainLookupStart`, `connectStart`, `secureConnectionStart`, `requestStart`,
+and `responseStart` ([MDN][mdn]). Those are precisely the fields that would
+otherwise separate "slow server" from "never connected", and precisely the requests
+Opslane cares about are cross-origin. The phase breakdown Sentry advertises is
+mostly zeros for B2B SaaS traffic. Merging it stays available as a later seam.
+
+The discriminator that does survive cross-origin is **concurrency**: sibling
+requests to the same origin completing in ~200ms while one sits at 10,002ms
+identifies a single slow endpoint without any header cooperation. That signal is
+free, and it is what the buffer is shaped to produce.
+
+[mdn]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming
+
+## Scope
+
+In scope:
+
+- `packages/sdk/src/network.ts` — timing capture and rolling buffer
+- `packages/sdk/src/core.ts` — attach buffer snapshot to the payload
+- `shared/src/types.ts` — `NetworkTiming` type, optional payload field
+- `packages/ingestion` — migration, sanitization, storage
+- `docs/contracts/events.md`, frozen fixture pair
+
+Out of scope, deferred to a follow-up PR:
+
+- `packages/worker/src/db.ts` event select
+- `packages/worker/src/pipeline.ts` threading
+- Prompt sections in `investigate.ts` and `agent-fix.ts`
+- Any triage behavior change
+
+**This PR changes no diagnosis behavior.** The column is written and read by
+nothing until the follow-up lands. The migration carries a comment saying so, and
+the PR description must say so, or it will be misread as a fix for the PR #1297
+class of error.
+
+## SDK capture
+
+A module-local buffer in `network.ts`, hard-capped at 20 entries, **with no age
+eviction**. This differs deliberately from breadcrumbs, whose 30s window
+(`breadcrumbs.ts:5`) would discard a 30s timeout's own start record.
+
+```ts
+export interface NetworkTiming {
+  method: string;
+  url: string;
+  start: number;
+  duration_ms: number;
+  outcome: 'ok' | 'http_error' | 'timeout' | 'abort' | 'network_error' | 'in_flight';
+  status?: number;
+}
+```
+
+`url` is passed through the existing `scrubUrl` (`scrub.ts:6`), which already strips
+query strings, userinfo, and token-bearing fragments. Requests to the SDK's own
+endpoint are excluded by the existing `isSdkEndpoint` check.
+
+`outcome` is classified at the patch point from the rejection's `name`
+(`TimeoutError` / `AbortError`), never inferred from duration. This is the field
+that would have flipped PR #1297.
+
+`in_flight` entries are snapshotted when the error fires, with `duration_ms` set to
+elapsed-so-far. Without them the buffer records only completions, and the
+concurrency signal — the main discriminator available cross-origin — is lost.
+
+`start` is `Date.now()`, an absolute timestamp correlatable with breadcrumbs.
+`duration_ms` is computed from `performance.now()` deltas, because `Date.now()` can
+jump backwards on NTP correction or on a laptop waking from sleep, producing
+negative or inflated durations on exactly the long-running requests that matter.
+Existing telemetry uses `Date.now()` for both; that is not changed here, only not
+copied.
+
+No request headers and no bodies. PostHog captures both and needs a header
+deny-list plus payload redaction to do it safely. Capturing neither means this
+slice adds no new privacy surface beyond URLs, which are already captured and
+already scrubbed.
+
+`buildPayload` (`core.ts:65`) takes a copy of the buffer at error time. The buffer
+is **not** cleared afterwards, so a second error in the same session still carries
+the preceding request history; the count cap alone bounds it.
+
+Every buffer write is wrapped in `try {} catch {}`, matching every sibling in
+`network.ts`. The SDK must never throw into a customer's app.
+
+## Wire and storage
+
+New optional top-level field on `ErrorEventPayload`:
+
+```ts
+network_timings?: NetworkTiming[];
+```
+
+Append-only per `docs/contracts/events.md`: optional server-side, existing fixtures
+unaffected, decoding stays tolerant of unknown fields.
+
+The SDK sends the scrubbed raw URL, not a templated route. `/api/assets/12345`
+aggregates badly, but baking templating rules into a released SDK makes them
+unfixable — customers upgrade on their own schedule. Server-side templating can be
+corrected on any deploy. The cost is that grouping for the future aggregate slice is
+deferred work rather than free.
+
+Migration `033_event_network_timings.sql` follows `028_event_debug_meta.sql`: a
+JSONB column defaulting to `'[]'::jsonb`, with a `NOT VALID` type check validated in
+a second statement.
+
+Sanitization in `handler/error_event.go` mirrors `sanitizeDebugMeta`
+(`error_event.go:304`):
+
+- a non-array container becomes `[]`;
+- non-object entries are dropped;
+- at most 20 entries retained, in first-seen order;
+- `url` must be 1–2048 bytes and free of control characters;
+- `start` and `duration_ms` must be finite and non-negative, and `duration_ms` at
+  most 600000 (ten minutes), above which the entry is dropped rather than clamped;
+- `status`, when present, must be an integer in 100–599;
+- `outcome` must be one of the six known values;
+- discards increment a counter with a reason label, as `RecordDebugMetaDiscard` does.
+
+Malformed timing data never fails an event. This is the same guarantee that already
+governs `debug_meta`, and it matters more here because the data is advisory.
+
+## Testing
+
+SDK unit tests: duration is recorded on success and failure; a `TimeoutError`
+classifies as `timeout`; in-flight requests are snapshotted with elapsed time; the
+buffer caps at 20 and drops oldest; `scrubUrl` is applied; the SDK's own endpoint is
+excluded.
+
+Real-browser contract test covering capture, confirmed to **execute rather than
+skip** per `packages/sdk/AGENTS.md`.
+
+Wire contract: add `test-fixtures/wire/events/v4.1.0-minimal.json` (field omitted)
+and `v4.1.0-full.json` (field populated), and bump `WIRE_FIXTURE_VERSION` at
+`packages/sdk/src/__tests__/wire-shape.test.ts:20` from `3.0.0` to `4.1.0`. That
+constant tracks wire-shape changes rather than releases, which is why it currently
+lags the package version. Bump `packages/sdk/package.json` from `4.0.0` to `4.1.0`.
+`wire_compat_test.go` replays every fixture including the new pair. No existing
+fixture is edited or deleted.
+
+Go sanitizer tests for each malformed shape above.
+
+Live smoke per root `AGENTS.md`: apply migrations, seed, rebuild ingestion, drive a
+browser fixture that issues a request which times out, POST the event to
+`$INGESTION_URL/api/v1/events`, and assert the stored `network_timings` contains the
+timed-out entry with a plausible duration and `outcome: "timeout"`. Export the
+worktree port block as a unit, and confirm `go test ./...` reports **zero** skips —
+a storage misconfiguration reports `ok` while ~30 tests never run.
+
+## What this does not deliver
+
+No improvement in diagnosis quality. That arrives only when the follow-up PR reads
+the column into the agent prompt. The likely payoff there is narrower than better
+fixes: given sibling requests returning in 200ms while one hangs at 10s, the correct
+triage verdict for the PR #1297 class is `unfixable_infra` — an incident naming the
+slow endpoint, rather than a PR raising a constant. The reason code already exists
+and already carries a remediation string.
+
+Also not delivered: backend correlation, aggregate latency history, main-thread
+blocking, and page load timing.

--- a/packages/ingestion/db/migrations/033_event_network_timings.sql
+++ b/packages/ingestion/db/migrations/033_event_network_timings.sql
@@ -1,0 +1,12 @@
+SET lock_timeout = '3s';
+
+-- Written by ingestion, read by nothing. The worker slice that renders these
+-- into the investigation prompt lands separately.
+ALTER TABLE error_events
+  ADD COLUMN IF NOT EXISTS network_timings JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE error_events DROP CONSTRAINT IF EXISTS error_events_network_timings_array;
+ALTER TABLE error_events ADD CONSTRAINT error_events_network_timings_array
+  CHECK (jsonb_typeof(network_timings) = 'array') NOT VALID;
+
+ALTER TABLE error_events VALIDATE CONSTRAINT error_events_network_timings_array;

--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -420,6 +420,7 @@ type IngestParams struct {
 	Context              string // JSON, defaults to "{}"
 	Release              string // source map lookup
 	DebugMeta            string // JSON, defaults to {"images":[]}
+	NetworkTimings       string // JSON array, defaults to "[]"
 	CommitSHA            string // optional lowercase Git object ID
 	SessionID            string // links error event to replay
 	Platform             string // javascript | python | future wire token; empty defaults to javascript
@@ -461,6 +462,9 @@ func (q *Queries) InsertErrorEventAndGroup(ctx context.Context, p IngestParams) 
 	}
 	if p.DebugMeta == "" {
 		p.DebugMeta = `{"images":[]}`
+	}
+	if p.NetworkTimings == "" {
+		p.NetworkTimings = "[]"
 	}
 	if p.Platform == "" {
 		p.Platform = "javascript"
@@ -516,10 +520,10 @@ func (q *Queries) InsertErrorEventAndGroup(ctx context.Context, p IngestParams) 
 	// 1. Insert error event
 	var eventID string
 	err = tx.QueryRow(ctx,
-		`INSERT INTO error_events (project_id, environment_id, timestamp, error_type, error_message, stack_trace_raw, breadcrumbs, context, release, session_id, platform, debug_meta, commit_sha)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10, $11, $12::jsonb, $13)
+		`INSERT INTO error_events (project_id, environment_id, timestamp, error_type, error_message, stack_trace_raw, breadcrumbs, context, release, session_id, platform, debug_meta, commit_sha, network_timings)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10, $11, $12::jsonb, $13, $14::jsonb)
 		 RETURNING id`,
-		p.ProjectID, environmentID, eventTime, p.ErrorType, p.ErrorMessage, p.StackTraceRaw, p.Breadcrumbs, p.Context, nilIfEmpty(p.Release), nilIfEmpty(p.SessionID), p.Platform, p.DebugMeta, nilIfEmpty(p.CommitSHA),
+		p.ProjectID, environmentID, eventTime, p.ErrorType, p.ErrorMessage, p.StackTraceRaw, p.Breadcrumbs, p.Context, nilIfEmpty(p.Release), nilIfEmpty(p.SessionID), p.Platform, p.DebugMeta, nilIfEmpty(p.CommitSHA), p.NetworkTimings,
 	).Scan(&eventID)
 	if err != nil {
 		return nil, fmt.Errorf("insert error event: %w", err)

--- a/packages/ingestion/db/queries_test.go
+++ b/packages/ingestion/db/queries_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sort"
 	"strings"
@@ -13,6 +14,55 @@ import (
 
 	"github.com/opslane/opslane/packages/ingestion/db"
 )
+
+func TestInsertErrorEventStoresNetworkTimings(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+
+	org, err := q.CreateOrg(ctx, "test-network-timings")
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	t.Cleanup(func() { cleanupTenant(t, pool, org.ID) })
+
+	proj, err := q.CreateProject(ctx, org.ID, "proj-network-timings", ptrStr("org/repo"))
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	env, err := q.CreateEnvironment(ctx, proj.ID, "production")
+	if err != nil {
+		t.Fatalf("CreateEnvironment: %v", err)
+	}
+
+	timings := `[{"transport":"fetch","method":"POST","url":"https://api.test/search","started_at_ms":1,"duration_ms":10002,"outcome":"timeout"}]`
+	result, err := q.InsertErrorEventAndGroup(ctx, db.IngestParams{
+		ProjectID:            proj.ID,
+		DefaultEnvironmentID: env.ID,
+		ErrorType:            "TimeoutError",
+		ErrorMessage:         "signal timed out",
+		Fingerprint:          "fp-network-timings",
+		Title:                "TimeoutError: signal timed out",
+		NetworkTimings:       timings,
+	})
+	if err != nil {
+		t.Fatalf("InsertErrorEventAndGroup: %v", err)
+	}
+
+	var stored string
+	if err := pool.QueryRow(ctx,
+		`SELECT network_timings::text FROM error_events WHERE id = $1`, result.EventID,
+	).Scan(&stored); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	var decoded []map[string]any
+	if err := json.Unmarshal([]byte(stored), &decoded); err != nil {
+		t.Fatalf("unmarshal stored timings: %v", err)
+	}
+	if len(decoded) != 1 || decoded[0]["outcome"] != "timeout" {
+		t.Fatalf("stored timings unexpected: %s", stored)
+	}
+}
 
 // seedGroup creates an org/project/environment hierarchy plus one ingested
 // error group and returns the pieces tests need.

--- a/packages/ingestion/handler/error_event.go
+++ b/packages/ingestion/handler/error_event.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -95,16 +97,17 @@ func (d *Dependencies) ingestErrorEvent(w http.ResponseWriter, r *http.Request, 
 			Message string `json:"message"`
 			Stack   string `json:"stack"`
 		} `json:"error"`
-		Breadcrumbs json.RawMessage `json:"breadcrumbs"`
-		Context     json.RawMessage `json:"context"`
-		Platform    string          `json:"platform"`
-		Runtime     json.RawMessage `json:"runtime"`
-		SDKVersion  string          `json:"sdk_version"`
-		Release     string          `json:"release"`
-		DebugMeta   json.RawMessage `json:"debug_meta"`
-		CommitSHA   json.RawMessage `json:"commit_sha"`
-		SessionID   string          `json:"session_id"`
-		Environment string          `json:"environment"`
+		Breadcrumbs    json.RawMessage `json:"breadcrumbs"`
+		Context        json.RawMessage `json:"context"`
+		Platform       string          `json:"platform"`
+		Runtime        json.RawMessage `json:"runtime"`
+		SDKVersion     string          `json:"sdk_version"`
+		Release        string          `json:"release"`
+		DebugMeta      json.RawMessage `json:"debug_meta"`
+		NetworkTimings json.RawMessage `json:"network_timings"`
+		CommitSHA      json.RawMessage `json:"commit_sha"`
+		SessionID      string          `json:"session_id"`
+		Environment    string          `json:"environment"`
 	}
 
 	if err := json.Unmarshal(body, &payload); err != nil {
@@ -131,6 +134,7 @@ func (d *Dependencies) ingestErrorEvent(w http.ResponseWriter, r *http.Request, 
 		payload.Platform = "javascript"
 	}
 	debugMeta := sanitizeDebugMeta(payload.DebugMeta)
+	networkTimings := sanitizeNetworkTimings(payload.NetworkTimings)
 	commitSHA := sanitizeCommitSHA(payload.CommitSHA)
 
 	// Default breadcrumbs/context
@@ -238,6 +242,7 @@ func (d *Dependencies) ingestErrorEvent(w http.ResponseWriter, r *http.Request, 
 		Context:              ctx,
 		Release:              payload.Release,
 		DebugMeta:            debugMeta.JSON,
+		NetworkTimings:       networkTimings,
 		CommitSHA:            commitSHA,
 		SessionID:            payload.SessionID,
 		Platform:             payload.Platform,
@@ -397,6 +402,142 @@ func sanitizeDebugMeta(raw json.RawMessage) debugMetaValidation {
 	}
 	result.ImageCount = len(retained)
 	return result
+}
+
+const (
+	maxNetworkTimings  = 20
+	maxTimingURLBytes  = 2048
+	maxTimingElapsedMs = 600000
+)
+
+var (
+	timingMethodBytes  = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+.^_`|~-"
+	validTransports    = map[string]struct{}{"fetch": {}, "xhr": {}}
+	validTimingOutcome = map[string]struct{}{
+		"ok": {}, "http_error": {}, "timeout": {},
+		"abort": {}, "network_error": {}, "in_flight": {},
+	}
+)
+
+type validatedNetworkTiming struct {
+	Transport   string   `json:"transport"`
+	Method      string   `json:"method"`
+	URL         string   `json:"url"`
+	StartedAtMs *float64 `json:"started_at_ms"`
+	DurationMs  *float64 `json:"duration_ms"`
+	TTFBMs      *float64 `json:"ttfb_ms,omitempty"`
+	Outcome     string   `json:"outcome"`
+	Status      *int     `json:"status,omitempty"`
+}
+
+func validTimingMethod(value string) bool {
+	if len(value) == 0 || len(value) > 16 {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if !strings.ContainsRune(timingMethodBytes, rune(value[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+func validTimingURL(value string) bool {
+	if len(value) == 0 || len(value) > maxTimingURLBytes {
+		return false
+	}
+	return strings.IndexFunc(value, func(r rune) bool { return r < 0x20 || r == 0x7f }) < 0
+}
+
+func validElapsed(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0) && value >= 0 && value <= maxTimingElapsedMs
+}
+
+// sanitizeNetworkTimings validates advisory timing data independently of the
+// SDK. Invalid entries are dropped rather than causing event ingestion to fail.
+func sanitizeNetworkTimings(raw json.RawMessage) string {
+	const empty = `[]`
+	if len(raw) == 0 {
+		return empty
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		RecordNetworkTimingDiscard("malformed_container")
+		return empty
+	}
+
+	var entries []json.RawMessage
+	if err := json.Unmarshal(trimmed, &entries); err != nil || entries == nil {
+		RecordNetworkTimingDiscard("malformed_container")
+		return empty
+	}
+
+	retained := make([]validatedNetworkTiming, 0, min(len(entries), maxNetworkTimings))
+	for _, entry := range entries {
+		if len(retained) == maxNetworkTimings {
+			RecordNetworkTimingDiscard("over_limit")
+			continue
+		}
+
+		var candidate validatedNetworkTiming
+		trimmedEntry := bytes.TrimSpace(entry)
+		if len(trimmedEntry) == 0 || trimmedEntry[0] != '{' || json.Unmarshal(trimmedEntry, &candidate) != nil {
+			RecordNetworkTimingDiscard("non_object_entry")
+			continue
+		}
+		if _, ok := validTransports[candidate.Transport]; !ok {
+			RecordNetworkTimingDiscard("bad_transport")
+			continue
+		}
+		candidate.Method = strings.ToUpper(candidate.Method)
+		if !validTimingMethod(candidate.Method) {
+			RecordNetworkTimingDiscard("bad_method")
+			continue
+		}
+		if !validTimingURL(candidate.URL) {
+			RecordNetworkTimingDiscard("bad_url")
+			continue
+		}
+		if _, ok := validTimingOutcome[candidate.Outcome]; !ok {
+			RecordNetworkTimingDiscard("bad_outcome")
+			continue
+		}
+		if candidate.StartedAtMs == nil || *candidate.StartedAtMs < 0 || math.IsInf(*candidate.StartedAtMs, 0) || math.IsNaN(*candidate.StartedAtMs) {
+			RecordNetworkTimingDiscard("bad_started_at")
+			continue
+		}
+		if candidate.DurationMs == nil || !validElapsed(*candidate.DurationMs) {
+			RecordNetworkTimingDiscard("bad_duration")
+			continue
+		}
+		if candidate.TTFBMs != nil && !validElapsed(*candidate.TTFBMs) {
+			RecordNetworkTimingDiscard("bad_ttfb")
+			continue
+		}
+		if candidate.Status != nil && (*candidate.Status < 100 || *candidate.Status > 599) {
+			RecordNetworkTimingDiscard("bad_status")
+			continue
+		}
+
+		candidate.URL = masking.RedactRequestURL(candidate.URL)
+		if !validTimingURL(candidate.URL) {
+			RecordNetworkTimingDiscard("bad_url")
+			continue
+		}
+
+		*candidate.StartedAtMs = math.Round(*candidate.StartedAtMs)
+		*candidate.DurationMs = math.Round(*candidate.DurationMs)
+		if candidate.TTFBMs != nil {
+			*candidate.TTFBMs = math.Round(*candidate.TTFBMs)
+		}
+		retained = append(retained, candidate)
+	}
+
+	encoded, err := json.Marshal(retained)
+	if err != nil {
+		return empty
+	}
+	return string(encoded)
 }
 
 func validCodeFile(value string) bool {

--- a/packages/ingestion/handler/metrics.go
+++ b/packages/ingestion/handler/metrics.go
@@ -23,6 +23,10 @@ var (
 		mu       sync.Mutex
 		byReason map[string]*atomic.Int64
 	}
+	networkTimingsDiscardedTotal struct {
+		mu       sync.Mutex
+		byReason map[string]*atomic.Int64
+	}
 	commitSHADiscardedTotal             atomic.Int64
 	eventsWithDebugImagesTotal          atomic.Int64
 	debugMetaRegistryZeroMatchedTotal   atomic.Int64
@@ -63,6 +67,7 @@ func init() {
 		"python":     {},
 	}
 	debugMetaDiscardedTotal.byReason = make(map[string]*atomic.Int64)
+	networkTimingsDiscardedTotal.byReason = make(map[string]*atomic.Int64)
 	ingestDuration.buckets = []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1.0}
 	ingestDuration.counts = make([]atomic.Int64, len(ingestDuration.buckets))
 }
@@ -94,6 +99,24 @@ func RecordDebugMetaDiscard(reason string) {
 		debugMetaDiscardedTotal.byReason[reason] = counter
 	}
 	debugMetaDiscardedTotal.mu.Unlock()
+	counter.Add(1)
+}
+
+func RecordNetworkTimingDiscard(reason string) {
+	switch reason {
+	case "malformed_container", "non_object_entry", "bad_transport", "bad_method",
+		"bad_url", "bad_outcome", "bad_started_at", "bad_duration", "bad_ttfb",
+		"bad_status", "over_limit":
+	default:
+		return
+	}
+	networkTimingsDiscardedTotal.mu.Lock()
+	counter, ok := networkTimingsDiscardedTotal.byReason[reason]
+	if !ok {
+		counter = &atomic.Int64{}
+		networkTimingsDiscardedTotal.byReason[reason] = counter
+	}
+	networkTimingsDiscardedTotal.mu.Unlock()
 	counter.Add(1)
 }
 
@@ -226,6 +249,20 @@ func Metrics(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "opslane_debug_meta_images_discarded_total{reason=%q} %d\n", reason, count)
 	}
 	debugMetaDiscardedTotal.mu.Unlock()
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "# HELP opslane_network_timings_discarded_total Network timing entries discarded during validation")
+	fmt.Fprintln(w, "# TYPE opslane_network_timings_discarded_total counter")
+	networkTimingsDiscardedTotal.mu.Lock()
+	timingReasons := []string{"malformed_container", "non_object_entry", "bad_transport", "bad_method", "bad_url", "bad_outcome", "bad_started_at", "bad_duration", "bad_ttfb", "bad_status", "over_limit"}
+	for _, reason := range timingReasons {
+		count := int64(0)
+		if counter := networkTimingsDiscardedTotal.byReason[reason]; counter != nil {
+			count = counter.Load()
+		}
+		fmt.Fprintf(w, "opslane_network_timings_discarded_total{reason=%q} %d\n", reason, count)
+	}
+	networkTimingsDiscardedTotal.mu.Unlock()
 	fmt.Fprintln(w)
 
 	fmt.Fprintln(w, "# HELP opslane_commit_sha_discarded_total Invalid optional commit SHA fields discarded")

--- a/packages/ingestion/handler/metrics_test.go
+++ b/packages/ingestion/handler/metrics_test.go
@@ -25,6 +25,21 @@ func TestRecordStacklessAccepted_AppearsInMetrics(t *testing.T) {
 	}
 }
 
+func TestRecordNetworkTimingDiscard_AppearsInMetrics(t *testing.T) {
+	RecordNetworkTimingDiscard("bad_url")
+	RecordNetworkTimingDiscard("unbounded_label")
+
+	w := httptest.NewRecorder()
+	Metrics(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := w.Body.String()
+	if !strings.Contains(body, `opslane_network_timings_discarded_total{reason="bad_url"}`) {
+		t.Fatalf("network timing discard metric missing:\n%s", body)
+	}
+	if strings.Contains(body, `reason="unbounded_label"`) {
+		t.Fatalf("unexpected unbounded reason label:\n%s", body)
+	}
+}
+
 func TestRecordSuppressed_AppearsInMetrics(t *testing.T) {
 	before := suppressedResizeObserverTotal.Load()
 	RecordSuppressed("resize_observer")

--- a/packages/ingestion/handler/network_timings_internal_test.go
+++ b/packages/ingestion/handler/network_timings_internal_test.go
@@ -1,0 +1,58 @@
+package handler
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeNetworkTimings(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"absent", ``, `[]`},
+		{"non-array container", `{"a":1}`, `[]`},
+		{"non-object entry", `["x"]`, `[]`},
+		{"bad transport", `[{"transport":"grpc","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok"}]`, `[]`},
+		{"bad method", `[{"transport":"fetch","method":"get@","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok"}]`, `[]`},
+		{"bad outcome", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"weird"}]`, `[]`},
+		{"negative duration", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":-2,"outcome":"ok"}]`, `[]`},
+		{"duration over cap", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":600001,"outcome":"ok"}]`, `[]`},
+		{"control chars in url", "[{\"transport\":\"fetch\",\"method\":\"GET\",\"url\":\"https://a.test/\\u0000\",\"started_at_ms\":1,\"duration_ms\":2,\"outcome\":\"ok\"}]", `[]`},
+		{"status out of range", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok","status":0}]`, `[]`},
+		{"missing duration", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"outcome":"ok"}]`, `[]`},
+		{"null started_at", `[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":null,"duration_ms":2,"outcome":"ok"}]`, `[]`},
+		{"hyphenated method the SDK can emit is accepted", `[{"transport":"xhr","method":"PROPFIND-VERY-LO","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok"}]`, `[{"transport":"xhr","method":"PROPFIND-VERY-LO","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok"}]`},
+		{
+			"valid entry is retained and its query stripped",
+			`[{"transport":"fetch","method":"get","url":"https://a.test/x?token=abc","started_at_ms":1,"duration_ms":2,"outcome":"timeout"}]`,
+			`[{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"timeout"}]`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeNetworkTimings(json.RawMessage(tc.in))
+			if got != tc.want {
+				t.Fatalf("sanitizeNetworkTimings(%s) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeNetworkTimingsCapsAtTwenty(t *testing.T) {
+	var entries []string
+	for i := 0; i < 30; i++ {
+		entries = append(entries, `{"transport":"fetch","method":"GET","url":"https://a.test/x","started_at_ms":1,"duration_ms":2,"outcome":"ok","status":200}`)
+	}
+	raw := "[" + strings.Join(entries, ",") + "]"
+
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(sanitizeNetworkTimings(json.RawMessage(raw))), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 20 {
+		t.Fatalf("retained %d entries, want 20", len(got))
+	}
+}

--- a/packages/ingestion/handler/wire_compat_test.go
+++ b/packages/ingestion/handler/wire_compat_test.go
@@ -26,17 +26,18 @@ type wireFixture struct {
 		Message string `json:"message"`
 		Stack   string `json:"stack"`
 	} `json:"error"`
-	Breadcrumbs json.RawMessage `json:"breadcrumbs"`
-	Context     json.RawMessage `json:"context"`
-	Platform    string          `json:"platform"`
-	Runtime     json.RawMessage `json:"runtime"`
-	SDKVersion  string          `json:"sdk_version"`
-	Release     string          `json:"release"`
-	DebugMeta   json.RawMessage `json:"debug_meta"`
-	CommitSHA   string          `json:"commit_sha"`
-	SessionID   string          `json:"session_id"`
-	Environment string          `json:"environment"`
-	ContextUser *struct {
+	Breadcrumbs    json.RawMessage `json:"breadcrumbs"`
+	Context        json.RawMessage `json:"context"`
+	Platform       string          `json:"platform"`
+	Runtime        json.RawMessage `json:"runtime"`
+	SDKVersion     string          `json:"sdk_version"`
+	Release        string          `json:"release"`
+	DebugMeta      json.RawMessage `json:"debug_meta"`
+	NetworkTimings json.RawMessage `json:"network_timings"`
+	CommitSHA      string          `json:"commit_sha"`
+	SessionID      string          `json:"session_id"`
+	Environment    string          `json:"environment"`
+	ContextUser    *struct {
 		ID          string `json:"id"`
 		Email       string `json:"email"`
 		AccountID   string `json:"account_id"`
@@ -172,18 +173,19 @@ func TestWireFixtures_AcceptedAndStored(t *testing.T) {
 			var (
 				timestamp                                                         time.Time
 				errorType, errorMessage, stack, release, sessionID, eventPlatform string
-				breadcrumbsText, contextText, debugMetaText, commitSHA, groupID   string
+				breadcrumbsText, contextText, debugMetaText, networkTimingsText   string
+				commitSHA, groupID                                                string
 				endUserID                                                         *string
 			)
 			if err := pool.QueryRow(context.Background(), `
 				SELECT "timestamp", error_type, error_message, stack_trace_raw,
 				       COALESCE(release,''), COALESCE(session_id,''),
-				       breadcrumbs::text, context::text, debug_meta::text,
+				       breadcrumbs::text, context::text, debug_meta::text, network_timings::text,
 				       COALESCE(commit_sha, ''),
 				       error_group_id::text, end_user_id::text, platform
 				FROM error_events WHERE id = $1`, eventID).
 				Scan(&timestamp, &errorType, &errorMessage, &stack, &release, &sessionID,
-					&breadcrumbsText, &contextText, &debugMetaText, &commitSHA,
+					&breadcrumbsText, &contextText, &debugMetaText, &networkTimingsText, &commitSHA,
 					&groupID, &endUserID, &eventPlatform); err != nil {
 				t.Fatalf("query stored event: %v", err)
 			}
@@ -224,6 +226,11 @@ func TestWireFixtures_AcceptedAndStored(t *testing.T) {
 				expectedDebugMeta = json.RawMessage(`{"images":[]}`)
 			}
 			semanticJSONEqual(t, "debug_meta", debugMetaText, expectedDebugMeta)
+			wantTimings := fixture.NetworkTimings
+			if len(wantTimings) == 0 {
+				wantTimings = json.RawMessage(`[]`)
+			}
+			semanticJSONEqual(t, "network_timings", networkTimingsText, wantTimings)
 			if commitSHA != fixture.CommitSHA {
 				t.Errorf("commit_sha = %q, want %q", commitSHA, fixture.CommitSHA)
 			}

--- a/packages/ingestion/masking/masking.go
+++ b/packages/ingestion/masking/masking.go
@@ -3,6 +3,7 @@ package masking
 import (
 	"bytes"
 	"encoding/json"
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -101,6 +102,31 @@ func RedactURL(s string) string {
 	out := urlCredRe.ReplaceAllString(s, `${1}[REDACTED]@`)
 	out = urlSecretQueryRe.ReplaceAllString(out, `${1}[REDACTED]`)
 	return out
+}
+
+// tokenFragmentRe matches fragments carrying an OAuth-style credential.
+var tokenFragmentRe = regexp.MustCompile(`(?i)(access_token|id_token|refresh_token|token|code)=`)
+
+// RedactRequestURL strips userinfo, the entire query string, and token-bearing
+// fragments from a single request URL. It is deliberately stricter than
+// RedactURL because ingestion cannot assume the client already scrubbed it.
+func RedactRequestURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		// Fail closed for malformed URLs too: retain only the portion before
+		// query/fragment delimiters, then apply the broad credential scrubber.
+		if index := strings.IndexAny(raw, "?#"); index >= 0 {
+			raw = raw[:index]
+		}
+		return RedactURL(raw)
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.ForceQuery = false
+	if u.Fragment != "" && tokenFragmentRe.MatchString(u.Fragment) {
+		u.Fragment = ""
+	}
+	return u.String()
 }
 
 var sensitiveContextKeys = map[string]struct{}{

--- a/packages/ingestion/masking/masking_test.go
+++ b/packages/ingestion/masking/masking_test.go
@@ -219,6 +219,38 @@ func TestRedactURL(t *testing.T) {
 	}
 }
 
+func TestRedactRequestURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"drops the whole query string", "https://api.example.com/v1/search?q=hi&token=abc", "https://api.example.com/v1/search"},
+		{"drops userinfo", "https://user:pw@api.example.com/v1/search", "https://api.example.com/v1/search"},
+		{"drops a token-bearing fragment", "https://api.example.com/cb#access_token=abc", "https://api.example.com/cb"},
+		{"drops a prefixed token fragment", "https://api.example.com/cb#oauth_access_token=abc", "https://api.example.com/cb"},
+		{"keeps a route fragment", "https://app.example.com/x#/dashboard", "https://app.example.com/x#/dashboard"},
+		{"leaves a clean URL alone", "https://api.example.com/v1/items", "https://api.example.com/v1/items"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := masking.RedactRequestURL(tc.in); got != tc.want {
+				t.Fatalf("RedactRequestURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRedactRequestURLUnparseable(t *testing.T) {
+	got := masking.RedactRequestURL("://not a url?token=abc")
+	if strings.Contains(got, "abc") {
+		t.Fatalf("RedactRequestURL leaked a token: %q", got)
+	}
+	if got := masking.RedactRequestURL("https://a.test/%zz?email=user@example.com"); strings.Contains(got, "user@example.com") {
+		t.Fatalf("RedactRequestURL leaked a malformed URL query: %q", got)
+	}
+}
+
 func TestRedactContext(t *testing.T) {
 	in := []byte(`{"user":{"id":"u1","email":"a@b.com"},"auth":{"Authorization":"Bearer ghp_tok123"},"note":"key sk_live_zzz here","url":"https://u:p@h/x","n":7}`)
 	out := masking.RedactContext(in)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opslane/sdk",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "type": "module",
   "description": "Browser error monitoring SDK for Opslane",
   "license": "MIT",

--- a/packages/sdk/src/__tests__/browser-contract.test.ts
+++ b/packages/sdk/src/__tests__/browser-contract.test.ts
@@ -36,6 +36,8 @@ interface ViteDevServer {
 
 let mockServer: http.Server;
 let mockPort: number;
+let hangServer: http.Server;
+let hangPort: number;
 let receivedEvents: unknown[];
 let viteServer: ViteDevServer;
 let vitePort: number;
@@ -82,6 +84,14 @@ describe.skipIf(!playwrightAvailable)('SDK browser contract', () => {
       r();
     }));
 
+    hangServer = http.createServer(() => {
+      // Deliberately never respond; AbortSignal.timeout ends the request.
+    });
+    await new Promise<void>(r => hangServer.listen(0, () => {
+      hangPort = (hangServer.address() as { port: number }).port;
+      r();
+    }));
+
     // 2. Start Vite dev server for fixture app
     const { createServer } = await import('vite');
     const vue = (await import('@vitejs/plugin-vue')).default;
@@ -94,6 +104,9 @@ describe.skipIf(!playwrightAvailable)('SDK browser contract', () => {
         },
       },
       server: { port: 0 },
+      define: {
+        'import.meta.env.VITE_OPSLANE_HANG_URL': JSON.stringify(`http://localhost:${hangPort}/hang`),
+      },
       plugins: [
         vue(),
         {
@@ -130,6 +143,8 @@ describe.skipIf(!playwrightAvailable)('SDK browser contract', () => {
     await page?.close();
     await browser?.close();
     await viteServer?.close();
+    hangServer?.closeAllConnections();
+    await new Promise<void>(r => hangServer?.close(() => r()));
     await new Promise<void>(r => mockServer?.close(() => r()));
   });
 
@@ -166,4 +181,27 @@ describe.skipIf(!playwrightAvailable)('SDK browser contract', () => {
     const event = receivedEvents[0] as Record<string, unknown>;
     expect((event.error as Record<string, unknown>).message).toContain('Sync failed');
   }, 15_000);
+
+  it('captures a timed-out fetch with its duration in a real browser', async () => {
+    receivedEvents = [];
+
+    await page.goto(`http://localhost:${vitePort}`);
+    await page.click('[data-testid="nav-fetch"]');
+    await page.click('[data-testid="load-slow-btn"]');
+    await page.waitForTimeout(4000);
+
+    expect(receivedEvents.length).toBeGreaterThanOrEqual(1);
+    const event = receivedEvents.find(
+      (entry) => Array.isArray((entry as Record<string, unknown>).network_timings),
+    ) as Record<string, unknown> | undefined;
+    expect(event).toBeDefined();
+
+    const timings = event!.network_timings as Array<Record<string, unknown>>;
+    const hung = timings.find((timing) => String(timing.url).includes('/hang'));
+    expect(hung).toBeDefined();
+    expect(hung!.transport).toBe('fetch');
+    expect(hung!.outcome).toBe('timeout');
+    expect(hung).not.toHaveProperty('ttfb_ms');
+    expect(hung!.duration_ms as number).toBeGreaterThanOrEqual(900);
+  }, 20_000);
 });

--- a/packages/sdk/src/__tests__/core.test.ts
+++ b/packages/sdk/src/__tests__/core.test.ts
@@ -5,6 +5,7 @@ import { addBreadcrumb, clearBreadcrumbs, getBreadcrumbs } from '../breadcrumbs'
 import * as transport from '../transport';
 import { TEST_PK } from './test-keys';
 import { COMMIT_SHA_GLOBAL } from '../build/registry-contract';
+import { clearNetworkTimings, finalizeTiming, startTiming } from '../network-timing';
 
 vi.mock('../transport', () => ({
   enqueueEvent: vi.fn(),
@@ -14,6 +15,7 @@ describe('Core Error Capture', () => {
   beforeEach(() => {
     resetConfig();
     clearBreadcrumbs();
+    clearNetworkTimings();
     loadConfig({
       endpoint: 'https://ingest.example.com',
       apiKey: TEST_PK,
@@ -24,6 +26,7 @@ describe('Core Error Capture', () => {
     uninstallGlobalHandlers();
     resetConfig();
     clearBreadcrumbs();
+    clearNetworkTimings();
     vi.restoreAllMocks();
     delete (globalThis as Record<string, unknown>)[COMMIT_SHA_GLOBAL];
   });
@@ -303,5 +306,30 @@ describe('Core Error Capture', () => {
       type: 'error', timestamp: new Date().toISOString(), category: 'exception', message: 'x', level: 'error',
     });
     expect(payload.release).toBe('sha-abc123');
+  });
+});
+
+describe('network timings on the payload', () => {
+  beforeEach(() => {
+    clearNetworkTimings();
+    loadConfig({ apiKey: TEST_PK, endpoint: 'https://api.test', errorThrottleMs: 0 });
+  });
+
+  it('omits the field entirely when nothing was captured', () => {
+    const payload = buildPayload('TypeError', 'boom', '', {
+      type: 'error', timestamp: new Date().toISOString(), category: 'exception', message: 'boom',
+    });
+    expect(payload).not.toHaveProperty('network_timings');
+  });
+
+  it('attaches captured timings', () => {
+    const handle = startTiming('fetch', 'GET', 'https://app.example.com/api/items');
+    finalizeTiming(handle, 'timeout');
+
+    const payload = buildPayload('TypeError', 'boom', '', {
+      type: 'error', timestamp: new Date().toISOString(), category: 'exception', message: 'boom',
+    });
+    expect(payload.network_timings).toHaveLength(1);
+    expect(payload.network_timings?.[0].outcome).toBe('timeout');
   });
 });

--- a/packages/sdk/src/__tests__/network-timing-teardown.test.ts
+++ b/packages/sdk/src/__tests__/network-timing-teardown.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { destroy, init } from '../index';
+import { buildPayload } from '../core';
+import { clearNetworkTimings, finalizeTiming, snapshotNetworkTimings, startTiming } from '../network-timing';
+import { TEST_PK } from './test-keys';
+
+vi.mock('../transport', () => ({
+  enqueueEvent: vi.fn(),
+  flushEvents: vi.fn(),
+  startTransport: vi.fn(),
+  stopTransport: vi.fn(),
+}));
+
+describe('network timing teardown', () => {
+  beforeEach(() => clearNetworkTimings());
+
+  it('carries no history across destroy() and re-init()', () => {
+    init({ apiKey: TEST_PK, endpoint: 'https://api.test', errorThrottleMs: 0 });
+    const handle = startTiming('fetch', 'GET', 'https://app.example.com/api/before');
+    finalizeTiming(handle, 'ok', 200);
+    expect(snapshotNetworkTimings()).toHaveLength(1);
+
+    destroy();
+    expect(snapshotNetworkTimings()).toHaveLength(0);
+
+    init({ apiKey: TEST_PK, endpoint: 'https://api.test', errorThrottleMs: 0 });
+    const payload = buildPayload('TypeError', 'boom', '', {
+      type: 'error', timestamp: new Date().toISOString(), category: 'exception', message: 'boom',
+    });
+    expect(payload).not.toHaveProperty('network_timings');
+    destroy();
+  });
+});

--- a/packages/sdk/src/__tests__/network-timing.test.ts
+++ b/packages/sdk/src/__tests__/network-timing.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearNetworkTimings,
+  discardTiming,
+  finalizeTiming,
+  markHeaders,
+  snapshotNetworkTimings,
+  startTiming,
+} from '../network-timing';
+
+describe('network timing store', () => {
+  beforeEach(() => clearNetworkTimings());
+
+  it('records a completed request', () => {
+    const handle = startTiming('fetch', 'GET', 'https://api.test/a');
+    markHeaders(handle);
+    finalizeTiming(handle, 'ok', 200);
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.transport).toBe('fetch');
+    expect(entry.method).toBe('GET');
+    expect(entry.url).toBe('https://api.test/a');
+    expect(entry.outcome).toBe('ok');
+    expect(entry.status).toBe(200);
+    expect(entry.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(entry.ttfb_ms).toBeGreaterThanOrEqual(0);
+    expect(entry.started_at_ms).toBeGreaterThan(0);
+  });
+
+  it('omits ttfb_ms and status when never observed', () => {
+    const handle = startTiming('fetch', 'POST', 'https://api.test/b');
+    finalizeTiming(handle, 'timeout');
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.outcome).toBe('timeout');
+    expect(entry).not.toHaveProperty('ttfb_ms');
+    expect(entry).not.toHaveProperty('status');
+  });
+
+  it('scrubs the query string and truncates oversized values', () => {
+    const handle = startTiming('fetch', 'GET', 'https://api.test/c?token=secret#x');
+    finalizeTiming(handle, 'ok', 200);
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.url).not.toContain('secret');
+
+    clearNetworkTimings();
+    const long = startTiming('xhr', 'propfind-very-long-method', `https://api.test/${'a'.repeat(4000)}`);
+    finalizeTiming(long, 'ok', 200);
+
+    const [big] = snapshotNetworkTimings();
+    expect(big.url.length).toBe(2048);
+    expect(big.method).toBe('PROPFIND-VERY-LO');
+  });
+
+  it('truncates the url by utf-8 bytes, not utf-16 units', () => {
+    const handle = startTiming('fetch', 'GET', `https://api.test/${'é'.repeat(2000)}`);
+    finalizeTiming(handle, 'ok', 200);
+
+    const [entry] = snapshotNetworkTimings();
+    expect(new TextEncoder().encode(entry.url).length).toBeLessThanOrEqual(2048);
+    expect(entry.url).not.toMatch(/�$/);
+  });
+
+  it('keeps one long-running active request across 20 later completions', () => {
+    const slow = startTiming('fetch', 'POST', 'https://api.test/slow');
+    for (let i = 0; i < 20; i += 1) {
+      const fast = startTiming('fetch', 'GET', `https://api.test/fast-${i}`);
+      finalizeTiming(fast, 'ok', 200);
+    }
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot[0].url).toBe('https://api.test/slow');
+    expect(snapshot[0].outcome).toBe('in_flight');
+    expect(snapshot).toHaveLength(20);
+    expect(slow).toBeGreaterThanOrEqual(0);
+  });
+
+  it('refuses new requests at capacity and keeps the oldest twenty', () => {
+    const handles = [];
+    for (let i = 0; i < 25; i += 1) handles.push(startTiming('fetch', 'GET', `https://api.test/active-${i}`));
+
+    expect(handles[19]).not.toBe(-1);
+    expect(handles[20]).toBe(-1);
+    expect(handles[24]).toBe(-1);
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(20);
+    expect(snapshot.every((e) => e.outcome === 'in_flight')).toBe(true);
+    expect(snapshot[0].url).toBe('https://api.test/active-0');
+    expect(snapshot[19].url).toBe('https://api.test/active-19');
+    expect(snapshot.some((e) => e.url === 'https://api.test/active-20')).toBe(false);
+  });
+
+  it('no-ops on the untracked handle', () => {
+    for (let i = 0; i < 20; i += 1) startTiming('fetch', 'GET', `https://api.test/a-${i}`);
+    const untracked = startTiming('fetch', 'GET', 'https://api.test/refused');
+    expect(untracked).toBe(-1);
+
+    markHeaders(untracked);
+    finalizeTiming(untracked, 'ok', 200);
+    discardTiming(untracked);
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(20);
+    expect(snapshot.some((e) => e.url === 'https://api.test/refused')).toBe(false);
+  });
+
+  it('snapshots in-flight elapsed time from the monotonic clock', () => {
+    const nowSpy = vi.spyOn(performance, 'now');
+    nowSpy.mockReturnValue(1000);
+    startTiming('fetch', 'POST', 'https://api.test/slow');
+    nowSpy.mockReturnValue(11002);
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.outcome).toBe('in_flight');
+    expect(entry.duration_ms).toBe(10002);
+    nowSpy.mockRestore();
+  });
+
+  it('clamps elapsed values at the ingestion ceiling', () => {
+    const nowSpy = vi.spyOn(performance, 'now');
+    nowSpy.mockReturnValue(0);
+    const handle = startTiming('fetch', 'GET', 'https://api.test/forever');
+    nowSpy.mockReturnValue(900000);
+    finalizeTiming(handle, 'timeout');
+
+    expect(snapshotNetworkTimings()[0].duration_ms).toBe(600000);
+    nowSpy.mockRestore();
+  });
+
+  it('does not reuse handles after clearing', () => {
+    const stale = startTiming('fetch', 'GET', 'https://api.test/old');
+    clearNetworkTimings();
+    const fresh = startTiming('fetch', 'GET', 'https://api.test/new');
+    expect(fresh).not.toBe(stale);
+
+    finalizeTiming(stale, 'ok', 200);
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].url).toBe('https://api.test/new');
+    expect(snapshot[0].outcome).toBe('in_flight');
+  });
+
+  it('finalizes at most once', () => {
+    const handle = startTiming('xhr', 'GET', 'https://api.test/d');
+    finalizeTiming(handle, 'timeout');
+    finalizeTiming(handle, 'ok', 200);
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].outcome).toBe('timeout');
+  });
+
+  it('discards a record without recording it', () => {
+    const handle = startTiming('xhr', 'GET', 'https://api.test/e');
+    discardTiming(handle);
+    expect(snapshotNetworkTimings()).toHaveLength(0);
+  });
+
+  it('clears both collections', () => {
+    startTiming('fetch', 'GET', 'https://api.test/f');
+    const done = startTiming('fetch', 'GET', 'https://api.test/g');
+    finalizeTiming(done, 'ok', 200);
+
+    clearNetworkTimings();
+    expect(snapshotNetworkTimings()).toEqual([]);
+  });
+});

--- a/packages/sdk/src/__tests__/network.test.ts
+++ b/packages/sdk/src/__tests__/network.test.ts
@@ -9,10 +9,12 @@ import {
 import { clearBreadcrumbs, getBreadcrumbs } from '../breadcrumbs';
 import { loadConfig, resetConfig } from '../config';
 import { TEST_PK } from './test-keys';
+import { clearNetworkTimings, snapshotNetworkTimings } from '../network-timing';
 
 describe('Network Interceptor', () => {
   beforeEach(() => {
     clearBreadcrumbs();
+    clearNetworkTimings();
     resetConfig();
     loadConfig({
       endpoint: 'https://ingest.example.com',
@@ -24,6 +26,7 @@ describe('Network Interceptor', () => {
     unpatchFetch();
     unpatchXHR();
     clearBreadcrumbs();
+    clearNetworkTimings();
     resetConfig();
     vi.restoreAllMocks();
   });
@@ -184,5 +187,201 @@ describe('Network Interceptor', () => {
 
       expect(XMLHttpRequest.prototype.open).toBe(originalOpen);
     });
+  });
+});
+
+describe('fetch timing capture', () => {
+  beforeEach(() => {
+    clearNetworkTimings();
+    loadConfig({ apiKey: TEST_PK, endpoint: 'https://api.test', errorThrottleMs: 0 });
+  });
+  afterEach(() => {
+    unpatchFetch();
+    vi.unstubAllGlobals();
+  });
+
+  it('records ok with status and ttfb', async () => {
+    vi.stubGlobal('fetch', async () => ({ status: 200, ok: true, type: 'basic' }) as Response);
+    patchFetch();
+    await fetch('https://app.example.com/api/items');
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.transport).toBe('fetch');
+    expect(entry.outcome).toBe('ok');
+    expect(entry.status).toBe(200);
+    expect(entry.ttfb_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('records http_error for a 4xx/5xx response', async () => {
+    vi.stubGlobal('fetch', async () => ({ status: 503, ok: false, type: 'basic' }) as Response);
+    patchFetch();
+    await fetch('https://app.example.com/api/items');
+
+    expect(snapshotNetworkTimings()[0].outcome).toBe('http_error');
+  });
+
+  it('records an opaque response as ok with no status', async () => {
+    vi.stubGlobal('fetch', async () => ({ status: 0, ok: false, type: 'opaque' }) as Response);
+    patchFetch();
+    await fetch('https://cdn.example.com/pixel.gif');
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.outcome).toBe('ok');
+    expect(entry).not.toHaveProperty('status');
+  });
+
+  it.each([
+    ['TimeoutError', 'timeout'],
+    ['AbortError', 'abort'],
+    ['TypeError', 'network_error'],
+  ] as const)('classifies a %s rejection as %s with no ttfb', async (name, expected) => {
+    vi.stubGlobal('fetch', async () => {
+      const error = new Error('boom');
+      error.name = name;
+      throw error;
+    });
+    patchFetch();
+    await expect(fetch('https://app.example.com/api/items')).rejects.toThrow('boom');
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.outcome).toBe(expected);
+    expect(entry).not.toHaveProperty('ttfb_ms');
+  });
+
+  it("does not time the SDK's own endpoint", async () => {
+    vi.stubGlobal('fetch', async () => ({ status: 200, ok: true, type: 'basic' }) as Response);
+    patchFetch();
+    await fetch('https://api.test/api/v1/events');
+
+    expect(snapshotNetworkTimings()).toHaveLength(0);
+  });
+});
+
+class FakeXHR {
+  readyState = 0;
+  status = 0;
+  private listeners = new Map<string, Array<() => void>>();
+  open(_method: string, _url: string): void {}
+  send(): void {}
+  addEventListener(type: string, fn: () => void): void {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(fn);
+    this.listeners.set(type, existing);
+  }
+  emit(type: string): void {
+    for (const fn of this.listeners.get(type) ?? []) fn();
+  }
+  setReadyState(state: number): void {
+    this.readyState = state;
+    this.emit('readystatechange');
+  }
+}
+
+describe('xhr timing capture', () => {
+  beforeEach(() => {
+    clearNetworkTimings();
+    loadConfig({ apiKey: TEST_PK, endpoint: 'https://api.test', errorThrottleMs: 0 });
+    vi.stubGlobal('XMLHttpRequest', FakeXHR);
+    patchXHR();
+  });
+  afterEach(() => {
+    unpatchXHR();
+    vi.unstubAllGlobals();
+  });
+
+  function drive(terminal: string, status: number, withHeaders: boolean): void {
+    const xhr = new (globalThis.XMLHttpRequest as unknown as typeof FakeXHR)();
+    xhr.open('GET', 'https://app.example.com/api/items');
+    xhr.send();
+    if (withHeaders) xhr.setReadyState(2);
+    xhr.status = status;
+    xhr.emit(terminal);
+    xhr.emit('loadend');
+  }
+
+  it.each([
+    ['load', 200, 'ok'],
+    ['load', 500, 'http_error'],
+    ['timeout', 0, 'timeout'],
+    ['abort', 0, 'abort'],
+    ['error', 0, 'network_error'],
+  ] as const)('maps %s/%i to %s', (terminal, status, expected) => {
+    drive(terminal, status, false);
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].transport).toBe('xhr');
+    expect(snapshot[0].outcome).toBe(expected);
+  });
+
+  it('records ttfb from HEADERS_RECEIVED, so a body-phase timeout is distinguishable', () => {
+    drive('timeout', 0, true);
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.outcome).toBe('timeout');
+    expect(entry.ttfb_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not double-finalize when loadend follows a terminal event', () => {
+    drive('timeout', 0, false);
+    expect(snapshotNetworkTimings()).toHaveLength(1);
+  });
+
+  it('falls back to network_error when loadend fires with no terminal event', () => {
+    const xhr = new (globalThis.XMLHttpRequest as unknown as typeof FakeXHR)();
+    xhr.open('GET', 'https://app.example.com/api/items');
+    xhr.send();
+    xhr.emit('loadend');
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].outcome).toBe('network_error');
+  });
+
+  it('omits status 0 on load', () => {
+    drive('load', 0, false);
+
+    const [entry] = snapshotNetworkTimings();
+    expect(entry.outcome).toBe('ok');
+    expect(entry).not.toHaveProperty('status');
+  });
+
+  it('continues timing when an XHR instance is reused', () => {
+    const xhr = new (globalThis.XMLHttpRequest as unknown as typeof FakeXHR)();
+    xhr.open('GET', 'https://app.example.com/api/first');
+    xhr.send();
+    xhr.status = 200;
+    xhr.emit('load');
+    xhr.emit('loadend');
+
+    xhr.open('POST', 'https://app.example.com/api/second');
+    xhr.send();
+    xhr.emit('timeout');
+    xhr.emit('loadend');
+
+    const snapshot = snapshotNetworkTimings();
+    expect(snapshot).toHaveLength(2);
+    expect(snapshot.map((entry) => entry.outcome)).toEqual(['timeout', 'ok']);
+    expect(snapshot.map((entry) => entry.url)).toEqual([
+      'https://app.example.com/api/second',
+      'https://app.example.com/api/first',
+    ]);
+  });
+
+  it('discards the record and rethrows when send() throws synchronously', () => {
+    class ThrowingXHR extends FakeXHR {
+      send(): void {
+        throw new Error('InvalidStateError');
+      }
+    }
+    unpatchXHR();
+    vi.stubGlobal('XMLHttpRequest', ThrowingXHR);
+    patchXHR();
+
+    const xhr = new (globalThis.XMLHttpRequest as unknown as typeof ThrowingXHR)();
+    xhr.open('GET', 'https://app.example.com/api/items');
+    expect(() => xhr.send()).toThrow('InvalidStateError');
+
+    expect(snapshotNetworkTimings()).toHaveLength(0);
   });
 });

--- a/packages/sdk/src/__tests__/wire-shape.test.ts
+++ b/packages/sdk/src/__tests__/wire-shape.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Breadcrumb } from '@opslane/shared';
 import { clearBreadcrumbs } from '../breadcrumbs';
+import { clearNetworkTimings, finalizeTiming, startTiming } from '../network-timing';
 import { loadConfig } from '../config';
 import { buildPayload, clearUser, setUser } from '../core';
 import { resetSessionId } from '../session';
@@ -18,7 +19,7 @@ import {
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixtureDir = join(here, '../../../../test-fixtures/wire/events');
-const WIRE_FIXTURE_VERSION = '3.0.0';
+const WIRE_FIXTURE_VERSION = '4.1.0';
 
 function loadFixture(kind: 'minimal' | 'full'): unknown {
   return JSON.parse(
@@ -53,6 +54,14 @@ function normalize(input: unknown): unknown {
       if (breadcrumb && typeof breadcrumb.timestamp === 'string') breadcrumb.timestamp = SENTINEL;
     }
   }
+  if (Array.isArray(value.network_timings)) {
+    for (const timing of value.network_timings as Array<Record<string, unknown>>) {
+      if (!timing) continue;
+      if (typeof timing.started_at_ms === 'number') timing.started_at_ms = SENTINEL;
+      if (typeof timing.duration_ms === 'number') timing.duration_ms = SENTINEL;
+      if (typeof timing.ttfb_ms === 'number') timing.ttfb_ms = SENTINEL;
+    }
+  }
   return value;
 }
 
@@ -78,6 +87,7 @@ describe('SDK emits the frozen wire shape', () => {
     _resetQueue();
     _resetThrottle();
     clearBreadcrumbs();
+    clearNetworkTimings();
     clearUser();
     delete (globalThis as Record<string, unknown>)[REGISTRY_GLOBAL];
     delete (globalThis as Record<string, unknown>)[COMMIT_SHA_GLOBAL];
@@ -168,6 +178,9 @@ describe('SDK emits the frozen wire shape', () => {
       category: 'navigation',
       message: 'https://app.example.com/dashboard',
     };
+
+    const timingHandle = startTiming('fetch', 'POST', 'https://api.example.com/v1/assets/search');
+    finalizeTiming(timingHandle, 'timeout');
 
     const wire = await captureWire(buildPayload('TypeError', FIXTURE_MESSAGE, FIXTURE_STACK, breadcrumb));
     expect(normalize(wire)).toEqual(normalize(loadFixture('full')));

--- a/packages/sdk/src/core.ts
+++ b/packages/sdk/src/core.ts
@@ -5,6 +5,7 @@ import { enqueueEvent } from './transport';
 import { getSessionId, getSessionProgress, setSessionUser, type SessionProgress } from './session.js';
 import { SDK_VERSION } from './version';
 import { COMMIT_SHA_GLOBAL } from './build/registry-contract.js';
+import { snapshotNetworkTimings } from './network-timing';
 
 declare const __OPSLANE_COMMIT_SHA__: string;
 
@@ -81,7 +82,7 @@ export function buildPayload(
     context.user = buildUserContext(currentUser);
   }
 
-  return {
+  const payload: ErrorEventPayload = {
     timestamp: new Date().toISOString(),
     error: {
       type: errorType,
@@ -96,6 +97,11 @@ export function buildPayload(
     session_id: getSessionId() || undefined,
     environment: config.environment || undefined,
   };
+
+  const timings = snapshotNetworkTimings();
+  if (timings.length > 0) payload.network_timings = timings;
+
+  return payload;
 }
 
 function readCommitSha(): string | undefined {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,6 +8,7 @@ import { clearBreadcrumbs } from './breadcrumbs';
 import { registerSession, resetSessionRegistrations, startReplayCapture, stopReplayCapture } from './replay';
 import { ensureSessionID } from './session.js';
 import { installInteractionTelemetry, uninstallInteractionTelemetry } from './telemetry';
+import { clearNetworkTimings } from './network-timing';
 
 export { opslaneVuePlugin } from './vue';
 export type { SdkInitOptions } from './config';
@@ -64,6 +65,7 @@ export function destroy(): void {
   safeCall(stopReplayCapture);
   safeCall(resetSessionRegistrations);
   safeCall(clearBreadcrumbs);
+  safeCall(clearNetworkTimings);
   safeCall(() => onIdentityChange(null));
   safeCall(clearUser);
   safeCall(resetConfig);

--- a/packages/sdk/src/network-timing.ts
+++ b/packages/sdk/src/network-timing.ts
@@ -1,0 +1,135 @@
+import type { NetworkTiming } from '@opslane/shared';
+import { scrubUrl } from './scrub';
+
+/** Shared with ingestion's sanitizer; both must agree or events get rejected upstream. */
+const MAX_ENTRIES = 20;
+const MAX_URL_BYTES = 2048;
+const MAX_METHOD_BYTES = 16;
+const MAX_ELAPSED_MS = 600000;
+
+/** Returned by startTiming when the active registry is full. All other exports no-op on it. */
+const UNTRACKED = -1;
+
+/** RFC 7230 token, the same set ingestion accepts. Kept in sync deliberately. */
+const TOKEN = /^[A-Z0-9!#$%&'*+.^_`|~-]{1,16}$/;
+
+const encoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+const decoder = typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8') : null;
+
+export type Transport = NetworkTiming['transport'];
+export type Outcome = NetworkTiming['outcome'];
+
+interface ActiveRecord {
+  transport: Transport;
+  method: string;
+  url: string;
+  startedAtMs: number;
+  startMark: number;
+  ttfbMs?: number;
+}
+
+let active = new Map<number, ActiveRecord>();
+let completed: NetworkTiming[] = [];
+let nextHandle = 0;
+
+/** Monotonic where supported, avoiding wall-clock jumps in elapsed values. */
+function mark(): number {
+  return typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+}
+
+/** Truncate to at most `maxBytes` UTF-8 bytes. */
+function capBytes(value: string, maxBytes: number): string {
+  if (!encoder || !decoder) return value.slice(0, Math.floor(maxBytes / 3));
+  const bytes = encoder.encode(value);
+  if (bytes.length <= maxBytes) return value;
+  return decoder.decode(bytes.subarray(0, maxBytes)).replace(/�+$/, '');
+}
+
+/** Clamped because ingestion drops elapsed values above the shared ceiling. */
+function elapsed(from: number, to: number): number {
+  return Math.min(MAX_ELAPSED_MS, Math.max(0, Math.round(to - from)));
+}
+
+export function startTiming(transport: Transport, method: string, url: string): number {
+  const scrubbed = capBytes(scrubUrl(url), MAX_URL_BYTES);
+  if (!scrubbed) return UNTRACKED;
+
+  const safeMethod = capBytes(method.toUpperCase(), MAX_METHOD_BYTES);
+  if (!TOKEN.test(safeMethod)) return UNTRACKED;
+  if (active.size >= MAX_ENTRIES) return UNTRACKED;
+
+  const handle = nextHandle;
+  nextHandle += 1;
+  active.set(handle, {
+    transport,
+    method: safeMethod,
+    url: scrubbed,
+    startedAtMs: Date.now(),
+    startMark: mark(),
+  });
+  return handle;
+}
+
+/** Records time-to-response-headers. First call wins. */
+export function markHeaders(handle: number): void {
+  const record = active.get(handle);
+  if (!record || record.ttfbMs !== undefined) return;
+  record.ttfbMs = elapsed(record.startMark, mark());
+}
+
+/** Moves a record from active to completed; subsequent finalization is a no-op. */
+export function finalizeTiming(handle: number, outcome: Outcome, status?: number): void {
+  const record = active.get(handle);
+  if (!record) return;
+  active.delete(handle);
+
+  const entry: NetworkTiming = {
+    transport: record.transport,
+    method: record.method,
+    url: record.url,
+    started_at_ms: record.startedAtMs,
+    duration_ms: elapsed(record.startMark, mark()),
+    outcome,
+  };
+  if (record.ttfbMs !== undefined) entry.ttfb_ms = record.ttfbMs;
+  if (status !== undefined) entry.status = status;
+
+  completed.push(entry);
+  if (completed.length > MAX_ENTRIES) completed = completed.slice(completed.length - MAX_ENTRIES);
+}
+
+/** Drops a record entirely, such as when XHR.send throws synchronously. */
+export function discardTiming(handle: number): void {
+  active.delete(handle);
+}
+
+export function snapshotNetworkTimings(): NetworkTiming[] {
+  const at = mark();
+  const inFlight: NetworkTiming[] = [...active.values()]
+    .sort((a, b) => a.startMark - b.startMark)
+    .slice(0, MAX_ENTRIES)
+    .map((record) => {
+      const entry: NetworkTiming = {
+        transport: record.transport,
+        method: record.method,
+        url: record.url,
+        started_at_ms: record.startedAtMs,
+        duration_ms: elapsed(record.startMark, at),
+        outcome: 'in_flight',
+      };
+      if (record.ttfbMs !== undefined) entry.ttfb_ms = record.ttfbMs;
+      return entry;
+    });
+
+  const remaining = MAX_ENTRIES - inFlight.length;
+  if (remaining <= 0) return inFlight;
+  return [...inFlight, ...completed.slice(-remaining).reverse()];
+}
+
+export function clearNetworkTimings(): void {
+  active = new Map();
+  completed = [];
+  // Handles are never reused: callbacks from pre-destroy requests can fire late.
+}

--- a/packages/sdk/src/network.ts
+++ b/packages/sdk/src/network.ts
@@ -1,6 +1,13 @@
 import type { Breadcrumb } from '@opslane/shared';
 import { addBreadcrumb } from './breadcrumbs';
 import { getConfig } from './config';
+import {
+  discardTiming,
+  finalizeTiming,
+  markHeaders,
+  startTiming,
+  type Outcome,
+} from './network-timing';
 import { currentClickId, emitTelemetry, nextRequestId } from './telemetry';
 
 // -- Fetch interceptor --
@@ -66,8 +73,31 @@ export function patchFetch(): void {
       at: Date.now(),
     });
 
+    let timingHandle = -1;
+    try {
+      timingHandle = startTiming('fetch', method, url);
+    } catch {
+      // SDK must never throw
+    }
+
     try {
       const response = await orig.call(globalThis, input, init);
+
+      try {
+        markHeaders(timingHandle);
+        if (response.type === 'opaque' || response.type === 'opaqueredirect') {
+          finalizeTiming(timingHandle, 'ok');
+        } else {
+          const storableStatus = response.status >= 100 && response.status <= 599;
+          finalizeTiming(
+            timingHandle,
+            response.status >= 400 ? 'http_error' : 'ok',
+            storableStatus ? response.status : undefined,
+          );
+        }
+      } catch {
+        // SDK must never throw
+      }
 
       emitTelemetry({ kind: 'request_end', requestId, status: response.status, at: Date.now() });
 
@@ -92,6 +122,18 @@ export function patchFetch(): void {
       return response;
     } catch (error: unknown) {
       emitTelemetry({ kind: 'request_end', requestId, status: 0, at: Date.now() });
+      try {
+        const name =
+          typeof error === 'object' && error !== null && typeof (error as { name?: unknown }).name === 'string'
+            ? (error as { name: string }).name
+            : '';
+        finalizeTiming(
+          timingHandle,
+          name === 'TimeoutError' ? 'timeout' : name === 'AbortError' ? 'abort' : 'network_error',
+        );
+      } catch {
+        // SDK must never throw
+      }
       try {
         const crumb: Breadcrumb = {
           type: 'fetch',
@@ -130,6 +172,8 @@ interface XHRWithOpslane extends XMLHttpRequest {
   _opslaneMethod?: string;
   _opslaneUrl?: string;
   _opslaneRequestId?: string;
+  _opslaneTimingHandle?: number;
+  _opslaneTimingBound?: boolean;
 }
 
 export function patchXHR(): void {
@@ -182,6 +226,7 @@ export function patchXHR(): void {
     this: XHRWithOpslane,
     ...args: Parameters<XMLHttpRequest['send']>
   ): void {
+    const previousTimingHandle = this._opslaneTimingHandle;
     try {
       const url = this._opslaneUrl || '';
       if (url && !isSdkEndpoint(url)) {
@@ -198,11 +243,58 @@ export function patchXHR(): void {
         this.addEventListener('loadend', () => {
           emitTelemetry({ kind: 'request_end', requestId, status: this.status, at: Date.now() });
         }, { once: true });
+
+        const timingHandle = startTiming('xhr', this._opslaneMethod || 'GET', url);
+        this._opslaneTimingHandle = timingHandle;
+
+        // Bind persistent listeners once. XHR instances may be reused, and
+        // each callback reads the current request handle from the instance.
+        if (!this._opslaneTimingBound) {
+          this._opslaneTimingBound = true;
+
+          this.addEventListener('readystatechange', () => {
+            if (this.readyState === 2 && this._opslaneTimingHandle !== undefined) {
+              try {
+                markHeaders(this._opslaneTimingHandle);
+              } catch {
+                // SDK must never throw
+              }
+            }
+          });
+
+          const finalize = (outcome: Outcome, withStatus: boolean): void => {
+            try {
+              const handle = this._opslaneTimingHandle;
+              if (handle === undefined) return;
+              finalizeTiming(handle, outcome, withStatus ? this.status : undefined);
+            } catch {
+              // SDK must never throw
+            }
+          };
+          this.addEventListener('load', () => {
+            const storable = this.status >= 100 && this.status <= 599;
+            finalize(this.status >= 400 ? 'http_error' : 'ok', storable);
+          });
+          this.addEventListener('timeout', () => finalize('timeout', false));
+          this.addEventListener('abort', () => finalize('abort', false));
+          this.addEventListener('error', () => finalize('network_error', false));
+          this.addEventListener('loadend', () => finalize('network_error', false));
+        }
       }
     } catch {
       // SDK must never throw.
     }
-    return origSend.apply(this, args);
+    try {
+      return origSend.apply(this, args);
+    } catch (error) {
+      try {
+        if (this._opslaneTimingHandle !== undefined) discardTiming(this._opslaneTimingHandle);
+        this._opslaneTimingHandle = previousTimingHandle;
+      } catch {
+        // SDK must never throw
+      }
+      throw error;
+    }
   };
 }
 

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -79,6 +79,7 @@ export interface ErrorEventPayload {
   release?: string;      // source map lookup
   commit_sha?: string;   // build provenance
   debug_meta?: DebugMeta;
+  network_timings?: NetworkTiming[];  // observed request timing; omitted when empty
   session_id?: string;   // links error event to replay
   environment?: string;  // project-scoped environment name override
 }
@@ -101,6 +102,26 @@ export type BreadcrumbType =
   | 'navigation'
   | 'http'
   | 'log';
+
+/**
+ * One observed browser request, attached to an error event.
+ *
+ * `ttfb_ms` is the cross-transport comparable field: fetch resolves at
+ * response headers while XHR `loadend` fires after the transfer completes,
+ * so `duration_ms` means different things per transport and `transport`
+ * records which. `ttfb_ms` absent on a `timeout` means no headers ever
+ * arrived; present means the server responded and the body stalled.
+ */
+export interface NetworkTiming {
+  transport: 'fetch' | 'xhr';
+  method: string;
+  url: string;
+  started_at_ms: number;
+  duration_ms: number;
+  ttfb_ms?: number;
+  outcome: 'ok' | 'http_error' | 'timeout' | 'abort' | 'network_error' | 'in_flight';
+  status?: number;
+}
 
 // === Error group statuses ===
 

--- a/test-fixtures/vue-app/src/components/FetchUser.vue
+++ b/test-fixtures/vue-app/src/components/FetchUser.vue
@@ -14,6 +14,11 @@ async function loadUser() {
   userName.value = data.name;
   loading.value = false;
 }
+
+async function loadSlow() {
+  const url = import.meta.env['VITE_OPSLANE_HANG_URL'] ?? 'http://localhost:1/hang';
+  await fetch(url, { signal: AbortSignal.timeout(1000) });
+}
 </script>
 
 <template>
@@ -24,6 +29,7 @@ async function loadUser() {
       placeholder="Enter user ID"
     />
     <button data-testid="load-user-btn" @click="loadUser">Load User</button>
+    <button data-testid="load-slow-btn" @click="loadSlow">Load Slow</button>
     <p v-if="loading">Loading...</p>
     <p v-else-if="userName" data-testid="fetched-name">{{ userName }}</p>
   </div>

--- a/test-fixtures/wire/events/v4.1.0-full.json
+++ b/test-fixtures/wire/events/v4.1.0-full.json
@@ -1,0 +1,50 @@
+{
+  "timestamp": "2026-07-16T00:00:00.000Z",
+  "error": {
+    "type": "TypeError",
+    "message": "Cannot read properties of null (reading 'name')",
+    "stack": "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)"
+  },
+  "breadcrumbs": [
+    {
+      "type": "navigation",
+      "timestamp": "2026-07-16T00:00:00.000Z",
+      "category": "navigation",
+      "message": "https://app.example.com/dashboard"
+    }
+  ],
+  "context": {
+    "url": "https://app.example.com/dashboard",
+    "user_agent": "Mozilla/5.0",
+    "user": {
+      "id": "user-123",
+      "email": "jane@example.com",
+      "account_id": "acct-42",
+      "account_name": "Example Inc"
+    }
+  },
+  "sdk_version": "4.1.0",
+  "release": "web@2026.07.16",
+  "commit_sha": "e60b4d1e113538d40f09e31717e949aaa08659f8",
+  "debug_meta": {
+    "images": [
+      {
+        "type": "sourcemap",
+        "code_file": "https://app.example.com/assets/index.js",
+        "debug_id": "01234567-89ab-cdef-0123-456789abcdef"
+      }
+    ]
+  },
+  "session_id": "sess-abc",
+  "environment": "staging",
+  "network_timings": [
+    {
+      "transport": "fetch",
+      "method": "POST",
+      "url": "https://api.example.com/v1/assets/search",
+      "started_at_ms": 1784160000000,
+      "duration_ms": 10002,
+      "outcome": "timeout"
+    }
+  ]
+}

--- a/test-fixtures/wire/events/v4.1.0-minimal.json
+++ b/test-fixtures/wire/events/v4.1.0-minimal.json
@@ -1,0 +1,14 @@
+{
+  "timestamp": "2026-07-16T00:00:00.000Z",
+  "error": {
+    "type": "TypeError",
+    "message": "Cannot read properties of null (reading 'name')",
+    "stack": "TypeError: Cannot read properties of null (reading 'name')\n    at UserCard (https://app.example.com/assets/index.js:8:20)"
+  },
+  "breadcrumbs": [],
+  "context": {
+    "url": "https://app.example.com/dashboard",
+    "user_agent": "Mozilla/5.0"
+  },
+  "sdk_version": "4.1.0"
+}


### PR DESCRIPTION
## Why

The SDK reports what threw, never how long anything took. For timeout-class errors that leaves the investigation agent unable to say anything about the failing request beyond its existence.

[PR #1297 on `conelike/asset-management-jira`](https://github.com/conelike/asset-management-jira/pull/1297) is the worked example. A `TimeoutError: signal timed out` produced a fix that raised `FETCH_TIMEOUT` from 10000 to 30000 in three files, and it was closed unmerged. The agent had a minified stack, breadcrumbs, and nothing else — the PR body records `Visual replay analysis not available` and `Signals not available`. Given that input, changing the constant was the only action the evidence supported.

Timing already existed in the system (`telemetry.ts` emits `request_start`/`request_end`) but rides inside the rrweb replay stream and reaches the agent only when replay analysis succeeds. On that error it did not. **Timing stored somewhere the error event does not reach is equivalent to timing not stored.**

## What this does not do

**No diagnosis behavior changes.** The `network_timings` column is written by ingestion and read by nothing until the worker slice lands. Please don't read this as a fix for the PR #1297 class — it is the capture half.

Also deliberately out of scope: `traceparent` propagation (adding a header to a cross-origin request forces a CORS preflight and could start failing requests that worked yesterday), continuous performance capture, and main-thread profiling.

## Design notes worth reviewing

- **Retention is two collections, not one buffer.** A single FIFO ring evicts the record the feature exists to capture: a request open 30s becomes the oldest entry while shorter requests finish around it. Snapshot takes actives longest-running first, and at capacity the store refuses the *new* request rather than evicting an existing one.
- **`ttfb_ms` is the cross-transport comparable field.** `fetch` resolves at headers; XHR `loadend` fires after the transfer. `duration_ms` therefore means different things per transport, which is why `transport` is on the wire. `ttfb_ms` absent on a timeout means no headers arrived; present means the body stalled.
- **Resource Timing is not used.** Cross-origin without `Timing-Allow-Origin` zeroes `responseStart`, `requestStart` and every connection phase — precisely the fields that would separate a slow server from a connection that never established, and precisely the requests we see.
- **Handles are never reissued**, including across `clearNetworkTimings()`, because unpatching cannot cancel an already-awaiting request.
- **Server-side URL redaction is independent of the SDK.** `masking.RedactURL` preserves non-sensitive query params, so a stricter `RedactRequestURL` was added rather than trusting the client.

## Verification

Driven against a live stack (Postgres, MinIO, real ingestion binary, real Chromium) rather than unit tests. 11 acceptance criteria, all passed. Artifacts under `.verify/runs/20260806-175409/`.

The load-bearing observation, from a real browser through live ingestion into Postgres:

```json
[{"url":"http://localhost:8503/hang","outcome":"in_flight","transport":"fetch","duration_ms":810,...},
 {"url":"/api/users/999","outcome":"ok","ttfb_ms":4,"duration_ms":4,...},
 {"url":"/api/users/999","outcome":"ok","ttfb_ms":3,"duration_ms":3,...}]
```

One request at 810ms while siblings return in 3–4ms, ordered actives-first. That is the concurrency signal the whole design rests on, and it survived 48 competing requests.

Also covered: malformed entries dropped while a valid sibling survives (so the sanitizer is not discarding wholesale); credential-bearing URLs stripped while a clean URL and route fragment are stored byte-identical (so the redactor is not truncating everything); events with no `network_timings` still accepted; all 14 frozen wire fixtures replay 202; XHR captured with `transport: "xhr"`.

Migration 033 confirmed idempotent against a live database with existing rows.

## Needs a call before merge

**The SDK version was bumped by hand** (`4.0.0` → `4.1.0`) because the frozen fixture pair is named `v4.1.0` and `wire-shape.test.ts` asserts the wire `sdk_version` matches `package.json`. But this repo releases through changesets, which bump versions themselves. Adding a changeset now would likely double-bump to `4.2.0` on release, so none was added. Someone who owns the release pipeline should decide whether to keep the manual bump, revert it and rename the fixtures, or add a changeset and accept the version.

## Known gaps

- `destroy()` teardown wiring is not verified end to end; it is not user-reachable in the fixture app. `network-timing-teardown.test.ts` covers it.
- `src/__tests__/debug-id-browser.test.ts` fails locally on missing Playwright system libraries. It fails identically at the base commit and is unrelated to this change.
- Go migration tests skip locally because `psql` is not on the host; migration 033 was applied and re-applied manually instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
