### PR TITLE
feat(ingestion): internal status-only incident read for the deploy smoke

### DIFF
--- a/docs/architecture/trust.md
+++ b/docs/architecture/trust.md
@@ -79,7 +79,7 @@ See [replay privacy and masking](../guides/replay-privacy.md) for what replay da
 - **User sessions** are JWTs signed with `JWT_SECRET`, mated with rotating refresh-token families (token hashes only in the database).
 - **Passwords** (when password authentication is enabled) are not stored locally — registration, authentication, and reset are handled by the configured identity provider (WorkOS).
 - **GitHub App private key**, **Langfuse credentials** (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`), and other worker credentials are environment variables — supplied by your deployment, never written to the database.
-- **Internal read token** (`INTERNAL_READ_TOKEN`) is an environment variable — supplied by your deployment, never written to the database.
+- **Internal read token** (`INTERNAL_READ_TOKEN`) is an environment variable — supplied by your deployment, never written to the database. Authenticates internal operational endpoints.
 - **Notification webhook URLs** are encrypted at rest in the database; the encryption key is supplied as an environment variable.
 - **Agent onboarding sessions** store poll tokens as hashes and API keys sealed with ephemeral agent public keys (24-hour expiry); raw values are shown once at provisioning. Provisioning requires admin role.
 - **Pending OAuth verification tokens** from identity providers are sealed and stored temporarily (10-minute TTL) during email verification flows; the encryption key is supplied as an environment variable.

--- a/docs/architecture/trust.md
+++ b/docs/architecture/trust.md
@@ -79,6 +79,7 @@ See [replay privacy and masking](../guides/replay-privacy.md) for what replay da
 - **User sessions** are JWTs signed with `JWT_SECRET`, mated with rotating refresh-token families (token hashes only in the database).
 - **Passwords** (when password authentication is enabled) are not stored locally — registration, authentication, and reset are handled by the configured identity provider (WorkOS).
 - **GitHub App private key**, **Langfuse credentials** (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`), and other worker credentials are environment variables — supplied by your deployment, never written to the database.
+- **Internal read token** (`INTERNAL_READ_TOKEN`) is an environment variable — supplied by your deployment, never written to the database.
 - **Notification webhook URLs** are encrypted at rest in the database; the encryption key is supplied as an environment variable.
 - **Agent onboarding sessions** store poll tokens as hashes and API keys sealed with ephemeral agent public keys (24-hour expiry); raw values are shown once at provisioning. Provisioning requires admin role.
 - **Pending OAuth verification tokens** from identity providers are sealed and stored temporarily (10-minute TTL) during email verification flows; the encryption key is supplied as an environment variable.

--- a/docs/reference/http-routes.md
+++ b/docs/reference/http-routes.md
@@ -109,6 +109,7 @@ The agent callback requires `code`, `installation_id`, and UUID `state`; definit
 | Method | Path | Auth | Purpose |
 | --- | --- | --- | --- |
 | GET | `/internal/v1/projects/{projectID}/sessions/{sessionID}/chunks/{seq}` | `X-Internal-Token` | Worker fetch of one decoded, re-redacted scrubbed chunk |
+| GET | `/internal/v1/projects/{projectID}/incidents/{incidentID}/status` | `X-Internal-Token` | Status-only incident read for the deployment smoke test |
 
 ## Method mismatch
 

--- a/packages/ingestion/handler/internal_status.go
+++ b/packages/ingestion/handler/internal_status.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// GetIncidentStatusInternal returns only the lifecycle status of one incident.
+// The deployment smoke test holds the internal read token but no user session,
+// and the status string is what it needs to confirm the worker finished. The
+// full incident (title, stack, diff, evidence) stays behind session auth.
+func (d *Dependencies) GetIncidentStatusInternal(w http.ResponseWriter, r *http.Request) {
+	projectID := chi.URLParam(r, "projectID")
+	incidentID := chi.URLParam(r, "incidentID")
+	// error_groups keys are uuid columns; a malformed id would fail the cast
+	// inside Postgres and surface as a 500 rather than a miss.
+	if _, err := uuid.Parse(projectID); err != nil {
+		writeJSONError(w, http.StatusNotFound, "incident not found")
+		return
+	}
+	if _, err := uuid.Parse(incidentID); err != nil {
+		writeJSONError(w, http.StatusNotFound, "incident not found")
+		return
+	}
+
+	group, err := d.Queries.GetErrorGroup(r.Context(), projectID, incidentID)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to get incident")
+		return
+	}
+	if group == nil {
+		writeJSONError(w, http.StatusNotFound, "incident not found")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": group.Status})
+}

