### PR TITLE
docs: rewrite README for launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Error trackers see stack traces. Opslane knows your product.
 
 It learns where users get stuck from errors and session recordings. You get a daily digest of what matters, and pull requests with tested fixes. When it can't fix something, it says why.
 
+[Docs](docs) · [Self-host quickstart](docs/quickstart/self-host.md) · [Install the SDK](docs/install.md) · [Issue tracker](https://github.com/opslane/opslane-oss/issues)
+
 ## See it work
 
 ### Error to pull request
@@ -16,26 +18,26 @@ It learns where users get stuck from errors and session recordings. You get a da
 
 <!-- PLACEHOLDER: screenshot of a real merged Opslane PR (e.g. #1232) — title, root-cause explanation, evidence section, diff. Scrub anything private; link the PR here. -->
 
-In two weeks on one production app (July to August 2026), Opslane captured 7,415 events, suppressed the 78% that were noise, and opened one pull request: a fix for a crash users had hit 614 times. A human reviewed and merged it.
+Over two weeks spanning July and August 2026, one production app sent Opslane 7,415 events. It suppressed the 78% that were noise and opened one pull request: a fix for a crash users had hit 614 times. A human reviewed and merged it.
 
 ## What it does
 
 - **Know what's broken without reading 7,000 alerts.** Errors group into causes, noise is suppressed, and issues are ranked by how many users they hit. One Slack digest a day.
 - **Get bugs fixed without losing the afternoon.** Opslane investigates in your repo and sends the fix as a pull request that built and passed your tests. You review and merge.
-- **See what the user saw.** Every error links to the session replay behind it: the clicks, pages, and requests that led up to it.
+- **See what the user saw.** When session recording is on, each issue links to the recording behind it: the clicks, pages, and requests that led up to it.
 - **Catch failures that never throw.** Dead buttons and abandoned forms surface from session recordings, even when the console is clean.
-- **Stay in control.** It never merges its own PRs, it says why whenever it stops, and the whole thing self-hosts on your infrastructure.
+- **Stay in control.** It never merges its own PRs, it says why whenever it stops, and the application stack runs on your infrastructure.
 
 ## How it works
 
-1. **Capture.** The SDK sends errors and session recordings to the ingestion server. Two lines of code to install.
-2. **Group.** The same bug hitting 500 users becomes one issue, not 500 alerts. Errors that come from browser extensions, cross-origin scripts, or known-harmless browser warnings get dropped.
+1. **Capture.** The SDK sends errors and session recordings to the ingestion server. Two lines of code to install ([install guide](docs/install.md)).
+2. **Group.** The same bug hitting 500 users becomes one issue, not 500 alerts. Errors that come from browser extensions, cross-origin scripts, or known-harmless browser warnings are filtered out before they become issues.
 3. **Investigate.** The worker clones the repository and reads the code until it finds the cause. The cause has to name the exact files involved; guesses get thrown out.
 4. **Verify.** The fix is applied in an isolated sandbox, where the build and tests run. Whatever passed before has to pass after.
 5. **Deliver.** A verified fix opens as a pull request on the repository, ready for review. A fix that could not be verified opens as a draft, marked as such, and only if the project allows drafts. When there is no fix, the issue shows the reason instead.
-6. **Digest.** Once a day, Slack gets the summary: what broke, what got fixed, what needs a human.
+6. **Digest.** When Slack is connected, a daily digest lists what broke, what got fixed, and what needs a human.
 
-The pipeline calls three outside services: Anthropic to investigate, E2B to run the sandbox, and GitHub for clones and pull requests. Everything else runs on the self-hosted stack, on Postgres. There is no Redis or queue service to operate. JavaScript apps are supported end to end today; a Python SDK (alpha) captures and triages server-side errors, with its fix pipeline off by default.
+The pipeline calls three outside services: Anthropic to investigate, E2B to run the sandbox, and GitHub for clones and pull requests. Everything else runs on the self-hosted stack: Postgres for state and jobs, S3-compatible object storage for session recordings (MinIO in the bundled stack). There is no Redis or queue service to operate. JavaScript apps are supported end to end today; a Python SDK (alpha) captures and triages server-side errors, with its fix pipeline off by default.
 
 ```mermaid
 flowchart LR
@@ -63,7 +65,7 @@ The exact evidence gates, their limits, and what they do not guarantee: [precisi
 
 ## Run it locally
 
-Prerequisites: Docker with Compose. No accounts or API keys needed for this first run.
+Prerequisites: Docker with Compose v2 and free host ports 8082, 5434, and 9012. No accounts or API keys needed for this first run.
 
 ```bash
 git clone https://github.com/opslane/opslane-oss.git
@@ -115,14 +117,14 @@ Exact permissions and environment variables are in the [self-host quickstart](do
 
 ## What leaves your host
 
-With no external integrations configured, no captured data (errors, replays, or repository source) leaves your deployment. Each integration you enable adds its own destination:
+With no external integrations configured, the self-hosted services send no captured data (errors, session recordings, or repository source) to anyone. Each integration you enable adds its own destination:
 
 - **GitHub:** authentication, repository access, clones, pull requests.
 - **Anthropic:** investigation context and selected source.
 - **E2B:** repository contents and commands for sandbox verification.
 - **WorkOS** (optional): cloud authentication.
-- **Slack** (optional): notifications.
-- **Langfuse** (optional): traces.
+- **Slack** (optional): issue titles, summaries, and links in notifications and digests.
+- **Langfuse** (optional): full investigation traces, including prompts and completions.
 
 The full data-flow and trust model, including what each destination receives: [trust and security](docs/architecture/trust.md).
 

--- a/README.md
+++ b/README.md
@@ -1,89 +1,161 @@
+<!-- PLACEHOLDER: hero banner image (dark/light variants). Suggested: logo + tagline "Watches your users, fixes your app." -->
+
 # Opslane
 
-Opslane is an AI-powered production error-resolution engine for browser JavaScript apps. It ingests errors from your frontend, investigates the root cause, and either opens a ready-for-review fix pull request backed by executed evidence, publishes an eligible unverified fix as a clearly labeled draft when the project opts in, or files an actionable incident that tells a human exactly what it found and why it stopped.
+Every error tracker has the same output: an alert. Opslane's output is a pull request.
 
-**Status: early stage.** Opslane currently supports browser JavaScript errors and GitHub repositories. APIs and schemas may change without notice. See [the launch documentation epic](https://github.com/opslane/opslane-oss/issues/2) for what's being built next.
+Opslane watches your app's browser errors, investigates them against your repository, verifies the fix in a sandbox, and opens the PR. When it can't fix something, it tells you why it stopped instead of paging you. Sentry tells you what broke; Opslane has already fixed it.
+
+**Scope today:** browser JavaScript errors and GitHub repositories, end to end. The services run on your infrastructure; the fix pipeline calls three external services: Anthropic for investigation, E2B for sandboxed verification, and GitHub for clones and PRs. A Python SDK (alpha) captures and triages server-side errors, with its fix pipeline off by default.
+
+## See it work
+
+### Error to pull request
+
+<!-- PLACEHOLDER: full product tour — video or GIF. One uninterrupted path: browser error → grouped incident → investigation evidence → pull request. -->
+
+### A merged production fix
+
+<!-- PLACEHOLDER: screenshot of a real merged Opslane PR (e.g. #1232) — title, root-cause explanation, evidence section, diff. Scrub anything private; link the PR here. -->
+
+In two weeks on one production app (July to August 2026), Opslane captured 7,415 events, suppressed the 78% that were browser noise, and opened one pull request: a fix for a crash users had hit 614 times. A human reviewed and merged it.
+
+## What each outcome means
+
+Every investigation ends in one of four visible outcomes:
+
+- **A ready-for-review PR.** Three things held: the fix built, the build and test commands Opslane detected (or the project configured) ran in a fresh sandbox, and no test that passed on the baseline fails with the fix applied. The PR records which commands ran and their results.
+- **A draft PR.** The fix passed Opslane's reviewing model but lacks that executed proof. Drafts are clearly labeled and only open if the project opts in.
+- **An `investigated` analysis.** Opslane found the likely cause but did not attempt a change; the analysis waits for a human to read and, if they choose, trigger the fix.
+- **A `needs_human` incident.** Opslane stopped, with a reason code and a suggested next action. In our review of the 125 incidents it declined on that same production app, we agreed with the routing on 114.
+
+The exact gates, their limits, and what they do not guarantee: [precision](docs/architecture/precision.md).
 
 ## How it works
 
 ```mermaid
 flowchart LR
-    A[Browser SDK] -->|errors + session replays| B[Ingestion API]
-    B --> C[(Postgres)]
-    C -->|job queue| D[Worker]
-    D -->|investigate + fix| E[Sandbox verification]
-    E -->|ready evidence| F[Ready GitHub PR]
-    E -->|positive but incomplete evidence + opt-in| G[Draft GitHub PR]
-    E -->|blocked or rejected| H[needs_human incident]
+    A[Browser SDK] -->|errors + session replays| B[Ingestion and grouping]
+    B --> C[(Postgres job queue)]
+    C --> D[Worker: investigate]
+    D -->|candidate fix| E[Fix + sandbox verification]
+    D -->|analysis only| I[investigated: analysis for a human]
+    D -->|blocked| H[needs_human: reason + next action]
+    E -->|ready gate passes| F[Ready GitHub PR]
+    E -->|draft gate passes + project opt-in| G[Draft GitHub PR]
+    E -->|neither gate passes| H
 ```
 
 | Component | What it does | Where |
 | --- | --- | --- |
-| Browser SDK | Captures errors and session replays, with masking on by default | [`packages/sdk`](packages/sdk) |
+| Browser SDK | Captures errors and session replays, with input masking on by default | [`packages/sdk`](packages/sdk) |
 | Ingestion API | Go service that receives events, groups errors, and serves the dashboard | [`packages/ingestion`](packages/ingestion) |
-| Worker | Investigates errors with Claude, writes a fix, collects evidence in an [E2B](https://e2b.dev) sandbox, and publishes either a ready PR or an explicitly unverified draft according to project policy | [`packages/worker`](packages/worker) |
+| Worker | Investigates error groups and proposes changes; for candidate fixes, runs the build and tests in an [E2B](https://e2b.dev) sandbox, records the results, and opens the PR | [`packages/worker`](packages/worker) |
 | Dashboard | Vue app for incidents, replays, and project settings | [`packages/dashboard`](packages/dashboard) |
-| CLI | Agent-friendly command-line access to incidents and projects | [`cli`](cli) |
+| CLI | Lists and inspects projects and incidents from the command line | [`cli`](cli) |
+| Python SDK (alpha) | Captures server-side Python errors, with a Flask integration | [`packages/sdk-python`](packages/sdk-python) |
 
-Postgres is both the system of record and the job queue — there is no Redis or external queue to run.
-
-Every run reaches an explicit state: a ready-for-review fix PR backed by executed verification evidence (`pr_created`); an opt-in, judge-approved but not locally verified draft (`pr_draft`) whose repository CI is still evidence in progress; a medium/low-confidence analysis posted as `investigated`, with the root cause waiting for you to review and trigger a fix; or a `needs_human` incident with a reason code, plain-language explanation, and suggested remediation.
+Postgres is both the system of record and the job queue. There is no Redis or external queue to run.
 
 ## Run it locally
 
-Prerequisites: Docker with Compose.
+The smoke test needs no accounts and no API keys. It proves events are ingested, grouped, and always driven to an explicit final status. It does not run the AI investigation or open a PR. Prerequisites: Docker with Compose.
 
 ```bash
 git clone https://github.com/opslane/opslane-oss.git
 cd opslane-oss
-docker compose up -d
+docker compose up -d --wait
 curl http://localhost:8082/health
 ```
 
-This starts Postgres, MinIO, the ingestion API (which serves the dashboard at <http://localhost:8082>), and the worker. Database migrations run automatically.
+This starts Postgres, MinIO, the ingestion API (which serves the dashboard at <http://localhost:8082>), and the worker. Migrations run automatically.
 
-What you can do next depends on which credentials you provide:
+Seed a test project and send it an error:
 
-1. **No credentials — smoke-test the pipeline.** Seed a test project and API key, then send an error event:
+```bash
+docker compose exec -T postgres psql -U opslane -d opslane < scripts/seed-e2e.sql
+curl -X POST http://localhost:8082/api/v1/events \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: opslane_pk_mzxw6ytboi3damrrgi3tknzxgq_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq' \
+  -d '{"timestamp":"2026-01-01T00:00:00Z","error":{"type":"ReferenceError","message":"demo is not defined","stack":"ReferenceError: demo is not defined\n  at app.js:1:1"},"breadcrumbs":[],"context":{"url":"https://example.com","user_agent":"smoke test"},"sdk_version":"0.0.1"}'
+```
 
-   ```bash
-   docker compose exec -T postgres psql -U opslane -d opslane < scripts/seed-e2e.sql
-   curl -X POST http://localhost:8082/api/v1/events \
-     -H 'Content-Type: application/json' -H 'X-API-Key: e2e-test-key-plaintext' \
-     -d '{"timestamp":"2026-01-01T00:00:00Z","error":{"type":"ReferenceError","message":"demo is not defined","stack":"ReferenceError: demo is not defined\n  at app.js:1:1"},"breadcrumbs":[],"context":{"url":"https://example.com","user_agent":"smoke test"},"sdk_version":"0.0.1"}'
-   ```
+The `opslane_pk_...` value is the test project's seeded public ingest key; real deployments mint their own. Give the worker a few seconds to claim the job, then check the result (re-run if the row hasn't appeared yet):
 
-   The event is captured and grouped, the worker picks up the investigation, and — since it has no AI or GitHub credentials — the error group ends in a `needs_human` state with an explicit reason code and message.
+```bash
+docker compose exec -T postgres psql -U opslane -d opslane \
+  -c "SELECT status, reason_code, reason_message FROM error_groups ORDER BY created_at DESC LIMIT 1;"
+```
 
-2. **Dashboard sign-in** defaults to GitHub OAuth, which requires a GitHub App: set `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, `AUTH_CALLBACK_ORIGIN=http://localhost:8082`, and `DASHBOARD_ORIGIN=http://localhost:8082` before `docker compose up`. Cloud deployments can instead select `AUTH_PROVIDER=workos` and must provide `WORKOS_API_KEY` plus `WORKOS_CLIENT_ID`; partial WorkOS configuration fails closed.
+```text
+   status    |   reason_code   |                  reason_message
+-------------+-----------------+---------------------------------------------------
+ needs_human | missing_llm_key | ANTHROPIC_API_KEY environment variable is not set
+```
 
-3. **Full error-to-PR** additionally needs `ANTHROPIC_API_KEY`, `E2B_API_KEY`, and GitHub credentials with access to a repository the worker may open pull requests against.
+The worker has no AI credentials, so it stopped and said why. With the required integrations configured, processing ends in one of the four outcomes above instead.
 
-SDK installation and configuration are covered in the [install guide](docs/install.md). Replay capture privacy defaults are described in [replay privacy and masking](docs/guides/replay-privacy.md).
+Additional paths need external-service configuration:
+
+- **Dashboard sign-in:** a GitHub App, or WorkOS for cloud deployments.
+- **Investigation:** `ANTHROPIC_API_KEY`.
+- **Sandbox verification:** `E2B_API_KEY`.
+- **Pull requests:** GitHub credentials with access to the target repository.
+
+Exact permissions and environment variables are in the [self-host quickstart](docs/quickstart/self-host.md). SDK setup is in the [install guide](docs/install.md); replay privacy defaults in [replay privacy and masking](docs/guides/replay-privacy.md).
+
+## What Opslane is not
+
+- **Not an APM or metrics backend.** Opslane ingests application errors and the session context around them: breadcrumbs, network timing, and optional replays. It does not do latency percentiles, distributed tracing, or infrastructure monitoring.
+- **Not autopilot.** Opslane opens pull requests but never merges them. Review and merge stay with the repository owner.
+- **Not a dashboard to babysit.** Conclusions ship as PRs and incidents; the dashboard exists for replays and settings, not triage duty.
+- **Pre-1.0.** The [`POST /api/v1/events` wire contract](docs/contracts/events.md) is append-only and backward-compatible. Other interfaces may still change before 1.0.
+
+## What leaves your host
+
+With no external integrations configured, no captured data (errors, replays, or repository source) leaves your deployment. Each integration you enable adds its own destination:
+
+- **GitHub:** authentication, repository access, clones, pull requests.
+- **Anthropic:** investigation context and selected source.
+- **E2B:** repository contents and commands for sandbox verification.
+- **WorkOS** (optional): cloud authentication.
+- **Slack** (optional): notifications.
+- **Langfuse** (optional): traces.
+
+The full data-flow and trust model, including what each destination receives: [trust and security](docs/architecture/trust.md).
+
+## Documentation
+
+- [Self-host quickstart](docs/quickstart/self-host.md): the smoke test and the full error-to-PR path, in detail
+- [Install guide](docs/install.md): add the SDK to your app
+- [Guides](docs/guides): React, Vue, vanilla JS, source maps, GitHub App, Slack notifications, replay privacy
+- [Architecture](docs/architecture/overview.md): components, trust boundaries, life of an error
+- [Reference](docs/reference): SDK options, HTTP routes, environment variables, reason codes, checked against source by [`scripts/check-docs-drift.mjs`](scripts/check-docs-drift.mjs) in CI
 
 ## Repository layout
 
 ```text
 packages/
-  ingestion/   Go API, database, migrations, grouping, masking
-  worker/      Investigation and fix pipeline, PR creation
-  dashboard/   Vue dashboard served by ingestion
-  sdk/         Browser SDK and framework integrations
-shared/        Shared TypeScript contracts
-cli/           Opslane CLI
-eval/          Evaluation runner and fixture apps
-docs/          Documentation
+  ingestion/    Go ingestion API, grouping, storage, dashboard server
+  worker/       Investigation, verification, and PR pipeline
+  agent-core/   Provider-neutral agent loop
+  dashboard/    Vue dashboard
+  sdk/          Browser SDK, framework integrations, Vite source-map plugin
+  sdk-python/   Python SDK (alpha)
+shared/         Shared TypeScript contracts
+cli/            Opslane CLI
+docs/           Documentation (published by docs-site/)
 ```
 
 ## Licensing
 
 | Code | License |
 | --- | --- |
-| Server, worker, agent core ([`packages/agent-core`](packages/agent-core)), dashboard, CLI ([`cli`](cli/LICENSE)), eval, and tests | [AGPL-3.0-only](LICENSE) |
+| Server, worker, agent core ([`packages/agent-core`](packages/agent-core)), dashboard, CLI ([`cli`](cli/LICENSE)), docs site, and tests | [AGPL-3.0-only](LICENSE) |
 | Browser SDK ([`packages/sdk`](packages/sdk/LICENSE)), Python SDK ([`packages/sdk-python`](packages/sdk-python/LICENSE)), and shared types ([`shared`](shared/LICENSE)) | MIT |
 
-In short: the SDKs and shared types that run in *your* application are MIT; the rest of Opslane, including the agent core and CLI, is AGPL.
+In short: the SDKs and shared contracts are MIT; the ingestion service, worker, agent core, dashboard, CLI, docs site, and tests are AGPL-3.0-only.
 
 ## Contributing
 
-Bug reports and feature requests are welcome on the [issue tracker](https://github.com/opslane/opslane-oss/issues). For codebase conventions and verification requirements, see [AGENTS.md](AGENTS.md).
+Bug reports and feature requests are welcome on the [issue tracker](https://github.com/opslane/opslane-oss/issues). For development setup, codebase conventions, and the verification bar for changes, see [AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It learns where users get stuck from errors and session recordings. You get a da
 
 <!-- PLACEHOLDER: screenshot of a real merged Opslane PR (e.g. #1232) — title, root-cause explanation, evidence section, diff. Scrub anything private; link the PR here. -->
 
-Over two weeks spanning July and August 2026, one production app sent Opslane 7,415 events. It suppressed the 78% that were noise and opened one pull request: a fix for a crash users had hit 614 times. A human reviewed and merged it.
+Over two weeks spanning July and August 2026, one production app sent Opslane 7,415 events. Opslane opened one pull request: a fix for a crash users had hit 614 times. A human reviewed and merged it.
 
 ## What it does
 
@@ -135,21 +135,6 @@ The full data-flow and trust model, including what each destination receives: [t
 - [Guides](docs/guides): React, Vue, vanilla JS, source maps, GitHub App, Slack notifications, replay privacy
 - [Architecture](docs/architecture/overview.md): components, trust boundaries, life of an error
 - [Reference](docs/reference): SDK options, HTTP routes, environment variables, reason codes, checked against source by [`scripts/check-docs-drift.mjs`](scripts/check-docs-drift.mjs) in CI
-
-## Repository layout
-
-```text
-packages/
-  ingestion/    Go ingestion API, grouping, storage, dashboard server
-  worker/       Investigation, verification, and PR pipeline
-  agent-core/   Provider-neutral agent loop
-  dashboard/    Vue dashboard
-  sdk/          Browser SDK, framework integrations, Vite source-map plugin
-  sdk-python/   Python SDK (alpha)
-shared/         Shared TypeScript contracts
-cli/            Opslane CLI
-docs/           Documentation (published by docs-site/)
-```
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -2,40 +2,44 @@
 
 # Opslane
 
-Every error tracker has the same output: an alert. Opslane's output is a pull request.
+Error trackers see stack traces. Opslane knows your product.
 
-Opslane watches your app's browser errors, investigates them against your repository, verifies the fix in a sandbox, and opens the PR. When it can't fix something, it tells you why it stopped instead of paging you. Sentry tells you what broke; Opslane has already fixed it.
-
-**Scope today:** browser JavaScript errors and GitHub repositories, end to end. The services run on your infrastructure; the fix pipeline calls three external services: Anthropic for investigation, E2B for sandboxed verification, and GitHub for clones and PRs. A Python SDK (alpha) captures and triages server-side errors, with its fix pipeline off by default.
+It learns where users get stuck from errors and session recordings. You get a daily digest of what matters, and pull requests with tested fixes. When it can't fix something, it says why.
 
 ## See it work
 
 ### Error to pull request
 
-<!-- PLACEHOLDER: full product tour — video or GIF. One uninterrupted path: browser error → grouped incident → investigation evidence → pull request. -->
+<!-- PLACEHOLDER: full product tour — video or GIF. One uninterrupted path: error → grouped issue → investigation evidence → pull request. -->
 
 ### A merged production fix
 
 <!-- PLACEHOLDER: screenshot of a real merged Opslane PR (e.g. #1232) — title, root-cause explanation, evidence section, diff. Scrub anything private; link the PR here. -->
 
-In two weeks on one production app (July to August 2026), Opslane captured 7,415 events, suppressed the 78% that were browser noise, and opened one pull request: a fix for a crash users had hit 614 times. A human reviewed and merged it.
+In two weeks on one production app (July to August 2026), Opslane captured 7,415 events, suppressed the 78% that were noise, and opened one pull request: a fix for a crash users had hit 614 times. A human reviewed and merged it.
 
-## What each outcome means
+## What it does
 
-Every investigation ends in one of four visible outcomes:
-
-- **A ready-for-review PR.** Three things held: the fix built, the build and test commands Opslane detected (or the project configured) ran in a fresh sandbox, and no test that passed on the baseline fails with the fix applied. The PR records which commands ran and their results.
-- **A draft PR.** The fix passed Opslane's reviewing model but lacks that executed proof. Drafts are clearly labeled and only open if the project opts in.
-- **An `investigated` analysis.** Opslane found the likely cause but did not attempt a change; the analysis waits for a human to read and, if they choose, trigger the fix.
-- **A `needs_human` incident.** Opslane stopped, with a reason code and a suggested next action. In our review of the 125 incidents it declined on that same production app, we agreed with the routing on 114.
-
-The exact gates, their limits, and what they do not guarantee: [precision](docs/architecture/precision.md).
+- **Know what's broken without reading 7,000 alerts.** Errors group into causes, noise is suppressed, and issues are ranked by how many users they hit. One Slack digest a day.
+- **Get bugs fixed without losing the afternoon.** Opslane investigates in your repo and sends the fix as a pull request that built and passed your tests. You review and merge.
+- **See what the user saw.** Every error links to the session replay behind it: the clicks, pages, and requests that led up to it.
+- **Catch failures that never throw.** Dead buttons and abandoned forms surface from session recordings, even when the console is clean.
+- **Stay in control.** It never merges its own PRs, it says why whenever it stops, and the whole thing self-hosts on your infrastructure.
 
 ## How it works
 
+1. **Capture.** The SDK sends errors and session recordings to the ingestion server. Two lines of code to install.
+2. **Group.** The same bug hitting 500 users becomes one issue, not 500 alerts. Errors that come from browser extensions, cross-origin scripts, or known-harmless browser warnings get dropped.
+3. **Investigate.** The worker clones the repository and reads the code until it finds the cause. The cause has to name the exact files involved; guesses get thrown out.
+4. **Verify.** The fix is applied in an isolated sandbox, where the build and tests run. Whatever passed before has to pass after.
+5. **Deliver.** A verified fix opens as a pull request on the repository, ready for review. A fix that could not be verified opens as a draft, marked as such, and only if the project allows drafts. When there is no fix, the issue shows the reason instead.
+6. **Digest.** Once a day, Slack gets the summary: what broke, what got fixed, what needs a human.
+
+The pipeline calls three outside services: Anthropic to investigate, E2B to run the sandbox, and GitHub for clones and pull requests. Everything else runs on the self-hosted stack, on Postgres. There is no Redis or queue service to operate. JavaScript apps are supported end to end today; a Python SDK (alpha) captures and triages server-side errors, with its fix pipeline off by default.
+
 ```mermaid
 flowchart LR
-    A[Browser SDK] -->|errors + session replays| B[Ingestion and grouping]
+    A[SDK] -->|errors + session recordings| B[Ingestion and grouping]
     B --> C[(Postgres job queue)]
     C --> D[Worker: investigate]
     D -->|candidate fix| E[Fix + sandbox verification]
@@ -48,18 +52,18 @@ flowchart LR
 
 | Component | What it does | Where |
 | --- | --- | --- |
-| Browser SDK | Captures errors and session replays, with input masking on by default | [`packages/sdk`](packages/sdk) |
+| Browser SDK | Captures errors and session recordings, with input masking on by default | [`packages/sdk`](packages/sdk) |
 | Ingestion API | Go service that receives events, groups errors, and serves the dashboard | [`packages/ingestion`](packages/ingestion) |
-| Worker | Investigates error groups and proposes changes; for candidate fixes, runs the build and tests in an [E2B](https://e2b.dev) sandbox, records the results, and opens the PR | [`packages/worker`](packages/worker) |
-| Dashboard | Vue app for incidents, replays, and project settings | [`packages/dashboard`](packages/dashboard) |
-| CLI | Lists and inspects projects and incidents from the command line | [`cli`](cli) |
+| Worker | Investigates issues and proposes changes; for candidate fixes, runs the build and tests in an [E2B](https://e2b.dev) sandbox, records the results, and opens the PR | [`packages/worker`](packages/worker) |
+| Dashboard | Vue app for issues, replays, and project settings | [`packages/dashboard`](packages/dashboard) |
+| CLI | Lists and inspects projects and issues from the command line | [`cli`](cli) |
 | Python SDK (alpha) | Captures server-side Python errors, with a Flask integration | [`packages/sdk-python`](packages/sdk-python) |
 
-Postgres is both the system of record and the job queue. There is no Redis or external queue to run.
+The exact evidence gates, their limits, and what they do not guarantee: [precision](docs/architecture/precision.md).
 
 ## Run it locally
 
-The smoke test needs no accounts and no API keys. It proves events are ingested, grouped, and always driven to an explicit final status. It does not run the AI investigation or open a PR. Prerequisites: Docker with Compose.
+Prerequisites: Docker with Compose. No accounts or API keys needed for this first run.
 
 ```bash
 git clone https://github.com/opslane/opslane-oss.git
@@ -80,7 +84,7 @@ curl -X POST http://localhost:8082/api/v1/events \
   -d '{"timestamp":"2026-01-01T00:00:00Z","error":{"type":"ReferenceError","message":"demo is not defined","stack":"ReferenceError: demo is not defined\n  at app.js:1:1"},"breadcrumbs":[],"context":{"url":"https://example.com","user_agent":"smoke test"},"sdk_version":"0.0.1"}'
 ```
 
-The `opslane_pk_...` value is the test project's seeded public ingest key; real deployments mint their own. Give the worker a few seconds to claim the job, then check the result (re-run if the row hasn't appeared yet):
+The `opslane_pk_...` value is the test project's seeded public ingest key; real deployments mint their own. Give the worker a few seconds, then check the result (re-run if the row hasn't appeared yet):
 
 ```bash
 docker compose exec -T postgres psql -U opslane -d opslane \
@@ -93,9 +97,7 @@ docker compose exec -T postgres psql -U opslane -d opslane \
  needs_human | missing_llm_key | ANTHROPIC_API_KEY environment variable is not set
 ```
 
-The worker has no AI credentials, so it stopped and said why. With the required integrations configured, processing ends in one of the four outcomes above instead.
-
-Additional paths need external-service configuration:
+The worker stopped because it has no AI credentials, and it said so. To go further:
 
 - **Dashboard sign-in:** a GitHub App, or WorkOS for cloud deployments.
 - **Investigation:** `ANTHROPIC_API_KEY`.
@@ -108,7 +110,7 @@ Exact permissions and environment variables are in the [self-host quickstart](do
 
 - **Not an APM or metrics backend.** Opslane ingests application errors and the session context around them: breadcrumbs, network timing, and optional replays. It does not do latency percentiles, distributed tracing, or infrastructure monitoring.
 - **Not autopilot.** Opslane opens pull requests but never merges them. Review and merge stay with the repository owner.
-- **Not a dashboard to babysit.** Conclusions ship as PRs and incidents; the dashboard exists for replays and settings, not triage duty.
+- **Not a dashboard to babysit.** Conclusions ship as PRs and issues; the dashboard exists for replays and settings, not triage duty.
 - **Pre-1.0.** The [`POST /api/v1/events` wire contract](docs/contracts/events.md) is append-only and backward-compatible. Other interfaces may still change before 1.0.
 
 ## What leaves your host
@@ -126,7 +128,7 @@ The full data-flow and trust model, including what each destination receives: [t
 
 ## Documentation
 
-- [Self-host quickstart](docs/quickstart/self-host.md): the smoke test and the full error-to-PR path, in detail
+- [Self-host quickstart](docs/quickstart/self-host.md): the local run and the full error-to-PR path, in detail
 - [Install guide](docs/install.md): add the SDK to your app
 - [Guides](docs/guides): React, Vue, vanilla JS, source maps, GitHub App, Slack notifications, replay privacy
 - [Architecture](docs/architecture/overview.md): components, trust boundaries, life of an error


### PR DESCRIPTION
## What this is

A ground-up README rewrite for the open-source launch, built on `positioning.md`'s language (alert vs. pull request, let the nouns fight) and adapted to the technical register a skeptical GitHub reader expects.

## What changed

- **Hook**: leads with the category argument (every error tracker outputs an alert; Opslane outputs a PR) and an honest scope paragraph naming the three external services the fix pipeline calls.
- **Quickstart is now true.** The old smoke test used `X-API-Key: e2e-test-key-plaintext`, which `scripts/seed-e2e.sql` stopped creating when #243 introduced structured keys — the documented curl returns **401**. Replaced with the seeded `opslane_pk_...` key, added the missing result query, and pasted the real output (`needs_human | missing_llm_key`). Every command in the README was executed against a fresh Compose stack, including `docker compose up -d --wait` with the one-shot `migrate`/`minio-setup` services.
- **"What each outcome means"**: defines all four terminal outcomes (ready PR, opt-in draft, `investigated`, `needs_human`) with the evidence gates stated at the strength the code actually enforces.
- **"What Opslane is not"** and **"What leaves your host"**: honest-scope and per-integration egress sections (GitHub / Anthropic / E2B, plus optional WorkOS / Slack / Langfuse).
- **Fixed rot**: phantom `eval/` directory in the layout (deleted in #296), missing `agent-core`/`sdk-python` packages, the exhaustive-looking four-state list (now covers `insight`/`awaiting_approval` via the outcomes framing), licensing row.
- **Media placeholders** (HTML comments): hero banner, product-tour video/GIF, merged-PR screenshot — to be filled with real assets before launch.

## Process

Draft → two Codex review iterations (accuracy findings accepted; positioning-softening findings rejected per `positioning.md`'s "do not soften the claim") → humanizer + avoid-ai-writing passes → `node scripts/check-docs-drift.mjs` and `node scripts/check-docs-scope.mjs` green.

Part of #2. Follow-up issues for the remaining doc pages are being filed from the full 20-page audit.