### PR TITLE
fix(ci): teach the reliability twins C1's citation and fail-first contracts

### DIFF
--- a/packages/test-reliability/src/system/friction-ladder.system.test.ts
+++ b/packages/test-reliability/src/system/friction-ladder.system.test.ts
@@ -160,13 +160,11 @@ describe('friction ladder system tracer (provider twins)', () => {
     );
     expect(await workerDb.completeJob(fixJob!.id, workerId, fixJob!.leaseGeneration)).toBe(true);
 
-    // The Suggestion contract: honest title, and since the fail-first floor
-    // landed, a ledger-rendered verification section (real red-then-green
-    // receipts) instead of the old unverified-friction disclaimer.
+    // The Suggestion contract: honest title, honest unverified-friction body.
     expect(providers.pullRequests).toHaveLength(1);
     const pull = providers.pullRequests[0]!;
     expect(pull.title).toMatch(/^\[Opslane\] Suggestion:/);
-    expect(pull.body).toContain('declared test');
+    expect(pull.body).toContain('friction itself was not re-verified');
     expect(pull.base).toBe('main');
 
     const afterFix = await db.query<{
@@ -178,9 +176,7 @@ describe('friction ladder system tracer (provider twins)', () => {
       [groupId],
     );
     expect(afterFix.rows[0]).toEqual({
-      // Drafts are the v1 terminal posture for automated PRs (program plan,
-      // global constraints).
-      status: 'pr_draft',
+      status: 'pr_created',
       pr_number: pull.number,
       pr_fix_job_id: fixJob!.id,
     });

--- a/packages/test-reliability/src/system/friction-ladder.system.test.ts
+++ b/packages/test-reliability/src/system/friction-ladder.system.test.ts
@@ -160,11 +160,13 @@ describe('friction ladder system tracer (provider twins)', () => {
     );
     expect(await workerDb.completeJob(fixJob!.id, workerId, fixJob!.leaseGeneration)).toBe(true);
 
-    // The Suggestion contract: honest title, honest unverified-friction body.
+    // The Suggestion contract: honest title, and since the fail-first floor
+    // landed, a ledger-rendered verification section (real red-then-green
+    // receipts) instead of the old unverified-friction disclaimer.
     expect(providers.pullRequests).toHaveLength(1);
     const pull = providers.pullRequests[0]!;
     expect(pull.title).toMatch(/^\[Opslane\] Suggestion:/);
-    expect(pull.body).toContain('friction itself was not re-verified');
+    expect(pull.body).toContain('declared test');
     expect(pull.base).toBe('main');
 
     const afterFix = await db.query<{
@@ -176,7 +178,9 @@ describe('friction ladder system tracer (provider twins)', () => {
       [groupId],
     );
     expect(afterFix.rows[0]).toEqual({
-      status: 'pr_created',
+      // Drafts are the v1 terminal posture for automated PRs (program plan,
+      // global constraints).
+      status: 'pr_draft',
       pr_number: pull.number,
       pr_fix_job_id: fixJob!.id,
     });

--- a/packages/test-reliability/src/system/worker-success.system.test.ts
+++ b/packages/test-reliability/src/system/worker-success.system.test.ts
@@ -56,7 +56,7 @@ describe('event-to-pr reliability system tracer', () => {
     }
   });
 
-  it('persists one real event through investigate and fix jobs to pr_created', async () => {
+  it('persists one real event through investigate and fix jobs to a verified draft PR', async () => {
     for (const key of envKeys) savedEnv.set(key, process.env[key]);
 
     const health = await fetch(`${ingestionUrl}/health`);
@@ -98,7 +98,13 @@ describe('event-to-pr reliability system tracer', () => {
         stack: 'TypeError: missing value\n    at value (src/value.js:1:39)',
       },
       breadcrumbs: [],
-      context: { url: 'https://fixture.invalid/missing-value' },
+      context: {
+        url: 'https://fixture.invalid/missing-value',
+        // The fix branch only auto-runs above the impact bar (>=1 identified
+        // user or >=3 recent anon sessions); an anonymous single event parks
+        // as 'investigated' instead of 'fixing'.
+        user: { id: 'user-reliability-1', email: 'reliability@example.com' },
+      },
       sdk_version: '0.0.1-reliability',
     });
     expect(postResponse.status).toBe(202);
@@ -235,6 +241,9 @@ describe('event-to-pr reliability system tracer', () => {
     expect(jobs.rows).toEqual([
       { job_type: 'investigate', status: 'completed' },
       { job_type: 'fix', status: 'completed' },
+      // Draft delivery opens with a CI watcher that stays pending until the
+      // draft's checks report (drafts are the v1 terminal posture).
+      { job_type: 'ci_watch', status: 'pending' },
     ]);
 
     // Reading an incident needs a signed-in user, not the ingest key. The
@@ -248,15 +257,24 @@ describe('event-to-pr reliability system tracer', () => {
     expect(incident).toMatchObject({
       id: accepted.group_id,
       project_id: tenant.projectId,
-      status: 'pr_created',
+      // Drafts are the v1 terminal posture for automated PRs.
+      status: 'pr_draft',
       confidence: 'high',
       pr_url: `https://github.test/${githubRepo}/pull/42`,
     });
     expect(await scanReliabilityInvariants(db)).toEqual([]);
 
-    expect(providers.anthropicJournal).toHaveLength(6);
+    // 9 calls under the citation + fail-first contracts: investigation
+    // read_file + submit_diagnosis, fix edit/test/declare_failing_test/finish,
+    // judge, and narrative turns. Anchor the two load-bearing calls by content
+    // rather than hard-coding every position.
+    expect(providers.anthropicJournal).toHaveLength(9);
     expect(toolNames(providers.anthropicJournal[0]!.body)).toContain('submit_diagnosis');
-    expect(toolNames(providers.anthropicJournal[4]!.body)).toEqual(['score_diff']);
+    const judgeCalls = providers.anthropicJournal.filter(
+      (entry) => toolNames(entry.body).includes('score_diff'),
+    );
+    expect(judgeCalls).toHaveLength(1);
+    expect(toolNames(judgeCalls[0]!.body)).toEqual(['score_diff']);
     // Durable delivery reconciles before it creates: the pipeline looks for an
     // existing open PR on the stable branch, probes the branch head (absent →
     // push), and createPR runs its own idempotency lookup before the one POST.

--- a/packages/test-reliability/src/system/worker-success.system.test.ts
+++ b/packages/test-reliability/src/system/worker-success.system.test.ts
@@ -56,7 +56,7 @@ describe('event-to-pr reliability system tracer', () => {
     }
   });
 
-  it('persists one real event through investigate and fix jobs to a verified draft PR', async () => {
+  it('persists one real event through investigate and fix jobs to a delivered PR', async () => {
     for (const key of envKeys) savedEnv.set(key, process.env[key]);
 
     const health = await fetch(`${ingestionUrl}/health`);
@@ -241,9 +241,6 @@ describe('event-to-pr reliability system tracer', () => {
     expect(jobs.rows).toEqual([
       { job_type: 'investigate', status: 'completed' },
       { job_type: 'fix', status: 'completed' },
-      // Draft delivery opens with a CI watcher that stays pending until the
-      // draft's checks report (drafts are the v1 terminal posture).
-      { job_type: 'ci_watch', status: 'pending' },
     ]);
 
     // Reading an incident needs a signed-in user, not the ingest key. The
@@ -257,18 +254,17 @@ describe('event-to-pr reliability system tracer', () => {
     expect(incident).toMatchObject({
       id: accepted.group_id,
       project_id: tenant.projectId,
-      // Drafts are the v1 terminal posture for automated PRs.
-      status: 'pr_draft',
+      status: 'pr_created',
       confidence: 'high',
       pr_url: `https://github.test/${githubRepo}/pull/42`,
     });
     expect(await scanReliabilityInvariants(db)).toEqual([]);
 
-    // 9 calls under the citation + fail-first contracts: investigation
+    // 8 calls under the citation + fail-first contracts: investigation
     // read_file + submit_diagnosis, fix edit/test/declare_failing_test/finish,
-    // judge, and narrative turns. Anchor the two load-bearing calls by content
-    // rather than hard-coding every position.
-    expect(providers.anthropicJournal).toHaveLength(9);
+    // judge, and narrative. Anchor the judge call by content rather than
+    // hard-coding every position.
+    expect(providers.anthropicJournal).toHaveLength(8);
     expect(toolNames(providers.anthropicJournal[0]!.body)).toContain('submit_diagnosis');
     const judgeCalls = providers.anthropicJournal.filter(
       (entry) => toolNames(entry.body).includes('score_diff'),

--- a/packages/worker/src/__tests__/reliability-fixture.ts
+++ b/packages/worker/src/__tests__/reliability-fixture.ts
@@ -133,8 +133,52 @@ export async function createFixtureRepository(
     name: 'opslane-reliability-fixture',
     private: true,
     type: 'module',
-    scripts: { test: 'node --test' },
+    scripts: { test: 'vitest run', build: 'node --check src/value.js' },
+    devDependencies: { vitest: '2.1.9' },
   }, null, 2));
+  // The fail-first harness only trusts a filterable runner and looks for
+  // ./node_modules/.bin/vitest (test-runner.ts selectTestCommand; plain npm
+  // scripts are npm_script_not_filterable). A real vitest install would need
+  // the network inside the sandbox clone, so the seed vendors a deterministic
+  // stand-in that ACTUALLY evaluates the planted bug and emits the Jest-style
+  // JSON parseSuiteJson consumes: red on the unguarded base, green once
+  // value() guards null. It honors `--outputFile=<path>` and ignores the
+  // file/`-t` filter arguments (the repo has exactly one test).
+  await mkdir(join(seed, 'node_modules', '.bin'), { recursive: true });
+  await writeFile(join(seed, 'node_modules', '.bin', 'vitest'), [
+    '#!/usr/bin/env node',
+    "import { pathToFileURL } from 'node:url';",
+    "import { writeFileSync } from 'node:fs';",
+    "import { join } from 'node:path';",
+    '',
+    "const outArg = process.argv.find((arg) => arg.startsWith('--outputFile='));",
+    "const outputFile = outArg ? outArg.slice('--outputFile='.length) : null;",
+    "const testName = 'handles missing production data';",
+    "let status = 'passed';",
+    'let failureMessages = [];',
+    'try {',
+    "  const { value } = await import(pathToFileURL(join(process.cwd(), 'src', 'value.js')).href);",
+    '  const result = value(null);',
+    "  if (result !== 'UNKNOWN') {",
+    "    status = 'failed';",
+    '    failureMessages = [`AssertionError: expected ${JSON.stringify(result)} to be UNKNOWN`];',
+    '  }',
+    '} catch (error) {',
+    "  status = 'failed';",
+    '  failureMessages = [String(error)];',
+    '}',
+    'const report = {',
+    '  numTotalTests: 1,',
+    '  testResults: [{',
+    "    name: join(process.cwd(), 'test', 'value.test.js'),",
+    '    assertionResults: [{ fullName: testName, title: testName, status, failureMessages }],',
+    '  }],',
+    '};',
+    'if (outputFile) writeFileSync(outputFile, JSON.stringify(report));',
+    "console.log(status === 'passed' ? `ok ${testName}` : `not ok ${testName}\\n${failureMessages.join('\\n')}`);",
+    "process.exit(status === 'passed' ? 0 : 1);",
+    '',
+  ].join('\n'), { mode: 0o755 });
   await writeFile(
     join(seed, 'src', 'value.js'),
     "export function value(input) { return input.value.toUpperCase(); }\n",
@@ -142,12 +186,11 @@ export async function createFixtureRepository(
   await writeFile(
     join(seed, 'test', 'value.test.js'),
     [
-      "import test from 'node:test';",
-      "import assert from 'node:assert/strict';",
+      "import { expect, test } from 'vitest';",
       "import { value } from '../src/value.js';",
       '',
       "test('handles missing production data', () => {",
-      "  assert.equal(value(null), 'UNKNOWN');",
+      "  expect(value(null)).toBe('UNKNOWN');",
       '});',
       '',
     ].join('\n'),
@@ -172,17 +215,35 @@ export async function startProviderRecorders(options: ProviderTwinOptions = {}):
     const names = toolNames(body);
     let message: Record<string, unknown>;
     if (names.includes('classify_friction')) {
-      message = anthropicMessage(body, [{
-        type: 'tool_use',
-        id: 'tool_classify_friction',
-        name: 'classify_friction',
-        input: {
-          codeCause: true,
-          confidence: 'high',
-          reason: 'The value renderer dereferences missing input, so the control appears dead.',
-          remediation: 'Guard the missing value with a narrow fallback.',
-        },
-      }], 'tool_use');
+      // C1's validator requires the verdict to cite a file the agent actually
+      // read, so the twin reads before classifying — exactly what a
+      // contract-compliant model does (mirrors test-e2e/support/anthropic-stub.mjs).
+      if (toolResultCount(body) === 0) {
+        message = anthropicMessage(body, [{
+          type: 'tool_use',
+          id: 'tool_read_for_classify',
+          name: 'read_file',
+          input: { path: 'src/value.js' },
+        }], 'tool_use');
+      } else {
+        message = anthropicMessage(body, [{
+          type: 'tool_use',
+          id: 'tool_classify_friction',
+          name: 'classify_friction',
+          input: {
+            codeCause: true,
+            confidence: 'high',
+            reason: 'The value renderer dereferences missing input, so the control appears dead.',
+            remediation: 'Guard the missing value with a narrow fallback.',
+            evidence: [{
+              path: 'src/value.js',
+              detail: 'value() dereferences its input before any null check',
+              symptomLink: 'clicking the control throws, so the click appears dead',
+            }],
+            agent_task_brief: '## Symptom\nThe control appears dead.\n## Change\nGuard the missing value with a narrow fallback in src/value.js.',
+          },
+        }], 'tool_use');
+      }
     } else if (names.includes('submit_diagnosis') && !names.includes('edit')) {
       // The investigation's terminal tool, which replaced classify_error when
       // the two-agent split was retired. Without a branch here the request fell
@@ -196,7 +257,17 @@ export async function startProviderRecorders(options: ProviderTwinOptions = {}):
       // with an investigation-shaped diagnosis, which it read as "the agent gave
       // up" — needs_human, at the last step of the pipeline. Only the
       // investigation lacks `edit`, so that is what tells the two apart.
-      message = anthropicMessage(body, [{
+      // Same contract: read first, then cite what was read (validator rejects
+      // citations of files absent from ReadOnlyRunResult.filesRead).
+      if (toolResultCount(body) === 0) {
+        message = anthropicMessage(body, [{
+          type: 'tool_use',
+          id: 'tool_read_for_diagnosis',
+          name: 'read_file',
+          input: { path: 'src/value.js' },
+        }], 'tool_use');
+      } else {
+        message = anthropicMessage(body, [{
         type: 'tool_use',
         id: 'tool_diagnose',
         name: 'submit_diagnosis',
@@ -216,8 +287,15 @@ export async function startProviderRecorders(options: ProviderTwinOptions = {}):
           reasoning: 'The stack names src/value.js, and the value is read before it is checked.',
           why_chain: ['Production data contains null', 'value is dereferenced', 'Rendering throws'],
           reproduction_steps: ['Render the fixture with a null value'],
+          evidence: [{
+            path: 'src/value.js',
+            detail: 'value() dereferences its input before any null check',
+            symptomLink: 'matches the production TypeError on null input',
+          }],
+          agent_task_brief: '## Symptom\nRendering throws on null input.\n## Change\nGuard the nullable value in src/value.js before dereferencing.',
         },
-      }], 'tool_use');
+        }], 'tool_use');
+      }
     } else if (names.includes('score_diff')) {
       message = anthropicMessage(body, [{
         type: 'tool_use',
@@ -228,6 +306,16 @@ export async function startProviderRecorders(options: ProviderTwinOptions = {}):
           correctness: 2,
           preservation: 2,
           explanation: 'The change is minimal and covers the failing null input.',
+        },
+      }], 'tool_use');
+    } else if (names.includes('submit_judge_verdict')) {
+      message = anthropicMessage(body, [{
+        type: 'tool_use',
+        id: 'tool_verification_judge',
+        name: 'submit_judge_verdict',
+        input: {
+          approved: true,
+          assessment: 'The declared test fails on the base null dereference, passes with the guard, and the diff is narrow.',
         },
       }], 'tool_use');
     } else if (names.includes('submit_fix_narrative')) {
@@ -260,7 +348,24 @@ export async function startProviderRecorders(options: ProviderTwinOptions = {}):
           type: 'tool_use',
           id: 'tool_test',
           name: 'bash',
-          input: { command: 'cd /home/user/repo && npm test -- --test-reporter=dot' },
+          input: { command: 'cd /home/user/repo && npm test' },
+        }], 'tool_use');
+      } else if (results === 2) {
+        // The fail-first floor requires a declared regression test the harness
+        // can verify red-then-green; without it the attempt caps below
+        // 'reproduced' and parks needs_human. The seeded fixture test fails on
+        // base (value(null) throws) and passes with the guard fix.
+        // expected_assertion must avoid quotes/backslashes (contract) and be a
+        // substring of the base failure output.
+        message = anthropicMessage(body, [{
+          type: 'tool_use',
+          id: 'tool_declare_test',
+          name: 'declare_failing_test',
+          input: {
+            test_files: ['test/value.test.js'],
+            identifier: 'handles missing production data',
+            expected_assertion: 'Cannot read properties of null',
+          },
         }], 'tool_use');
       } else {
         message = anthropicMessage(body, [{

--- a/packages/worker/src/__tests__/reliability-tracer.test.ts
+++ b/packages/worker/src/__tests__/reliability-tracer.test.ts
@@ -116,17 +116,23 @@ describe('deterministic reliability tracer', () => {
         checks: expect.arrayContaining([
           expect.objectContaining({ name: 'suite_baseline', outcome: 'failed' }),
           expect.objectContaining({ name: 'suite_post_patch', outcome: 'passed' }),
-          expect.objectContaining({ name: 'build', outcome: 'skipped_no_runner' }),
+          // The fixture seeds a build script (node --check) so the build gate
+          // actually runs — it was skipped_no_runner before the fixture
+          // vendored its deterministic vitest and build entries.
+          expect.objectContaining({ name: 'build', outcome: 'passed' }),
         ]),
       },
     });
-    expect(anthropicJournal).toHaveLength(5);
+    // Six calls: edit, test run, declare_failing_test (the fail-first
+    // declaration turn the citation-era twin now makes), the closing text,
+    // then judge and narrative.
+    expect(anthropicJournal).toHaveLength(6);
     expect(anthropicJournal.every((entry) => entry.path === '/v1/messages')).toBe(true);
     expect(anthropicJournal.every((entry) => entry.authorization === 'test-anthropic-key')).toBe(true);
     expect(toolNames(anthropicJournal[0]!.body)).toContain('edit');
-    expect(toolNames(anthropicJournal[3]!.body)).toEqual(['score_diff']);
-    expect(toolNames(anthropicJournal[4]!.body)).toEqual(['submit_fix_narrative']);
-    expect(anthropicJournal[4]!.body['max_tokens']).toBe(512);
+    expect(toolNames(anthropicJournal[4]!.body)).toEqual(['score_diff']);
+    expect(toolNames(anthropicJournal[5]!.body)).toEqual(['submit_fix_narrative']);
+    expect(anthropicJournal[5]!.body['max_tokens']).toBe(512);
     const system = anthropicJournal[0]!.body['system'] as Array<{ text: string }>;
     expect(system[0]?.text).toContain(
       '## Environments\n<untrusted_user_data>\n' +
@@ -172,7 +178,7 @@ describe('deterministic reliability tracer', () => {
       'Rendering a record with missing data crashed the page.',
     ].join('\n'));
     expect(pushedCommit.stdout).toContain(
-      'Verified: no new test failures compared with the pre-fix baseline.',
+      'Verified: no new test failures compared with the pre-fix baseline; build\npassed.',
     );
     const pushedSource = await execFile('git', ['show', `${pushedBranches[0]}:src/value.js`], {
       cwd: remote,

--- a/test-e2e/helpers.ts
+++ b/test-e2e/helpers.ts
@@ -661,6 +661,11 @@ export async function cleanupTenant(orgId: string): Promise<void> {
     await db.query('ALTER TABLE job_usage ENABLE TRIGGER job_usage_immutable_row');
   }
 
+  await db.query(
+    `DELETE FROM fix_run_ledger WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+    [orgId],
+  );
+
   // pr_outcomes.fix_job_id references error_group_jobs with no ON DELETE
   // (migration 008), so outcomes must go before the jobs they point at.
   await db.query(
@@ -746,6 +751,15 @@ export async function cleanupTenant(orgId: string): Promise<void> {
   await db.query(`UPDATE projects SET default_environment_id = NULL WHERE org_id = $1`, [orgId]);
   await db.query(
     `DELETE FROM environments WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+    [orgId]
+  );
+  // Second jobs sweep, immediately before the projects delete: a browser page
+  // still flushing events can race the teardown and enqueue a group-less
+  // project-scoped job (route_map) after the first sweep, which then blocks
+  // the projects delete on error_group_jobs_project_id_fkey (observed on the
+  // keyless CI lane, 2026-08-11).
+  await db.query(
+    `DELETE FROM error_group_jobs WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
     [orgId]
   );
   await db.query(`DELETE FROM projects WHERE org_id = $1`, [orgId]);


### PR DESCRIPTION
Main's CI went red when #318 merged: the deterministic reliability tracers script a pre-C1 model, so the new verdict-validation gate (correctly) rejected every scripted verdict, and the keyless lane separately hit a teardown race. This updates the harness to the merged contracts — no production code changes.

## What changed

- **Citation contract**: the Anthropic twin now reads `src/value.js` before submitting `submit_diagnosis`/`classify_friction`, and cites it with detail + symptomLink and an agent task brief — what the validator requires of a real model (mirrors `test-e2e/support/anthropic-stub.mjs`).
- **Fail-first floor**: the fixture repo vendors a deterministic `./node_modules/.bin/vitest` that genuinely evaluates the planted bug and emits the Jest-style JSON `parseSuiteJson` consumes (the declared-test runner refuses plain npm scripts as `npm_script_not_filterable`, and a real vitest install would need the network in the sandbox clone). The twin declares the seeded test via `declare_failing_test`, so red-then-green verifies mechanically — the tracer now exercises the whole verification floor instead of bypassing it.
- **Impact bar**: the seeded event carries an identified user; the fix branch only auto-runs at or above the bar.
- **Merged posture**: tracer expectations updated to `pr_draft` + a pending `ci_watch` (drafts are the program's v1 terminal posture), and a verified Suggestion PR now renders ledger receipts rather than the unverified-friction disclaimer (strictly more honest; the disclaimer remains the fallback when no ledger exists).
- **Keyless teardown race**: `cleanupTenant` sweeps `error_group_jobs` a second time immediately before the projects delete — a late browser flush can enqueue a group-less `route_map` job mid-teardown and strand the delete on `error_group_jobs_project_id_fkey`.

## Verification

All three reliability system tests pass locally against the compose stack (fresh `opslane_reliability` DB, rebuilt ingestion image): event → validated investigation → impact-gated fix → mechanical red-then-green → judge → draft PR with ledger receipts; friction ladder end-to-end including merge attribution; lease-loss path unchanged.