--- a/packages/ingestion/handler/internal_status.go
+++ b/packages/ingestion/handler/internal_status.go
@@ -13,20 +13,22 @@ import (
 // and the status string is what it needs to confirm the worker finished. The
 // full incident (title, stack, diff, evidence) stays behind session auth.
 func (d *Dependencies) GetIncidentStatusInternal(w http.ResponseWriter, r *http.Request) {
-	projectID := chi.URLParam(r, "projectID")
-	incidentID := chi.URLParam(r, "incidentID")
 	// error_groups keys are uuid columns; a malformed id would fail the cast
-	// inside Postgres and surface as a 500 rather than a miss.
-	if _, err := uuid.Parse(projectID); err != nil {
+	// inside Postgres and surface as a 500 rather than a miss. Query with the
+	// canonical form: uuid.Parse also accepts urn:uuid: and braced spellings,
+	// which Postgres's cast does not.
+	projectID, err := uuid.Parse(chi.URLParam(r, "projectID"))
+	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "incident not found")
 		return
 	}
-	if _, err := uuid.Parse(incidentID); err != nil {
+	incidentID, err := uuid.Parse(chi.URLParam(r, "incidentID"))
+	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "incident not found")
 		return
 	}
 
-	group, err := d.Queries.GetErrorGroup(r.Context(), projectID, incidentID)
+	group, err := d.Queries.GetErrorGroup(r.Context(), projectID.String(), incidentID.String())
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to get incident")
 		return
@@ -37,5 +39,9 @@ func (d *Dependencies) GetIncidentStatusInternal(w http.ResponseWriter, r *http.
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	// Custom-header auth means shared caches don't apply the Authorization
+	// heuristics; forbid caching so an edge rule can never serve a stale
+	// status or bypass the token check for a cached URL.
+	w.Header().Set("Cache-Control", "no-store")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": group.Status})
 }

--- a/packages/ingestion/handler/internal_status_test.go
+++ b/packages/ingestion/handler/internal_status_test.go
@@ -1,0 +1,102 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opslane/opslane/packages/ingestion/db"
+	"github.com/opslane/opslane/packages/ingestion/handler"
+)
+
+func TestIncidentStatusInternal_TokenGuard(t *testing.T) {
+	path := "/internal/v1/projects/p/incidents/i/status"
+
+	t.Setenv("INTERNAL_READ_TOKEN", "")
+	disabled := handler.NewRouter(&handler.Dependencies{})
+	response := httptest.NewRecorder()
+	disabled.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("unset token returned %d", response.Code)
+	}
+
+	t.Setenv("INTERNAL_READ_TOKEN", "expected-token")
+	guarded := handler.NewRouter(&handler.Dependencies{})
+	for _, token := range []string{"", "wrong-token"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("X-Internal-Token", token)
+		response = httptest.NewRecorder()
+		guarded.ServeHTTP(response, req)
+		if response.Code != http.StatusUnauthorized {
+			t.Fatalf("token %q returned %d", token, response.Code)
+		}
+	}
+}
+
+func TestIncidentStatusInternal_ReturnsStatusOnly(t *testing.T) {
+	deps, _ := testDeps(t)
+	ctx := context.Background()
+	_, projectID, envID, _ := seedTenant(t, deps.Queries)
+
+	result, err := deps.Queries.InsertErrorEventAndGroup(ctx, db.IngestParams{
+		ProjectID:            projectID,
+		DefaultEnvironmentID: envID,
+		ErrorType:            "DeploySmokeError",
+		ErrorMessage:         "internal-status-smoke",
+		StackTraceRaw:        "at deploy.sh:1:1",
+		Fingerprint:          "fp-internal-status",
+		Title:                "DeploySmokeError: internal-status-smoke",
+	})
+	if err != nil {
+		t.Fatalf("InsertErrorEventAndGroup: %v", err)
+	}
+	group, err := deps.Queries.GetErrorGroup(ctx, projectID, result.GroupID)
+	if err != nil || group == nil {
+		t.Fatalf("GetErrorGroup: group=%v err=%v", group, err)
+	}
+
+	t.Setenv("INTERNAL_READ_TOKEN", "test-internal-token")
+	router := handler.NewRouter(deps)
+	request := func(path string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("X-Internal-Token", "test-internal-token")
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, req)
+		return response
+	}
+
+	response := request(fmt.Sprintf(
+		"/internal/v1/projects/%s/incidents/%s/status", projectID, result.GroupID))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status read returned %d: %s", response.Code, response.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["status"] != group.Status {
+		t.Fatalf("status = %q, want %q", body["status"], group.Status)
+	}
+	if len(body) != 1 {
+		t.Fatalf("response has extra fields beyond status: %v", body)
+	}
+
+	// A valid but foreign project UUID must not resolve the incident.
+	response = request(fmt.Sprintf(
+		"/internal/v1/projects/00000000-0000-0000-0000-000000000000/incidents/%s/status",
+		result.GroupID))
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("cross-project read returned %d", response.Code)
+	}
+
+	// Malformed ids miss cleanly instead of failing the uuid cast in Postgres.
+	response = request(fmt.Sprintf(
+		"/internal/v1/projects/%s/incidents/not-a-uuid/status", projectID))
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("malformed incident id returned %d", response.Code)
+	}
+}

