### PR TITLE
fix(sdk): derive error type from err.name, not the minified constructor name

### DIFF
--- a/packages/sdk/src/__tests__/core.test.ts
+++ b/packages/sdk/src/__tests__/core.test.ts
@@ -282,6 +282,56 @@ describe('Core Error Capture', () => {
     expect(elapsed).toBeLessThan(250);
   });
 
+  it('prefers err.name over the constructor name for the error type', () => {
+    installGlobalHandlers();
+
+    // A minified bundle renames the class identifier (FetchError -> Nu) but
+    // cannot touch the string assigned to this.name.
+    class Nu extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'FetchError';
+      }
+    }
+
+    window.dispatchEvent(
+      new ErrorEvent('error', { message: 'Error deleting Assets', error: new Nu('Error deleting Assets') })
+    );
+
+    const payload = (transport.enqueueEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.error.type).toBe('FetchError');
+  });
+
+  it('reports the inherited "Error" name for subclasses that never set one', () => {
+    installGlobalHandlers();
+
+    // err.name is inherited from Error.prototype here. Reporting "Error"
+    // matches Sentry and PostHog and stays stable across minified builds,
+    // where the constructor name would churn every release.
+    class Xy extends Error {}
+
+    window.dispatchEvent(new ErrorEvent('error', { message: 'boom', error: new Xy('boom') }));
+
+    const payload = (transport.enqueueEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.error.type).toBe('Error');
+  });
+
+  it('falls back to the constructor name when err.name is emptied', () => {
+    installGlobalHandlers();
+
+    class NamedError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = '';
+      }
+    }
+
+    window.dispatchEvent(new ErrorEvent('error', { message: 'boom', error: new NamedError('boom') }));
+
+    const payload = (transport.enqueueEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.error.type).toBe('NamedError');
+  });
+
   it('should never throw even if internal processing fails', () => {
     // Make enqueueEvent throw
     (transport.enqueueEvent as ReturnType<typeof vi.fn>).mockImplementation(() => {

--- a/packages/sdk/src/__tests__/vue.test.ts
+++ b/packages/sdk/src/__tests__/vue.test.ts
@@ -60,6 +60,25 @@ describe('Vue 3 Plugin', () => {
     expect(payload.error.message).toBe('Cannot read properties of undefined');
   });
 
+  it('prefers err.name over the constructor name for the error type', () => {
+    const app = createMockApp();
+    app.use(opslaneVuePlugin);
+
+    // Simulates a minified bundle: the class identifier churns per release,
+    // the string assigned to this.name does not.
+    class Nu extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'FetchError';
+      }
+    }
+
+    app.config.errorHandler!(new Nu('Error deleting Assets'), null, 'render function');
+
+    const payload = (transport.enqueueEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.error.type).toBe('FetchError');
+  });
+
   it('should include Vue lifecycle info in breadcrumb data', () => {
     const app = createMockApp();
     app.use(opslaneVuePlugin);

--- a/packages/sdk/src/core.ts
+++ b/packages/sdk/src/core.ts
@@ -192,7 +192,10 @@ function normalizeError(input: unknown, fallbackMessage?: string, fallbackType =
     }
 
     return {
-      errorType: input.constructor.name || fallbackType,
+      // err.name first: it survives minification (it is a string, not an
+      // identifier), so titles and fingerprints stay stable across releases.
+      // The constructor name is minified junk in production bundles.
+      errorType: input.name || input.constructor.name || fallbackType,
       errorMessage: input.message,
       stack,
     };

--- a/packages/sdk/src/vue.ts
+++ b/packages/sdk/src/vue.ts
@@ -40,7 +40,8 @@ export const opslaneVuePlugin = {
         let stack: string;
 
         if (err instanceof Error) {
-          errorType = err.constructor.name || 'Error';
+          // err.name survives minification; the constructor name does not.
+          errorType = err.name || err.constructor.name || 'Error';
           errorMessage = err.message;
           stack = err.stack || '';
         } else {


### PR DESCRIPTION
## Why

Opslane group titles for AMFJ show minified class names: `Nu: Error deleting Assets`, `rl: Error deleting Assets`. The SDK reads `err.constructor.name`, which is the minifier-assigned identifier of the class in that particular build. Sentry shows `FetchError` for the same errors because it reads `err.name`, a string assignment (`this.name = 'FetchError'`) the minifier cannot rewrite.

Because the grouping fingerprint includes the error type, the constructor-name source also re-splits groups on every customer release that reshuffles minified identifiers — prod currently has 4 `Nu:`/`rl:` groups for the same delete-assets bug.

## What

`normalizeError` (core.ts) and the Vue plugin now use `err.name || err.constructor.name || fallback`.

- Matches PostHog's order exactly; Sentry uses `name` alone.
- Built-in errors (`TypeError`, etc.) are unchanged: prototype `name` already matches.
- Subclasses that never set `name` now report the inherited `Error` (what Sentry and PostHog both show) instead of a per-build identifier.
- Behavioral consequence: affected groups re-split one final time after customers deploy the updated SDK, then stop churning.

## Verification

- TDD: the three new tests (minified-class simulation, inherited-name subclass, emptied-name fallback) failed before the change; all pass after.
- `pnpm --filter @opslane/sdk build` and full suite: 349 passed. Real-browser Chromium contract tests executed (not skipped).
- Pre-existing, unrelated failure: `debug-id-browser.test.ts` WebKit matrix cannot launch on this host (missing GTK/GStreamer libs); fails identically on a clean checkout of main.