### PR TITLE
feat: C3 — impact from recordings, watchable session pointers, readiness backfill

### DIFF
--- a/docs/superpowers/plans/2026-08-11-c3-impact-readiness-session-pointers.md
+++ b/docs/superpowers/plans/2026-08-11-c3-impact-readiness-session-pointers.md
@@ -1,0 +1,755 @@
+# C3: Impact, Readiness Backfill, and Session Pointers — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every open incident carries a mechanically computed impact stamp (`blocked/degraded/invisible` from session recordings, both lanes), a watchable session pointer that actually plays (stitched ±15s coverage, friction retraction fallback), and a `digest_readiness` row (the backfill retires C1's absent-row policy) — and the friction fix rung stops reading confidence, discharging C2's frozen-rung debt.
+
+**Architecture:** The existing priority sweeper gains a transactional impact pass: one temp-table rollup over both lanes' sessions (error events for `kind='error'`, accepted friction signals for `kind='friction'`), a single stamp UPDATE, and a stale-clear guarded on non-NULL so unknown groups are never rewritten. `SessionPointerForGroup` gains a friction branch (representative signal, earliest-accepted fallback); a new coverage-gated `WatchableSessionForGroup` feeds the digest's replay links with a `?t=` anchor the dashboard already understands. Migration 046 adds the `(error_group_id, "timestamp")` index the rollup needs; migration 047 is the one-shot readiness backfill. The worker's friction auto-fix rung swaps its confidence conjunct for a live signal-session impact bar recorded as `policy_eligible`/`policy_basis`.
+
+**Tech Stack:** Go 1.24 (ingestion: sweeper, queries, digest, migrations, plain `testing`), Postgres (plain SQL migrations under `packages/ingestion/db/migrations/`), TypeScript + Vitest (worker: friction impact bar).
+
+**Parent:** `docs/superpowers/plans/2026-08-10-unified-actionable-program-plan.md` §C3. Authority: `docs/design/2026-08-10-unified-actionable-program.md` (decisions 2, 3). Carried-forward detail: `docs/superpowers/plans/2026-08-10-actionable-receipts-v1.md` Tasks B1/B2 (revised SQL, coverage definition), amended below where exploration of the working tree contradicted them (see "Deviations from carried-forward text").
+
+## Dependencies on C0, C1, C2 (hard prerequisites)
+
+Consumed, never edited:
+
+- **C0 / migration 044** (`044_actionable_receipts_contracts.sql:38-44`): the four impact columns already exist on `error_groups` — `impact_class TEXT CHECK (impact_class IN ('blocked','degraded','invisible'))`, `impact_visits BIGINT`, `impact_visits_recovered BIGINT`, `impact_computed_at TIMESTAMPTZ` — **C3 adds no impact columns**, only the query index (Task 1). `digest_readiness` (`:80-90`: `incident_id` PK, `project_id`, `status IN ('eligible','ineligible','pending')`, `reason`, `updated_at`, composite FK → `error_groups` ON DELETE CASCADE).
+- **C1**: the interim digest gate (`digest/build.go:108-111` and 4 siblings — `NOT EXISTS (… dr.status IN ('ineligible','pending'))`; absent rows render as today) — Task 8's backfill is exactly the retirement of that absent-row clause the C1 comment promises; the incident DTO readiness gate (`read_api.go`: `ineligible`/`pending` null the cause) and honest-state dashboard card; the requeue transition (`queries.go:731-739`, UPDATE-only `('pending','reinvestigating')`); readiness reasons `'validated_cause'`, `'reinvestigating'`, `'quarantined_degenerate'`; migration 045's one-shot guard shape and `applied_data_migrations` (`028_project_api_keys.sql:28-31`: columns `name`, `applied_at`).
+- **C2** (`docs/superpowers/plans/2026-08-11-c2-worker-verification-judge-policy.md`; merged before Task 9 and before CP3's AC3.7 fix-outcome leg — Tasks 1–8 need only C1): `DecisionRow.policyEligible/policyBasis` and their persistence in `insertDiagnosisDecision` (C2 Task 2); the `ImpactBar` type and error-lane `getGroupImpactBar` (C2 Task 2 — Task 9 reuses the type and thresholds verbatim); the frozen friction rung with its debt comment (`index.ts`, C2 Task 3: `// C3 replaces this confidence check with the signal-session impact bar…`); fix-outcome readiness reasons `'fix_pr_opened'`, `'fix_attempt_failed_with_diff'`, `'fix_attempt_failed_no_diff'` (C2 Task 13 — AC3.7's middle leg witnesses them, C3 does not write them).
+- Line numbers in this plan are anchors into the working tree, verified 2026-08-11. Where a symbol has moved, locate it by name (`grep -n`); the named function is the contract, not the line.
+
+## Global Constraints
+
+- Postgres queue only; wire contract append-only (`test-fixtures/wire/` untouched); lease and terminal-status contracts preserved; human-trigger bypass untouched.
+- **No judgment-based impact labels** (design decision 2, overturning nothing softer): `impact_class` is computed from session recordings or it is NULL. Unknown is **all four columns NULL** — one representation for never-computed and computed-found-nothing. The "recording impact unavailable" sentence is C4/C5 rendering scope; C3 stores NULLs and renders nothing new.
+- Named contracts, frozen here: `impactWindowDays = 30` (deliberately wider than the priority 7d/24h windows; it is not "the retention window"), `impactRecoveryMs = 60_000` (last recorded activity ≥ 60s after the session's last crash/signal counts as recovered), `watchWindowMs = 15_000` (stitched-span coverage each side of the anchor), `watchCandidateEvents = 50` (newest events examined per group for a watchable pointer).
+- **Sweeper contract preserved:** single-flight via session advisory lock `0x7072696F7269`; `RunOnce` returns `(0, nil)` on contention (pinned by `sweeper_test.go:253`); the impact pass runs on the same held connection but inside **its own transaction** (temp table + two statements — the rest of `RunOnce` stays autocommit-per-statement, unchanged).
+- Every read of `session_chunks` gates on `scrubbed_at IS NOT NULL` (the fail-closed rule in `002_sessions.sql:40-46`), and impact/coverage arithmetic additionally requires non-NULL `first_event_ms`/`last_event_ms` — NULL-bounded chunks are excluded everywhere (unknown evidence is not proof of death).
+- Client-clock consistency: crash times use `error_events."timestamp"` and signal times use `friction_signals.occurred_at` because they are compared against `session_chunks.first_event_ms/last_event_ms`, which are client-clock epoch ms (`003_chunk_event_times.sql`). The dashboard's `?t=` query param is an **absolute epoch-ms event timestamp** (`SessionDetail.vue:13-15`), the same clock domain — pointers emit it directly.
+- Migrations are idempotent under unconditional replay (`scripts/run-migrations.sh` replays every file every boot, per-statement autocommit); one-shot data migrations guard via `applied_data_migrations` (045's Shape A). 046/047 widen no constraint or enum, so `scripts/check-migration-reapply.sh` needs no new seed rows (stated so the reviewer doesn't hunt).
+- **Readiness single-writer discipline holds:** steady-state writers remain exactly C1/C2's (`upsertDigestReadiness` in the worker, the Go requeue UPDATE). C3 adds only the one-shot migration 047. New frozen backfill reason strings: `'backfill_receipt_state'`, `'backfill_validated_cause'`, `'backfill_unverified'`. **C4 must key its gate on `status` alone** (eligible-only), never on eligible-side reason strings — recorded here because 047 makes eligible reasons heterogeneous.
+- **Customer-visible deploy note (deliberate, program-intended):** the moment 047 runs, open legacy incidents classified `pending` fall out of the digest (C1's interim gate already excludes `pending`) and their incident pages show the honest not-verified state (C1's DTO gate). That is the point — the absent-row policy dies, unverified legacy prose stops rendering, and receipt/validated legacy keeps rendering via the eligible carve-outs. The rollout runbook (Task 10) records the per-class counts from a prod copy before the release.
+- Go tests may not skip beyond the `check-go-skips.mjs` allowlist; new DB-gated tests follow each package's existing gating (`priority`: skip only when `DATABASE_URL` unset, fatal on unreachable; `db`: skip on unreachable, `defaultTestDSN` fallback).
+- Copy rule inherited: C3 writes no customer copy. Impact class strings are stored enum values, not sentences.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `packages/ingestion/db/migrations/046_impact_query_index.sql` (create) | Partial index `(error_group_id, "timestamp") WHERE session_id IS NOT NULL` on `error_events`, CONCURRENTLY with 044's invalid-index drop guard |
+| `packages/ingestion/db/migrations/047_readiness_backfill.sql` (create) | One-shot classification of every open, absent-row incident into `digest_readiness` |
+| `packages/ingestion/priority/sweeper.go` (modify) | `stampImpact` pass: temp-table rollup (both lanes), stamp UPDATE, guarded stale-clear; named constants |
+| `packages/ingestion/priority/impact_test.go` (create) | DB-gated impact tests: AC3.1–AC3.4 shapes incl. xmin stability |
+| `packages/ingestion/priority/impact_explain_test.go` (create) | AC3.8: 100k-event seed, `EXPLAIN (ANALYZE, BUFFERS)`, examined-row ratio assertion |
+| `packages/ingestion/db/sessions_read.go` (modify) | `SessionPointerForGroup` friction branch; new `WatchableSessionForGroup` |
+| `packages/ingestion/db/sessions_read_test.go` (extend) | Pointer + coverage tests: AC3.5/AC3.6 query halves |
+| `packages/ingestion/db/migration_046_test.go`, `migration_047_test.go` (create) | Index presence; backfill classification, marker, idempotence |
+| `packages/ingestion/digest/digest.go` (modify) | `sessionURLAt(sessionID, anchorMs)` emitting `/sessions/{id}?t={ms}` |
+| `packages/ingestion/digest/build.go` (modify) | Replay links from `WatchableSessionForGroup` (issues + insights) |
+| `packages/ingestion/digest/build_test.go` (extend) | Chunk-seeded replay-link matrix |
+| `packages/worker/src/db.ts` (modify) | `getFrictionGroupImpactBar` (signal-session arithmetic, `ImpactBar` reused) |
+| `packages/worker/src/index.ts` (modify) | Friction rung: impact bar replaces the frozen confidence conjunct; policy stamp on friction `code_fix` decisions |
+| `packages/worker/src/__tests__/index.test.ts` (extend) | AC3.9 routing tests |
+| `packages/worker/src/__tests__/db.test.ts` (extend) | Friction bar boundary tests |
+
+**PR train** (each PR = consecutive tasks, merged in order): PR1 = Tasks 1–4 (impact) · PR2 = Tasks 5–7 (pointers + digest links) · PR3 = Task 8 (readiness backfill — deployed after PR1/PR2 so the flip lands with impact stamps and working pointers live) · PR4 = Task 9 (friction routing; requires C2 merged) · CP3 = Task 10.
+
+## Deviations from carried-forward text (each deliberate, source-verified)
+
+1. **Open-group predicate:** receipts B1 wrote `archived_at IS NULL AND status NOT IN ('resolved','merged')`. The sweeper's own five existing queries use `status NOT IN ('resolved','merged','archived')` (`sweeper.go:40,61,97,147,175`) — `'archived'` is an enum status and `archived_at` accompanies it. The impact pass uses the in-file spelling; mixing predicates inside one file is the bug factory.
+2. **One migration became two:** B1's "no backfill — next sweep fills" holds for impact (046 carries only the index); the readiness backfill (program W3.B, not in the receipts plan) is 047, its own PR, because it is the customer-visible flip.
+3. **`?t=` confirmed, semantics pinned:** B2 said "extend with `?t={offsetMs}` only after confirming the dashboard router accepts it." Confirmed: `SessionDetail.vue:13-15` parses `t` as an absolute epoch-ms timestamp (not an offset) and threads it to `useSessionPlayback({ seekAtMs })`; `IncidentDetail.vue:385-393` already emits `t: Date.parse(error_at)`. Pointers emit absolute ms; no dashboard work needed.
+4. **Digest insights switch selection rules:** today `buildInsights` links the newest signal's session (`(array_agg(fs.session_id ORDER BY fs.occurred_at DESC))[1]`, `build.go:101`) with no coverage check, and `buildTopNewIssues` reads `representative_session_id`, which is written only for friction — error issues get no link. Both sections now route through `WatchableSessionForGroup`: links that exist can play; links that can't play don't exist. Existing digest tests are updated (they currently seed no `session_chunks`, so their expected links change — asserted explicitly in Task 7).
+5. **Bounded candidate scan:** B2's coverage rule is kept verbatim, but the error-branch search examines only the newest `watchCandidateEvents = 50` session-bearing events per group, so a coverage-less group costs a bounded probe, not a full-history walk.
+6. **The TS mirror stays error-lane:** `getSessionPointerForGroup` (`worker/src/db.ts:1594`) mirrors the Go pointer 1:1 today. Its consumers are error-lane replay evidence only; Task 5 changes the Go function and leaves the mirror untouched, updating its comment to say the friction branch is Go-only and why. (Verify the consumer claim by grep before relying on it; if a friction path consumes it, extend the mirror identically instead.)
+
+---
+
+### Task 1: Migration 046 — the index the rollup stands on
+
+`error_events` has no index serving "this group's events in a client-time window": `idx_error_events_group_created` (039) is on `created_at`, and the rollup must bound on `"timestamp"` (client clock, to compare against chunk event ms). Without this, examined rows ∝ all events of open groups and AC3.8 is unpassable.
+
+**Files:**
+- Create: `packages/ingestion/db/migrations/046_impact_query_index.sql`
+- Test: `packages/ingestion/db/migration_046_test.go` (create)
+
+**Interfaces:**
+- Produces: `idx_error_events_group_timestamp ON error_events (error_group_id, "timestamp") WHERE session_id IS NOT NULL` — consumed by Task 2's rollup and asserted by Task 4's planner test.
+
+- [ ] **Step 1: Write the failing test** (pattern: `migrations_test.go` harness + the `pg_indexes` probe from `sessions_index_test.go:139`):
+
+```go
+func TestMigration046ImpactQueryIndex(t *testing.T) {
+	admin := testPool(t)
+	psql := findPsql(t)
+	pool, dsn := disposableDB(t, admin)
+	for _, file := range migrationFiles(t) {
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("apply %s: %v", file, err)
+		}
+	}
+	var def string
+	err := pool.QueryRow(context.Background(),
+		`SELECT indexdef FROM pg_indexes WHERE tablename = 'error_events' AND indexname = 'idx_error_events_group_timestamp'`,
+	).Scan(&def)
+	if err != nil {
+		t.Fatalf("index missing: %v", err)
+	}
+	if !strings.Contains(def, `(error_group_id, "timestamp")`) {
+		t.Fatalf("indexdef %q: columns missing or misordered — want (error_group_id, \"timestamp\")", def)
+	}
+	if !strings.Contains(def, "session_id IS NOT NULL") {
+		t.Fatalf("indexdef %q missing the partial predicate", def)
+	}
+	// Second index, same probe: idx_friction_signals_incident_occurred on
+	// friction_signals with (incident_id, occurred_at) in order and all four
+	// partial-predicate conjuncts (incident_id, superseded_by, retracted_at,
+	// adjudication_status = 'accepted').
+}
+```
+
+- [ ] **Step 2: Run → FAIL** (index absent). `DATABASE_URL=… go test ./db/ -run TestMigration046`
+- [ ] **Step 3: Write the migration.** Copy 044's two-part shape exactly: a `DO $$` guard that drops the index only if it exists **and is invalid** (`pg_index.indisvalid = false` — an interrupted `CONCURRENTLY` build leaves an invalid index that `IF NOT EXISTS` would happily keep forever), then the concurrent create:
+
+```sql
+-- 046_impact_query_index.sql
+-- C3/W3.1: the impact rollup bounds error_events per group on client "timestamp"
+-- (chunk event ms are client-clock; created_at cannot serve the predicate).
+-- IDEMPOTENCY IS MANDATORY: scripts/run-migrations.sh replays every file on
+-- every boot, per-statement autocommit (which is what makes CONCURRENTLY legal here).
+DO $$
+DECLARE idx regclass;
+BEGIN
+  SELECT c.oid INTO idx
+  FROM pg_class c
+  JOIN pg_index i ON i.indexrelid = c.oid
+  JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = current_schema()
+  WHERE c.relname = 'idx_error_events_group_timestamp' AND NOT i.indisvalid;
+  IF idx IS NOT NULL THEN
+    EXECUTE 'DROP INDEX ' || idx;
+  END IF;
+END
+$$;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_error_events_group_timestamp
+  ON error_events (error_group_id, "timestamp")
+  WHERE session_id IS NOT NULL;
+
+-- The friction arm and the friction impact bar filter accepted-active signals by
+-- occurred_at; 039's reach index is ordered by created_at, so a long-lived incident
+-- with a large aged-but-still-active accepted set would be re-examined every sweep.
+-- Same guard shape applies (add the invalid-index drop for this name to the DO block).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_friction_signals_incident_occurred
+  ON friction_signals (incident_id, occurred_at)
+  WHERE incident_id IS NOT NULL AND superseded_by IS NULL
+    AND retracted_at IS NULL AND adjudication_status = 'accepted';
+```
+
+- [ ] **Step 4: Run → PASS**, and run the umbrella suite (`go test ./db/ -run TestMigrations_`) — the glob-driven apply/idempotency/roll-forward tests pick 046 up automatically; `TestMigrations_RollForwardFromPreviousSchema` now rolls 046 forward by construction (expected; note it in the PR).
+- [ ] **Step 5: Commit.** `feat(db): index error_events by group and client timestamp for the impact rollup (C3/W3.1)`
+
+### Task 2: The impact pass — error lane, transactional, stamp + guarded clear
+
+**Files:**
+- Modify: `packages/ingestion/priority/sweeper.go` (constants near `:13`; new SQL consts after `scoreFrictionGroupsSQL`; `stampImpact` method; one call in `RunOnce` after the scoring statements, before `enqueueRouteMapJobsSQL`)
+- Test: `packages/ingestion/priority/impact_test.go` (create; helpers `testPool`/`mustExec`/`seedTenant`/`seedGroup` from `testutil_test.go`)
+
+**Interfaces:**
+- Consumes: the 044 impact columns; Task 1's index; `session_chunks` bounds.
+- Produces (consumed by Task 3, C4's cards, C5's badges/PR body):
+  - Constants: `const impactWindowDays = 30`, `const impactRecoveryMs = 60_000`.
+  - `func (s *Sweeper) stampImpact(ctx context.Context, conn *pgxpool.Conn) error` — one transaction on the already-held advisory-locked connection: `CREATE TEMPORARY TABLE impact_rollup ON COMMIT DROP AS <rollup>`, then the stamp UPDATE, then the guarded clear. `RunOnce` calls it and propagates errors exactly like its existing statements; `updated` (the scoring row count) is **not** changed — impact counts are `slog.Debug`ged, keeping every existing `RunOnce` assertion byte-stable.
+  - Semantics (B1 revised, frozen): a **visit** = a distinct session among the group's in-window occurrences that has usable chunk evidence (some scrubbed chunk with non-NULL bounds). **Recovered** = that session's `max(last_event_ms) >= last_hit_ms + 60000`. `blocked` = recovered 0; `degraded` = 0 < recovered < visits; `invisible` = recovered = visits. Groups with no rollup row: previously stamped → cleared to all-NULL once; never stamped → untouched (no WAL churn, AC3.4).
+
+The rollup (error lane in this task; Task 3 adds the friction arm to the same temp table — the UNION ALL seam is built now):
+
+```sql
+CREATE TEMPORARY TABLE impact_rollup ON COMMIT DROP AS
+WITH open_groups AS (
+  SELECT id, project_id, kind FROM error_groups
+  WHERE status NOT IN ('resolved','merged','archived')
+), err_sess AS (
+  SELECT g.id AS group_id, e.project_id, e.session_id,
+         (max(extract(epoch FROM e."timestamp")) * 1000)::bigint AS last_hit_ms
+  FROM open_groups g
+  JOIN error_events e ON e.error_group_id = g.id AND e.project_id = g.project_id
+  WHERE g.kind = 'error' AND e.session_id IS NOT NULL
+    AND e."timestamp" > now() - interval '30 days'
+  GROUP BY 1, 2, 3
+), sess AS (
+  SELECT * FROM err_sess
+  -- Task 3 appends: UNION ALL SELECT * FROM fric_sess
+), chunks AS (
+  SELECT c.project_id, c.session_id, max(c.last_event_ms) AS last_activity_ms
+  FROM session_chunks c
+  WHERE c.scrubbed_at IS NOT NULL
+    AND c.first_event_ms IS NOT NULL AND c.last_event_ms IS NOT NULL
+    AND (c.project_id, c.session_id) IN (SELECT DISTINCT project_id, session_id FROM sess)
+  GROUP BY 1, 2
+)
+SELECT sess.group_id,
+       count(*)::bigint AS visits,
+       (count(*) FILTER (WHERE ch.last_activity_ms >= sess.last_hit_ms + 60000))::bigint AS recovered
+FROM sess
+JOIN chunks ch ON ch.project_id = sess.project_id AND ch.session_id = sess.session_id
+GROUP BY 1;
+```
+
+The stamp and the clear (same transaction; the temp table is why this is a transaction at all — a CTE cannot span statements):
+
+```sql
+UPDATE error_groups g SET
+  impact_visits = r.visits,
+  impact_visits_recovered = r.recovered,
+  impact_class = CASE WHEN r.recovered = 0 THEN 'blocked'
+                      WHEN r.recovered < r.visits THEN 'degraded'
+                      ELSE 'invisible' END,
+  impact_computed_at = now()
+FROM impact_rollup r
+WHERE g.id = r.group_id
+  AND g.status NOT IN ('resolved','merged','archived');
+
+UPDATE error_groups g SET
+  impact_class = NULL, impact_visits = NULL,
+  impact_visits_recovered = NULL, impact_computed_at = NULL
+WHERE g.status NOT IN ('resolved','merged','archived')
+  AND (g.impact_class IS NOT NULL OR g.impact_visits IS NOT NULL
+       OR g.impact_visits_recovered IS NOT NULL OR g.impact_computed_at IS NOT NULL)
+  AND NOT EXISTS (SELECT 1 FROM impact_rollup r WHERE r.group_id = g.id);
+```
+
+(The stamp re-checks open status inside the UPDATE — a group resolved between the rollup materialization and the stamp must not be written. The clear guards on **any** of the four columns being non-NULL, not just `impact_class`: only these two statements write the columns and both write all four, but the all-NULL "unknown" representation is a contract, so the guard enforces it rather than assuming it.)
+
+(The interval literal is built from `impactWindowDays` and the `60000` from `impactRecoveryMs` via `fmt.Sprintf` at package init, the way `maxURLsPerGroup` parameterizes the tally SQL — one source for each number.)
+
+- [ ] **Step 1: Write the failing tests** in `impact_test.go`. Local seed helpers (sessions and chunks; `seedTenant`'s cleanup deletes `sessions`, and `session_chunks` cascades from it):
+
+```go
+func seedSession(t *testing.T, pool *pgxpool.Pool, projectID, envID, id string, user *string) { /* INSERT INTO sessions (id, project_id, environment_id, end_user_id, started_at, status) VALUES (..., now(), 'recording') — 002's CHECK admits only recording/closed/analyzing/analyzed/analysis_failed/deleting; copy the column list build_test.go:103-108 uses */ }
+func seedChunk(t *testing.T, pool *pgxpool.Pool, projectID, sessionID string, seq int, firstMs, lastMs *int64, fullSnap bool) { /* INSERT INTO session_chunks (..., scrubbed_at) VALUES (..., now()) */ }
+func seedEvent(t *testing.T, pool *pgxpool.Pool, projectID, envID, groupID, sessionID string, at time.Time) { /* INSERT INTO error_events (project_id, environment_id, error_group_id, session_id, "timestamp", error_type, error_message, stack_trace_raw) */ }
+```
+
+Tests (all one `TestImpactPass` with subtests, one `RunOnce` per subtest arrangement):
+
+```go
+// AC3.1a: crash-loop-only group → blocked, 2 visits, 0 recovered.
+//   Two sessions; each: crash at T, chunk bounds [T-60s .. T+5s] (activity dies within 60s).
+// AC3.1b: loop-plus-recovery group → degraded, visits 2, recovered 1.
+//   Session A as above; session B: crash at T, chunk last_event_ms = T+17min.
+// invisible: single session whose activity continues past T+60s on its only crash → invisible 1/1.
+// AC3.3: group whose only session has NULL-bounded chunks (first_event_ms/last_event_ms NULL)
+//   → all four impact columns NULL after the sweep.
+// half-NULL bounds: a chunk with first_event_ms NULL but last_event_ms set (and vice versa)
+//   is NOT usable evidence — a group whose only session has only such chunks stays all-NULL
+//   (the both-bounds filter in the chunks CTE, not just the both-NULL case).
+// window: a group whose only events are 31 days old → no stamp (columns NULL).
+// AC3.4: stamp a group (in-window seed), then age it out (UPDATE error_events SET "timestamp" =
+//   now() - interval '31 days'), sweep → all four NULL; then prove write-stability.
+// closed groups: a resolved group with in-window sessions → never stamped.
+```
+
+The row-version-stability witness AC3.4 names **cannot** ride `RunOnce`: the scoring pass rewrites `priority_scored_at = now()` on every open group every sweep (`sweeper.go:100/:150`), so the group row's `xmin` changes on every full pass regardless of the impact clear. The assertion therefore drives `stampImpact` directly (in-package test, method visible), twice, after the aging step:
+
+```go
+conn, _ := pool.Acquire(ctx)
+defer conn.Release()
+if err := sw.stampImpact(ctx, conn); err != nil { t.Fatal(err) } // the clear happens here
+var xminBefore, xminAfter string
+// Read through the SAME acquired conn — a second pool checkout can deadlock a
+// small test pool while conn is held.
+conn.QueryRow(ctx, `SELECT xmin::text FROM error_groups WHERE id = $1`, groupID).Scan(&xminBefore)
+if err := sw.stampImpact(ctx, conn); err != nil { t.Fatal(err) } // second pass: nothing to write
+conn.QueryRow(ctx, `SELECT xmin::text FROM error_groups WHERE id = $1`, groupID).Scan(&xminAfter)
+if xminBefore != xminAfter { t.Fatalf("second impact pass rewrote an unknown-impact row: %s → %s", xminBefore, xminAfter) }
+```
+
+(`xmin` scans through pgx as `::text`; the clear-once semantics are proven at the statement that owns them, and one earlier `RunOnce`-driven subtest still proves the pass runs inside the full sweep.)
+- [ ] **Step 2: Run → FAIL** (`DATABASE_URL=… go test ./priority/ -run TestImpactPass` — columns stay NULL, no pass exists).
+- [ ] **Step 3: Implement** `stampImpact` + constants + the `RunOnce` call. Keep the existing `RunOnce` error style (wrap with `fmt.Errorf("impact: %w", err)`).
+- [ ] **Step 4: Run → PASS**, plus the whole package: `go test ./priority/` — the five existing sweeper tests must pass unmodified (single-flight, tallies, scoring untouched).
+- [ ] **Step 5: Commit.** `feat(ingestion): impact stamped from session recordings in the priority sweeper (C3/W3.1)`
+
+### Task 3: The friction arm of the same rollup
+
+**Files:**
+- Modify: `packages/ingestion/priority/sweeper.go` (the `sess` CTE seam from Task 2)
+- Test: extend `packages/ingestion/priority/impact_test.go`
+
+**Interfaces:**
+- Produces: friction incidents stamped by the **same arithmetic** over their signals' sessions (program §C3). The friction arm, appended into `sess` via `UNION ALL`:
+
+```sql
+fric_sess AS (
+  SELECT g.id AS group_id, fs.project_id, fs.session_id,
+         (max(extract(epoch FROM fs.occurred_at)) * 1000)::bigint AS last_hit_ms
+  FROM open_groups g
+  JOIN friction_signals fs ON fs.incident_id = g.id AND fs.project_id = g.project_id
+  WHERE g.kind = 'friction'
+    AND fs.adjudication_status = 'accepted'
+    AND fs.retracted_at IS NULL AND fs.superseded_by IS NULL
+    AND fs.occurred_at > now() - interval '30 days'
+  GROUP BY 1, 2, 3
+)
+```
+
+  Signal filters match the sweeper's own friction-reach discipline (`scoreFrictionGroupsSQL`): accepted, active (not retracted, not superseded). The `g.kind = 'friction'` guard matters: fold-attached signals point `incident_id` at **error** groups, whose impact must come from their crashes, not from folded friction signals. Index support: `idx_friction_signals_incident_reach` (039) — partial on exactly these filters; its second column is `created_at`, not `occurred_at`, which is acceptable because the incident's accepted-active signal set is small (asserted cheap in Task 4's plan review, not indexed further).
+
+- [ ] **Step 1: Failing tests** (extend `TestImpactPass`):
+
+```go
+// AC3.2: friction incident, two accepted dead_click signals in two sessions.
+//   Session A: signal occurred_at T, chunks end T+5s  → not recovered (5s < 60s).
+//   Session B: signal occurred_at T, chunks end T+10min → recovered.
+//   → impact_class 'degraded', impact_visits 2, impact_visits_recovered 1.
+// retracted/superseded/pending signals contribute nothing: same shape but session B's signal
+//   retracted → visits 1, recovered 0, class 'blocked'.
+// fold guard: an accepted signal whose incident_id is a kind='error' group adds no friction
+//   visit to that group (its impact comes from err_sess only) — seed a crash session too and
+//   assert visits counts only the crash session.
+// (Window semantics differ by purpose, deliberately: the ROLLUP windows on occurred_at —
+//  client clock, because it is compared against chunk event ms — while the Task 9 policy
+//  bar windows on created_at; see Task 9's rationale.)
+```
+
+Signal seeding: copy the `insertSignal` closure shape from `sweeper_test.go:126-138` (columns: `session_id, project_id, environment_id, end_user_id, rule_version, signal_type, fingerprint, page_url_normalized, occurred_at, adjudication_status, retracted_at, superseded_by, incident_id`).
+- [ ] **Step 2: Run → FAIL.** **Step 3: Implement** (add the CTE + UNION ALL). **Step 4: Run → PASS** including Task 2's subtests unchanged.
+- [ ] **Step 5: Commit.** `feat(ingestion): friction incidents stamped by the same recordings arithmetic (C3/W3.1, AC3.2)`
+
+### Task 4: AC3.8 — the planner proof at 100k events
+
+**Files:**
+- Modify: `packages/ingestion/priority/sweeper.go` (export `ImpactRollupSelectSQL` — the SELECT body without the `CREATE TEMPORARY TABLE` wrapper, an exported package `var` built once by `fmt.Sprintf` from the named constants — a `const` cannot carry Sprintf output; production concatenates the `CREATE TEMPORARY TABLE` wrapper onto this exact var, one source of truth)
+- Create: `packages/ingestion/db/impact_explain_test.go` — **`package db_test`**, pinned: every existing test file in that directory (`migrations_test.go`, `testhelper_test.go`, `sessions_index_test.go`) declares `package db_test`, so `disposableDB`/`migrationFiles`/`applyMigration`/`testPool` are same-package helpers, directly callable; `db_test` importing `priority` creates no cycle (`priority` imports only pgx, verified by grep). The test lives here and not in `priority` because the production rollup scans every tenant's open groups — on the shared dev database, unrelated rows make an examined-rows ratio nondeterministic; a disposable DB gives controlled statistics.
+
+**Interfaces:**
+- Consumes: Task 1's two indexes, `priority.ImpactRollupSelectSQL`, the `migrations_test.go` harness.
+
+- [ ] **Step 1: Write the failing test.** In a disposable DB with all migrations applied: seed via `generate_series` (the `sessions_index_test.go:67` pattern), then `ANALYZE error_events; ANALYZE friction_signals; ANALYZE session_chunks`. Shape: one tenant, two error groups and one friction incident — an **open** error group with 20,000 in-window session-bearing events; 80,000 events that must not be examined (40,000 on the same open group but older than 31 days; 40,000 in-window on a **resolved** group); the friction incident with 500 accepted-active in-window signals and **20,000 aged (32+ days) but still accepted-active** signals plus 500 retracted ones. The aged-active set is what makes the friction assertion falsifiable: those rows sit inside `idx_friction_signals_incident_reach`'s partial predicate (039 orders it by `created_at`), so a plan using the old index — or a seq scan over the 20,500-row table — examines them all and blows the cap; only Task 1's `(incident_id, occurred_at)` index passes. Also seed **bounded scrubbed chunks** for a subset of the in-window sessions so the rollup's chunk join produces output — an empty branch reports zero examined rows while the plan text still name-drops indexes, so the test first runs the SELECT itself and asserts ≥1 rollup row, then EXPLAINs. Sessions can repeat (e.g. 200 distinct sessions round-robin) — the ratio under test is examined rows. Then:
+
+```go
+planJSON := explainAnalyze(t, pool, "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) "+priority.ImpactRollupSelectSQL)
+// Walk the JSON plan. For every node whose "Relation Name" is the target table, EXAMINED =
+// ("Actual Rows" + "Rows Removed by Filter" + "Rows Removed by Index Recheck") * "Actual Loops".
+// "Actual Rows" alone counts EMITTED rows — a seq scan that filters 80k rows down to 20k
+// would pass a naive sum; the removed-rows terms are what make the metric mean "examined".
+examinedEvents := sumExamined(planJSON, "error_events")
+if examinedEvents > int(float64(20_000)*1.5) {
+	t.Fatalf("rollup examined %d error_events rows for 20000 in-window (ratio %.2f > 1.5)", examinedEvents, float64(examinedEvents)/20_000)
+}
+examinedSignals := sumExamined(planJSON, "friction_signals")
+if examinedSignals > int(float64(500)*3.0) {
+	t.Fatalf("friction arm examined %d signal rows for 500 in-window accepted-active (ratio > 3.0; the 20k aged-active set leaked in)", examinedSignals)
+}
+for _, idx := range []string{"idx_error_events_group_timestamp", "idx_friction_signals_incident_occurred"} {
+	if !strings.Contains(planJSON, idx) {
+		t.Fatalf("rollup does not use %s; plan:\n%s", idx, planJSON)
+	}
+}
+t.Logf("AC3.8 plan (paste into the PR):\n%s", planJSON) // BUFFERS numbers recorded here
+```
+
+  `explainAnalyze` mirrors `explainWithoutSeqScan` (`sessions_index_test.go:31`) minus the seqscan toggle — ANALYZE with real settings is the point; the examined-rows ratio and the index-name assertions together are the gate. `sumExamined` is real parsing code with its own unit test over canned plan-JSON fixtures (Seq Scan with `Rows Removed by Filter`, Index Scan, Bitmap Index + Bitmap Heap pair — counted once, not twice — and a nested-loop inner scan with `Actual Loops` > 1; absent metrics read as zero); an unverified walker would make the whole gate decorative.
+- [ ] **Step 2: Run → observe.** If it fails, the index or the rollup's join order is wrong — fix the query, not the threshold.
+- [ ] **Step 3: Run** `go test ./db/ -run TestImpactRollupExamined -v` (the `-v` matters: `t.Logf` output on a passing test is hidden without it, and the logged plan is the PR artifact) plus the whole `priority` and `db` packages → PASS.
+- [ ] **Step 4: Commit.** `test(ingestion): impact rollup examined-rows ratio pinned at 100k events (C3, AC3.8)`
+
+### Task 5: `SessionPointerForGroup` grows the friction branch
+
+**Files:**
+- Modify: `packages/ingestion/db/sessions_read.go` (`SessionPointerForGroup` at `:331`)
+- Test: extend `packages/ingestion/db/sessions_read_test.go` (helpers `addReadSignal` `:42`, `addReadError` `:63` already exist)
+
+**Interfaces:**
+- Consumes: `error_groups.kind`, `representative_signal_id` (written at promotion, `promotion-db.ts:765-782`), friction signal liveness/verdict columns.
+- Produces: same signature — `SessionPointerForGroup(ctx, errorGroupID, projectID) (sessionID string, errorAt time.Time, ok bool, err error)` — now kind-branched. The incident read API (`read_api.go:349-351`) and the dashboard player consume it unchanged: a friction incident's page gains `session_pointer` and therefore the windowed player and the "Open full session →" link with `t = Date.parse(error_at)` — zero dashboard edits (AC3.5's surface is already built).
+- Semantics: first `SELECT kind FROM error_groups WHERE id = $1 AND project_id = $2` (absent group → `ok=false`). `kind='error'`: the existing query, untouched. `kind='friction'`:
+
+```sql
+SELECT fs.session_id, fs.occurred_at
+  FROM friction_signals fs
+  JOIN sessions s ON s.id = fs.session_id AND s.project_id = fs.project_id
+  JOIN error_groups g ON g.id = $1
+ WHERE fs.incident_id = $1 AND fs.project_id = $2
+   AND fs.adjudication_status = 'accepted'
+   AND fs.retracted_at IS NULL AND fs.superseded_by IS NULL
+   AND s.status <> 'deleting'
+ ORDER BY (fs.id = g.representative_signal_id) DESC, fs.occurred_at ASC, fs.id ASC
+ LIMIT 1
+```
+
+  One query, both B2 rules: the representative signal wins while it is accepted and live; a retracted/superseded/rejected representative simply fails the WHERE and the earliest accepted signal (`occurred_at ASC, id ASC`) is the fallback. No accepted signals → `ok=false` (the page keeps today's "no replay" state). No coverage gate here — the pointer is identity+offset, and the player owns graceful degradation (poll/partial/unavailable states), exactly as the error branch behaves today.
+
+- [ ] **Step 1: Failing tests** in `sessions_read_test.go`:
+
+```go
+// friction pointer: incident with representative signal R (accepted, occurred_at T2) and an
+//   earlier accepted sibling (T1) → pointer = R's session at T2 (representative wins over earliest).
+// AC3.5 fallback: retract R (retracted_at = now()) → pointer = sibling's session at T1.
+// superseded representative → same fallback.
+// all signals rejected/retracted → ok == false.
+// deleting session excluded: representative's session status='deleting' → fallback signal's session.
+// error-kind regression: existing error-branch test still passes byte-identical (newest event).
+```
+
+- [ ] **Step 2: Run → FAIL.** **Step 3: Implement.** **Step 4: Run → PASS** (`go test ./db/ -run SessionPointer` plus the package). Also grep the TS mirror's consumers (`grep -rn "getSessionPointerForGroup" packages/worker/src`) and record in the PR that they are error-lane only (or extend the mirror if that grep says otherwise — Deviation 6).
+- [ ] **Step 5: Commit.** `feat(ingestion): friction incidents get a session pointer — representative signal with retraction fallback (C3/W3.2, AC3.5)`
+
+### Task 6: `WatchableSessionForGroup` — coverage-gated pointer for links that must play
+
+**Files:**
+- Modify: `packages/ingestion/db/sessions_read.go` (new function below `SessionPointerForGroup`)
+- Test: extend `packages/ingestion/db/sessions_read_test.go`
+
+**Interfaces:**
+- Produces (consumed by Task 7 and by C4's `ReceiptItem.SessionURL` producer later):
+
+```go
+// WatchableSessionForGroup returns a session pointer that is proven playable at
+// its anchor: the session's scrubbed, bounded chunks must STITCH across the full
+// ±15s window around the anchor (min(first_event_ms) <= anchor-15s AND
+// max(last_event_ms) >= anchor+15s — a 1ms chunk at the anchor is not coverage;
+// intra-span gaps are accepted in v1), and some full-snapshot chunk must start
+// at-or-before the window start. anchorMs is client-clock epoch ms — the same
+// value the dashboard's ?t= expects.
+func (q *Queries) WatchableSessionForGroup(ctx context.Context, errorGroupID, projectID string) (sessionID string, anchorMs int64, ok bool, err error)
+```
+
+- Semantics: kind-branched like Task 5. Error branch — newest covered event among the newest `watchCandidateEvents = 50` session-bearing events (ties by newest `created_at DESC, id DESC`, matching the existing pointer's ordering):
+
+```sql
+SELECT cand.session_id, cand.anchor_ms FROM (
+  SELECT e.session_id, (extract(epoch FROM e."timestamp") * 1000)::bigint AS anchor_ms,
+         e.created_at, e.id
+    FROM error_events e
+    JOIN sessions s ON s.id = e.session_id AND s.project_id = e.project_id
+   WHERE e.error_group_id = $1 AND e.project_id = $2
+     AND e.session_id IS NOT NULL AND s.status <> 'deleting'
+   ORDER BY e.created_at DESC, e.id DESC
+   LIMIT 50
+) cand
+WHERE EXISTS (
+  SELECT 1 FROM session_chunks c
+   WHERE c.session_id = cand.session_id AND c.project_id = $2
+     AND c.scrubbed_at IS NOT NULL
+     AND c.first_event_ms IS NOT NULL AND c.last_event_ms IS NOT NULL
+  HAVING min(c.first_event_ms) <= cand.anchor_ms - 15000
+     AND max(c.last_event_ms) >= cand.anchor_ms + 15000
+)
+AND EXISTS (
+  SELECT 1 FROM session_chunks c2
+   WHERE c2.session_id = cand.session_id AND c2.project_id = $2
+     AND c2.scrubbed_at IS NOT NULL AND c2.has_full_snapshot
+     AND c2.first_event_ms IS NOT NULL AND c2.last_event_ms IS NOT NULL
+     AND c2.first_event_ms <= cand.anchor_ms - 15000
+)
+ORDER BY cand.created_at DESC, cand.id DESC
+LIMIT 1
+```
+
+  Friction branch: Task 5's friction query (representative-first ordering) with the same two `EXISTS` predicates over `fs.session_id` at anchor `(extract(epoch FROM fs.occurred_at) * 1000)::bigint`. The `15000`s and the `LIMIT 50` are emitted from `watchWindowMs`/`watchCandidateEvents` via `fmt.Sprintf` the same way Task 2 parameterizes its constants — the frozen values have one source each. Terminology note: "stitched-span" here means the **bounding span** of the session's usable chunks covers the window; intra-span gaps are accepted in v1 and documented (carried forward from receipts B2 verbatim — the program's AC3.6 uses the same term with the same documented limit).
+
+- [ ] **Step 1: Failing tests:**
+
+```go
+// AC3.6 positive: session with three chunks [T-20s..T-8s], [T-8s..T+2s], [T+2s..T+16s],
+//   full snapshot on the first → covered (stitched span [T-20s, T+16s] ⊇ [T-15s, T+15s])
+//   → pointer returned, anchorMs == T in epoch ms.
+// AC3.6 negative: session whose only chunk is [T..T+1ms] → ok == false.
+// overlap-but-not-coverage: single chunk [T-1s..T+1s] → ok == false (the old overlap
+//   predicate would have passed this; the stitched-span rule is the difference under test).
+// playability: three covering chunks but has_full_snapshot only on a chunk starting at
+//   T-10s (> window start T-15s) → ok == false.
+// NULL-bounded chunks are invisible: coverage chunks + one NULL-bounds chunk → still covered
+//   (NULL rows neither help nor veto).
+// newest-covered wins: event E1 (old, covered session) and E2 (new, uncovered session)
+//   → E1's session returned (the newest COVERED candidate, not nothing).
+// friction: representative signal's session uncovered, earlier accepted sibling covered
+//   → sibling returned at its occurred_at anchor.
+// unscrubbed chunks don't count: coverage chunks with scrubbed_at NULL → ok == false.
+```
+
+- [ ] **Step 2: Run → FAIL.** **Step 3: Implement.** **Step 4: Run → PASS** (package suite; zero skips with DB up).
+- [ ] **Step 5: Commit.** `feat(ingestion): watchable session pointers — stitched coverage and snapshot playability (C3/W3.2, AC3.6)`
+
+### Task 7: Digest replay links that play, with the `?t=` anchor
+
+**Files:**
+- Modify: `packages/ingestion/digest/digest.go` (add `sessionURLAt` beside `sessionURL` at `:42-48`)
+- Modify: `packages/ingestion/digest/build.go` (`buildTopNewIssues` `:200`, `buildInsights` `:96`)
+- Test: extend `packages/ingestion/digest/build_test.go`
+
+**Interfaces:**
+- Consumes: `WatchableSessionForGroup` (Task 6). The digest `Sweeper` holds only a pool — construct the queries wrapper the way `main.go` builds it for the handler (locate with `grep -n "db.New\|Queries{" packages/ingestion/main.go` and mirror; if the constructor takes the pool, build it once in `digest.New` and store it on the Sweeper).
+- Produces:
+
+```go
+func (s *Sweeper) sessionURLAt(sessionID string, anchorMs int64) *string {
+	if sessionID == "" || s.dashboardURL == "" {
+		return nil
+	}
+	u := s.dashboardURL + "/sessions/" + url.PathEscape(sessionID) + "?t=" + strconv.FormatInt(anchorMs, 10)
+	return &u
+}
+```
+
+- Wiring: `buildTopNewIssues` drops its `COALESCE(g.representative_session_id,'')` selection (it never fired for error groups anyway — the column is friction-only); `buildInsights` drops the `(array_agg(fs.session_id ORDER BY fs.occurred_at DESC))[1]` pick. Both collect their scanned rows first, and **only after `rows.Close()`** loop the collected group ids calling `WatchableSessionForGroup(ctx, groupID, projectID)` per item (≤ `listCap = 3` per section — bounded; issuing nested queries while the cursor is open is the pool-exhaustion pattern these builders' own comments warn about), setting `ReplayURL = s.sessionURLAt(sessionID, anchorMs)` when `ok`, `nil` otherwise. The group id must be in each section's scan — `buildTopNewIssues` already selects `g.id`; add it to `buildInsights`' select if absent (read the query first). `DigestIssue`/`DigestInsight` shapes are unchanged (`ReplayURL *string` already exists) — **no payload schema change, no wire change**; v1 formatter behavior (`slackDigestLink(*ReplayURL, "Watch replay")`) is untouched.
+- Behavior change, stated: an insight whose newest signal's session cannot play no longer gets a dead link — it gets no link (and the C1-era test expectation `ReplayURL == …/sessions/SessIn2` changes accordingly). A link that exists now proves coverage.
+
+- [ ] **Step 1: Failing tests** in `build_test.go`:
+
+```go
+// Extend seedDigestFixture (or a sibling seeder) to add session_chunks:
+//   SessIn2 (the newest-signal session): one 1ms chunk at its signal time → NOT watchable.
+//   SessIn1 (older accepted signal): three stitched chunks covering ±15s + full snapshot → watchable.
+// TestBuildDigestReplayLinksRequireCoverage:
+//   buildInsights → insight.ReplayURL == "https://dash.example/sessions/"+SessIn1+"?t="+<SessIn1 signal ms>
+//   (the covered fallback, not the uncovered newest — the old expectation is deleted, not kept).
+// error issue: seed the fp-new group's event with a covered session → issue.ReplayURL carries ?t=<event ms>;
+//   remove the chunks → ReplayURL nil.
+// TestDigestExcerptAndSessionURLHelpers extended: sessionURLAt("a/b", 123) == ".../sessions/a%2Fb?t=123";
+//   sessionURLAt("", 5) == nil.
+```
+
+  Existing digest tests that asserted the old newest-signal link (`TestBuildDigestSections:195`) are **updated in this task** — enumerate every changed expectation in the PR description (they are the visible spec of Deviation 4).
+- [ ] **Step 2: Run → FAIL.** **Step 3: Implement.** **Step 4: Run → PASS**: `go test ./digest/` and the ingestion build; confirm `git diff -- test-fixtures/wire/` is empty.
+- [ ] **Step 5: Commit.** `feat(digest): replay links prove coverage and land at the moment of impact (C3/W3.2)`
+
+### Task 8: Migration 047 — the readiness backfill (W3.B)
+
+**Files:**
+- Create: `packages/ingestion/db/migrations/047_readiness_backfill.sql`
+- Test: `packages/ingestion/db/migration_047_test.go` (create; harness from `migrations_test.go` + the 045 test's shape)
+
+**Interfaces:**
+- Consumes: `digest_readiness`, `applied_data_migrations`, `diagnosis_decisions` (camelCase `diagnosis` JSONB keys per the C0 case rule — `evidence` is a camelCase-side key).
+- Produces: every **open** incident enters the projection; C1's absent-row clause becomes vestigial (C4 deletes it when flipping to eligible-only). Classification, mechanical and frozen:
+  - `receipt_state` := `status IN ('pr_created','pr_draft')` (both are `error_group_status` enum values — `pr_draft` added by `015_draft_prs.sql:4`) OR (`status = 'needs_human'` AND (a non-empty `candidate_diff` OR **usable** verification evidence)) — an attempt artifact exists; the receipt is the artifact, not the prose. "Usable evidence" is a defined predicate, not `IS NOT NULL` (which would count JSON `null`, `{}`, or empty text): a `checks` array with ≥1 element whose `name` is a non-empty string (`EvidenceRecord.checks` is the persisted executed-check list, `shared/src/types.ts:232` — `[null]` or `[{}]` elements fail the name check).
+  - `validated_cause` := the group's **latest** decision row has `outcome IN ('code_fix','not_actionable')` and the frozen C1 validity shape, checked structurally: ≥1 evidence element, **every** element carrying non-empty `path`/`detail`/`symptomLink`, and — for `code_fix` — a non-empty `agentTaskBrief` that fails the anchored filler regex (`^\s*(placeholder|tbd|to be determined)\M`, 045's spelling). Expectation, recorded: C1 writes decisions and readiness **in one transaction**, so this arm should match ≈0 rows — it exists for crash-window stragglers, and the runbook records its actual match count so a surprise is visible. (Deliberate limit, mirroring C1's recorded rationale: the migration checks structure, not re-verified citations against a checkout — mechanical re-verification is a checkpoint activity, not a boot-time data migration.)
+  - Everything else open → `('pending', 'backfill_unverified')` — the honest-state flip for the unverified legacy book (see the Global Constraints deploy note).
+  - Closed incidents (`resolved`/`merged`/`archived`) stay absent-row, per the program's "every existing open incident." Recorded for C4: C1's interim gate covers all five digest sections including `PRsMerged`, but it only *excludes* `ineligible`/`pending` rows — closed groups keep rendering there because they are absent-row, and this backfill keeps them absent. C4's eligible-only flip must therefore either scope the merged section out of the flip or backfill closed receipts itself — its decision, recorded here so it isn't discovered as a surprise.
+  - The headline invariant, asserted in the test and the runbook: after 047, **zero open incidents lack a readiness row** — per-arm counts can look plausible while rows are omitted; the anti-join is the proof.
+
+```sql
+-- 047_readiness_backfill.sql
+-- C3/W3.B: classify every open incident into digest_readiness, retiring C1's
+-- absent-row policy before C4 flips the digest to eligible-only.
+-- One-shot via applied_data_migrations: pipeline-written rows must never be
+-- overwritten by a boot replay. IDEMPOTENCY IS MANDATORY.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM applied_data_migrations WHERE name = '047_readiness_backfill') THEN
+    INSERT INTO digest_readiness (incident_id, project_id, status, reason)
+    SELECT g.id, g.project_id,
+           CASE WHEN c.receipt_state OR c.validated_cause THEN 'eligible' ELSE 'pending' END,
+           CASE WHEN c.receipt_state THEN 'backfill_receipt_state'
+                WHEN c.validated_cause THEN 'backfill_validated_cause'
+                ELSE 'backfill_unverified' END
+      FROM error_groups g
+      CROSS JOIN LATERAL (
+        SELECT
+          (g.status IN ('pr_created','pr_draft')
+           OR (g.status = 'needs_human'
+               AND (NULLIF(btrim(g.candidate_diff), '') IS NOT NULL
+                    OR (CASE WHEN jsonb_typeof(g.verification_evidence->'checks') = 'array'
+                             THEN EXISTS (
+                               SELECT 1 FROM jsonb_array_elements(g.verification_evidence->'checks') chk
+                                WHERE btrim(coalesce(chk->>'name','')) <> ''
+                             )
+                             ELSE false END)))) AS receipt_state,
+          EXISTS (
+            SELECT 1
+              FROM (SELECT d.outcome, d.diagnosis
+                      FROM diagnosis_decisions d
+                     WHERE d.error_group_id = g.id AND d.project_id = g.project_id
+                     ORDER BY d.decided_at DESC, d.id DESC
+                     LIMIT 1) latest
+             WHERE latest.outcome IN ('code_fix','not_actionable')
+               AND (CASE WHEN jsonb_typeof(latest.diagnosis->'evidence') = 'array'
+                         THEN jsonb_array_length(latest.diagnosis->'evidence') >= 1
+                          AND NOT EXISTS (
+                            SELECT 1 FROM jsonb_array_elements(latest.diagnosis->'evidence') e
+                             WHERE btrim(coalesce(e->>'path',''))        = ''
+                                OR btrim(coalesce(e->>'detail',''))      = ''
+                                OR btrim(coalesce(e->>'symptomLink','')) = ''
+                          )
+                         ELSE false END)
+               AND (latest.outcome <> 'code_fix'
+                    OR (NULLIF(btrim(latest.diagnosis->>'agentTaskBrief'), '') IS NOT NULL
+                        AND latest.diagnosis->>'agentTaskBrief' !~* '^\s*(placeholder|tbd|to be determined)\M'))
+          ) AS validated_cause
+      ) c
+     WHERE g.status NOT IN ('resolved','merged','archived')
+       AND NOT EXISTS (SELECT 1 FROM digest_readiness dr WHERE dr.incident_id = g.id)
+    ON CONFLICT (incident_id) DO NOTHING;
+    INSERT INTO applied_data_migrations (name) VALUES ('047_readiness_backfill');
+  END IF;
+END
+$$;
+```
+
+  (`ON CONFLICT DO NOTHING` is belt-and-braces under the `NOT EXISTS` — a worker writing a row mid-migration must win. Verify the `diagnosis_decisions` sort column is `decided_at` by reading the table DDL before implementing; if it differs, follow the DDL — the "latest decision" semantic is the contract.)
+
+- [ ] **Step 1: Write the failing test** (`migration_047_test.go`, disposable DB, apply through 046 first): seed one project and one group per matrix row below (rows that name a sibling seed two), then apply 047 and assert each row:
+
+| seed | expected row |
+| --- | --- |
+| `status='pr_draft'` | `('eligible','backfill_receipt_state')` |
+| `status='pr_created'` | `('eligible','backfill_receipt_state')` |
+| `status='needs_human'`, `candidate_diff='diff --git …'` | `('eligible','backfill_receipt_state')` |
+| `status='needs_human'`, no diff, no evidence | `('pending','backfill_unverified')` |
+| `status='needs_human'`, `verification_evidence='{}'` (empty object) | `('pending','backfill_unverified')` |
+| `status='needs_human'`, `verification_evidence='null'::jsonb` | `('pending','backfill_unverified')` — and the migration does not throw |
+| `status='needs_human'`, `verification_evidence='{"checks":[{"name":"suite"}]}'` | `('eligible','backfill_receipt_state')` |
+| `status='needs_human'`, `verification_evidence='{"checks":[null]}'` and a sibling with `'{"checks":[{}]}'` | `('pending','backfill_unverified')` (elements without a non-empty name are not usable evidence) |
+| `status='investigated'`, latest decision `code_fix`, sound evidence but `agentTaskBrief` absent (and a sibling with `agentTaskBrief='tbd'`) | `('pending','backfill_unverified')` (the frozen validity shape requires a non-filler brief for code_fix) |
+| `status='investigated'`, latest decision `code_fix` with `diagnosis: {"evidence":[{"path":"a.ts","detail":"d","symptomLink":"s"}]}` | `('eligible','backfill_validated_cause')` |
+| `status='investigated'`, latest decision `code_fix`, no `evidence` key (legacy) | `('pending','backfill_unverified')` |
+| `status='investigated'`, latest decision `code_fix`, `diagnosis: {"evidence":"corrupt"}` (scalar) | `('pending','backfill_unverified')` — no throw (the CASE guards `jsonb_array_length`) |
+| `status='investigated'`, latest decision `code_fix`, `evidence: [{"path":"a.ts","detail":"","symptomLink":"s"}]` | `('pending','backfill_unverified')` (empty citation field fails the shape check) |
+| `status='resolved'` | **no row** |
+| `status='new'`, pre-existing readiness row `('ineligible','quarantined_degenerate')` | row **unchanged** |
+
+  Plus the headline invariant: `SELECT count(*) FROM error_groups g WHERE g.status NOT IN ('resolved','merged','archived') AND NOT EXISTS (SELECT 1 FROM digest_readiness dr WHERE dr.incident_id = g.id)` → **0** after apply.
+  Then: apply 047 again → zero new rows and the quarantined row still untouched (marker respected); flip one backfilled row to `('eligible','validated_cause')` and apply again → still `validated_cause` (one-shot proven against pipeline overwrites). Decision-row seeding must satisfy 034's trigger discipline — copy the INSERT shape `migration_045_test.go` or `error_group_ingestion_test.go` uses for decision rows (read first).
+- [ ] **Step 2: Run → FAIL** (047 absent). **Step 3: Write the migration. Step 4: Run → PASS**, plus `go test ./db/ -run TestMigration` (the umbrella idempotency/roll-forward suites absorb 047).
+- [ ] **Step 5: Commit.** `feat(db): readiness backfill classifies the legacy book — absent-row policy retired (C3/W3.B)`
+
+### Task 9: Friction fix routing reads the impact bar, not confidence
+
+Discharges C2 Task 3's frozen rung (`// C3 replaces this confidence check with the signal-session impact bar…`). Program authority: decision 3 (any usable `code_fix` on an issue meeting the impact bar gets an attempt) and the global constraint (confidence out of routing). The friction autonomy opt-in (`friction_autonomy = 'auto_fix'`) is a customer setting, not a self-grade — it stays. **Honesty note for the reviewer:** bucket promotion already requires ≥5 identified users (`PROMOTION_THRESHOLD_USERS`), so promoted friction incidents virtually always pass the ≥1-identified bar — the change's value is uniformity and the recorded `policy_basis`, plus correctness for edge incidents whose users aged past the 7-day window; it is not a wide behavior swing. AC3.9 is plan-added (CP3 in the program plan predates C2's freeze decision).
+
+**Files:**
+- Modify: `packages/worker/src/db.ts` — new `getFrictionGroupImpactBar` beside the error-lane `getGroupImpactBar` (C2 Task 2)
+- Modify: `packages/worker/src/index.ts` — the friction verdict branch (locate the C2 freeze comment; the rung is the `verdict.confidence === 'high' && autonomyAllowsFix` conjunction)
+- Test: extend `packages/worker/src/__tests__/db.test.ts` (DB-gated) and `packages/worker/src/__tests__/index.test.ts` (mock seams `vi.mock('../db.js')`)
+
+**Interfaces:**
+- Produces:
+
+```ts
+/** Live impact bar over the incident's accepted, active friction-signal sessions.
+ *  Same thresholds and ImpactBar type as the error lane (C2 Task 2). The 7-day
+ *  window uses server-observed created_at, matching the sweeper's friction-reach
+ *  discipline (sweeper.go frictionReach) — an authorization input should not ride
+ *  the client clock (003's comment scopes client event times to playback
+ *  arithmetic; the impact ROLLUP uses occurred_at because it compares against
+ *  chunk event ms, which is exactly that playback domain). */
+export async function getFrictionGroupImpactBar(errorGroupId: string, projectId: string): Promise<ImpactBar> {
+  const res = await pool.query(
+    `SELECT
+       (SELECT count(DISTINCT fs.end_user_id) FROM friction_signals fs
+         WHERE fs.incident_id = $1 AND fs.project_id = $2
+           AND fs.end_user_id IS NOT NULL
+           AND fs.adjudication_status = 'accepted'
+           AND fs.retracted_at IS NULL AND fs.superseded_by IS NULL
+           AND fs.created_at > now() - interval '7 days') AS identified_users,
+       (SELECT count(*) FROM (
+          SELECT fs.session_id FROM friction_signals fs
+           WHERE fs.incident_id = $1 AND fs.project_id = $2
+             AND fs.adjudication_status = 'accepted'
+             AND fs.retracted_at IS NULL AND fs.superseded_by IS NULL
+             AND fs.created_at > now() - interval '7 days'
+           GROUP BY fs.session_id
+           HAVING bool_and(fs.end_user_id IS NULL)
+        ) anon) AS recent_anon_sessions`,
+    [errorGroupId, projectId],
+  );
+  const identifiedUsers = Number(res.rows[0].identified_users);
+  const recentAnonSessions = Number(res.rows[0].recent_anon_sessions);
+  return { identifiedUsers, recentAnonSessions, eligible: impactBarEligible(identifiedUsers, recentAnonSessions) };
+}
+```
+
+  **One threshold source:** the eligibility expression is a shared pure helper, not restated. If C2 landed it inline in `getGroupImpactBar`, this task extracts `export function impactBarEligible(identifiedUsers: number, recentAnonSessions: number): boolean { return identifiedUsers >= 1 || recentAnonSessions >= 3; }` and points **both** bar functions at it (pure refactor; C2's error-lane bar tests must pass unmodified — that is the proof the thresholds didn't drift). The values are the design's (decision 3: "≥1 identified user or ≥3 recent anonymous sessions"); CP2's AC2.1 seeding of 2 users is a comfortably-above-bar fixture, not a different threshold.
+  Note `friction_signals.session_id` is `NOT NULL` by schema (`004_friction.sql:37`), so the anon subquery needs no NULL-session guard — unlike the error lane, where `error_events.session_id` is nullable.
+
+- Routing: in the friction verdict branch, for `codeCause` verdicts compute the bar once; the auto-fix rung becomes `bar.eligible && autonomyAllowsFix` (the `verdict.confidence === 'high'` conjunct and the freeze comment die); below-bar or non-auto-fix parks at `'awaiting_approval'` exactly as today. The friction `code_fix` decision row gains `policyEligible: bar.eligible, policyBasis: { v: 1, identified_users: bar.identifiedUsers, recent_anon_sessions: bar.recentAnonSessions }` (C2's `DecisionRow` fields; non-`code_fix` friction decisions keep NULLs, mirroring the error lane). `verdict.confidence` still flows to storage. The human approval path and C1's report-only guard are untouched.
+
+- [ ] **Step 1: Failing tests.** `db.test.ts` (DB-gated): bar boundaries over seeded signals — 1 identified user → eligible; 0 identified + 3 anon sessions → eligible; 0 + 2 → not; a session with one identified and one anonymous signal is not anonymous (`bool_and`); retracted/pending signals don't count; signals with `created_at` older than 7 days don't count even when `occurred_at` is recent (the server-clock window pinned). `index.test.ts` (AC3.9):
+
+```ts
+it('AC3.9: identical friction codeCause verdicts with different confidence route identically', async () => {
+  for (const confidence of ['high', 'low'] as const) {
+    vi.mocked(investigateFriction).mockResolvedValueOnce(frictionVerdict({ codeCause: true, confidence }));
+    vi.mocked(db.getFrictionGroupImpactBar).mockResolvedValueOnce({ identifiedUsers: 5, recentAnonSessions: 0, eligible: true });
+    await processFrictionInvestigateJob(makeJob({ jobType: 'friction_investigate' }), signal());
+  }
+  expect(vi.mocked(db.updateGroupAndCreateFixJob)).toHaveBeenCalledTimes(2); // both attempted
+  for (const call of vi.mocked(db.updateGroupAndCreateFixJob).mock.calls) {
+    expect(call[2].decision).toMatchObject({          // the TRUE side is stamped too, exactly
+      policyEligible: true,
+      policyBasis: { v: 1, identified_users: 5, recent_anon_sessions: 0 },
+    });
+  }
+});
+it('AC3.9: below-bar friction codeCause parks awaiting_approval with policy_eligible=false and basis', async () => {
+  vi.mocked(db.getFrictionGroupImpactBar).mockResolvedValueOnce({ identifiedUsers: 0, recentAnonSessions: 1, eligible: false });
+  // → no fix job; updateGroupInvestigation called with 'awaiting_approval' and decision
+  //   { policyEligible: false, policyBasis: { v: 1, identified_users: 0, recent_anon_sessions: 1 } }
+});
+it('autonomy still gates: eligible bar but friction_autonomy ask_first → awaiting_approval, no fix job', ...);
+it('report-only friction jobs still never create a fix job even above the bar', ...);
+```
+
+  The C2 Task 3 pin ("friction auto_fix rung is byte-for-byte unchanged") asserted the *old* semantics — it is **replaced** by AC3.9's pair in this task, not kept alongside (its purpose was to freeze the rung until C3; C3 is here).
+- [ ] **Step 2: Run → FAIL.** **Step 3: Implement. Step 4: Run → PASS** (full worker suite, with and without `DATABASE_URL`).
+- [ ] **Step 5: Commit.** `feat(worker): friction fix routing reads the signal-session impact bar, confidence retired (C3, AC3.9)`
+
+### Task 10: CP3 verification run
+
+No new production code. Prove the checkpoint criteria (program §CP3) plus plan-added AC3.9, then the repository gate. Use the worktree port block from root `AGENTS.md` if the default ports are taken; export the full env block as a unit.
+
+- [ ] **Step 1: Full gate.** `pnpm install --frozen-lockfile && pnpm -r build && pnpm test` with `DATABASE_URL` exported (read skip counts); `(cd packages/ingestion && go build ./... && go test ./...)` → **zero skips**; `docker compose config --quiet`.
+- [ ] **Step 2: AC3.1–AC3.4, AC3.6 drivable.** These run as the DB-gated tests from Tasks 2/3/6 driving the real sweeper and queries (seed → `RunOnce` → assert columns). Re-run them against the live stack's database once (`go test ./priority/ ./db/` with the stack's `DATABASE_URL`) and record outputs.
+- [ ] **Step 3: AC3.5 drivable — playback, not just a URL.** On the dev stack: seed a friction incident with two accepted signals via the `bucket-promotion` seed shapes (or drive `test-e2e/friction-incidents.test.ts`'s `analyzeSessionInProcess` path), **with real scrubbed chunks for the fallback signal's session** (the e2e chunk builders `rageChunk`/`stepperChunk` produce playable rrweb data — the criterion says "player loads", and a correct URL over an unplayable session would pass a URL-only check while failing the criterion). Stamp one signal as representative, retract it with SQL, load the incident page → the player reaches its ready state on the fallback signal's session at the signal's offset (not the "no replay" fallback text), and "Open full session →" carries `?t=` equal to the fallback signal's `occurred_at` in epoch ms. Screenshot + SQL output recorded.
+- [ ] **Step 4: AC3.6 drivable (digest half).** Seed the three-stitched-chunks session and the 1ms-chunk session from Task 7's fixture; build a digest (`Sweeper.Build`) → the covered session's item carries `?t=`; the 1ms one carries no replay link.
+- [ ] **Step 5: AC3.7 drivable — transitions written by pipeline and migration, never seeded.** (a) Drive a valid investigation through the real pipeline (the C1 `anthropic-stub.mjs` scripted-verdict rig at `test-e2e/support/`) → readiness `('eligible','validated_cause')` written by the worker. (b) Drive a fix attempt to a terminal outcome (C2's CP2 rig — requires C2 merged) → readiness carries the receipt reason (`fix_pr_opened` or `fix_attempt_failed_*`). (c) Apply 047 on a database seeded with the legacy book from Task 8's table → rows land per the classification matrix. All three asserted with read-only SQL, outputs recorded.
+- [ ] **Step 6: AC3.8 [gate].** Task 4's test output (ratio + BUFFERS plan) pasted into the PR; reviewer sign-off on the index review recorded there.
+- [ ] **Step 7: Backfill prod runbook (pre-release).** Against a prod copy via `~/deploy/scripts/prod-sql.sh`: run 047's SELECT (without the INSERT) grouped by the CASE arms → record per-class counts and the eligible IDs in the PR. Sanity: `eligible` counts should roughly match open `pr_created`/`pr_draft`/diff-bearing `needs_human` groups; a surprise (e.g. thousands eligible) stops the release. The predicate stays content-driven rather than count-asserted in the migration itself — a group arriving between rehearsal and boot *should* be classified (C1's recorded rationale for 045 applies verbatim) — but two operational gates are hard:
+  1. **Impact-first gate:** before the 047 release, confirm the **deployed** sweeper completed a pass against prod — `SELECT max(impact_computed_at) FROM error_groups` is later than the recorded PR1 deploy timestamp (a bare `count(*) > 0` would accept a stale or manual stamp), corroborated by the sweeper's pass log line.
+  2. **Post-apply invariant:** the headline anti-join (open incidents with no readiness row) must return 0.
+  Recovery path, recorded here so the one-shot marker is not a trap. Preferred: **correct misclassified rows in place** (`UPDATE digest_readiness SET status = …, reason = … WHERE incident_id = ANY(…)`) — targeted, no surface flapping. Last resort, one transaction so no partial state is ever visible: `BEGIN; DELETE FROM digest_readiness WHERE reason IN ('backfill_receipt_state','backfill_validated_cause','backfill_unverified'); DELETE FROM applied_data_migrations WHERE name = '047_readiness_backfill'; COMMIT;` — removes only migration-written rows (pipeline rows carry other reasons) and re-arms the migration. Stated plainly: the full rollback restores the pre-047 surface, **including** legacy prose rendering via the absent-row policy — that is what "roll back" means here, and it is why in-place correction is preferred.
+  After deploy: re-run the counts live, confirm the digest build excludes `pending` legacy, and spot-check one `pending` incident page for the honest state.
+- [ ] **Step 8:** Run `/opslane-verify:verify` with the CP3 drivable criteria (AC3.1–AC3.7) as the pre-drafted half, per the program's verification method.
+
+## CP3 criteria → task map
+
+| AC | Covered by |
+|---|---|
+| AC3.1 (schippers shapes → blocked/degraded) | Task 2; Task 10 Step 2 |
+| AC3.2 (friction incident degraded 2/1) | Task 3; Task 10 Step 2 |
+| AC3.3 (NULL-bounded chunks → all NULL) | Task 2; Task 10 Step 2 |
+| AC3.4 (age-out clears once, row version stable) | Task 2 (xmin test); Task 10 Step 2 |
+| AC3.5 (retracted representative → fallback plays at offset) | Task 5 (query), C1 surfaces (player); Task 10 Step 3 |
+| AC3.6 (three stitched chunks → pointer; 1ms chunk → none) | Tasks 6–7; Task 10 Step 4 |
+| AC3.7 (pipeline-written transitions + backfill rules) | C1/C2 writers witnessed + Task 8; Task 10 Step 5 |
+| AC3.8 [gate] (examined-rows ratio, buffers in PR) | Tasks 1, 4; Task 10 Step 6 |
+| AC3.9 (plan-added: friction bar routing, confidence inert) | Task 9 |
+
+## Execution notes
+
+- Tasks 1–8 depend only on C1 being merged; Task 9 and Task 10 Step 5(b) require C2. If C2's merge slips, PR1–PR3 proceed and PR4 waits — the frozen rung stays frozen, which is exactly its contract.
+- The impact pass and the backfill are independent; the deploy order that matters is PR3 (backfill) after PR1/PR2 are live, so the digest that legacy incidents vanish from is the same digest whose remaining links play and whose eligible incidents carry impact stamps.
+- Deliberate non-goals: no impact fields on the incident DTO or PR body (C5 owns rendering); no `ReceiptItems`/`SessionURL` production (C4 owns the payload); no eligible-only digest flip (C4); no re-evaluation of parked below-bar incidents when later signals cross the bar (the error lane's documented v1 limitation applies to friction identically); no session-facts backfill coupling (#314 stays off every critical path).
+- The `priority` package's DB-gating differs from `db`'s (skip only on unset `DATABASE_URL`, fatal on unreachable) — new tests follow their host package's convention, and `check-go-skips.mjs` counts stay green.
+
+## Revision log
+
+**v2 after Codex round 1 (26 findings: 13 P1, 12 P2, 1 P3; Codex's sandbox could not read repo files — bwrap bootstrap failure, same as C1 round 1 — so findings are plan-internal; source-dependent ones were verified by direct grep before folding).** Accepted: both-bounds chunk filter in the rollup (`first_event_ms IS NOT NULL` added; half-NULL test case added); stamp UPDATE re-checks open status; stale-clear guards on any of the four impact columns; composite `(project_id, session_id)` chunk predicate; xmin witness moved off `RunOnce` onto direct `stampImpact` calls (the scoring pass rewrites `priority_scored_at` every sweep — source-confirmed at `sweeper.go:100/:150` — so the original test design could never pass); AC3.8 examined-rows metric redefined as `Actual Rows + Rows Removed by Filter/Recheck` × loops with an index-name assertion (Actual Rows alone counts emitted rows); explain test moved to the db package on a disposable DB (the rollup is cross-tenant; the shared dev DB makes ratios nondeterministic) with the rollup SQL exported as `priority.ImpactRollupSelectSQL`; friction-arm examined ratio added to the same test; `-v` on the test command so the logged plan artifact is visible; playability EXISTS gains `last_event_ms IS NOT NULL`; `watchCandidateEvents` bound into the SQL via Sprintf; 046 invalid-index guard schema-qualified; 046 test asserts column order; 047 `jsonb_array_length` wrapped in CASE (Postgres does not guarantee AND short-circuit; scalar/`null` evidence must not throw — test rows added); `verification_evidence IS NOT NULL` replaced with a usable-evidence predicate (≥1 recorded check); `validated_cause` strengthened to structural citation-shape checking (non-empty path/detail/symptomLink per element); headline invariant added (zero open incidents without a readiness row, in test and runbook); AC3.5 runbook requires actual playback via seeded playable chunks, not URL correctness; sweep-completed gate before the 047 release; documented rollback SQL for the backfill (reason-scoped DELETE + marker re-arm); `PRsMerged` rationale corrected (C1 gates all five sections; closed groups render because absent-row, and stay absent — C4's flip must scope accordingly); "stitched-span" glossed as bounding-span with the documented v1 gap acceptance. Rejected, with rationale: (R1#7) `friction_signals.session_id` is `NOT NULL` by schema (`004_friction.sql:37`) — no NULL-session guard needed in the friction bar; (R1#8's threshold claim) the ≥1/≥3 values are design decision 3's, and CP2's 2-user seed is an above-bar fixture, not a different bar — the shared-helper half of the finding was accepted; (R1#19) `applied_data_migrations` is created in `028_project_api_keys.sql:28` (source-confirmed by grep; C1's "since 038" described the guard-shape example, not the table's home); (R1#23) wiring the digest links is carried-forward receipts-B2 scope ("per-issue watchable session selection" modifies `digest/build.go`) and AC3.6's drivable witness needs a consumer — C4 owns the receipt payload, not the v1 sections' link column.
+
+**v3 after Codex round 2 (18 findings: 10 P1, 7 P2, 1 P3; load-bearing sources inlined into the prompt this round — Codex confirmed both source-dependent round-1 rejections).** Accepted (source-confirmed by direct grep before folding): session seed status `'recording'` (002's CHECK rejects `'active'`); explain test pinned to `package db_test` (every db test file already declares it, so `disposableDB`/`migrationFiles` are same-package helpers; `priority` imports no db package — no cycle); friction policy bar windows on server-observed `created_at` (the sweeper's friction-reach discipline; 003 scopes client event times to playback arithmetic — the rollup keeps `occurred_at` because chunk event ms are that domain, divergence recorded in both tasks); `validated_cause` requires the full frozen validity shape (non-filler `agentTaskBrief` for `code_fix`) with the recorded expectation that the arm matches ≈0 rows (C1 writes decision+readiness transactionally) and the runbook records its actual count; usable-evidence predicate requires ≥1 check element with a non-empty `name` (`[null]`/`[{}]` fail); friction planner assertion made falsifiable (20k aged-but-active accepted signals seeded; a seq scan or the 039 `created_at` index blows the cap) with a new 046 index `idx_friction_signals_incident_occurred` on `(incident_id, occurred_at)` under the accepted-active partial predicate; planner fixture seeds bounded chunks and asserts the SELECT returns ≥1 rollup row before EXPLAINing (empty-branch zero-examined false pass); `sumExamined` walker gets unit fixtures (seq/index/bitmap-pair-counted-once/loops, absent metrics = 0); rollback reframed — in-place correction preferred, full rollback transactional and plainly labeled as restoring the pre-047 surface including legacy prose; impact-first gate sharpened to `max(impact_computed_at)` after the recorded PR1 deploy time plus the pass log; xmin reads through the held `conn` (pool deadlock); digest watchable lookups explicitly after `rows.Close()` (the builders' own pool-exhaustion warning); `ImpactRollupSelectSQL` specified as an exported `var` built by Sprintf (a `const` cannot carry it); AC3.9 asserts the true-side `policyEligible`/`policyBasis` stamp, not just call counts; fixture-count wording fixed (one group per matrix row). Rejected, with rationale: (R2#2) `pr_draft` **is** an `error_group_status` enum value — added by `015_draft_prs.sql:4` (`ALTER TYPE … ADD VALUE`), outside the migrations Codex was shown; the 047 predicate stands.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| Codex Review | `/codex review` | Independent 2nd opinion | 2 | issues_found → addressed | R1: 13 P1 / 12 P2 / 1 P3; R2: 10 P1 / 7 P2 / 1 P3; 39 accepted (5 partial), 5 rejected with recorded rationale |
+| Eng Review | `/plan-eng-review` | Architecture & tests | 0 | not run | — |
+
+**CODEX:** Two consult-mode iterations (session `019fee8c`, resumed from the program's C0–C2 reviews). Round 1 (sandboxed from source; plan-internal): chunk-bounds asymmetry, EXPLAIN Actual-Rows semantics, shared-DB plan nondeterminism, the jsonb short-circuit throw in 047, weak evidence/citation predicates, the xmin witness broken by the scoring pass, the missing headline invariant, URL-only AC3.5, and deploy-order gaps. Round 2 (load-bearing sources inlined; both source-dependent round-1 rejections confirmed): the illegal session-status seed, test-package mechanics, client-clock authorization windows, falsifiability of the friction planner assertion plus the missing `(incident_id, occurred_at)` index, `[null]`-element evidence, rollback surface-flap honesty, and the pool-deadlock xmin read. All P1/P2s folded into v2/v3 except five rejected with recorded rationale (NOT-NULL friction session ids; design-decision thresholds; the `applied_data_migrations` home; digest-link wiring as carried-forward B2 scope; `pr_draft`'s enum membership via 015).
+
+**VERDICT:** CODEX CLEARED after two iterations — eng review not yet run (recommended before execution, matching the program plan's own review posture).
+
+NO UNRESOLVED DECISIONS

--- a/packages/ingestion/db/impact_explain_test.go
+++ b/packages/ingestion/db/impact_explain_test.go
@@ -1,0 +1,226 @@
+package db_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/opslane/opslane/packages/ingestion/priority"
+)
+
+func sumExaminedPlanJSON(t *testing.T, raw []byte, relation string) int {
+	t.Helper()
+	var roots any
+	if err := json.Unmarshal(raw, &roots); err != nil {
+		t.Fatalf("decode plan JSON: %v", err)
+	}
+	var walk func(any) float64
+	walk = func(value any) float64 {
+		switch node := value.(type) {
+		case []any:
+			var total float64
+			for _, child := range node {
+				total += walk(child)
+			}
+			return total
+		case map[string]any:
+			var total float64
+			if node["Relation Name"] == relation && node["Node Type"] != "Bitmap Index Scan" {
+				loops, _ := node["Actual Loops"].(float64)
+				if loops == 0 {
+					loops = 1
+				}
+				for _, metric := range []string{"Actual Rows", "Rows Removed by Filter", "Rows Removed by Index Recheck"} {
+					value, _ := node[metric].(float64)
+					total += value * loops
+				}
+			}
+			for _, child := range node {
+				total += walk(child)
+			}
+			return total
+		default:
+			return 0
+		}
+	}
+	return int(walk(roots))
+}
+
+func TestSumExaminedPlanJSON(t *testing.T) {
+	raw := []byte(`[{"Plan":{"Node Type":"Nested Loop","Plans":[
+		{"Node Type":"Seq Scan","Relation Name":"target","Actual Rows":10,"Rows Removed by Filter":90,"Actual Loops":1},
+		{"Node Type":"Index Scan","Relation Name":"target","Actual Rows":2,"Rows Removed by Index Recheck":1,"Actual Loops":3},
+		{"Node Type":"Bitmap Heap Scan","Relation Name":"target","Actual Rows":4,"Actual Loops":1,"Plans":[
+			{"Node Type":"Bitmap Index Scan","Relation Name":"target","Actual Rows":4,"Actual Loops":1}
+		]},
+		{"Node Type":"Seq Scan","Relation Name":"other","Actual Rows":999,"Actual Loops":1},
+		{"Node Type":"Index Scan","Relation Name":"target"}
+	]}}]`)
+	if got, want := sumExaminedPlanJSON(t, raw, "target"), 113; got != want {
+		t.Fatalf("examined = %d, want %d", got, want)
+	}
+}
+
+func TestImpactRollupExaminedRows(t *testing.T) {
+	admin := testPool(t)
+	psql := findPsql(t)
+	pool, dsn := disposableDB(t, admin)
+	for _, file := range migrationFiles(t) {
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("apply %s: %v", file, err)
+		}
+	}
+
+	ctx := context.Background()
+	var orgID, projectID, envID, openID, resolvedID, frictionID string
+	if err := pool.QueryRow(ctx, `INSERT INTO orgs (name) VALUES ('impact-plan') RETURNING id`).Scan(&orgID); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `INSERT INTO projects (org_id, name) VALUES ($1, 'impact-plan') RETURNING id`, orgID).Scan(&projectID); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `INSERT INTO environments (project_id, name) VALUES ($1, 'production') RETURNING id`, projectID).Scan(&envID); err != nil {
+		t.Fatal(err)
+	}
+	seedGroup := func(fingerprint, kind, status string) string {
+		var id string
+		err := pool.QueryRow(ctx, `INSERT INTO error_groups
+			(project_id, environment_id, fingerprint, title, first_seen, last_seen, status, kind)
+			VALUES ($1, $2, $3, $3, now(), now(), $4, $5) RETURNING id`,
+			projectID, envID, fingerprint, status, kind).Scan(&id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+	openID = seedGroup("plan-open", "error", "new")
+	resolvedID = seedGroup("plan-resolved", "error", "resolved")
+	frictionID = seedGroup("plan-friction", "friction", "insight")
+
+	if _, err := pool.Exec(ctx, `INSERT INTO sessions (id, project_id, environment_id, started_at, status)
+		SELECT 'plan-session-' || n, $1, $2, now(), 'recording'
+		FROM generate_series(1, 200) n`, projectID, envID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO session_chunks
+		(session_id, seq, project_id, object_key, has_full_snapshot, scrubbed_at, first_event_ms, last_event_ms)
+		SELECT 'plan-session-' || n, 0, $1, 'plan/' || n, true, now(),
+		       (extract(epoch FROM now() - interval '1 minute') * 1000)::bigint,
+		       (extract(epoch FROM now() + interval '5 minutes') * 1000)::bigint
+		FROM generate_series(1, 200) n`, projectID); err != nil {
+		t.Fatal(err)
+	}
+	// Cold ballast: sessions and scrubbed chunks that belong to no in-window
+	// group. They make the chunk-side examined-rows bound falsifiable — a plan
+	// that scans the whole chunk table (the always-on-recording table) instead
+	// of probing per rollup session examines all 20k of these and fails.
+	if _, err := pool.Exec(ctx, `INSERT INTO sessions (id, project_id, environment_id, started_at, status)
+		SELECT 'cold-session-' || n, $1, $2, now(), 'recording'
+		FROM generate_series(1, 20000) n`, projectID, envID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO session_chunks
+		(session_id, seq, project_id, object_key, has_full_snapshot, scrubbed_at, first_event_ms, last_event_ms)
+		SELECT 'cold-session-' || n, 0, $1, 'cold/' || n, true, now(),
+		       (extract(epoch FROM now() - interval '1 minute') * 1000)::bigint,
+		       (extract(epoch FROM now() + interval '5 minutes') * 1000)::bigint
+		FROM generate_series(1, 20000) n`, projectID); err != nil {
+		t.Fatal(err)
+	}
+
+	insertEvents := func(groupID string, count int, age string) {
+		t.Helper()
+		_, err := pool.Exec(ctx, `INSERT INTO error_events
+			(project_id, environment_id, error_group_id, session_id, "timestamp", error_type, error_message, stack_trace_raw)
+			SELECT $1, $2, $3, 'plan-session-' || (1 + (n % 200)), now() - $4::interval,
+			       'TypeError', 'boom', 'at plan'
+			FROM generate_series(1, $5::int) n`, projectID, envID, groupID, age, count)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	insertEvents(openID, 20_000, "1 day")
+	insertEvents(openID, 40_000, "31 days")
+	insertEvents(resolvedID, 40_000, "1 day")
+
+	if _, err := pool.Exec(ctx, `INSERT INTO friction_signals
+		(session_id, project_id, environment_id, rule_version, signal_type, fingerprint,
+		 page_url_normalized, occurred_at, adjudication_status, incident_id, created_at)
+		SELECT 'plan-session-' || (1 + (n % 200)), $1::uuid, $2::uuid, 1, 'dead_click', 'recent-' || n,
+		       '/plan', now() - interval '1 day', 'accepted', $3::uuid, now() - interval '1 day'
+		FROM generate_series(1, 500) n
+		UNION ALL
+		SELECT 'plan-session-' || (1 + (n % 200)), $1::uuid, $2::uuid, 1, 'dead_click', 'aged-' || n,
+		       '/plan', now() - interval '32 days', 'accepted', $3::uuid, now() - interval '32 days'
+		FROM generate_series(1, 20000) n
+		UNION ALL
+		SELECT 'plan-session-' || (1 + (n % 200)), $1::uuid, $2::uuid, 1, 'dead_click', 'retracted-' || n,
+		       '/plan', now() - interval '1 day', 'accepted', $3::uuid, now() - interval '1 day'
+		FROM generate_series(1, 500) n`, projectID, envID, frictionID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE friction_signals SET retracted_at=now() WHERE fingerprint LIKE 'retracted-%'`); err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range []string{"error_events", "friction_signals", "session_chunks", "error_groups"} {
+		if _, err := pool.Exec(ctx, "ANALYZE "+table); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var rollupRows int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM (`+priority.ImpactRollupSelectSQL+`) impact`).Scan(&rollupRows); err != nil {
+		t.Fatal(err)
+	}
+	if rollupRows < 1 {
+		t.Fatal("impact rollup returned no rows; planner metrics would be meaningless")
+	}
+
+	// Deterministic usability posture (the sessions_index_test.go philosophy):
+	// the assertion is "the rollup's shape lets the 046 indexes bound examined
+	// rows", not "the planner wins a cost race". The pre-046 single-column
+	// idx_error_events_group and the created_at/reach indexes are close enough
+	// in estimated cost that ANALYZE sampling flips the choice run to run
+	// (observed: the group index scanning all 60k events with 40k filtered).
+	// Dropping the competitors inside a rolled-back transaction removes the
+	// race without touching the schema; the prod-side cost race is recorded in
+	// the PR as follow-up (the 001 index is redundant next to 039's).
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `DROP INDEX idx_error_events_group, idx_error_events_group_created,
+		idx_friction_signals_incident, idx_friction_signals_incident_reach`); err != nil {
+		t.Fatal(err)
+	}
+	var raw []byte
+	if err := tx.QueryRow(ctx, `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) `+priority.ImpactRollupSelectSQL).Scan(&raw); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+	plan := string(raw)
+	events := sumExaminedPlanJSON(t, raw, "error_events")
+	if events > 30_000 {
+		t.Fatalf("rollup examined %d error events for 20000 relevant rows (ratio %.2f > 1.5)\n%s", events, float64(events)/20_000, plan)
+	}
+	signals := sumExaminedPlanJSON(t, raw, "friction_signals")
+	if signals > 1_500 {
+		t.Fatalf("rollup examined %d friction signals for 500 relevant rows (ratio %.2f > 3)\n%s", signals, float64(signals)/500, plan)
+	}
+	chunks := sumExaminedPlanJSON(t, raw, "session_chunks")
+	if chunks > 600 {
+		t.Fatalf("rollup examined %d session chunks for 200 rollup sessions (ratio %.2f > 3; the 20k cold chunks leaked into the scan)\n%s", chunks, float64(chunks)/200, plan)
+	}
+	for _, index := range []string{"idx_error_events_group_timestamp", "idx_friction_signals_incident_occurred"} {
+		if !strings.Contains(plan, index) {
+			t.Fatalf("rollup does not use %s\n%s", index, plan)
+		}
+	}
+	t.Logf("AC3.8 plan: error_events=%d (%.2fx), friction_signals=%d (%.2fx)\n%s",
+		events, float64(events)/20_000, signals, float64(signals)/500, fmt.Sprintf("%s", raw))
+}

--- a/packages/ingestion/db/migration_046_test.go
+++ b/packages/ingestion/db/migration_046_test.go
@@ -1,0 +1,59 @@
+package db_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestMigration046ImpactQueryIndexes(t *testing.T) {
+	admin := testPool(t)
+	psql := findPsql(t)
+	pool, dsn := disposableDB(t, admin)
+	for _, file := range migrationFiles(t) {
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("apply %s: %v", file, err)
+		}
+	}
+
+	tests := []struct {
+		name       string
+		wantCols   string
+		predicates []string
+	}{
+		{
+			name:       "idx_error_events_group_timestamp",
+			wantCols:   `(error_group_id, "timestamp")`,
+			predicates: []string{"session_id IS NOT NULL"},
+		},
+		{
+			name:     "idx_friction_signals_incident_occurred",
+			wantCols: "(incident_id, occurred_at)",
+			predicates: []string{
+				"incident_id IS NOT NULL",
+				"superseded_by IS NULL",
+				"retracted_at IS NULL",
+				"adjudication_status = 'accepted'::text",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var def string
+			if err := pool.QueryRow(context.Background(),
+				`SELECT indexdef FROM pg_indexes WHERE tablename = CASE WHEN $1 LIKE 'idx_error_events%' THEN 'error_events' ELSE 'friction_signals' END AND indexname = $1`,
+				tt.name,
+			).Scan(&def); err != nil {
+				t.Fatalf("index missing: %v", err)
+			}
+			if !strings.Contains(def, tt.wantCols) {
+				t.Fatalf("indexdef %q missing ordered columns %s", def, tt.wantCols)
+			}
+			for _, predicate := range tt.predicates {
+				if !strings.Contains(def, predicate) {
+					t.Fatalf("indexdef %q missing predicate %q", def, predicate)
+				}
+			}
+		})
+	}
+}

--- a/packages/ingestion/db/migration_047_test.go
+++ b/packages/ingestion/db/migration_047_test.go
@@ -1,0 +1,135 @@
+package db_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMigration047BackfillsEveryOpenIncidentOnce(t *testing.T) {
+	admin := testPool(t)
+	psql := findPsql(t)
+	pool, dsn := disposableDB(t, admin)
+	for _, file := range migrationFiles(t) {
+		if filepath.Base(file) == "047_readiness_backfill.sql" {
+			break
+		}
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("apply %s: %v", file, err)
+		}
+	}
+
+	ctx := context.Background()
+	var orgID, projectID string
+	if err := pool.QueryRow(ctx, `INSERT INTO orgs (name) VALUES ('migration-047') RETURNING id`).Scan(&orgID); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `INSERT INTO projects (org_id, name) VALUES ($1, 'p') RETURNING id`, orgID).Scan(&projectID); err != nil {
+		t.Fatal(err)
+	}
+
+	type expected struct{ status, reason string }
+	want := make(map[string]expected)
+	seedGroup := func(name, status string, diff *string, evidence *string) string {
+		t.Helper()
+		var id string
+		if err := pool.QueryRow(ctx, `INSERT INTO error_groups
+			(project_id, fingerprint, title, first_seen, last_seen, status, candidate_diff, verification_evidence)
+			VALUES ($1, $2, $2, now(), now(), $3, $4, $5::jsonb) RETURNING id`,
+			projectID, name, status, diff, evidence).Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+	str := func(value string) *string { return &value }
+	seedDecision := func(groupID, outcome, diagnosis string, decidedAt time.Time) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, `INSERT INTO diagnosis_decisions
+			(error_group_id, project_id, outcome, decision_reason, diagnosis, model, prompt_version, decided_at)
+			VALUES ($1, $2, $3, 'backfill test', $4::jsonb, 'test-model', 'test-v1', $5)`,
+			groupID, projectID, outcome, diagnosis, decidedAt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	add := func(name, status string, diff, evidence *string, expected expected) string {
+		id := seedGroup(name, status, diff, evidence)
+		want[id] = expected
+		return id
+	}
+
+	add("draft", "pr_draft", nil, nil, expected{"eligible", "backfill_receipt_state"})
+	add("created", "pr_created", nil, nil, expected{"eligible", "backfill_receipt_state"})
+	add("diff", "needs_human", str("diff --git a/a b/a"), nil, expected{"eligible", "backfill_receipt_state"})
+	add("no-receipt", "needs_human", nil, nil, expected{"pending", "backfill_unverified"})
+	add("empty-evidence", "needs_human", nil, str(`{}`), expected{"pending", "backfill_unverified"})
+	add("null-evidence", "needs_human", nil, str(`null`), expected{"pending", "backfill_unverified"})
+	add("usable-check", "needs_human", nil, str(`{"checks":[{"name":"suite"}]}`), expected{"eligible", "backfill_receipt_state"})
+	add("null-check", "needs_human", nil, str(`{"checks":[null]}`), expected{"pending", "backfill_unverified"})
+	add("empty-check", "needs_human", nil, str(`{"checks":[{}]}`), expected{"pending", "backfill_unverified"})
+
+	missingBrief := add("missing-brief", "investigated", nil, nil, expected{"pending", "backfill_unverified"})
+	seedDecision(missingBrief, "code_fix", `{"evidence":[{"path":"a.ts","detail":"d","symptomLink":"s"}]}`, time.Now().Add(-time.Minute))
+	fillerBrief := add("filler-brief", "investigated", nil, nil, expected{"pending", "backfill_unverified"})
+	seedDecision(fillerBrief, "code_fix", `{"agentTaskBrief":"tbd later","evidence":[{"path":"a.ts","detail":"d","symptomLink":"s"}]}`, time.Now())
+	validCause := add("valid-cause", "investigated", nil, nil, expected{"eligible", "backfill_validated_cause"})
+	seedDecision(validCause, "code_fix", `{"agentTaskBrief":"Fix the null guard","evidence":[{"path":"a.ts","detail":"d","symptomLink":"s"}]}`, time.Now())
+	validNotActionable := add("valid-not-actionable", "investigated", nil, nil, expected{"eligible", "backfill_validated_cause"})
+	seedDecision(validNotActionable, "not_actionable", `{"evidence":[{"path":"a.ts","detail":"d","symptomLink":"s"}]}`, time.Now())
+	corruptEvidence := add("corrupt-decision", "investigated", nil, nil, expected{"pending", "backfill_unverified"})
+	seedDecision(corruptEvidence, "code_fix", `{"agentTaskBrief":"Fix it","evidence":"corrupt"}`, time.Now())
+	emptyCitation := add("empty-citation", "investigated", nil, nil, expected{"pending", "backfill_unverified"})
+	seedDecision(emptyCitation, "code_fix", `{"agentTaskBrief":"Fix it","evidence":[{"path":"a.ts","detail":"","symptomLink":"s"}]}`, time.Now())
+	latestInvalid := add("latest-invalid", "investigated", nil, nil, expected{"pending", "backfill_unverified"})
+	seedDecision(latestInvalid, "not_actionable", `{"evidence":[{"path":"a.ts","detail":"d","symptomLink":"s"}]}`, time.Now().Add(-time.Hour))
+	seedDecision(latestInvalid, "needs_more_context", `{}`, time.Now())
+
+	resolvedID := seedGroup("resolved", "resolved", nil, nil)
+	preexistingID := seedGroup("preexisting", "new", nil, nil)
+	if _, err := pool.Exec(ctx, `INSERT INTO digest_readiness
+		(incident_id, project_id, status, reason) VALUES ($1, $2, 'ineligible', 'quarantined_degenerate')`,
+		preexistingID, projectID); err != nil {
+		t.Fatal(err)
+	}
+	want[preexistingID] = expected{"ineligible", "quarantined_degenerate"}
+
+	path := filepath.Join("migrations", "047_readiness_backfill.sql")
+	if err := applyMigration(t, psql, dsn, path); err != nil {
+		t.Fatal(err)
+	}
+	for id, expected := range want {
+		var status, reason string
+		if err := pool.QueryRow(ctx, `SELECT status, reason FROM digest_readiness WHERE incident_id=$1`, id).Scan(&status, &reason); err != nil {
+			t.Fatalf("readiness for %s: %v", id, err)
+		}
+		if status != expected.status || reason != expected.reason {
+			t.Errorf("readiness %s = %s/%s, want %s/%s", id, status, reason, expected.status, expected.reason)
+		}
+	}
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM digest_readiness WHERE incident_id=$1`, resolvedID).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("resolved readiness count=%d err=%v, want 0", count, err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM error_groups g
+		WHERE g.status NOT IN ('resolved','merged','archived')
+		  AND NOT EXISTS (SELECT 1 FROM digest_readiness dr WHERE dr.incident_id=g.id)`).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("open incidents without readiness=%d err=%v", count, err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM applied_data_migrations WHERE name='047_readiness_backfill'`).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("migration markers=%d err=%v", count, err)
+	}
+
+	if _, err := pool.Exec(ctx, `UPDATE digest_readiness SET status='eligible', reason='validated_cause' WHERE incident_id=$1`, missingBrief); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyMigration(t, psql, dsn, path); err != nil {
+		t.Fatal(err)
+	}
+	var status, reason string
+	if err := pool.QueryRow(ctx, `SELECT status, reason FROM digest_readiness WHERE incident_id=$1`, missingBrief).Scan(&status, &reason); err != nil {
+		t.Fatal(err)
+	}
+	if status != "eligible" || reason != "validated_cause" {
+		t.Fatalf("reapply overwrote pipeline row with %s/%s", status, reason)
+	}
+}

--- a/packages/ingestion/db/migrations/046_impact_query_index.sql
+++ b/packages/ingestion/db/migrations/046_impact_query_index.sql
@@ -1,0 +1,35 @@
+-- C3/W3.1: impact arithmetic bounds occurrences by client event time, which
+-- shares a clock domain with session chunk event bounds. The migration runner
+-- replays every file with per-statement autocommit, so every statement must be
+-- safe to run again and CONCURRENTLY is legal here.
+DO $$
+DECLARE
+  invalid_index record;
+BEGIN
+  FOR invalid_index IN
+    SELECT n.nspname AS schema_name, c.relname AS index_name
+      FROM pg_class c
+      JOIN pg_index i ON i.indexrelid = c.oid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = current_schema()
+       AND c.relname IN (
+         'idx_error_events_group_timestamp',
+         'idx_friction_signals_incident_occurred'
+       )
+       AND NOT i.indisvalid
+  LOOP
+    EXECUTE format('DROP INDEX %I.%I', invalid_index.schema_name, invalid_index.index_name);
+  END LOOP;
+END
+$$;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_error_events_group_timestamp
+  ON error_events (error_group_id, "timestamp")
+  WHERE session_id IS NOT NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_friction_signals_incident_occurred
+  ON friction_signals (incident_id, occurred_at)
+  WHERE incident_id IS NOT NULL
+    AND superseded_by IS NULL
+    AND retracted_at IS NULL
+    AND adjudication_status = 'accepted';

--- a/packages/ingestion/db/migrations/047_readiness_backfill.sql
+++ b/packages/ingestion/db/migrations/047_readiness_backfill.sql
@@ -1,0 +1,86 @@
+-- C3/W3.B: classify every open legacy incident into digest_readiness. This is
+-- a one-shot data migration: steady-state worker and requeue writers own all
+-- later transitions, and boot-time replay must never overwrite them.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM applied_data_migrations WHERE name = '047_readiness_backfill'
+  ) THEN
+    INSERT INTO digest_readiness (incident_id, project_id, status, reason)
+    SELECT g.id,
+           g.project_id,
+           CASE
+             WHEN classification.receipt_state OR classification.validated_cause
+               THEN 'eligible'
+             ELSE 'pending'
+           END,
+           CASE
+             WHEN classification.receipt_state THEN 'backfill_receipt_state'
+             WHEN classification.validated_cause THEN 'backfill_validated_cause'
+             ELSE 'backfill_unverified'
+           END
+      FROM error_groups g
+      CROSS JOIN LATERAL (
+        SELECT
+          (
+            g.status IN ('pr_created', 'pr_draft')
+            OR (
+              g.status = 'needs_human'
+              AND (
+                NULLIF(btrim(g.candidate_diff), '') IS NOT NULL
+                OR CASE
+                  WHEN jsonb_typeof(g.verification_evidence->'checks') = 'array'
+                    THEN EXISTS (
+                      SELECT 1
+                        FROM jsonb_array_elements(g.verification_evidence->'checks') check_item
+                       WHERE btrim(coalesce(check_item->>'name', '')) <> ''
+                    )
+                  ELSE false
+                END
+              )
+            )
+          ) AS receipt_state,
+          EXISTS (
+            SELECT 1
+              FROM (
+                SELECT d.outcome, d.diagnosis
+                  FROM diagnosis_decisions d
+                 WHERE d.error_group_id = g.id
+                   AND d.project_id = g.project_id
+                 ORDER BY d.decided_at DESC, d.id DESC
+                 LIMIT 1
+              ) latest
+             WHERE latest.outcome IN ('code_fix', 'not_actionable')
+               AND CASE
+                 WHEN jsonb_typeof(latest.diagnosis->'evidence') = 'array'
+                   THEN jsonb_array_length(latest.diagnosis->'evidence') >= 1
+                    AND NOT EXISTS (
+                      SELECT 1
+                        FROM jsonb_array_elements(latest.diagnosis->'evidence') evidence_item
+                       WHERE btrim(coalesce(evidence_item->>'path', '')) = ''
+                          OR btrim(coalesce(evidence_item->>'detail', '')) = ''
+                          OR btrim(coalesce(evidence_item->>'symptomLink', '')) = ''
+                    )
+                 ELSE false
+               END
+               AND (
+                 latest.outcome <> 'code_fix'
+                 OR (
+                   NULLIF(btrim(latest.diagnosis->>'agentTaskBrief'), '') IS NOT NULL
+                   AND latest.diagnosis->>'agentTaskBrief'
+                     !~* '^\s*(placeholder|tbd|to be determined)\M'
+                 )
+               )
+          ) AS validated_cause
+      ) classification
+     WHERE g.status NOT IN ('resolved', 'merged', 'archived')
+       AND NOT EXISTS (
+         SELECT 1 FROM digest_readiness readiness WHERE readiness.incident_id = g.id
+       )
+    ON CONFLICT (incident_id) DO NOTHING;
+
+    INSERT INTO applied_data_migrations (name)
+    VALUES ('047_readiness_backfill');
+  END IF;
+END
+$$;

--- a/packages/ingestion/db/sessions_read.go
+++ b/packages/ingestion/db/sessions_read.go
@@ -325,19 +325,124 @@ func (q *Queries) GetPlayableChunk(ctx context.Context, projectID, sessionID str
 	return &chunk, nil
 }
 
-// SessionPointerForGroup resolves pointer identity independently of chunk
-// readiness. The newest ingested occurrence wins, while errorAt comes from the
-// event-time column so #27 can improve accuracy without changing this contract.
-func (q *Queries) SessionPointerForGroup(ctx context.Context, errorGroupID, projectID string) (sessionID string, errorAt time.Time, ok bool, err error) {
+const (
+	watchWindowMs         = 15_000
+	watchCandidateEvents  = 50
+	watchCandidateSignals = 50
+)
+
+// watchCoverageSQL is the single source of the watchability contract, applied
+// to a candidate row exposing session_id + anchor_ms: the session's scrubbed,
+// bounded chunks must stitch across the full ±15s window around the anchor,
+// and a full-snapshot chunk must start at-or-before the window. Shared by the
+// error and friction watchable queries so the two lanes cannot drift.
+var watchCoverageSQL = fmt.Sprintf(`
+WHERE EXISTS (
+  SELECT 1 FROM session_chunks c
+   WHERE c.session_id = cand.session_id AND c.project_id = $2
+     AND c.scrubbed_at IS NOT NULL
+     AND c.first_event_ms IS NOT NULL AND c.last_event_ms IS NOT NULL
+  HAVING min(c.first_event_ms) <= cand.anchor_ms - %d
+     AND max(c.last_event_ms) >= cand.anchor_ms + %d
+)
+AND EXISTS (
+  SELECT 1 FROM session_chunks c
+   WHERE c.session_id = cand.session_id AND c.project_id = $2
+     AND c.scrubbed_at IS NOT NULL AND c.has_full_snapshot
+     AND c.first_event_ms IS NOT NULL AND c.last_event_ms IS NOT NULL
+     AND c.first_event_ms <= cand.anchor_ms - %d
+)`, watchWindowMs, watchWindowMs, watchWindowMs)
+
+// frictionCandidateSQL is the single source of "the incident's live signals,
+// representative first, then earliest accepted": shared by the incident-page
+// pointer and the digest watchable query so retraction/supersession semantics
+// stay identical on both surfaces.
+const frictionCandidateSQL = `
+  SELECT fs.session_id,
+         (extract(epoch FROM fs.occurred_at) * 1000)::bigint AS anchor_ms,
+         fs.occurred_at,
+         (fs.id = g.representative_signal_id) AS representative,
+         fs.id
+    FROM friction_signals fs
+    JOIN sessions s ON s.id = fs.session_id AND s.project_id = fs.project_id
+    JOIN error_groups g ON g.id = $1 AND g.project_id = $2
+   WHERE fs.incident_id = $1 AND fs.project_id = $2
+     AND fs.adjudication_status = 'accepted'
+     AND fs.retracted_at IS NULL AND fs.superseded_by IS NULL
+     AND s.status <> 'deleting'
+   ORDER BY (fs.id = g.representative_signal_id) DESC, fs.occurred_at ASC, fs.id ASC`
+
+// One candidate per session (a looping session cannot evict every covered
+// sibling from the pool), newest sessions first, pool bounded before the
+// coverage probes run.
+var watchableErrorSessionSQL = fmt.Sprintf(`
+SELECT cand.session_id, cand.anchor_ms FROM (
+  SELECT per_session.* FROM (
+    SELECT DISTINCT ON (e.session_id)
+           e.session_id,
+           (extract(epoch FROM e."timestamp") * 1000)::bigint AS anchor_ms,
+           e.created_at, e.id
+      FROM error_events e
+      JOIN sessions s ON s.id = e.session_id AND s.project_id = e.project_id
+     WHERE e.error_group_id = $1 AND e.project_id = $2
+       AND e.session_id IS NOT NULL AND s.status <> 'deleting'
+     ORDER BY e.session_id, e.created_at DESC, e.id DESC
+  ) per_session
+  ORDER BY per_session.created_at DESC, per_session.id DESC
+  LIMIT %d
+) cand
+%s
+ORDER BY cand.created_at DESC, cand.id DESC
+LIMIT 1`, watchCandidateEvents, watchCoverageSQL)
+
+var watchableFrictionSessionSQL = fmt.Sprintf(`
+SELECT cand.session_id, cand.anchor_ms FROM (%s
+   LIMIT %d
+) cand
+%s
+ORDER BY cand.representative DESC, cand.occurred_at ASC, cand.id ASC
+LIMIT 1`, frictionCandidateSQL, watchCandidateSignals, watchCoverageSQL)
+
+// groupKind resolves an incident's lane; found=false when the group does not
+// exist in the tenant.
+func (q *Queries) groupKind(ctx context.Context, errorGroupID, projectID string) (kind string, found bool, err error) {
 	err = q.pool.QueryRow(ctx,
-		`SELECT ee.session_id, ee.timestamp
+		`SELECT kind FROM error_groups WHERE id=$1 AND project_id=$2`, errorGroupID, projectID).Scan(&kind)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return kind, true, nil
+}
+
+// SessionPointerForGroup resolves pointer identity independently of chunk
+// readiness. Error incidents use their newest ingested occurrence; friction
+// incidents prefer the live representative signal and otherwise use their
+// earliest accepted, active signal.
+func (q *Queries) SessionPointerForGroup(ctx context.Context, errorGroupID, projectID string) (sessionID string, errorAt time.Time, ok bool, err error) {
+	kind, found, err := q.groupKind(ctx, errorGroupID, projectID)
+	if err != nil {
+		return "", time.Time{}, false, fmt.Errorf("session pointer group kind: %w", err)
+	}
+	if !found {
+		return "", time.Time{}, false, nil
+	}
+
+	query := `SELECT ee.session_id, ee.timestamp
 		   FROM error_events ee
 		   JOIN sessions s ON s.id = ee.session_id AND s.project_id = $2
 		  WHERE ee.error_group_id = $1 AND ee.project_id = $2
 		    AND ee.session_id IS NOT NULL
 		    AND s.status <> 'deleting'
 		  ORDER BY ee.created_at DESC, ee.id DESC
-		  LIMIT 1`, errorGroupID, projectID).Scan(&sessionID, &errorAt)
+		  LIMIT 1`
+	if kind == "friction" {
+		query = `SELECT cand.session_id, cand.occurred_at FROM (` + frictionCandidateSQL + `
+		   LIMIT 1) cand`
+	}
+	err = q.pool.QueryRow(ctx, query, errorGroupID, projectID).Scan(&sessionID, &errorAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", time.Time{}, false, nil
 	}
@@ -345,4 +450,31 @@ func (q *Queries) SessionPointerForGroup(ctx context.Context, errorGroupID, proj
 		return "", time.Time{}, false, fmt.Errorf("session pointer for group: %w", err)
 	}
 	return sessionID, errorAt, true, nil
+}
+
+// WatchableSessionForGroup returns a pointer whose scrubbed, bounded chunks
+// span the full +/-15 second playback window and whose opening side has a full
+// snapshot. The span may contain gaps in v1. anchorMs is absolute client-clock
+// epoch milliseconds, matching the dashboard's ?t= contract.
+func (q *Queries) WatchableSessionForGroup(ctx context.Context, errorGroupID, projectID string) (sessionID string, anchorMs int64, ok bool, err error) {
+	kind, found, err := q.groupKind(ctx, errorGroupID, projectID)
+	if err != nil {
+		return "", 0, false, fmt.Errorf("watchable session group kind: %w", err)
+	}
+	if !found {
+		return "", 0, false, nil
+	}
+
+	query := watchableErrorSessionSQL
+	if kind == "friction" {
+		query = watchableFrictionSessionSQL
+	}
+	err = q.pool.QueryRow(ctx, query, errorGroupID, projectID).Scan(&sessionID, &anchorMs)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", 0, false, nil
+	}
+	if err != nil {
+		return "", 0, false, fmt.Errorf("watchable session for group: %w", err)
+	}
+	return sessionID, anchorMs, true, nil
 }

--- a/packages/ingestion/db/sessions_read_test.go
+++ b/packages/ingestion/db/sessions_read_test.go
@@ -393,6 +393,189 @@ func TestSessionPointerForGroup_UsesNewestIngestedOccurrenceAndEventTime(t *test
 	}
 }
 
+func seedPointerGroup(t *testing.T, pool *pgxpool.Pool, projectID, envID, fingerprint, kind string) string {
+	t.Helper()
+	var id string
+	if err := pool.QueryRow(context.Background(), `INSERT INTO error_groups
+		(project_id, environment_id, fingerprint, title, first_seen, last_seen, status, kind)
+		VALUES ($1, $2, $3, $3, now(), now(), $4, $5) RETURNING id`,
+		projectID, envID, fingerprint, map[string]string{"error": "new", "friction": "insight"}[kind], kind).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func seedPointerSignal(t *testing.T, pool *pgxpool.Pool, projectID, envID, groupID, sessionID, fingerprint string, at time.Time) string {
+	t.Helper()
+	var id string
+	if err := pool.QueryRow(context.Background(), `INSERT INTO friction_signals
+		(session_id, project_id, environment_id, rule_version, signal_type, fingerprint,
+		 page_url_normalized, occurred_at, adjudication_status, incident_id)
+		VALUES ($1, $2, $3, 1, 'dead_click', $4, '/pointer', $5, 'accepted', $6)
+		RETURNING id`, sessionID, projectID, envID, fingerprint, at, groupID).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func seedPointerChunk(t *testing.T, pool *pgxpool.Pool, projectID, sessionID string, seq int, firstMs, lastMs *int64, snapshot, scrubbed bool) {
+	t.Helper()
+	var scrubbedAt any
+	if scrubbed {
+		scrubbedAt = time.Now()
+	}
+	if _, err := pool.Exec(context.Background(), `INSERT INTO session_chunks
+		(session_id, seq, project_id, object_key, has_full_snapshot, scrubbed_at, first_event_ms, last_event_ms)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		sessionID, seq, projectID, fmt.Sprintf("pointer/%s/%d", sessionID, seq), snapshot, scrubbedAt, firstMs, lastMs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSessionPointerForGroup_FrictionRepresentativeAndFallback(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	groupID := seedPointerGroup(t, pool, projectID, envID, "friction-pointer", "friction")
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `UPDATE error_groups SET representative_signal_id=NULL WHERE id=$1`, groupID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM friction_signals WHERE incident_id=$1`, groupID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM error_groups WHERE id=$1`, groupID)
+	})
+
+	earlySession, representativeSession := newSessionID(t), newSessionID(t)
+	insertReadSession(t, q, pool, projectID, envID, nil, earlySession, time.Now())
+	insertReadSession(t, q, pool, projectID, envID, nil, representativeSession, time.Now())
+	t1 := time.Now().UTC().Truncate(time.Millisecond).Add(-time.Minute)
+	t2 := t1.Add(30 * time.Second)
+	earlyID := seedPointerSignal(t, pool, projectID, envID, groupID, earlySession, "early", t1)
+	representativeID := seedPointerSignal(t, pool, projectID, envID, groupID, representativeSession, "representative", t2)
+	if _, err := pool.Exec(ctx, `UPDATE error_groups SET representative_signal_id=$2 WHERE id=$1`, groupID, representativeID); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID, anchor, ok, err := q.SessionPointerForGroup(ctx, groupID, projectID)
+	if err != nil || !ok || sessionID != representativeSession || !anchor.Equal(t2) {
+		t.Fatalf("representative pointer = %q %v ok=%v err=%v", sessionID, anchor, ok, err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE sessions SET status='deleting' WHERE id=$1`, representativeSession); err != nil {
+		t.Fatal(err)
+	}
+	sessionID, anchor, ok, err = q.SessionPointerForGroup(ctx, groupID, projectID)
+	if err != nil || !ok || sessionID != earlySession || !anchor.Equal(t1) {
+		t.Fatalf("deleting-session fallback = %q %v ok=%v err=%v", sessionID, anchor, ok, err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE sessions SET status='recording' WHERE id=$1`, representativeSession); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE friction_signals SET superseded_by=$2 WHERE id=$1`, representativeID, earlyID); err != nil {
+		t.Fatal(err)
+	}
+	sessionID, anchor, ok, err = q.SessionPointerForGroup(ctx, groupID, projectID)
+	if err != nil || !ok || sessionID != earlySession || !anchor.Equal(t1) {
+		t.Fatalf("superseded fallback = %q %v ok=%v err=%v", sessionID, anchor, ok, err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE friction_signals SET superseded_by=NULL WHERE id=$1`, representativeID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE friction_signals SET retracted_at=now() WHERE id=$1`, representativeID); err != nil {
+		t.Fatal(err)
+	}
+	sessionID, anchor, ok, err = q.SessionPointerForGroup(ctx, groupID, projectID)
+	if err != nil || !ok || sessionID != earlySession || !anchor.Equal(t1) {
+		t.Fatalf("retraction fallback = %q %v ok=%v err=%v", sessionID, anchor, ok, err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE friction_signals SET adjudication_status='rejected' WHERE id=$1`, earlyID); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, ok, err := q.SessionPointerForGroup(ctx, groupID, projectID); err != nil || ok {
+		t.Fatalf("all-inactive pointer ok=%v err=%v", ok, err)
+	}
+}
+
+func TestWatchableSessionForGroup_CoverageAndCandidateFallback(t *testing.T) {
+	q, pool := sessionTestQueries(t)
+	ctx := context.Background()
+	projectID, envID := seedSessionProject(t, pool)
+	groupID := seedPointerGroup(t, pool, projectID, envID, "watchable-error", "error")
+	frictionID := seedPointerGroup(t, pool, projectID, envID, "watchable-friction", "friction")
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `UPDATE error_groups SET representative_signal_id=NULL WHERE id IN ($1,$2)`, groupID, frictionID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM friction_signals WHERE incident_id=$1`, frictionID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM error_events WHERE error_group_id=$1`, groupID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM error_groups WHERE id IN ($1,$2)`, groupID, frictionID)
+	})
+
+	anchor := time.Now().UTC().Truncate(time.Millisecond).Add(-time.Minute)
+	coveredSession, uncoveredSession := newSessionID(t), newSessionID(t)
+	insertReadSession(t, q, pool, projectID, envID, nil, coveredSession, anchor)
+	insertReadSession(t, q, pool, projectID, envID, nil, uncoveredSession, anchor)
+	spans := [][2]int64{
+		{anchor.Add(-20 * time.Second).UnixMilli(), anchor.Add(-8 * time.Second).UnixMilli()},
+		{anchor.Add(-8 * time.Second).UnixMilli(), anchor.Add(2 * time.Second).UnixMilli()},
+		{anchor.Add(2 * time.Second).UnixMilli(), anchor.Add(16 * time.Second).UnixMilli()},
+	}
+	for i, span := range spans {
+		first, last := span[0], span[1]
+		seedPointerChunk(t, pool, projectID, coveredSession, i, &first, &last, i == 0, true)
+	}
+	oneFirst, oneLast := anchor.UnixMilli(), anchor.UnixMilli()+1
+	seedPointerChunk(t, pool, projectID, uncoveredSession, 0, &oneFirst, &oneLast, true, true)
+	if _, err := pool.Exec(ctx, `INSERT INTO error_events
+		(project_id, environment_id, error_group_id, session_id, "timestamp", error_type, error_message, stack_trace_raw, created_at)
+		VALUES ($1,$2,$3,$4,$5,'TypeError','boom','at test',$6),
+		       ($1,$2,$3,$7,$5,'TypeError','boom','at test',$8)`,
+		projectID, envID, groupID, coveredSession, anchor, anchor.Add(-time.Second), uncoveredSession, anchor); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID, anchorMs, ok, err := q.WatchableSessionForGroup(ctx, groupID, projectID)
+	if err != nil || !ok || sessionID != coveredSession || anchorMs != anchor.UnixMilli() {
+		t.Fatalf("watchable error pointer = %q/%d ok=%v err=%v", sessionID, anchorMs, ok, err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE session_chunks SET has_full_snapshot=false WHERE session_id=$1`, coveredSession); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE session_chunks SET has_full_snapshot=true WHERE session_id=$1 AND seq=1`, coveredSession); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, ok, err := q.WatchableSessionForGroup(ctx, groupID, projectID); err != nil || ok {
+		t.Fatalf("late full snapshot coverage ok=%v err=%v, want false", ok, err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE session_chunks SET has_full_snapshot=(seq=0) WHERE session_id=$1`, coveredSession); err != nil {
+		t.Fatal(err)
+	}
+	seedPointerChunk(t, pool, projectID, coveredSession, 3, nil, nil, true, true)
+	if sessionID, _, ok, err := q.WatchableSessionForGroup(ctx, groupID, projectID); err != nil || !ok || sessionID != coveredSession {
+		t.Fatalf("NULL-bounded row changed coverage: session=%q ok=%v err=%v", sessionID, ok, err)
+	}
+
+	frictionCovered, frictionUncovered := newSessionID(t), newSessionID(t)
+	insertReadSession(t, q, pool, projectID, envID, nil, frictionCovered, anchor)
+	insertReadSession(t, q, pool, projectID, envID, nil, frictionUncovered, anchor)
+	for i, span := range spans {
+		first, last := span[0], span[1]
+		seedPointerChunk(t, pool, projectID, frictionCovered, i, &first, &last, i == 0, true)
+	}
+	seedPointerChunk(t, pool, projectID, frictionUncovered, 0, &oneFirst, &oneLast, true, true)
+	fallbackID := seedPointerSignal(t, pool, projectID, envID, frictionID, frictionCovered, "watchable-fallback", anchor)
+	representativeID := seedPointerSignal(t, pool, projectID, envID, frictionID, frictionUncovered, "watchable-representative", anchor.Add(time.Second))
+	if _, err := pool.Exec(ctx, `UPDATE error_groups SET representative_signal_id=$2 WHERE id=$1`, frictionID, representativeID); err != nil {
+		t.Fatal(err)
+	}
+	sessionID, anchorMs, ok, err = q.WatchableSessionForGroup(ctx, frictionID, projectID)
+	if err != nil || !ok || sessionID != frictionCovered || anchorMs != anchor.UnixMilli() {
+		t.Fatalf("watchable friction fallback = %q/%d ok=%v err=%v (fallback signal %s)", sessionID, anchorMs, ok, err, fallbackID)
+	}
+
+	if _, err := pool.Exec(ctx, `UPDATE session_chunks SET scrubbed_at=NULL WHERE session_id=$1`, coveredSession); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, ok, err := q.WatchableSessionForGroup(ctx, groupID, projectID); err != nil || ok {
+		t.Fatalf("unscrubbed coverage ok=%v err=%v", ok, err)
+	}
+}
+
 func TestInsertErrorEventAndGroup_PinsSessionWithoutLoweringLaterRetention(t *testing.T) {
 	q, pool := sessionTestQueries(t)
 	ctx := context.Background()

--- a/packages/ingestion/digest/build.go
+++ b/packages/ingestion/digest/build.go
@@ -97,8 +97,7 @@ func (s *Sweeper) buildInsights(ctx context.Context, projectID string, from, to 
 	rows, err := s.pool.Query(ctx, `
 		SELECT g.id, COALESCE(g.signal_type,''), COALESCE(g.page_url_normalized,''),
 		       SUM(fs.occurrence_count)::bigint,
-		       COUNT(DISTINCT fs.end_user_id),
-		       (array_agg(fs.session_id ORDER BY fs.occurred_at DESC))[1]
+		       COUNT(DISTINCT fs.end_user_id)
 		FROM friction_signals fs
 		JOIN error_groups g ON g.id = fs.incident_id
 		WHERE fs.project_id = $1 AND fs.occurred_at >= $2 AND fs.occurred_at < $3
@@ -119,14 +118,13 @@ func (s *Sweeper) buildInsights(ctx context.Context, projectID string, from, to 
 	items := make([]notify.DigestInsight, 0, listCap+1)
 	groupIDs := make([]string, 0, listCap+1)
 	for rows.Next() {
-		var groupID, replaySession string
+		var groupID string
 		var item notify.DigestInsight
 		var affectedUsers int64
-		if err := rows.Scan(&groupID, &item.SignalType, &item.Page, &item.Occurrences, &affectedUsers, &replaySession); err != nil {
+		if err := rows.Scan(&groupID, &item.SignalType, &item.Page, &item.Occurrences, &affectedUsers); err != nil {
 			return nil, false, fmt.Errorf("digest insights scan: %w", err)
 		}
 		item.AffectedUsers = int(affectedUsers)
-		item.ReplayURL = s.sessionURL(replaySession)
 		item.URL = notify.BuildIncidentURL(s.dashboardURL, groupID, projectID)
 		items = append(items, item)
 		groupIDs = append(groupIDs, groupID)
@@ -141,6 +139,7 @@ func (s *Sweeper) buildInsights(ctx context.Context, projectID string, from, to 
 
 	items, more := capped(items)
 	for i := range items {
+		items[i].ReplayURL = s.replayURLFor(ctx, groupIDs[i], projectID)
 		accounts, err := s.insightAccounts(ctx, groupIDs[i], from, to)
 		if err != nil {
 			return nil, false, err
@@ -200,7 +199,7 @@ func (s *Sweeper) accounts(ctx context.Context, query string, args ...any) (acco
 func (s *Sweeper) buildTopNewIssues(ctx context.Context, projectID string, from, to time.Time) ([]notify.DigestIssue, bool, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT g.id, g.title, g.occurrence_count::bigint, g.affected_users_count,
-		       g.root_cause, COALESCE(g.representative_session_id,'')
+		       g.root_cause
 		FROM error_groups g
 		WHERE g.project_id = $1 AND g.kind = 'error'
 		  AND g.first_seen >= $2 AND g.first_seen < $3
@@ -220,15 +219,14 @@ func (s *Sweeper) buildTopNewIssues(ctx context.Context, projectID string, from,
 	items := make([]notify.DigestIssue, 0, listCap+1)
 	groupIDs := make([]string, 0, listCap+1)
 	for rows.Next() {
-		var groupID, replaySession string
+		var groupID string
 		var rootCause *string
 		var item notify.DigestIssue
-		if err := rows.Scan(&groupID, &item.Title, &item.Occurrences, &item.AffectedUsers, &rootCause, &replaySession); err != nil {
+		if err := rows.Scan(&groupID, &item.Title, &item.Occurrences, &item.AffectedUsers, &rootCause); err != nil {
 			return nil, false, fmt.Errorf("digest top new issues scan: %w", err)
 		}
 		item.URL = notify.BuildIncidentURL(s.dashboardURL, groupID, projectID)
 		item.RootCauseExcerpt = rootCauseExcerpt(rootCause)
-		item.ReplayURL = s.sessionURL(replaySession)
 		items = append(items, item)
 		groupIDs = append(groupIDs, groupID)
 	}
@@ -239,6 +237,7 @@ func (s *Sweeper) buildTopNewIssues(ctx context.Context, projectID string, from,
 
 	items, more := capped(items)
 	for i := range items {
+		items[i].ReplayURL = s.replayURLFor(ctx, groupIDs[i], projectID)
 		accounts, err := s.groupAccounts(ctx, groupIDs[i])
 		if err != nil {
 			return nil, false, err

--- a/packages/ingestion/digest/build_test.go
+++ b/packages/ingestion/digest/build_test.go
@@ -2,6 +2,7 @@ package digest
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -73,6 +74,7 @@ func seedDigestFixtureWithSessionAge(t *testing.T, pool *pgxpool.Pool, now time.
 			`DELETE FROM notification_destinations WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 			`DELETE FROM friction_signals WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 			`DELETE FROM pr_outcomes WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+			`DELETE FROM error_events WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 			`DELETE FROM error_group_affected_users WHERE error_group_id IN (SELECT id FROM error_groups WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1))`,
 			`DELETE FROM sessions WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 			`DELETE FROM end_users WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
@@ -192,8 +194,8 @@ func TestBuildDigestSections(t *testing.T) {
 	if in.Occurrences != 5 || in.AffectedUsers != 2 {
 		t.Errorf("windowed metrics = %d occ / %d users, want 5/2", in.Occurrences, in.AffectedUsers)
 	}
-	if in.ReplayURL == nil || *in.ReplayURL != "https://dash.example/sessions/"+f.SessIn2 {
-		t.Errorf("replay should use latest signal session %s, got %v", f.SessIn2, in.ReplayURL)
+	if in.ReplayURL != nil {
+		t.Errorf("replay without proven chunk coverage = %v, want nil", in.ReplayURL)
 	}
 	if len(in.Accounts) != 2 || in.AccountsMore != 0 {
 		t.Errorf("accounts = %v +%d", in.Accounts, in.AccountsMore)
@@ -226,6 +228,82 @@ func TestBuildDigestSections(t *testing.T) {
 	}
 	if d.Watching.Sessions != 2 || d.Watching.Users != 2 {
 		t.Errorf("watching = %+v", d.Watching)
+	}
+}
+
+func TestBuildDigestReplayLinksRequireCoverage(t *testing.T) {
+	pool := testPool(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	f := seedDigestFixture(t, pool, now)
+	ctx := context.Background()
+
+	seedChunks := func(sessionID string, anchor time.Time, covered bool) {
+		t.Helper()
+		if !covered {
+			if _, err := pool.Exec(ctx, `INSERT INTO session_chunks
+				(session_id,seq,project_id,object_key,has_full_snapshot,scrubbed_at,first_event_ms,last_event_ms)
+				VALUES ($1,0,$2,$3,true,now(),$4::bigint,$4::bigint+1)`,
+				sessionID, f.ProjectID, "digest/"+sessionID+"/0", anchor.UnixMilli()); err != nil {
+				t.Fatal(err)
+			}
+			return
+		}
+		spans := [][2]int64{
+			{anchor.Add(-20 * time.Second).UnixMilli(), anchor.Add(-8 * time.Second).UnixMilli()},
+			{anchor.Add(-8 * time.Second).UnixMilli(), anchor.Add(2 * time.Second).UnixMilli()},
+			{anchor.Add(2 * time.Second).UnixMilli(), anchor.Add(16 * time.Second).UnixMilli()},
+		}
+		for i, span := range spans {
+			if _, err := pool.Exec(ctx, `INSERT INTO session_chunks
+				(session_id,seq,project_id,object_key,has_full_snapshot,scrubbed_at,first_event_ms,last_event_ms)
+				VALUES ($1,$2,$3,$4,$5,now(),$6,$7)`,
+				sessionID, i, f.ProjectID, fmt.Sprintf("digest/%s/%d", sessionID, i), i == 0, span[0], span[1]); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	insightCoveredAt := now.Add(-3 * time.Hour)
+	seedChunks(f.SessIn1, insightCoveredAt, true)
+	seedChunks(f.SessIn2, now.Add(-time.Hour), false)
+	if _, err := pool.Exec(ctx, `UPDATE friction_signals SET adjudication_status='accepted'
+		WHERE project_id=$1 AND retracted_at IS NULL`, f.ProjectID); err != nil {
+		t.Fatal(err)
+	}
+
+	issueAt := now.Add(-5 * time.Hour)
+	seedChunks(f.SessOld, issueAt, true)
+	var issueID string
+	if err := pool.QueryRow(ctx, `SELECT id FROM error_groups WHERE project_id=$1 AND fingerprint='fp-new'`, f.ProjectID).Scan(&issueID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO error_events
+		(project_id,environment_id,error_group_id,session_id,"timestamp",error_type,error_message,stack_trace_raw)
+		VALUES ($1,$2,$3,$4,$5,'TypeError','boom','at digest')`,
+		f.ProjectID, f.EnvID, issueID, f.SessOld, issueAt); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := New(pool, "https://dash.example").Build(ctx, f.ProjectID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := payload.Digest.Insights[0].ReplayURL; got == nil || *got != "https://dash.example/sessions/"+f.SessIn1+"?t="+fmt.Sprint(insightCoveredAt.UnixMilli()) {
+		t.Fatalf("covered friction fallback replay = %v", got)
+	}
+	if got := payload.Digest.TopNewIssues[0].ReplayURL; got == nil || *got != "https://dash.example/sessions/"+f.SessOld+"?t="+fmt.Sprint(issueAt.UnixMilli()) {
+		t.Fatalf("covered error replay = %v", got)
+	}
+
+	if _, err := pool.Exec(ctx, `DELETE FROM session_chunks WHERE session_id=$1`, f.SessOld); err != nil {
+		t.Fatal(err)
+	}
+	payload, err = New(pool, "https://dash.example").Build(ctx, f.ProjectID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := payload.Digest.TopNewIssues[0].ReplayURL; got != nil {
+		t.Fatalf("issue replay without coverage = %v, want nil", got)
 	}
 }
 
@@ -466,11 +544,11 @@ func TestBuildDigestUsesProjectLocalDate(t *testing.T) {
 
 func TestDigestExcerptAndSessionURLHelpers(t *testing.T) {
 	s := New(nil, "https://dash.example/")
-	if got := s.sessionURL(""); got != nil {
-		t.Fatalf("empty session URL = %v", got)
+	if got := s.sessionURLAt("a/b", 123); got == nil || *got != "https://dash.example/sessions/a%2Fb?t=123" {
+		t.Fatalf("anchored session URL = %v", got)
 	}
-	if got := s.sessionURL("a/b"); got == nil || *got != "https://dash.example/sessions/a%2Fb" {
-		t.Fatalf("escaped session URL = %v", got)
+	if got := s.sessionURLAt("", 5); got != nil {
+		t.Fatalf("empty anchored session URL = %v, want nil", got)
 	}
 	if rootCauseExcerpt(nil) != nil {
 		t.Fatal("nil root cause returned an excerpt")

--- a/packages/ingestion/digest/digest.go
+++ b/packages/ingestion/digest/digest.go
@@ -11,12 +11,14 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 	_ "time/tzdata"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	ingestiondb "github.com/opslane/opslane/packages/ingestion/db"
 	"github.com/opslane/opslane/packages/ingestion/notify"
 )
 
@@ -32,19 +34,35 @@ const (
 
 type Sweeper struct {
 	pool         *pgxpool.Pool
+	queries      *ingestiondb.Queries
 	dashboardURL string
 }
 
 func New(pool *pgxpool.Pool, dashboardURL string) *Sweeper {
-	return &Sweeper{pool: pool, dashboardURL: strings.TrimRight(dashboardURL, "/")}
+	return &Sweeper{pool: pool, queries: ingestiondb.New(pool), dashboardURL: strings.TrimRight(dashboardURL, "/")}
 }
 
-func (s *Sweeper) sessionURL(sessionID string) *string {
+func (s *Sweeper) sessionURLAt(sessionID string, anchorMs int64) *string {
 	if sessionID == "" || s.dashboardURL == "" {
 		return nil
 	}
-	u := s.dashboardURL + "/sessions/" + url.PathEscape(sessionID)
+	u := s.dashboardURL + "/sessions/" + url.PathEscape(sessionID) + "?t=" + strconv.FormatInt(anchorMs, 10)
 	return &u
+}
+
+// replayURLFor resolves the coverage-gated watch pointer best-effort. The
+// replay link is optional garnish on a digest item: a transient lookup failure
+// must cost one link, never the customer's whole digest.
+func (s *Sweeper) replayURLFor(ctx context.Context, groupID, projectID string) *string {
+	sessionID, anchorMs, ok, err := s.queries.WatchableSessionForGroup(ctx, groupID, projectID)
+	if err != nil {
+		slog.Warn("digest replay lookup failed; omitting the link", "group_id", groupID, "project_id", projectID, "error", err)
+		return nil
+	}
+	if !ok {
+		return nil
+	}
+	return s.sessionURLAt(sessionID, anchorMs)
 }
 
 func rootCauseExcerpt(rootCause *string) *string {

--- a/packages/ingestion/priority/impact_test.go
+++ b/packages/ingestion/priority/impact_test.go
@@ -1,0 +1,230 @@
+package priority
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type impactStamp struct {
+	class     *string
+	visits    *int64
+	recovered *int64
+	computed  *time.Time
+}
+
+func seedImpactSession(t *testing.T, pool *pgxpool.Pool, projectID, envID, sessionID string) {
+	t.Helper()
+	mustExec(t, pool, `INSERT INTO sessions
+		(id, project_id, environment_id, started_at, status)
+		VALUES ($1, $2, $3, now(), 'recording')`, sessionID, projectID, envID)
+}
+
+func seedImpactChunk(t *testing.T, pool *pgxpool.Pool, projectID, sessionID string, seq int, firstMs, lastMs *int64) {
+	t.Helper()
+	mustExec(t, pool, `INSERT INTO session_chunks
+		(session_id, seq, project_id, object_key, has_full_snapshot, scrubbed_at, first_event_ms, last_event_ms)
+		VALUES ($1, $2, $3, $4, true, now(), $5, $6)`,
+		sessionID, seq, projectID, sessionID, firstMs, lastMs)
+}
+
+func seedImpactEvent(t *testing.T, pool *pgxpool.Pool, projectID, envID, groupID, sessionID string, at time.Time) {
+	t.Helper()
+	mustExec(t, pool, `INSERT INTO error_events
+		(project_id, environment_id, error_group_id, session_id, "timestamp", error_type, error_message, stack_trace_raw)
+		VALUES ($1, $2, $3, $4, $5, 'TypeError', 'boom', 'at test')`,
+		projectID, envID, groupID, sessionID, at)
+}
+
+func seedImpactSignal(t *testing.T, pool *pgxpool.Pool, projectID, envID, groupID, sessionID, fingerprint string, at time.Time, accepted bool) string {
+	t.Helper()
+	status := "accepted"
+	if !accepted {
+		status = "pending"
+	}
+	var id string
+	if err := pool.QueryRow(context.Background(), `INSERT INTO friction_signals
+		(session_id, project_id, environment_id, rule_version, signal_type, fingerprint,
+		 page_url_normalized, occurred_at, adjudication_status, incident_id)
+		VALUES ($1, $2, $3, 1, 'dead_click', $4, '/impact', $5, $6, $7)
+		RETURNING id`, sessionID, projectID, envID, fingerprint, at, status, groupID).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func readImpactStamp(t *testing.T, pool *pgxpool.Pool, groupID string) impactStamp {
+	t.Helper()
+	var got impactStamp
+	if err := pool.QueryRow(context.Background(), `SELECT impact_class, impact_visits,
+		impact_visits_recovered, impact_computed_at FROM error_groups WHERE id = $1`, groupID).
+		Scan(&got.class, &got.visits, &got.recovered, &got.computed); err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
+func assertImpact(t *testing.T, got impactStamp, class string, visits, recovered int64) {
+	t.Helper()
+	if got.class == nil || *got.class != class || got.visits == nil || *got.visits != visits ||
+		got.recovered == nil || *got.recovered != recovered || got.computed == nil {
+		t.Fatalf("impact = %#v, want %s %d/%d with computed_at", got, class, visits, recovered)
+	}
+}
+
+func assertUnknownImpact(t *testing.T, got impactStamp) {
+	t.Helper()
+	if got.class != nil || got.visits != nil || got.recovered != nil || got.computed != nil {
+		t.Fatalf("impact = %#v, want all NULL", got)
+	}
+}
+
+func TestImpactPassErrorLane(t *testing.T) {
+	pool := testPool(t)
+	_, projectID, envID := seedTenant(t, pool, nil)
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	blockedID := seedGroup(t, pool, projectID, envID, "impact-blocked", "error")
+	degradedID := seedGroup(t, pool, projectID, envID, "impact-degraded", "error")
+	invisibleID := seedGroup(t, pool, projectID, envID, "impact-invisible", "error")
+	unknownID := seedGroup(t, pool, projectID, envID, "impact-unknown", "error")
+	halfNullID := seedGroup(t, pool, projectID, envID, "impact-half-null", "error")
+	oldID := seedGroup(t, pool, projectID, envID, "impact-old", "error")
+	resolvedID := seedGroup(t, pool, projectID, envID, "impact-resolved", "error")
+	mustExec(t, pool, `UPDATE error_groups SET status='resolved' WHERE id=$1`, resolvedID)
+
+	seed := func(groupID, label string, lastOffsets ...time.Duration) {
+		for i, lastOffset := range lastOffsets {
+			sessionID := label + "-" + string(rune('a'+i)) + "-" + groupID
+			seedImpactSession(t, pool, projectID, envID, sessionID)
+			first, last := now.Add(-time.Minute).UnixMilli(), now.Add(lastOffset).UnixMilli()
+			seedImpactChunk(t, pool, projectID, sessionID, 0, &first, &last)
+			seedImpactEvent(t, pool, projectID, envID, groupID, sessionID, now)
+		}
+	}
+	seed(blockedID, "blocked", 5*time.Second, 10*time.Second)
+	seed(degradedID, "degraded", 5*time.Second, 17*time.Minute)
+	seed(invisibleID, "invisible", 2*time.Minute)
+
+	unknownSession := "unknown-" + unknownID
+	seedImpactSession(t, pool, projectID, envID, unknownSession)
+	seedImpactChunk(t, pool, projectID, unknownSession, 0, nil, nil)
+	seedImpactEvent(t, pool, projectID, envID, unknownID, unknownSession, now)
+
+	halfNullSession := "half-null-" + halfNullID
+	seedImpactSession(t, pool, projectID, envID, halfNullSession)
+	first, last := now.Add(-time.Minute).UnixMilli(), now.Add(2*time.Minute).UnixMilli()
+	seedImpactChunk(t, pool, projectID, halfNullSession, 0, nil, &last)
+	seedImpactChunk(t, pool, projectID, halfNullSession, 1, &first, nil)
+	seedImpactEvent(t, pool, projectID, envID, halfNullID, halfNullSession, now)
+
+	oldSession := "old-" + oldID
+	seedImpactSession(t, pool, projectID, envID, oldSession)
+	seedImpactChunk(t, pool, projectID, oldSession, 0, &first, &last)
+	seedImpactEvent(t, pool, projectID, envID, oldID, oldSession, now.Add(-31*24*time.Hour))
+
+	resolvedSession := "resolved-" + resolvedID
+	seedImpactSession(t, pool, projectID, envID, resolvedSession)
+	seedImpactChunk(t, pool, projectID, resolvedSession, 0, &first, &last)
+	seedImpactEvent(t, pool, projectID, envID, resolvedID, resolvedSession, now)
+
+	if _, err := (&Sweeper{Pool: pool}).RunOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertImpact(t, readImpactStamp(t, pool, blockedID), "blocked", 2, 0)
+	assertImpact(t, readImpactStamp(t, pool, degradedID), "degraded", 2, 1)
+	assertImpact(t, readImpactStamp(t, pool, invisibleID), "invisible", 1, 1)
+	assertUnknownImpact(t, readImpactStamp(t, pool, unknownID))
+	assertUnknownImpact(t, readImpactStamp(t, pool, halfNullID))
+	assertUnknownImpact(t, readImpactStamp(t, pool, oldID))
+	assertUnknownImpact(t, readImpactStamp(t, pool, resolvedID))
+}
+
+func TestImpactPassFrictionLaneAndFoldGuard(t *testing.T) {
+	pool := testPool(t)
+	_, projectID, envID := seedTenant(t, pool, nil)
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	frictionID := seedGroup(t, pool, projectID, envID, "impact-friction", "friction")
+	errorID := seedGroup(t, pool, projectID, envID, "impact-fold-guard", "error")
+
+	for i, offset := range []time.Duration{5 * time.Second, 10 * time.Minute} {
+		sessionID := "friction-" + string(rune('a'+i)) + "-" + frictionID
+		seedImpactSession(t, pool, projectID, envID, sessionID)
+		first, last := now.Add(-time.Minute).UnixMilli(), now.Add(offset).UnixMilli()
+		seedImpactChunk(t, pool, projectID, sessionID, 0, &first, &last)
+		seedImpactSignal(t, pool, projectID, envID, frictionID, sessionID, "fric-"+string(rune('a'+i)), now, true)
+	}
+
+	ignoredSession := "folded-" + errorID
+	seedImpactSession(t, pool, projectID, envID, ignoredSession)
+	first, last := now.Add(-time.Minute).UnixMilli(), now.Add(10*time.Minute).UnixMilli()
+	seedImpactChunk(t, pool, projectID, ignoredSession, 0, &first, &last)
+	seedImpactSignal(t, pool, projectID, envID, errorID, ignoredSession, "folded", now, true)
+	crashSession := "crash-" + errorID
+	seedImpactSession(t, pool, projectID, envID, crashSession)
+	deadLast := now.Add(5 * time.Second).UnixMilli()
+	seedImpactChunk(t, pool, projectID, crashSession, 0, &first, &deadLast)
+	seedImpactEvent(t, pool, projectID, envID, errorID, crashSession, now)
+
+	if _, err := (&Sweeper{Pool: pool}).RunOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertImpact(t, readImpactStamp(t, pool, frictionID), "degraded", 2, 1)
+	assertImpact(t, readImpactStamp(t, pool, errorID), "blocked", 1, 0)
+
+	// Pending and retracted signals are excluded from the active accepted set.
+	secondSession := "friction-b-" + frictionID
+	mustExec(t, pool, `UPDATE friction_signals SET retracted_at=now() WHERE incident_id=$1 AND session_id=$2`, frictionID, secondSession)
+	pendingSession := "pending-" + frictionID
+	seedImpactSession(t, pool, projectID, envID, pendingSession)
+	seedImpactChunk(t, pool, projectID, pendingSession, 0, &first, &last)
+	seedImpactSignal(t, pool, projectID, envID, frictionID, pendingSession, "pending", now, false)
+	if _, err := (&Sweeper{Pool: pool}).RunOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertImpact(t, readImpactStamp(t, pool, frictionID), "blocked", 1, 0)
+}
+
+func TestImpactPassClearsAgedStampOnce(t *testing.T) {
+	pool := testPool(t)
+	_, projectID, envID := seedTenant(t, pool, nil)
+	groupID := seedGroup(t, pool, projectID, envID, "impact-clear", "error")
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	sessionID := "clear-" + groupID
+	seedImpactSession(t, pool, projectID, envID, sessionID)
+	first, last := now.Add(-time.Minute).UnixMilli(), now.Add(2*time.Minute).UnixMilli()
+	seedImpactChunk(t, pool, projectID, sessionID, 0, &first, &last)
+	seedImpactEvent(t, pool, projectID, envID, groupID, sessionID, now)
+
+	sweeper := &Sweeper{Pool: pool}
+	conn, err := pool.Acquire(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Release()
+	if err := sweeper.stampImpact(context.Background(), conn); err != nil {
+		t.Fatal(err)
+	}
+	assertImpact(t, readImpactStamp(t, pool, groupID), "invisible", 1, 1)
+	mustExec(t, pool, `UPDATE error_events SET "timestamp"=now()-interval '31 days' WHERE error_group_id=$1`, groupID)
+	if err := sweeper.stampImpact(context.Background(), conn); err != nil {
+		t.Fatal(err)
+	}
+	assertUnknownImpact(t, readImpactStamp(t, pool, groupID))
+
+	var before, after string
+	if err := conn.QueryRow(context.Background(), `SELECT xmin::text FROM error_groups WHERE id=$1`, groupID).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+	if err := sweeper.stampImpact(context.Background(), conn); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.QueryRow(context.Background(), `SELECT xmin::text FROM error_groups WHERE id=$1`, groupID).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if before != after {
+		t.Fatalf("second unknown-impact pass rewrote row: xmin %s -> %s", before, after)
+	}
+}

--- a/packages/ingestion/priority/sweeper.go
+++ b/packages/ingestion/priority/sweeper.go
@@ -3,6 +3,7 @@ package priority
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sort"
 	"time"
@@ -27,6 +28,11 @@ const sweepAdvisoryLockKey int64 = 0x7072696F7269
 // grow without limit inside the process that also serves all HTTP traffic.
 // The winner is by far the most frequent URL, so a deep tail cannot change it.
 const maxURLsPerGroup = 20
+
+const (
+	impactWindowDays = 30
+	impactRecoveryMs = 60_000
+)
 
 // Raw URLs for open error groups, capped per group. Ranking happens in SQL so
 // the tail never reaches this process.
@@ -165,6 +171,95 @@ FROM (
 ) sub
 WHERE eg.id = sub.id`
 
+// ImpactRollupSelectSQL is shared with the planner regression test so the
+// measured query is exactly the query production materializes. Occurrence
+// time and chunk bounds are both client-clock values; created_at is not a
+// valid substitute for this arithmetic.
+var ImpactRollupSelectSQL = fmt.Sprintf(`
+WITH open_groups AS (
+  SELECT id, project_id, kind
+  FROM error_groups
+  WHERE status NOT IN ('resolved','merged','archived')
+), err_sess AS (
+  SELECT g.id AS group_id, e.project_id, e.session_id,
+         (max(extract(epoch FROM e."timestamp")) * 1000)::bigint AS last_hit_ms
+  FROM open_groups g
+  JOIN error_events e ON e.error_group_id = g.id AND e.project_id = g.project_id
+  WHERE g.kind = 'error'
+    AND e.session_id IS NOT NULL
+    AND e."timestamp" > now() - interval '%d days'
+  GROUP BY 1, 2, 3
+), fric_sess AS (
+  SELECT g.id AS group_id, fs.project_id, fs.session_id,
+         (max(extract(epoch FROM fs.occurred_at)) * 1000)::bigint AS last_hit_ms
+  FROM open_groups g
+  JOIN friction_signals fs ON fs.incident_id = g.id AND fs.project_id = g.project_id
+  WHERE g.kind = 'friction'
+    AND fs.adjudication_status = 'accepted'
+    AND fs.retracted_at IS NULL
+    AND fs.superseded_by IS NULL
+    AND fs.occurred_at > now() - interval '%d days'
+  GROUP BY 1, 2, 3
+), sess AS (
+  SELECT * FROM err_sess
+  UNION ALL
+  SELECT * FROM fric_sess
+), chunks AS (
+  -- Per-session LATERAL against the (session_id, seq) PK: the rollup's chunk
+  -- reads stay proportional to the in-window session set, never a scan of the
+  -- always-on-recording chunk table (the semi-join form left the planner free
+  -- to hash-join a full scan of scrubbed chunks every sweep).
+  SELECT sk.project_id, sk.session_id, agg.last_activity_ms
+  FROM (SELECT DISTINCT project_id, session_id FROM sess) sk
+  CROSS JOIN LATERAL (
+    SELECT max(c.last_event_ms) AS last_activity_ms
+    FROM session_chunks c
+    WHERE c.session_id = sk.session_id AND c.project_id = sk.project_id
+      AND c.scrubbed_at IS NOT NULL
+      AND c.first_event_ms IS NOT NULL
+      AND c.last_event_ms IS NOT NULL
+  ) agg
+  WHERE agg.last_activity_ms IS NOT NULL
+)
+SELECT sess.group_id,
+       count(*)::bigint AS visits,
+       (count(*) FILTER (
+          WHERE chunks.last_activity_ms >= sess.last_hit_ms + %d
+       ))::bigint AS recovered
+FROM sess
+JOIN chunks ON chunks.project_id = sess.project_id
+           AND chunks.session_id = sess.session_id
+GROUP BY 1`, impactWindowDays, impactWindowDays, impactRecoveryMs)
+
+const stampImpactSQL = `
+UPDATE error_groups g SET
+  impact_visits = r.visits,
+  impact_visits_recovered = r.recovered,
+  impact_class = CASE
+    WHEN r.recovered = 0 THEN 'blocked'
+    WHEN r.recovered < r.visits THEN 'degraded'
+    ELSE 'invisible'
+  END,
+  impact_computed_at = now()
+FROM impact_rollup r
+WHERE g.id = r.group_id
+  AND g.status NOT IN ('resolved','merged','archived')`
+
+const clearStaleImpactSQL = `
+UPDATE error_groups g SET
+  impact_class = NULL,
+  impact_visits = NULL,
+  impact_visits_recovered = NULL,
+  impact_computed_at = NULL
+WHERE g.status NOT IN ('resolved','merged','archived')
+  AND (g.impact_class IS NOT NULL
+       OR g.impact_visits IS NOT NULL
+       OR g.impact_visits_recovered IS NOT NULL
+       OR g.impact_computed_at IS NOT NULL)
+  AND NOT EXISTS (
+    SELECT 1 FROM impact_rollup r WHERE r.group_id = g.id
+  )`
+
 const enqueueRouteMapJobsSQL = `
 INSERT INTO error_group_jobs (project_id, job_type)
 SELECT p.id, 'route_map' FROM projects p
@@ -260,10 +355,40 @@ func (s *Sweeper) RunOnce(ctx context.Context) (int, error) {
 		}
 		updated += int(tag.RowsAffected())
 	}
+	if err := s.stampImpact(ctx, conn); err != nil {
+		return updated, fmt.Errorf("impact: %w", err)
+	}
 	if _, err := conn.Exec(ctx, enqueueRouteMapJobsSQL); err != nil {
 		return updated, err
 	}
 	return updated, nil
+}
+
+// stampImpact materializes both occurrence lanes and applies the stamp and
+// stale clear atomically on the advisory-lock connection held by RunOnce.
+func (s *Sweeper) stampImpact(ctx context.Context, conn *pgxpool.Conn) error {
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+
+	if _, err := tx.Exec(ctx, `CREATE TEMPORARY TABLE impact_rollup ON COMMIT DROP AS `+ImpactRollupSelectSQL); err != nil {
+		return fmt.Errorf("rollup: %w", err)
+	}
+	stamped, err := tx.Exec(ctx, stampImpactSQL)
+	if err != nil {
+		return fmt.Errorf("stamp: %w", err)
+	}
+	cleared, err := tx.Exec(ctx, clearStaleImpactSQL)
+	if err != nil {
+		return fmt.Errorf("clear stale: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	slog.Debug("priority impact pass", "groups_stamped", stamped.RowsAffected(), "groups_cleared", cleared.RowsAffected())
+	return nil
 }
 
 type routeTally struct {

--- a/packages/test-reliability/src/system/friction-ladder.system.test.ts
+++ b/packages/test-reliability/src/system/friction-ladder.system.test.ts
@@ -110,6 +110,35 @@ describe('friction ladder system tracer (provider twins)', () => {
       [tenant.projectId],
     );
     const groupId = group.rows[0]!.id;
+
+    // C3: the friction auto-fix rung reads the live signal-session impact bar
+    // (>=1 identified user or >=3 anon sessions in the last 7 days) instead of
+    // the model's confidence, so the incident needs recorded reach before any
+    // automated attempt is authorized.
+    const environment = await db.query<{ id: string }>(
+      `SELECT id FROM environments WHERE project_id = $1 LIMIT 1`,
+      [tenant.projectId],
+    );
+    const environmentId = environment.rows[0]!.id;
+    await db.query(
+      `INSERT INTO sessions (id, project_id, environment_id, started_at, status)
+       VALUES ('friction-ladder-session', $1, $2, now() - interval '5 minutes', 'closed')`,
+      [tenant.projectId, environmentId],
+    );
+    const endUser = await db.query<{ id: string }>(
+      `INSERT INTO end_users (project_id, external_user_id, email)
+       VALUES ($1, 'friction-ladder-user', 'ladder@fixture.invalid') RETURNING id`,
+      [tenant.projectId],
+    );
+    await db.query(
+      `INSERT INTO friction_signals
+         (session_id, project_id, environment_id, end_user_id, rule_version, signal_type,
+          fingerprint, page_url_normalized, occurred_at, adjudication_status, incident_id)
+       VALUES ('friction-ladder-session', $1, $2, $3, 3, 'rage_click',
+               'fp-friction-ladder-signal', '/settings', now() - interval '5 minutes', 'accepted', $4)`,
+      [tenant.projectId, environmentId, endUser.rows[0]!.id, groupId],
+    );
+
     await db.query(
       `INSERT INTO error_group_jobs (error_group_id, project_id, job_type) VALUES ($1, $2, 'investigate')`,
       [groupId, tenant.projectId],
@@ -176,7 +205,8 @@ describe('friction ladder system tracer (provider twins)', () => {
       [groupId],
     );
     expect(afterFix.rows[0]).toEqual({
-      status: 'pr_created',
+      // C2 terminal posture: automated PRs are drafts, always.
+      status: 'pr_draft',
       pr_number: pull.number,
       pr_fix_job_id: fixJob!.id,
     });

--- a/packages/test-reliability/src/system/worker-success.system.test.ts
+++ b/packages/test-reliability/src/system/worker-success.system.test.ts
@@ -241,6 +241,9 @@ describe('event-to-pr reliability system tracer', () => {
     expect(jobs.rows).toEqual([
       { job_type: 'investigate', status: 'completed' },
       { job_type: 'fix', status: 'completed' },
+      // C2: automated PRs open as drafts, and a draft delivery enqueues the CI
+      // watcher that will report the draft's checks back onto the incident.
+      { job_type: 'ci_watch', status: 'pending' },
     ]);
 
     // Reading an incident needs a signed-in user, not the ingest key. The
@@ -254,23 +257,28 @@ describe('event-to-pr reliability system tracer', () => {
     expect(incident).toMatchObject({
       id: accepted.group_id,
       project_id: tenant.projectId,
-      status: 'pr_created',
+      // C2 terminal posture: automated PRs are drafts, always.
+      status: 'pr_draft',
       confidence: 'high',
       pr_url: `https://github.test/${githubRepo}/pull/42`,
     });
     expect(await scanReliabilityInvariants(db)).toEqual([]);
 
-    // 8 calls under the citation + fail-first contracts: investigation
+    // 9 calls under the citation + fail-first + judge contracts: investigation
     // read_file + submit_diagnosis, fix edit/test/declare_failing_test/finish,
-    // judge, and narrative. Anchor the judge call by content rather than
-    // hard-coding every position.
-    expect(providers.anthropicJournal).toHaveLength(8);
+    // the diff judge, C2's instrument judge (its own session), and narrative.
+    // Anchor the judge calls by content rather than hard-coding positions.
+    expect(providers.anthropicJournal).toHaveLength(9);
     expect(toolNames(providers.anthropicJournal[0]!.body)).toContain('submit_diagnosis');
     const judgeCalls = providers.anthropicJournal.filter(
       (entry) => toolNames(entry.body).includes('score_diff'),
     );
     expect(judgeCalls).toHaveLength(1);
     expect(toolNames(judgeCalls[0]!.body)).toEqual(['score_diff']);
+    const instrumentJudgeCalls = providers.anthropicJournal.filter(
+      (entry) => toolNames(entry.body).includes('submit_judge_verdict'),
+    );
+    expect(instrumentJudgeCalls).toHaveLength(1);
     // Durable delivery reconciles before it creates: the pipeline looks for an
     // existing open PR on the stable branch, probes the branch head (absent →
     // push), and createPR runs its own idempotency lookup before the one POST.

--- a/packages/worker/src/__tests__/db-queries.test.ts
+++ b/packages/worker/src/__tests__/db-queries.test.ts
@@ -416,16 +416,34 @@ describe('session replay pointer queries', () => {
   beforeEach(() => mockQuery.mockReset());
 
   it('resolves the newest session pointer with event time and project scope', async () => {
-    mockQuery.mockResolvedValueOnce({
-      rows: [{ session_id: 'sess-1', error_at: new Date('2026-07-15T12:00:00Z') }],
-    });
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ kind: 'error' }] })
+      .mockResolvedValueOnce({
+        rows: [{ session_id: 'sess-1', error_at: new Date('2026-07-15T12:00:00Z') }],
+      });
 
     const pointer = await getSessionPointerForGroup('g1', 'p1');
 
     expect(pointer).toEqual({ session_id: 'sess-1', error_at: '2026-07-15T12:00:00.000Z' });
-    expect(mockQuery.mock.calls[0][1]).toEqual(['g1', 'p1']);
-    expect(mockQuery.mock.calls[0][0]).toContain('ee.timestamp AS error_at');
-    expect(mockQuery.mock.calls[0][0]).not.toContain('scrubbed_at');
+    expect(mockQuery.mock.calls[1][1]).toEqual(['g1', 'p1']);
+    expect(mockQuery.mock.calls[1][0]).toContain('ee.timestamp AS error_at');
+    expect(mockQuery.mock.calls[1][0]).not.toContain('scrubbed_at');
+  });
+
+  it('uses the live friction representative with earliest accepted fallback ordering', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ kind: 'friction' }] })
+      .mockResolvedValueOnce({
+        rows: [{ session_id: 'sess-friction', error_at: '2026-07-15T12:00:00Z' }],
+      });
+
+    await expect(getSessionPointerForGroup('g1', 'p1')).resolves.toEqual({
+      session_id: 'sess-friction', error_at: '2026-07-15T12:00:00Z',
+    });
+    const query = String(mockQuery.mock.calls[1]?.[0]);
+    expect(query).toContain("fs.adjudication_status = 'accepted'");
+    expect(query).toContain('fs.retracted_at IS NULL');
+    expect(query).toContain('(fs.id = g.representative_signal_id) DESC');
   });
 
   it('returns scrubbed chunk metadata in sequence order and normalizes bigint strings', async () => {

--- a/packages/worker/src/__tests__/db.test.ts
+++ b/packages/worker/src/__tests__/db.test.ts
@@ -26,6 +26,7 @@ import {
   loadDiagnosisDecision,
   loadDiagnosisDecisionForSource,
   getGroupImpactBar,
+  getFrictionGroupImpactBar,
   insertFixRunLedger,
 } from '../db.js';
 import { createLedgerRecorder } from '../verification-ledger.js';
@@ -455,6 +456,75 @@ describeDb('db.ts integration tests', () => {
       expect(await getGroupImpactBar(errorGroupId, testProjectId)).toMatchObject({
         identifiedUsers: 1,
         eligible: true,
+      });
+    });
+
+    it('uses accepted active friction sessions and the server-observed seven-day window', async () => {
+      const environment = await testPool.query<{ id: string }>(
+        `INSERT INTO environments (project_id, name) VALUES ($1, $2) RETURNING id`,
+        [testProjectId, `friction-impact-${crypto.randomUUID()}`],
+      );
+      const user = await testPool.query<{ id: string }>(
+        `INSERT INTO end_users (project_id, external_user_id) VALUES ($1, $2) RETURNING id`,
+        [testProjectId, `friction-impact-user-${crypto.randomUUID()}`],
+      );
+      const seedGroup = async (label: string): Promise<string> => {
+        const result = await testPool.query<{ id: string }>(
+          `INSERT INTO error_groups
+             (project_id, environment_id, fingerprint, title, first_seen, last_seen, status, kind)
+           VALUES ($1, $2, $3, $3, now(), now(), 'insight', 'friction') RETURNING id`,
+          [testProjectId, environment.rows[0]!.id, `${label}-${crypto.randomUUID()}`],
+        );
+        return result.rows[0]!.id;
+      };
+      const seedSignal = async (options: {
+        groupId: string; sessionId: string; fingerprint: string;
+        endUserId?: string; status?: string; retracted?: boolean; old?: boolean;
+      }): Promise<void> => {
+        await testPool.query(
+          `INSERT INTO sessions (id, project_id, environment_id, started_at)
+           VALUES ($1, $2, $3, now()) ON CONFLICT (id) DO NOTHING`,
+          [options.sessionId, testProjectId, environment.rows[0]!.id],
+        );
+        await testPool.query(
+          `INSERT INTO friction_signals
+             (session_id, project_id, environment_id, end_user_id, rule_version, signal_type,
+              fingerprint, page_url_normalized, occurred_at, adjudication_status, incident_id,
+              retracted_at, created_at)
+           VALUES ($1,$2,$3,$4,1,'dead_click',$5,'/impact',now(),$6,$7,
+                   CASE WHEN $8 THEN now() ELSE NULL END,
+                   CASE WHEN $9 THEN now()-interval '8 days' ELSE now() END)`,
+          [options.sessionId, testProjectId, environment.rows[0]!.id, options.endUserId ?? null,
+            options.fingerprint, options.status ?? 'accepted', options.groupId,
+            options.retracted ?? false, options.old ?? false],
+        );
+      };
+
+      const identified = await seedGroup('identified');
+      const mixedSession = `mixed-${crypto.randomUUID()}`;
+      await seedSignal({ groupId: identified, sessionId: mixedSession, fingerprint: 'identified', endUserId: user.rows[0]!.id });
+      await seedSignal({ groupId: identified, sessionId: mixedSession, fingerprint: 'anonymous-in-mixed' });
+      await expect(getFrictionGroupImpactBar(identified, testProjectId)).resolves.toEqual({
+        identifiedUsers: 1, recentAnonSessions: 0, eligible: true,
+      });
+
+      const anonymous = await seedGroup('anonymous');
+      for (let i = 0; i < 3; i++) {
+        await seedSignal({ groupId: anonymous, sessionId: `anon-${i}-${crypto.randomUUID()}`, fingerprint: `anon-${i}` });
+      }
+      await expect(getFrictionGroupImpactBar(anonymous, testProjectId)).resolves.toEqual({
+        identifiedUsers: 0, recentAnonSessions: 3, eligible: true,
+      });
+
+      const below = await seedGroup('below');
+      for (let i = 0; i < 2; i++) {
+        await seedSignal({ groupId: below, sessionId: `below-${i}-${crypto.randomUUID()}`, fingerprint: `below-${i}` });
+      }
+      await seedSignal({ groupId: below, sessionId: `retracted-${crypto.randomUUID()}`, fingerprint: 'retracted', retracted: true });
+      await seedSignal({ groupId: below, sessionId: `pending-${crypto.randomUUID()}`, fingerprint: 'pending', status: 'pending' });
+      await seedSignal({ groupId: below, sessionId: `old-${crypto.randomUUID()}`, fingerprint: 'old', old: true });
+      await expect(getFrictionGroupImpactBar(below, testProjectId)).resolves.toEqual({
+        identifiedUsers: 0, recentAnonSessions: 2, eligible: false,
       });
     });
   });

--- a/packages/worker/src/__tests__/index.test.ts
+++ b/packages/worker/src/__tests__/index.test.ts
@@ -44,6 +44,16 @@ vi.mock('../db.js', () => ({
   finalizeDelivery: vi.fn(),
   recordJobUsage: vi.fn(),
   getGroupImpactBar: vi.fn(async () => ({ identifiedUsers: 1, recentAnonSessions: 0, eligible: true })),
+  getFrictionGroupImpactBar: vi.fn(async () => ({ identifiedUsers: 5, recentAnonSessions: 0, eligible: true })),
+  // Pure shape helper: mirror the real implementation so decision assertions
+  // see the exact persisted policy fields.
+  policyFields: (bar: { identifiedUsers: number; recentAnonSessions: number; eligible: boolean } | null) =>
+    bar
+      ? {
+          policyEligible: bar.eligible,
+          policyBasis: { v: 1, identified_users: bar.identifiedUsers, recent_anon_sessions: bar.recentAnonSessions },
+        }
+      : { policyEligible: null, policyBasis: null },
 }));
 vi.mock('../logger.js', () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
@@ -904,22 +914,51 @@ describe('friction worker path', () => {
     },
   );
 
-  it('parks medium-confidence friction even when autonomy allows auto-fix', async () => {
+  it('routes identical code-caused friction verdicts identically regardless of confidence', async () => {
     mockGetProject.mockResolvedValue({
       id: 'proj-1', name: 'app', github_repo: 'org/app', default_branch: 'main', friction_autonomy: 'auto_fix',
     });
+    vi.mocked(db.updateGroupAndCreateFixJob).mockResolvedValue({ created: true, fixJobId: 'fix-job' });
+    for (const confidence of ['high', 'low'] as const) {
+      vi.mocked(investigateFriction).mockResolvedValueOnce({
+        status: 'verdict', investigatedCommit: 'abc123', costUsd: 0.1,
+        usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+        verdict: { codeCause: true, confidence, reason: 'save handler is disconnected', remediation: 'wire the handler', evidence: [], agentTaskBrief: 'wire it' },
+      });
+      await processInvestigateJob(makeJob(), new AbortController().signal);
+    }
+
+    expect(db.updateGroupAndCreateFixJob).toHaveBeenCalledTimes(2);
+    for (const call of vi.mocked(db.updateGroupAndCreateFixJob).mock.calls) {
+      expect(call[2].decision).toMatchObject({
+        policyEligible: true,
+        policyBasis: { v: 1, identified_users: 5, recent_anon_sessions: 0 },
+      });
+    }
+  });
+
+  it('parks below-bar code-caused friction with its policy basis', async () => {
+    mockGetProject.mockResolvedValue({
+      id: 'proj-1', name: 'app', github_repo: 'org/app', default_branch: 'main', friction_autonomy: 'auto_fix',
+    });
+    vi.mocked(db.getFrictionGroupImpactBar).mockResolvedValueOnce({ identifiedUsers: 0, recentAnonSessions: 1, eligible: false });
     vi.mocked(investigateFriction).mockResolvedValue({
       status: 'verdict', investigatedCommit: 'abc123', costUsd: 0.1,
       usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
-      verdict: { codeCause: true, confidence: 'medium', reason: 'save handler is disconnected', remediation: 'wire the handler', evidence: [], agentTaskBrief: 'wire it' },
+      verdict: { codeCause: true, confidence: 'high', reason: 'save handler is disconnected', remediation: 'wire the handler', evidence: [], agentTaskBrief: 'wire it' },
     });
 
     await processInvestigateJob(makeJob(), new AbortController().signal);
 
-    expect(db.updateGroupInvestigation).toHaveBeenCalledWith(
-      'grp-1', 'proj-1', 'awaiting_approval', expect.objectContaining({ confidence: 'medium' }), makeJob(),
-    );
     expect(db.updateGroupAndCreateFixJob).not.toHaveBeenCalled();
+    expect(db.updateGroupInvestigation).toHaveBeenCalledWith(
+      'grp-1', 'proj-1', 'awaiting_approval', expect.objectContaining({
+        decision: expect.objectContaining({
+          policyEligible: false,
+          policyBasis: { v: 1, identified_users: 0, recent_anon_sessions: 1 },
+        }),
+      }), makeJob(),
+    );
   });
 
   it('records friction without a code cause as an insight', async () => {

--- a/packages/worker/src/__tests__/pr.test.ts
+++ b/packages/worker/src/__tests__/pr.test.ts
@@ -345,6 +345,25 @@ describe('buildPRBody', () => {
     expect(body).not.toContain('**Confidence:** High · ✅ Tests passing');
   });
 
+  it('keeps the friction caveat above a ledger-rendered verification section', () => {
+    const common = {
+      jobId: 'job-1', projectId: 'proj-1', runId: 'run-1',
+      workdirDirty: false, discovered: 1, passed: 1, failed: 0, skipped: 0,
+      truncated: false, timedOut: false, notRun: [] as string[],
+    };
+    const body = buildPRBody(makeInput({
+      kind: 'friction',
+      tierRecord: { tier: 'attempted', declaredTest: null, reproductionImpossibleReason: null },
+      ledger: [{ ...common, entrySeq: 1, command: 'vitest run', commitSha: 'fix1234567890' }],
+      ledgerRoles: [{ entrySeq: 1, role: 'suite_post_patch' }],
+    }));
+
+    // The ledger proves the code change; it cannot prove the friction is gone.
+    expect(body).toContain('friction itself was not re-verified');
+    expect(body).toContain('suite: 1 passed');
+    expect(body.indexOf('friction itself was not re-verified')).toBeLessThan(body.indexOf('suite: 1 passed'));
+  });
+
   it('renders the typed narrative in context-first order', () => {
     const body = buildPRBody(makeInput({
       narrative: {

--- a/packages/worker/src/db.ts
+++ b/packages/worker/src/db.ts
@@ -204,6 +204,27 @@ export interface ImpactBar {
   eligible: boolean;
 }
 
+export function impactBarEligible(identifiedUsers: number, recentAnonSessions: number): boolean {
+  return identifiedUsers >= 1 || recentAnonSessions >= 3;
+}
+
+/** The one place the persisted policy stamp is shaped: both lanes' decision
+ * rows must serialize the same policy_basis record or per-lane consumers of
+ * the versioned shape silently diverge. */
+export function policyFields(bar: ImpactBar | null): { policyEligible: boolean | null; policyBasis: { v: 1; identified_users: number; recent_anon_sessions: number } | null } {
+  if (!bar) {
+    return { policyEligible: null, policyBasis: null };
+  }
+  return {
+    policyEligible: bar.eligible,
+    policyBasis: {
+      v: 1,
+      identified_users: bar.identifiedUsers,
+      recent_anon_sessions: bar.recentAnonSessions,
+    },
+  };
+}
+
 export async function getGroupImpactBar(errorGroupId: string, projectId: string): Promise<ImpactBar> {
   const { rows } = await getPool().query<{
     identified_users: string;
@@ -227,7 +248,41 @@ export async function getGroupImpactBar(errorGroupId: string, projectId: string)
   return {
     identifiedUsers,
     recentAnonSessions,
-    eligible: identifiedUsers >= 1 || recentAnonSessions >= 3,
+    eligible: impactBarEligible(identifiedUsers, recentAnonSessions),
+  };
+}
+
+/** Live impact bar over accepted, active sessions for a friction incident.
+ * The authorization window uses server-observed created_at; occurred_at is a
+ * client clock and is reserved for playback arithmetic. */
+export async function getFrictionGroupImpactBar(errorGroupId: string, projectId: string): Promise<ImpactBar> {
+  const { rows } = await getPool().query<{
+    identified_users: string;
+    recent_anon_sessions: string;
+  }>(
+    `WITH active AS (
+       -- One definition of "the incident's live reach": both aggregates below
+       -- must count over the same signal population.
+       SELECT fs.session_id, fs.end_user_id
+         FROM friction_signals fs
+        WHERE fs.incident_id = $1 AND fs.project_id = $2
+          AND fs.adjudication_status = 'accepted'
+          AND fs.retracted_at IS NULL AND fs.superseded_by IS NULL
+          AND fs.created_at > now() - interval '7 days'
+     )
+     SELECT
+       (SELECT count(DISTINCT end_user_id) FROM active WHERE end_user_id IS NOT NULL) AS identified_users,
+       (SELECT count(*) FROM (
+          SELECT session_id FROM active GROUP BY session_id HAVING bool_and(end_user_id IS NULL)
+        ) anon) AS recent_anon_sessions`,
+    [errorGroupId, projectId],
+  );
+  const identifiedUsers = Number(rows[0]?.identified_users ?? 0);
+  const recentAnonSessions = Number(rows[0]?.recent_anon_sessions ?? 0);
+  return {
+    identifiedUsers,
+    recentAnonSessions,
+    eligible: impactBarEligible(identifiedUsers, recentAnonSessions),
   };
 }
 
@@ -1731,22 +1786,42 @@ export interface SessionPointer {
   error_at: string;
 }
 
-/** Resolves pointer identity independently from chunk readiness. */
+/** Resolves pointer identity independently from chunk readiness. This mirror
+ * serves both error and friction fix evidence, so it matches the Go reader's
+ * representative-first friction fallback. */
 export async function getSessionPointerForGroup(
   errorGroupId: string,
   projectId: string,
 ): Promise<SessionPointer | null> {
   const pool = getPool();
+  const kindResult = await pool.query<{ kind: 'error' | 'friction' }>(
+    `SELECT kind FROM error_groups WHERE id = $1 AND project_id = $2`,
+    [errorGroupId, projectId],
+  );
+  const kind = kindResult.rows[0]?.kind;
+  if (!kind) return null;
+  const query = kind === 'friction'
+    ? `SELECT fs.session_id, fs.occurred_at AS error_at
+         FROM friction_signals fs
+         JOIN sessions s ON s.id = fs.session_id AND s.project_id = fs.project_id
+         JOIN error_groups g ON g.id = $1 AND g.project_id = $2
+        WHERE fs.incident_id = $1 AND fs.project_id = $2
+          AND fs.adjudication_status = 'accepted'
+          AND fs.retracted_at IS NULL AND fs.superseded_by IS NULL
+          AND s.status <> 'deleting'
+        ORDER BY (fs.id = g.representative_signal_id) DESC, fs.occurred_at ASC, fs.id ASC
+        LIMIT 1`
+    : `SELECT ee.session_id, ee.timestamp AS error_at
+         FROM error_events ee
+         JOIN sessions s ON s.id = ee.session_id AND s.project_id = $2
+        WHERE ee.error_group_id = $1
+          AND ee.project_id = $2
+          AND ee.session_id IS NOT NULL
+          AND s.status <> 'deleting'
+        ORDER BY ee.created_at DESC, ee.id DESC
+        LIMIT 1`;
   const { rows } = await pool.query<{ session_id: string; error_at: Date | string }>(
-    `SELECT ee.session_id, ee.timestamp AS error_at
-       FROM error_events ee
-       JOIN sessions s ON s.id = ee.session_id AND s.project_id = $2
-      WHERE ee.error_group_id = $1
-        AND ee.project_id = $2
-        AND ee.session_id IS NOT NULL
-        AND s.status <> 'deleting'
-      ORDER BY ee.created_at DESC, ee.id DESC
-      LIMIT 1`,
+    query,
     [errorGroupId, projectId],
   );
   const row = rows[0];

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -641,14 +641,7 @@ export async function processInvestigateJob(job: ClaimedJob & { errorGroupId: st
       // run at all, and outcome alone cannot answer that.
       basis: triage.decisionBasis,
       confidence: triage.confidence,
-      ...(impactBar ? {
-        policyEligible: impactBar.eligible,
-        policyBasis: {
-          v: 1 as const,
-          identified_users: impactBar.identifiedUsers,
-          recent_anon_sessions: impactBar.recentAnonSessions,
-        },
-      } : {}),
+      ...db.policyFields(impactBar),
     };
 
     /** Set when the result is held for a human instead of opening a fix job. */
@@ -907,6 +900,9 @@ export async function processFrictionInvestigateJob(
     }
 
     const verdict = result.verdict;
+    const impactBar = verdict.codeCause
+      ? await db.getFrictionGroupImpactBar(job.errorGroupId, job.projectId)
+      : null;
     const decision = {
       outcome: verdict.codeCause ? 'code_fix' as const : 'not_actionable' as const,
       decisionReason: verdict.reason,
@@ -922,6 +918,7 @@ export async function processFrictionInvestigateJob(
       jobId: job.id,
       basis: 'friction_classify' as const,
       confidence: verdict.confidence,
+      ...db.policyFields(impactBar),
     };
 
     if (verdict.codeCause) {
@@ -929,9 +926,7 @@ export async function processFrictionInvestigateJob(
       // fixes exist; insights remain terminal and never produce a PR.
       const autonomyAllowsFix = project.friction_autonomy === 'auto_fix'
         || project.friction_autonomy === 'auto_fix_ux';
-      // C3 replaces this confidence check with the signal-session impact bar
-      // (program plan §C3); frozen, not endorsed — see C2 plan Task 3.
-      if (verdict.confidence === 'high' && autonomyAllowsFix && job.triggeredBy !== 'reinvestigate_report_only') {
+      if (impactBar?.eligible && autonomyAllowsFix && job.triggeredBy !== 'reinvestigate_report_only') {
         // allowFriction is the ladder's explicit opt-in past the kind gate;
         // refuse-by-default stays intact for every other caller (issue #56).
         const fixResult = await updateGroupAndCreateFixJob(job.errorGroupId, job.projectId, {

--- a/packages/worker/src/pr.ts
+++ b/packages/worker/src/pr.ts
@@ -413,7 +413,15 @@ function buildLedgerLines(input: PRInput): string[] | null {
 
 export function buildVerificationSection(input: PRInput): string {
   const ledgerLines = buildLedgerLines(input);
-  if (ledgerLines) return `${VERIFICATION_START}\n${ledgerLines.join('\n')}\n${VERIFICATION_END}`;
+  if (ledgerLines) {
+    // The ledger proves the code change; for friction it cannot prove the
+    // customer-visible friction is gone, so the suggestion caveat survives
+    // above the executed-check lines.
+    const lines = input.kind === 'friction'
+      ? ['**Confidence:** Suggestion · ⚠️ The friction itself was not re-verified — review before merging', ...ledgerLines]
+      : ledgerLines;
+    return `${VERIFICATION_START}\n${lines.join('\n')}\n${VERIFICATION_END}`;
+  }
   let content: string;
   if (input.kind === 'friction') {
     const lines = [


### PR DESCRIPTION
Program checkpoint C3 (`docs/superpowers/plans/2026-08-10-unified-actionable-program-plan.md` §C3; implementation plan `docs/superpowers/plans/2026-08-11-c3-impact-readiness-session-pointers.md`, Codex-cleared after 2 rounds).

## What this ships

**Impact stamps (W3.1).** The priority sweeper gains a transactional pass computing `impact_class`/`impact_visits`/`impact_visits_recovered`/`impact_computed_at` on open incidents from session recordings — both lanes through one temp-table rollup (error events by client `"timestamp"`, accepted-active friction signals by `occurred_at`, both compared against chunk event-ms bounds). Recovered = last activity ≥ 60s past the session's last hit; unknown = all four columns NULL (one representation); stale stamps clear once and are never rewritten (no WAL churn). Migration 046 adds the two supporting partial indexes.

**Watchable session pointers (W3.2).** `SessionPointerForGroup` gains the friction branch: representative signal first, earliest-accepted fallback when it is retracted/superseded — the friction incident page now has a working player with zero dashboard changes. New `WatchableSessionForGroup` returns a pointer only when the session's scrubbed, bounded chunks stitch across the full ±15s window and a full-snapshot chunk opens it; digest replay links come from it with an absolute-ms `?t=` anchor. Links that exist can play; links that can't play don't exist.

**Readiness backfill (W3.B).** One-shot migration 047 classifies every open, absent-row incident: receipt states (`pr_created`/`pr_draft`/diff- or usable-evidence-bearing `needs_human`) and structurally validated causes stay `eligible`; everything else goes `pending`. This retires C1's absent-row digest policy ahead of C4's eligible-only flip — **deploy note below**.

**Friction fix routing (Task 9).** The auto-fix rung reads the live signal-session impact bar (≥1 identified user or ≥3 anon sessions, server-clock 7-day window) instead of `confidence === 'high'`, discharging C2's frozen-rung debt; both lanes stamp `policy_eligible`/`policy_basis` via one shared helper.

## Review + hardening

`/code-review medium` returned 8 findings (no correctness bugs); all addressed in this diff: best-effort digest replay resolution (one failed lookup costs one link, never the digest), bounded friction candidate pool, LATERAL chunk probes in the rollup (the semi-join left the planner free to scan the whole chunk table), falsifiable chunk-side planner bound (20k cold-ballast rows), shared coverage/friction-candidate/kind SQL fragments, single-CTE friction bar, shared `policyFields`, per-session dedup in the error candidate pool, and the dead un-anchored `sessionURL` deleted.

One test-stability fix worth reviewer eyes: the planner test was flaky because 001's single-column `idx_error_events_group` sometimes wins the cost race against the 046 composite and filters 40k aged rows (observed live). The test now asserts **usability** deterministically (competing indexes dropped in a rolled-back transaction; ratios land at exactly 1.00x). **Follow-up question for a later PR:** `idx_error_events_group` looks redundant next to 039's `(error_group_id, created_at)` — dropping it would also remove the prod-side cost race.

## Verification

- `pnpm -r build`; worker suite 1053 passed / 6 pre-existing skips (DB-gated suites on a disposable database); `go build ./... && go test ./...` all 17 packages ok.
- AC3.8 planner artifact: `error_events=20000 (1.00x), friction_signals=500 (1.00x)`, chunk bound ≤3x with 20k cold chunks seeded; indexes `idx_error_events_group_timestamp` + `idx_friction_signals_incident_occurred` asserted in-plan.
- CP3 `/opslane-verify:verify` run: **8/8 drivable criteria passed** against the live stack (real sweeper, real browser playback on the friction fallback session, real worker + checked-in model stub, 047 on a disposable DB). Artifacts: `.verify/runs/20260812-155016/` (casts, screenshot, report). Bonus witness: the full receipt chain ran live — validated investigation → auto fix attempt → `('eligible','fix_attempt_failed_no_diff')`.

## Deploy notes (from the plan's runbook — release-time steps, not in this PR)

1. Before the release containing 047 reaches prod: rehearse the backfill SELECT on a prod copy (`~/deploy/scripts/prod-sql.sh`), record per-class counts; a surprise stops the release.
2. Impact-first gate: confirm `max(impact_computed_at)` postdates this PR's deploy before 047 lands, so the flipped digest carries stamps.
3. Post-apply invariant: zero open incidents without a readiness row.
4. The flip is customer-visible by design: unverified legacy incidents leave the digest and their pages show the honest state; receipt/validated legacy keeps rendering. In-place correction preferred over the documented transactional rollback.

Two smaller notes: the incident-page `?t=` is second-precision (the pointer's RFC3339 `error_at` contract, identical on the error lane); the TS pointer mirror gained the friction branch because fix evidence consumes it for both kinds.