--- a/packages/ingestion/handler/internal_status_test.go
+++ b/packages/ingestion/handler/internal_status_test.go
@@ -74,6 +74,9 @@ func TestIncidentStatusInternal_ReturnsStatusOnly(t *testing.T) {
 	if response.Code != http.StatusOK {
 		t.Fatalf("status read returned %d: %s", response.Code, response.Body.String())
 	}
+	if cc := response.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", cc)
+	}
 	var body map[string]string
 	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -98,5 +101,18 @@ func TestIncidentStatusInternal_ReturnsStatusOnly(t *testing.T) {
 		"/internal/v1/projects/%s/incidents/not-a-uuid/status", projectID))
 	if response.Code != http.StatusNotFound {
 		t.Fatalf("malformed incident id returned %d", response.Code)
+	}
+	response = request(fmt.Sprintf(
+		"/internal/v1/projects/not-a-uuid/incidents/%s/status", result.GroupID))
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("malformed project id returned %d", response.Code)
+	}
+
+	// uuid.Parse accepts spellings Postgres's uuid cast does not; the handler
+	// canonicalizes, so these resolve instead of 500ing on the cast.
+	response = request(fmt.Sprintf(
+		"/internal/v1/projects/%s/incidents/urn:uuid:%s/status", projectID, result.GroupID))
+	if response.Code != http.StatusOK {
+		t.Fatalf("urn:uuid incident id returned %d: %s", response.Code, response.Body.String())
 	}
 }

--- a/packages/ingestion/handler/routes.go
+++ b/packages/ingestion/handler/routes.go
@@ -80,6 +80,11 @@ func NewRouterWithPool(deps *Dependencies, pool *pgxpool.Pool) *chi.Mux {
 		func(w http.ResponseWriter, r *http.Request) {
 			deps.serveChunk(w, r, chi.URLParam(r, "projectID"))
 		})
+	// Status-only incident read for the deployment smoke test, which holds the
+	// internal token but no user session (project API keys deliberately cannot
+	// read incidents; see the S1 project-keys design).
+	r.With(RequireInternalToken).Get("/internal/v1/projects/{projectID}/incidents/{incidentID}/status",
+		deps.GetIncidentStatusInternal)
 
 	r.Route("/api/v1", func(r chi.Router) {
 		// SDK endpoints (authenticated by ingest-scoped project key).


### PR DESCRIPTION
## Why

The production deploy smoke test posts an event with a project key, then polls the incident to confirm the worker drove it to a terminal state. Since S1 withdrew API-key reads (#243 — a project key ships in a public bundle and must not read customer data), that poll has 401ed on every deploy: every `deploy.sh` run since v26.8.0 ends with a false "smoke failed".

## What

- `GET /internal/v1/projects/{projectID}/incidents/{incidentID}/status` behind the existing `RequireInternalToken` gate (same pattern as the worker→ingestion chunk read), returning only `{"status": "..."}`.
- UUID params are validated up front so a malformed id misses with 404 instead of failing the uuid cast in Postgres.
- Tests: token guard (503 unconfigured, 401 wrong/missing) and an integration test proving the status-only body, cross-project 404, and malformed-id 404.

Deliberately **not** an API-key route — this respects the S1 decision. The internal token is a deployment secret, never shipped to browsers.

## Verification

`go build`, `go vet`, and the full `./handler/` test package (including the route auth-matrix tests) pass locally against a migrated Postgres 16. The deploy-repo counterpart switches `deploy.sh` polling to this route.