### PR TITLE
Pipeline rewrite: Slice 0 digest repairs and Slice 1 inert storage + identity contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,6 +89,34 @@ confidence at decision time, and the PR outcome (merged/closed) later via
 the job queue when the GitHub webhook lands.
 _Avoid_: "eval" (scores record what happened; evals judge it)
 
+**Product context**:
+A project-owned, evolving account of what its routes and actions do, grounded in
+repository code and observed sessions. Every claim carries its evidence and
+confidence; missing context means unknown, never unimportant.
+_Avoid_: "route weight" (one ranking input), "product truth" (the account is partial)
+
+**Observation**:
+One captured error or friction signal. It is evidence that exists before Opslane
+has necessarily decided which problem it belongs to.
+_Avoid_: "issue" (identity may still be unsettled), "occurrence" (a count of observations)
+
+**Capture bucket**:
+A provisional collection of observations that share an immediately available raw
+fingerprint. It may appear as processing, but owns no impact or lifecycle decision.
+_Avoid_: "issue", "canonical group"
+
+**Canonical issue**:
+The durable identity of one customer problem. It owns impact, admission,
+investigation, lifecycle, and publication; many observations and fingerprints may
+belong to it.
+_Avoid_: "capture bucket", "error group" when canonical identity is intended
+
+**Fingerprint alias**:
+A versioned association from one exact fingerprint to a canonical issue. Raw,
+resolved, and component fingerprints may alias the same issue without being
+rewritten.
+_Avoid_: "canonical fingerprint" (an issue may have several equally valid aliases)
+
 ## Relationships
 
 - A **Project** has any number of active keys per **Scope**; minting never
@@ -103,6 +131,10 @@ _Avoid_: "eval" (scores record what happened; evals judge it)
   time; the URL routes uploads, the keyid+secret authenticate them.
 - Reads require a **User session**; writes require a key whose **Scope**
   matches the route.
+- An **Observation** belongs to one **Capture bucket** while identity is being
+  settled and to one **Canonical issue** after settlement.
+- A **Canonical issue** may have many **Fingerprint aliases**; each alias identifies
+  at most one canonical issue within a project and identity version.
 
 ## Flagged ambiguities
 

--- a/docs/contracts/events.md
+++ b/docs/contracts/events.md
@@ -30,12 +30,13 @@ outage we cannot hotfix.
 
 | Field | Meaning |
 | --- | --- |
-| `event_id` | Stable identifier for the stored observation. |
-| `group_id` | **Provisional capture handle.** It opens the processing item; it is not a stable issue identifier. Reads through it resolve or redirect to the canonical issue after identity settles. |
-| `error_group_id` | Deprecated alias for `group_id`, retained for compatibility. |
+| `event_id` | Identifier for the stored observation. Empty when the event was suppressed. |
+| `group_id` | **Provisional capture handle.** It identifies the processing item the event landed in; clients must not treat it as a stable issue identifier. Today it carries the current grouping row's id; once the identity pipeline lands, reads through it will resolve or redirect to the canonical issue. |
+| `error_group_id` | Deprecated alias for `group_id`, retained for compatibility. The two fields always carry the same value. |
 
-Suppressed events return an empty `group_id`. Clients must accept an empty value
-and must not use either group field as a durable issue key.
+Suppressed events return all three identifier fields empty plus
+`"suppressed": true`. Clients must accept empty values and must not use either
+group field as a durable issue key.
 
 ## Enforcement
 

--- a/docs/contracts/events.md
+++ b/docs/contracts/events.md
@@ -24,6 +24,19 @@ outage we cannot hotfix.
   file. Everything under `test-fixtures/wire/` is append-only — including its
   README — so document fixture provenance here instead.
 
+## Response
+
+`POST /api/v1/events` returns:
+
+| Field | Meaning |
+| --- | --- |
+| `event_id` | Stable identifier for the stored observation. |
+| `group_id` | **Provisional capture handle.** It opens the processing item; it is not a stable issue identifier. Reads through it resolve or redirect to the canonical issue after identity settles. |
+| `error_group_id` | Deprecated alias for `group_id`, retained for compatibility. |
+
+Suppressed events return an empty `group_id`. Clients must accept an empty value
+and must not use either group field as a durable issue key.
+
 ## Enforcement
 
 - `packages/ingestion/handler/wire_compat_test.go` (`go` CI job) replays every

--- a/docs/superpowers/plans/2026-08-16-pipeline-rewrite.md
+++ b/docs/superpowers/plans/2026-08-16-pipeline-rewrite.md
@@ -1,0 +1,4603 @@
+# Opslane Pipeline Rewrite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace synchronous write-time grouping with an asynchronous pipeline where identity settles after stack resolution, a cheap mechanical filter and an inquiry gate investigation, and a daily AI pass writes the customer's message from completed work.
+
+**Architecture:** Capture stores observations and decides nothing. A worker resolves stacks to source locations; Go binds fingerprints to a stable issue through an alias table rather than rewriting keys. A mechanical filter answers "enough reach, recently, in scope"; an inquiry with read-only repository access answers "is this a real product problem". Only work passing both is investigated. Postgres stays the queue.
+
+**Tech Stack:** Go 1.24 (chi, pgx) in `packages/ingestion`; Node 22 + TypeScript (vitest) in `packages/worker`; PostgreSQL; Cloudflare R2 for recordings and source maps.
+
+**Spec:** `docs/superpowers/specs/2026-08-15-pipeline-architecture-design.md`, with build order in `docs/superpowers/specs/2026-08-16-pipeline-implementation-plan.md` and decisions in `docs/superpowers/specs/2026-08-16-pipeline-design-record.md`.
+
+## Global Constraints
+
+- **Next migration number is 054.** The highest present is `053_delivery_policy.sql`.
+- **Every migration must be reapply-safe.** `run-migrations.sh` re-applies every file on every start. Use `CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, and `DO $$ ... IF NOT EXISTS ... END $$` guards for constraints.
+- **Never edit or delete a frozen fixture under `test-fixtures/wire/`.** New grouping fixtures live elsewhere. The `POST /api/v1/events` request contract is append-only.
+- **Do not introduce Redis, BullMQ, or a workflow engine.** Postgres is the queue.
+- **Every new table carries `project_id`** and is scoped by it in every query.
+- **The version column is `rule_version`** (singular), matching `friction_signals.rule_version`. Not `rules_version`.
+- **Nothing may read `sample_event_id`** for identity, evidence selection, or investigation. `db/queries.go:588` rewrites it on every event.
+- **Go alone computes fingerprints.** TypeScript writes a structured envelope; Go normalizes, serializes, and hashes.
+- **New server-side packages default to `AGPL-3.0-only`.**
+- **Go DB tests follow the existing guard**: read `os.Getenv("DATABASE_URL")`, `pgxpool.New`, and `t.Skipf` when unreachable (`digest/build_test.go:23-33`). Before accepting the cutover candidate, confirm **zero** skipped Go tests.
+- **Worker tests are vitest**, colocated in `packages/worker/src/__tests__/`, run with `pnpm --filter @opslane/worker test`.
+
+## Deploy boundaries
+
+Tasks 1 through 4 ship to production alone. Tasks 5 through 29 accumulate in one release candidate and are **not deployed individually**: Task 8 stops the request creating issues, and nothing creates them again until Tasks 12 and 14A settle identity and Tasks 18 and 19A admit work. Task 30 performs the cutover. Lettered tasks (12A, 14A, 16A, 19A, 25A, 28A) sit in sequence at their number and carry the same rules as the rest.
+
+## File structure
+
+| Path | Responsibility |
+| --- | --- |
+| `packages/ingestion/db/migrations/054_pipeline_rewrite.sql` | All new tables, inert until used |
+| `packages/ingestion/grouping/fingerprint.go` | Asset-hash regex fix (Task 3) |
+| `packages/ingestion/identity/` | New Go package: alias lookup, settlement, conflicts |
+| `packages/ingestion/identity/settle.go` | `Settle(ctx, observationID)` and its transaction |
+| `packages/ingestion/identity/alias.go` | Alias binding and conflict recording |
+| `packages/ingestion/identity/canonical.go` | Canonical string from the resolved envelope |
+| `packages/ingestion/filter/` | New Go package: the cheap filter |
+| `packages/ingestion/filter/evaluate.go` | `Evaluate(ctx, roundID)` and decision append |
+| `packages/ingestion/digest/freeze.go` | Daily candidate freeze |
+| `packages/ingestion/digest/validate.go` | Validation of AI-written payloads |
+| `packages/worker/src/resolve/` | Resolution job and position cache |
+| `packages/worker/src/inquiry/` | Inquiry prompt, schema, and job |
+| `packages/worker/src/product-context/` | Repository understanding job |
+| `packages/worker/src/digest-writer/` | Daily writing job |
+| `test-fixtures/grouping/resolved-envelope-v2.json` | Shared Go/TS golden fixture |
+
+---
+
+# Slice 0: repair the current message (deploys alone)
+
+### Task 1: Filter digest cards on occurrence time
+
+**Files:**
+- Modify: `packages/ingestion/digest/build.go:64`
+- Test: `packages/ingestion/digest/build_test.go`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: no new symbols; changes the WHERE clause of `receiptItemsFromClause`
+
+The digest currently selects on `digest_readiness.updated_at`, which is bookkeeping, not occurrence time. Two independent bugs follow: stale problems appear, and `worker/src/db.ts:141-147` only bumps `updated_at` when status or reason changed, so a re-investigation landing on the same values freezes a row out of every future window.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestReceiptItemsExcludeStaleProblems(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	// Readiness updated inside the window, but the problem stopped 10 days ago.
+	staleID := seedEligibleGroup(t, pool, projectID, seedOpts{
+		LastSeen:          time.Now().Add(-10 * 24 * time.Hour),
+		ReadinessUpdated:  time.Now().Add(-1 * time.Hour),
+	})
+	freshID := seedEligibleGroup(t, pool, projectID, seedOpts{
+		LastSeen:         time.Now().Add(-2 * time.Hour),
+		ReadinessUpdated: time.Now().Add(-1 * time.Hour),
+	})
+
+	items, err := ReceiptItems(ctx, pool, projectID,
+		time.Now().Add(-24*time.Hour), time.Now())
+	if err != nil {
+		t.Fatalf("ReceiptItems: %v", err)
+	}
+	ids := map[string]bool{}
+	for _, it := range items {
+		ids[it.IncidentID] = true
+	}
+	if ids[staleID] {
+		t.Errorf("stale problem (last_seen 10d ago) must not appear")
+	}
+	if !ids[freshID] {
+		t.Errorf("fresh problem must appear")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./digest -run TestReceiptItemsExcludeStaleProblems -v`
+Expected: FAIL, stale problem appears in the item list.
+
+- [ ] **Step 3: Add the liveness predicate**
+
+In `receiptItemsFromClause`, keep the readiness window and add a liveness bound on the group:
+
+```go
+AND dr.updated_at >= $2 AND dr.updated_at < $3
+AND g.last_seen >= now() - interval '7 days'
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./digest -run TestReceiptItemsExcludeStaleProblems -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/digest/build.go packages/ingestion/digest/build_test.go
+git commit -m "fix(digest): exclude problems that stopped occurring"
+```
+
+---
+
+### Task 2: Render approval states as requests
+
+**Files:**
+- Modify: `packages/ingestion/digest/build.go:186-198`
+- Test: `packages/ingestion/digest/build_test.go`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `receiptState` returns `awaiting_approval` and `pr_draft` distinctly
+
+`receiptState` has a catch-all `default: return "report_ready"` that swallows `awaiting_approval`. That state is real and means "code cause found, fix written, parked for a human" (`shared/src/types.ts:172`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestReceiptStateSurfacesApproval(t *testing.T) {
+	cases := map[string]string{
+		"awaiting_approval": "awaiting_approval",
+		"pr_draft":          "pr_draft",
+		"investigated":      "report_ready",
+	}
+	for groupStatus, want := range cases {
+		if got := receiptState(groupStatus, ""); got != want {
+			t.Errorf("receiptState(%q) = %q, want %q", groupStatus, got, want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/ingestion && go test ./digest -run TestReceiptStateSurfacesApproval -v`
+Expected: FAIL, `awaiting_approval` returns `report_ready`.
+
+- [ ] **Step 3: Add the explicit cases before the default**
+
+```go
+case "awaiting_approval":
+	return "awaiting_approval"
+case "pr_draft":
+	return "pr_draft"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/ingestion && go test ./digest -run TestReceiptStateSurfacesApproval -v`
+Expected: PASS
+
+- [ ] **Step 5: Update the card copy**
+
+In `packages/ingestion/narrative/narrative.go:84`, replace the `report_ready` sentence "Investigation report ready." with copy that names the action. For `awaiting_approval`: `"A fix is written and needs your approval."` For `report_ready` where no action exists: `"We could not establish a cause. Details in the issue."`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ingestion/digest/build.go packages/ingestion/digest/build_test.go packages/ingestion/narrative/narrative.go
+git commit -m "fix(digest): surface approval requests instead of report_ready"
+```
+
+---
+
+### Task 3: Normalize dot-separated content hashes
+
+**Files:**
+- Modify: `packages/ingestion/grouping/fingerprint.go:20`
+- Test: `packages/ingestion/grouping/fingerprint_test.go`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `reAssetToken` accepts `.` as well as `-` before the hash
+
+`reAssetToken` requires a hyphen before the content hash. AMFJ's Vite bundles are `entry-index.CaWHNXv4.js`, hash after a dot, so normalization never fires and every deploy mints a new identity. Measured on 466 production events, a dot-tolerant regex collapses 71 groups to 63 with zero groups holding more than one distinct message. `looksLikeHash` (eight or more characters, at least one digit) is what keeps `vue.runtime.esm.js` intact.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestFingerprintCollapsesDotSeparatedHashes(t *testing.T) {
+	stack1 := "at handler (entry-index.CaWHNXv4.js:17:78242)"
+	stack2 := "at handler (entry-index.DXhxKZv7.js:17:78242)"
+	a := Fingerprint("javascript", "TypeError", "boom", stack1)
+	b := Fingerprint("javascript", "TypeError", "boom", stack2)
+	if a != b {
+		t.Errorf("dot-separated hashes must collapse: %s != %s", a, b)
+	}
+}
+
+func TestFingerprintKeepsLibraryNames(t *testing.T) {
+	a := Fingerprint("javascript", "TypeError", "boom", "at f (vue.runtime.esm.js:1:1)")
+	b := Fingerprint("javascript", "TypeError", "boom", "at f (vue.runtime.prod.js:1:1)")
+	if a == b {
+		t.Errorf("distinct library files must not collapse")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify the first fails**
+
+Run: `cd packages/ingestion && go test ./grouping -run 'TestFingerprintCollapsesDotSeparatedHashes|TestFingerprintKeepsLibraryNames' -v`
+Expected: first FAILS, second PASSES.
+
+- [ ] **Step 3: Widen the separator**
+
+```go
+reAssetToken = regexp.MustCompile(`([A-Za-z0-9_.]+)[-.]([A-Za-z0-9_]+)\.(js|mjs|cjs|css|map)(\?[^\s:'")]*)?(:\d+:\d+)?`)
+```
+
+- [ ] **Step 4: Run the full grouping suite**
+
+Run: `cd packages/ingestion && go test ./grouping -v`
+Expected: PASS, including all pre-existing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/grouping/fingerprint.go packages/ingestion/grouping/fingerprint_test.go
+git commit -m "fix(grouping): normalize dot-separated bundle content hashes"
+```
+
+---
+
+### Task 4: Deploy Slice 0
+
+**Files:**
+- Modify: deploy repository ECS task definition (outside this repository)
+
+**Interfaces:**
+- Consumes: Tasks 1 through 3
+- Produces: a production digest with working links
+
+`DASHBOARD_URL` is already read at `packages/ingestion/main.go:147` and plumbed through `docker-compose.yml:96`. It is unset in production, so `BuildIncidentURL` returns empty (`notify/url.go:12-15`) and `slackDigestLink` degrades to plain text (`notify/slack_digest.go:371-378`).
+
+- [ ] **Step 1: Set `DASHBOARD_URL` in the production task definition**
+
+Set it to the dashboard origin. This is a deploy-repository change, not a code change.
+
+- [ ] **Step 2: Generate a digest from a production day and click every link**
+
+Run the digest sweep against production and open every link in the payload. Expected: every link resolves; no card describes a problem last seen more than seven days ago; approval requests read as requests.
+
+- [ ] **Step 3: Record the result**
+
+Append the generated digest and the link-check outcome to the cutover evidence file. This is the A3, A5, and A6 evidence.
+
+---
+
+# Slice 1: inert storage and shared contracts
+
+### Task 5: Create the pipeline tables
+
+**Files:**
+- Create: `packages/ingestion/db/migrations/054_pipeline_rewrite.sql`
+- Test: `packages/ingestion/db/migrations_test.go`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: tables `error_capture_buckets`, `error_event_resolutions`, `sourcemap_position_cache`, `error_event_identities`, `canonical_issue_fingerprints`, `issue_episodes`, `issue_decisions`, `issue_inquiry_decisions`, `issue_evidence_anchors`, `issue_publications`, `digest_runs`, `digest_run_items`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestMigration054CreatesPipelineTables(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	want := []string{
+		"error_capture_buckets", "error_event_resolutions", "sourcemap_position_cache",
+		"error_event_identities", "canonical_issue_fingerprints", "issue_episodes",
+		"issue_decisions", "issue_inquiry_decisions", "issue_evidence_anchors",
+		"issue_publications", "digest_runs", "digest_run_items",
+		"issue_alias_conflicts", "issue_merges", "session_request_failures",
+		"session_write_rollups",
+	}
+	for _, table := range want {
+		var exists bool
+		err := pool.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+			  WHERE table_schema='public' AND table_name=$1)`, table).Scan(&exists)
+		if err != nil {
+			t.Fatalf("query %s: %v", table, err)
+		}
+		if !exists {
+			t.Errorf("table %s missing", table)
+		}
+	}
+}
+
+func TestMigration054IsReapplySafe(t *testing.T) {
+	pool := testPool(t)
+	sql, err := os.ReadFile("migrations/054_pipeline_rewrite.sql")
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := pool.Exec(context.Background(), string(sql)); err != nil {
+			t.Fatalf("apply %d: %v", i+1, err)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./db -run 'TestMigration054' -v`
+Expected: FAIL, tables missing.
+
+- [ ] **Step 3: Write the migration**
+
+Order matters: `issue_episodes` must be created before `error_event_identities`,
+which carries a foreign key to it. A forward reference makes the whole file fail to
+apply, and because `run-migrations.sh` re-applies every file on every start, that
+failure blocks boot rather than showing up later.
+
+```sql
+-- 054_pipeline_rewrite.sql , asynchronous identity, filtering, the inquiry stage, publication.
+-- Inert until the runtime paths land. IDEMPOTENCY IS MANDATORY.
+
+CREATE TABLE IF NOT EXISTS error_capture_buckets (
+  project_id       UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  raw_fingerprint  TEXT NOT NULL,
+  identity_version INTEGER NOT NULL,
+  first_seen       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, identity_version, raw_fingerprint)
+);
+
+CREATE TABLE IF NOT EXISTS error_event_resolutions (
+  project_id       UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  event_id         UUID NOT NULL REFERENCES error_events(id) ON DELETE CASCADE,
+  status           TEXT NOT NULL CHECK (status IN ('resolved','no_map','failed','pending')),
+  envelope         JSONB,
+  resolver_version INTEGER NOT NULL,
+  resolved_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, event_id)
+);
+
+CREATE TABLE IF NOT EXISTS sourcemap_position_cache (
+  project_id        UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  debug_id          TEXT NOT NULL,
+  map_content_sha   TEXT NOT NULL,
+  resolver_version  INTEGER NOT NULL,
+  generated_line    INTEGER NOT NULL,
+  generated_column  INTEGER NOT NULL,
+  original_file     TEXT,
+  original_function TEXT,
+  original_line     INTEGER,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, debug_id, map_content_sha, resolver_version,
+               generated_line, generated_column)
+);
+
+CREATE TABLE IF NOT EXISTS issue_episodes (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id         UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  canonical_issue_id UUID NOT NULL REFERENCES error_groups(id) ON DELETE CASCADE,
+  sequence           INTEGER NOT NULL,
+  opened_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  closed_at          TIMESTAMPTZ,
+  UNIQUE (project_id, canonical_issue_id, sequence)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_one_open_episode
+  ON issue_episodes (canonical_issue_id) WHERE closed_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS error_event_identities (
+  project_id           UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  event_id             UUID NOT NULL REFERENCES error_events(id) ON DELETE CASCADE,
+  -- 'settling' is the claim marker: the loop sets it before doing the work so a
+  -- second replica cannot pick the same row up. A crash leaves it here, which is
+  -- why the reset sweep below exists.
+  status               TEXT NOT NULL CHECK (status IN ('pending','settling','settled','conflict')),
+  claimed_at           TIMESTAMPTZ,
+  canonical_issue_id   UUID REFERENCES error_groups(id) ON DELETE SET NULL,
+  raw_fingerprint      TEXT NOT NULL,
+  resolved_fingerprint TEXT,
+  identity_version     INTEGER NOT NULL,
+  -- The work round this observation belongs to. Without it the filter would
+  -- count every historical event against every episode of the issue.
+  episode_id           UUID REFERENCES issue_episodes(id) ON DELETE SET NULL,
+  settled_at           TIMESTAMPTZ,
+  PRIMARY KEY (project_id, event_id)
+);
+CREATE INDEX IF NOT EXISTS idx_identities_pending
+  ON error_event_identities (project_id, status) WHERE status = 'pending';
+
+CREATE TABLE IF NOT EXISTS canonical_issue_fingerprints (
+  project_id         UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  fingerprint        TEXT NOT NULL,
+  fingerprint_kind   TEXT NOT NULL CHECK (fingerprint_kind IN ('raw','resolved','friction')),
+  canonical_issue_id UUID NOT NULL REFERENCES error_groups(id) ON DELETE CASCADE,
+  identity_version   INTEGER NOT NULL,
+  confirmed_by       TEXT NOT NULL CHECK (confirmed_by IN ('exact','model','human')),
+  bound_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, identity_version, fingerprint)
+);
+CREATE INDEX IF NOT EXISTS idx_alias_by_issue
+  ON canonical_issue_fingerprints (canonical_issue_id);
+
+CREATE TABLE IF NOT EXISTS issue_merges (
+  id            BIGSERIAL PRIMARY KEY,
+  project_id    UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  winner_id     UUID NOT NULL REFERENCES error_groups(id) ON DELETE CASCADE,
+  loser_id      UUID NOT NULL REFERENCES error_groups(id) ON DELETE CASCADE,
+  confirmed_by  TEXT NOT NULL CHECK (confirmed_by IN ('model','human')),
+  actor         TEXT,
+  aliases_moved INTEGER NOT NULL,
+  events_moved  INTEGER NOT NULL,
+  merged_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS issue_alias_conflicts (
+  id             BIGSERIAL PRIMARY KEY,
+  project_id     UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  event_id       UUID NOT NULL REFERENCES error_events(id) ON DELETE CASCADE,
+  left_issue_id  UUID NOT NULL REFERENCES error_groups(id) ON DELETE CASCADE,
+  right_issue_id UUID NOT NULL REFERENCES error_groups(id) ON DELETE CASCADE,
+  status         TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open','resolved','dismissed')),
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_conflicts_open
+  ON issue_alias_conflicts (project_id, status) WHERE status = 'open';
+
+CREATE TABLE IF NOT EXISTS issue_decisions (
+  id           BIGSERIAL PRIMARY KEY,
+  project_id   UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  episode_id   UUID NOT NULL REFERENCES issue_episodes(id) ON DELETE CASCADE,
+  decision     TEXT NOT NULL CHECK (decision IN ('open_inquiry','watch','inactive','out_of_scope')),
+  reason       TEXT NOT NULL,
+  users_7d     INTEGER NOT NULL,
+  anon_7d      INTEGER NOT NULL,
+  rule_version INTEGER NOT NULL,
+  decided_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_decisions_latest
+  ON issue_decisions (project_id, episode_id, decided_at DESC, id DESC);
+
+CREATE TABLE IF NOT EXISTS issue_inquiry_decisions (
+  id             BIGSERIAL PRIMARY KEY,
+  project_id     UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  episode_id     UUID NOT NULL REFERENCES issue_episodes(id) ON DELETE CASCADE,
+  decision       TEXT NOT NULL CHECK (decision IN ('investigate','wait_for_more_evidence','do_not_pursue')),
+  reason         TEXT NOT NULL,
+  brief          TEXT,
+  related_issues UUID[] NOT NULL DEFAULT '{}',
+  evaluated_units INTEGER NOT NULL,
+  -- What the inquiry actually looked at. The reopen gate compares against this
+  -- rather than raw counts, so a changed route map or new failure kind can
+  -- reopen even when the unit count did not move.
+  evidence_signature TEXT NOT NULL,
+  model          TEXT NOT NULL,
+  prompt_version INTEGER NOT NULL,
+  decided_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_inquiry_latest
+  ON issue_inquiry_decisions (project_id, episode_id, decided_at DESC, id DESC);
+
+CREATE TABLE IF NOT EXISTS issue_evidence_anchors (
+  project_id  UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  episode_id  UUID NOT NULL REFERENCES issue_episodes(id) ON DELETE CASCADE,
+  anchor_kind TEXT NOT NULL CHECK (anchor_kind IN ('threshold','first','recent')),
+  event_id    UUID NOT NULL REFERENCES error_events(id) ON DELETE CASCADE,
+  frozen_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, episode_id, anchor_kind)
+);
+
+CREATE TABLE IF NOT EXISTS issue_publications (
+  project_id  UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  episode_id  UUID NOT NULL REFERENCES issue_episodes(id) ON DELETE CASCADE,
+  channel     TEXT NOT NULL CHECK (channel IN ('immediate','post_triage','digest')),
+  published_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, episode_id, channel)
+);
+
+CREATE TABLE IF NOT EXISTS digest_runs (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id   UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  window_from  TIMESTAMPTZ NOT NULL,
+  window_to    TIMESTAMPTZ NOT NULL,
+  status       TEXT NOT NULL CHECK (status IN ('frozen','written','validated','delivered','failed')),
+  payload      JSONB,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_one_run_per_window
+  ON digest_runs (project_id, window_to);
+
+CREATE TABLE IF NOT EXISTS digest_run_items (
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  run_id     UUID NOT NULL REFERENCES digest_runs(id) ON DELETE CASCADE,
+  episode_id UUID NOT NULL REFERENCES issue_episodes(id) ON DELETE CASCADE,
+  -- NULL at freeze time: Go records the candidate before any model runs, and
+  -- the writing pass fills the outcome in. A non-null CHECK here would make
+  -- freezing impossible.
+  outcome    TEXT CHECK (outcome IS NULL OR outcome IN ('included','deferred')),
+  reason     TEXT,
+  PRIMARY KEY (run_id, episode_id)
+);
+
+-- Existing table, new column. Jobs are scoped to a work round from here on:
+-- the inquiry and investigation both key off the episode, not the issue.
+ALTER TABLE error_group_jobs
+  ADD COLUMN IF NOT EXISTS episode_id UUID REFERENCES issue_episodes(id) ON DELETE CASCADE;
+
+-- One inquiry and one investigation per work round. These are constraints, not
+-- indexes: ON CONFLICT needs something to conflict with, and the retry
+-- guarantees in later tasks are meaningless without them.
+-- Scoped to ACTIVE jobs only. A total index would let one finished inquiry
+-- block every future reopen of that episode, and reopening is the whole point
+-- of `wait_for_more_evidence`. Every ON CONFLICT against this index must repeat
+-- the predicate so Postgres can infer it.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_one_active_job_per_episode_type
+  ON error_group_jobs (project_id, episode_id, job_type)
+  WHERE status IN ('pending','claimed');
+
+-- Includes evidence_signature: a reopened inquiry at the same unit count but
+-- new evidence must be able to insert. Keying on counts alone would block it.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_one_inquiry_per_evidence
+  ON issue_inquiry_decisions (project_id, episode_id, prompt_version, evidence_signature);
+
+-- route_map exists since migration 040 with columns (project_id, pattern, tier,
+-- name). Product understanding adds the grounded-claim columns here rather than
+-- assuming them.
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS purpose TEXT;
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS actions TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS client_refs TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS server_refs TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS audience TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS confidence REAL NOT NULL DEFAULT 0;
+-- `tier` and `name` predate this work and are required. Product understanding
+-- discovers routes the sweeper never saw, so they need defaults rather than a
+-- value invented per insert.
+ALTER TABLE route_map ALTER COLUMN tier SET DEFAULT 'standard';
+ALTER TABLE route_map ALTER COLUMN name SET DEFAULT '';
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS commit_sha TEXT;
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS prompt_version INTEGER;
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS model TEXT;
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'mechanical';
+
+-- The digest writer job needs to know which frozen run it is writing.
+ALTER TABLE error_group_jobs ADD COLUMN IF NOT EXISTS run_id UUID REFERENCES digest_runs(id) ON DELETE CASCADE;
+
+-- Capture no longer creates a group, so a job can exist before any issue does.
+-- 001_baseline.sql:113 declares this NOT NULL; every job the new pipeline
+-- enqueues would fail on it.
+ALTER TABLE error_group_jobs ALTER COLUMN error_group_id DROP NOT NULL;
+
+-- One digest-write job per run. The episode-keyed index cannot cover these:
+-- their episode_id is NULL and NULLs never collide, so it would permit
+-- unlimited duplicates.
+-- Active jobs only, so the scheduler can enqueue a rewrite after a failed run.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_one_active_write_job_per_run
+  ON error_group_jobs (project_id, run_id, job_type)
+  WHERE run_id IS NOT NULL AND status IN ('pending','claimed');
+
+-- Investigations key off the work round.
+ALTER TABLE diagnosis_decisions ADD COLUMN IF NOT EXISTS episode_id UUID REFERENCES issue_episodes(id) ON DELETE SET NULL;
+-- The terminal-result contract Task 25 selects on. The investigation writer in
+-- Task 24 persists one of these three; without the column the freeze query
+-- matches nothing and the digest is always empty.
+ALTER TABLE diagnosis_decisions ADD COLUMN IF NOT EXISTS outcome TEXT
+  CHECK (outcome IS NULL OR outcome IN ('verified_fix','needs_human','unable_to_establish_cause'));
+
+-- Compact session facts (architecture section 1). Detailed rows for failures,
+-- aggregate rows for successes. No input values, DOM text, bodies, query
+-- strings, or host names. Expiry cascades from the session.
+CREATE TABLE IF NOT EXISTS session_request_failures (
+  project_id       UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  session_id       TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  request_id_hash  TEXT NOT NULL,
+  page_route       TEXT NOT NULL,
+  method           TEXT NOT NULL,
+  endpoint_pattern TEXT NOT NULL,
+  status           INTEGER NOT NULL,
+  action_kind      TEXT CHECK (action_kind IS NULL OR action_kind IN ('click','form_submit')),
+  action_selector  TEXT,
+  action_link      TEXT NOT NULL CHECK (action_link IN ('direct','none')),
+  occurred_at      TIMESTAMPTZ NOT NULL,
+  rule_version     INTEGER NOT NULL,
+  PRIMARY KEY (project_id, session_id, request_id_hash, rule_version)
+);
+
+CREATE TABLE IF NOT EXISTS session_write_rollups (
+  project_id       UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  session_id       TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  page_route       TEXT NOT NULL,
+  method           TEXT NOT NULL,
+  endpoint_pattern TEXT NOT NULL,
+  status_class     INTEGER NOT NULL,
+  occurrence_count INTEGER NOT NULL,
+  rule_version     INTEGER NOT NULL,
+  PRIMARY KEY (project_id, session_id, page_route, method,
+               endpoint_pattern, status_class, rule_version)
+);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./db -run 'TestMigration054' -v`
+Expected: PASS both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/db/migrations/054_pipeline_rewrite.sql packages/ingestion/db/migrations_test.go
+git commit -m "feat(db): add inert pipeline rewrite tables"
+```
+
+---
+
+### Task 6: Freeze the resolved-envelope contract in both languages
+
+**Files:**
+- Create: `test-fixtures/grouping/resolved-envelope-v2.json`
+- Create: `packages/ingestion/identity/canonical.go`
+- Create: `packages/ingestion/identity/canonical_test.go`
+- Create: `packages/worker/src/resolve/envelope.ts`
+- Create: `packages/worker/src/__tests__/resolve-envelope.test.ts`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces:
+  - Go: `identity.CanonicalString(env Envelope) string`, `identity.Hash(env Envelope) string`, `type Envelope struct { Version int; Frames []Frame }`, `type Frame struct { OriginalFile, OriginalFunction string; OriginalLine int; Generated GeneratedPos }`
+  - TypeScript: `buildEnvelope(frames: ResolvedFrame[]): EnvelopeV2`
+
+This is the single highest-risk contract in the rewrite. TypeScript resolves frames; Go hashes them. A path separator or anonymous-function marker that drifts between the two silently re-keys every issue, and the symptom presents as mass fragmentation rather than as a bug.
+
+- [ ] **Step 1: Write the fixture**
+
+```json
+{
+  "version": 2,
+  "frames": [
+    {"original_file": "src/modules/assets/AssetDetails.vue", "original_function": "deleteAsset",
+     "original_line": 142, "generated": {"line": 17, "column": 78242}},
+    {"original_file": "node_modules/vue/dist/runtime-core.esm-bundler.js", "original_function": "callWithErrorHandling",
+     "original_line": 158, "generated": {"line": 17, "column": 41003}},
+    {"original_file": "src/shared/http/client.ts", "original_function": "<anonymous>",
+     "original_line": 61, "generated": {"line": 17, "column": 9120}}
+  ],
+  "expected_canonical": "v2|src/modules/assets/AssetDetails.vue#deleteAsset|node_modules/vue/dist/runtime-core.esm-bundler.js#callWithErrorHandling|src/shared/http/client.ts#L61",
+  "expected_hash": "COMPUTE_IN_STEP_4"
+}
+```
+
+- [ ] **Step 2: Write the failing Go test**
+
+```go
+func TestCanonicalStringMatchesFixture(t *testing.T) {
+	raw, err := os.ReadFile("../../../test-fixtures/grouping/resolved-envelope-v2.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var fx struct {
+		Version           int     `json:"version"`
+		Frames            []Frame `json:"frames"`
+		ExpectedCanonical string  `json:"expected_canonical"`
+		ExpectedHash      string  `json:"expected_hash"`
+	}
+	if err := json.Unmarshal(raw, &fx); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	env := Envelope{Version: fx.Version, Frames: fx.Frames}
+	if got := CanonicalString(env); got != fx.ExpectedCanonical {
+		t.Errorf("CanonicalString =\n  %q\nwant\n  %q", got, fx.ExpectedCanonical)
+	}
+	if got := Hash(env); got != fx.ExpectedHash {
+		t.Errorf("Hash = %q, want %q", got, fx.ExpectedHash)
+	}
+}
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `cd packages/ingestion && go test ./identity -run TestCanonicalStringMatchesFixture -v`
+Expected: FAIL, package does not exist.
+
+- [ ] **Step 4: Implement the canonical serializer**
+
+```go
+package identity
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
+
+const IdentityVersion = 2
+
+// ResolverVersion is the envelope contract version. It must equal
+// RESOLVER_VERSION in packages/worker/src/resolve/envelope.ts; the golden
+// fixture asserts both sides agree.
+const ResolverVersion = 2
+
+const maxIdentityFrames = 5
+
+type GeneratedPos struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+type Frame struct {
+	OriginalFile     string       `json:"original_file"`
+	OriginalFunction string       `json:"original_function"`
+	OriginalLine     int          `json:"original_line"`
+	Generated        GeneratedPos `json:"generated"`
+}
+
+type Envelope struct {
+	Version int     `json:"version"`
+	Frames  []Frame `json:"frames"`
+}
+
+// CanonicalString serializes an envelope into the identity key input.
+// An anonymous function falls back to file plus original line, so that two
+// unrelated anonymous callbacks in one file do not merge.
+func CanonicalString(env Envelope) string {
+	frames := env.Frames
+	if len(frames) > maxIdentityFrames {
+		frames = frames[:maxIdentityFrames]
+	}
+	parts := make([]string, 0, len(frames)+1)
+	parts = append(parts, fmt.Sprintf("v%d", env.Version))
+	for _, f := range frames {
+		file := strings.ReplaceAll(f.OriginalFile, "\\", "/")
+		if f.OriginalFunction == "" || f.OriginalFunction == "<anonymous>" {
+			parts = append(parts, fmt.Sprintf("%s#L%d", file, f.OriginalLine))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s#%s", file, f.OriginalFunction))
+	}
+	return strings.Join(parts, "|")
+}
+
+func Hash(env Envelope) string {
+	sum := sha256.Sum256([]byte(CanonicalString(env)))
+	return fmt.Sprintf("%x", sum[:16])
+}
+```
+
+Then run the test once, read the actual hash from the failure message, and write it into the fixture's `expected_hash`.
+
+- [ ] **Step 5: Run the Go test to verify it passes**
+
+Run: `cd packages/ingestion && go test ./identity -v`
+Expected: PASS
+
+- [ ] **Step 6: Write the failing TypeScript test**
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { buildEnvelope } from '../resolve/envelope.js';
+
+describe('resolved envelope v2', () => {
+  it('produces exactly the shape Go expects', () => {
+    const fixture = JSON.parse(
+      readFileSync('../../test-fixtures/grouping/resolved-envelope-v2.json', 'utf-8'),
+    );
+    const built = buildEnvelope(fixture.frames);
+    expect(built.version).toBe(2);
+    expect(built.frames).toEqual(fixture.frames);
+    // Key ordering is part of the contract: Go decodes by tag, but a reordered
+    // or renamed key means the two sides disagree about the same field.
+    expect(Object.keys(built.frames[0])).toEqual([
+      'original_file', 'original_function', 'original_line', 'generated',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 7: Run it to verify it fails**
+
+Run: `pnpm --filter @opslane/worker test -- resolve-envelope`
+Expected: FAIL, module not found.
+
+- [ ] **Step 8: Implement the envelope builder**
+
+```typescript
+export const RESOLVER_VERSION = 2;
+
+export interface GeneratedPos { line: number; column: number }
+export interface EnvelopeFrame {
+  original_file: string;
+  original_function: string;
+  original_line: number;
+  generated: GeneratedPos;
+}
+export interface EnvelopeV2 { version: 2; frames: EnvelopeFrame[] }
+
+export function buildEnvelope(frames: EnvelopeFrame[]): EnvelopeV2 {
+  return {
+    version: 2,
+    frames: frames.map((f) => ({
+      original_file: f.original_file.replace(/\\/g, '/'),
+      original_function: f.original_function || '<anonymous>',
+      original_line: f.original_line,
+      generated: { line: f.generated.line, column: f.generated.column },
+    })),
+  };
+}
+```
+
+- [ ] **Step 9: Run both suites**
+
+Run: `pnpm --filter @opslane/worker test -- resolve-envelope && cd packages/ingestion && go test ./identity -v`
+Expected: PASS both.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add test-fixtures/grouping/resolved-envelope-v2.json packages/ingestion/identity packages/worker/src/resolve/envelope.ts packages/worker/src/__tests__/resolve-envelope.test.ts
+git commit -m "feat(identity): freeze the v2 resolved-envelope contract in Go and TypeScript"
+```
+
+---
+
+### Task 7: Document the capture handle in the events contract
+
+**Files:**
+- Modify: `docs/contracts/events.md`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: documented meaning for `group_id` and `error_group_id` in the response
+
+`group_id` is returned at `handler/error_event.go:301-302` but appears nowhere in the contract document, no frozen wire fixture contains it, the SDK references it only in its own test mocks, and the suppression path at `:230` already returns it empty. It is about to become a provisional handle, so it needs documenting before that is true.
+
+- [ ] **Step 1: Add a response section to the contract**
+
+```markdown
+## Response
+
+`POST /api/v1/events` returns:
+
+| Field | Meaning |
+| --- | --- |
+| `event_id` | Stable identifier for the stored observation. |
+| `group_id` | **Provisional capture handle.** It opens the processing item and is not a stable issue identifier. Reads through it resolve or redirect to the canonical issue once identity settles. |
+| `error_group_id` | Deprecated alias for `group_id`, retained for compatibility. |
+
+A suppressed event returns an empty `group_id`. Clients must tolerate an empty
+value and must not treat either field as a durable issue key.
+```
+
+- [ ] **Step 2: Verify no frozen fixture asserts on the field**
+
+Run: `grep -rl "group_id" test-fixtures/wire/ || echo "clean"`
+Expected: `clean`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/contracts/events.md
+git commit -m "docs(contracts): define group_id as a provisional capture handle"
+```
+
+---
+
+# Slice 2: capture without judging
+
+### Task 8: Split capture out of InsertErrorEventAndGroup
+
+**Files:**
+- Modify: `packages/ingestion/db/queries.go:486` (`InsertErrorEventAndGroup`)
+- Create: `packages/ingestion/db/capture.go`
+- Test: `packages/ingestion/db/capture_test.go`
+
+**Interfaces:**
+- Consumes: `identity.IdentityVersion` from Task 6
+- Produces: `func (q *Queries) CaptureError(ctx context.Context, p IngestParams) (*CaptureReceipt, error)` where `type CaptureReceipt struct { EventID, CaptureHandle string }`
+
+Today `InsertErrorEventAndGroup` creates the event, the group, the investigation job, and the `issue.created` outbox row in one transaction. `queries.go:707` enqueues an investigation and publishes on the **first occurrence**, which is why one bug sent nineteen alerts in four days.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestCaptureCreatesNoIssueOrJobOrOutbox(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := &Queries{pool: pool}
+	projectID := seedProject(t, pool)
+
+	receipt, err := q.CaptureError(ctx, IngestParams{
+		ProjectID: projectID, Title: "TypeError: boom", Platform: "javascript",
+		StackRaw: "at f (entry-index.CaWHNXv4.js:1:1)",
+	})
+	if err != nil {
+		t.Fatalf("CaptureError: %v", err)
+	}
+	if receipt.EventID == "" {
+		t.Fatal("expected an event id")
+	}
+
+	// Capture DOES enqueue exactly one stack_resolve job. That is the only job
+	// it may create; the assertions below prove it creates nothing else.
+	var resolveJobs int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM error_group_jobs
+		  WHERE project_id=$1 AND job_type='stack_resolve'`, projectID).Scan(&resolveJobs); err != nil {
+		t.Fatalf("resolve jobs: %v", err)
+	}
+	if resolveJobs != 1 {
+		t.Errorf("stack_resolve jobs = %d, want 1", resolveJobs)
+	}
+
+	for _, check := range []struct {
+		name, query string
+	}{
+		{"investigation jobs", `SELECT count(*) FROM error_group_jobs
+		                          WHERE project_id=$1 AND job_type='investigate'`},
+		{"outbox events", `SELECT count(*) FROM outbound_events WHERE project_id=$1`},
+		{"stable issues", `SELECT count(*) FROM error_groups WHERE project_id=$1`},
+	} {
+		var n int
+		if err := pool.QueryRow(ctx, check.query, projectID).Scan(&n); err != nil {
+			t.Fatalf("%s: %v", check.name, err)
+		}
+		if n != 0 {
+			t.Errorf("capture created %d %s, want 0", n, check.name)
+		}
+	}
+
+	var pending int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM error_event_identities WHERE project_id=$1 AND status='pending'`,
+		projectID).Scan(&pending); err != nil {
+		t.Fatalf("identities: %v", err)
+	}
+	if pending != 1 {
+		t.Errorf("pending identities = %d, want 1", pending)
+	}
+}
+
+func TestCaptureSharesBucketAcrossConcurrentIdenticalEvents(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := &Queries{pool: pool}
+	projectID := seedProject(t, pool)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = q.CaptureError(ctx, IngestParams{
+				ProjectID: projectID, Title: "TypeError: boom", Platform: "javascript",
+				StackRaw: "at f (entry-index.CaWHNXv4.js:1:1)",
+			})
+		}()
+	}
+	wg.Wait()
+
+	var buckets, events int
+	pool.QueryRow(ctx, `SELECT count(*) FROM error_capture_buckets WHERE project_id=$1`, projectID).Scan(&buckets)
+	pool.QueryRow(ctx, `SELECT count(*) FROM error_events WHERE project_id=$1`, projectID).Scan(&events)
+	if buckets != 1 {
+		t.Errorf("buckets = %d, want 1", buckets)
+	}
+	if events != 8 {
+		t.Errorf("events = %d, want 8", events)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./db -run 'TestCapture' -v`
+Expected: FAIL, `CaptureError` undefined.
+
+- [ ] **Step 3: Implement CaptureError**
+
+```go
+type CaptureReceipt struct {
+	EventID       string
+	CaptureHandle string
+}
+
+// CaptureError stores one observation and schedules its resolution. It creates
+// no stable issue, investigation, or notification: every product decision moves
+// downstream of identity settlement.
+func (q *Queries) CaptureError(ctx context.Context, p IngestParams) (*CaptureReceipt, error) {
+	tx, err := q.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	rawFingerprint := grouping.Fingerprint(p.Platform, p.ErrorType, p.ErrorMessage, p.StackRaw)
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO error_capture_buckets (project_id, raw_fingerprint, identity_version)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (project_id, identity_version, raw_fingerprint)
+		 DO UPDATE SET last_seen = now()`,
+		p.ProjectID, rawFingerprint, identity.IdentityVersion,
+	); err != nil {
+		return nil, fmt.Errorf("upsert bucket: %w", err)
+	}
+
+	var eventID string
+	if err := tx.QueryRow(ctx,
+		`INSERT INTO error_events
+		   (project_id, environment_id, error_type, error_message, stack_trace_raw,
+		    platform, debug_meta, session_id, end_user_id, timestamp, release, commit_sha)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+		 RETURNING id`,
+		p.ProjectID, p.EnvironmentID, p.ErrorType, p.ErrorMessage, p.StackRaw,
+		p.Platform, p.DebugMeta, p.SessionID, p.EndUserID, p.Timestamp, p.Release, p.CommitSHA,
+	).Scan(&eventID); err != nil {
+		return nil, fmt.Errorf("insert event: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO error_event_identities
+		   (project_id, event_id, status, raw_fingerprint, identity_version)
+		 VALUES ($1, $2, 'pending', $3, $4)`,
+		p.ProjectID, eventID, rawFingerprint, identity.IdentityVersion,
+	); err != nil {
+		return nil, fmt.Errorf("insert identity: %w", err)
+	}
+
+	// The pending resolution row is what the watchdog sweeps. Without it a job
+	// that is never claimed leaves no trace and the event waits forever.
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO error_event_resolutions (project_id, event_id, status, resolver_version)
+		 VALUES ($1, $2, 'pending', $3)
+		 ON CONFLICT (project_id, event_id) DO NOTHING`,
+		p.ProjectID, eventID, identity.ResolverVersion,
+	); err != nil {
+		return nil, fmt.Errorf("insert pending resolution: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO error_group_jobs (project_id, event_id, job_type, status)
+		 VALUES ($1, $2, 'stack_resolve', 'pending')`,
+		p.ProjectID, eventID,
+	); err != nil {
+		return nil, fmt.Errorf("enqueue resolve: %w", err)
+	}
+
+	if err := q.pinSession(ctx, tx, p); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+	return &CaptureReceipt{EventID: eventID, CaptureHandle: rawFingerprint}, nil
+}
+```
+
+- [ ] **Step 4: Point the handler at CaptureError**
+
+In `handler/error_event.go`, replace the `InsertErrorEventAndGroup` call with `CaptureError`, and return `receipt.CaptureHandle` in both `group_id` and `error_group_id`. The response shape does not change.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./db ./handler -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ingestion/db/capture.go packages/ingestion/db/capture_test.go packages/ingestion/db/queries.go packages/ingestion/handler/error_event.go
+git commit -m "feat(capture): store observations without creating issues or alerts"
+```
+
+---
+
+# Slice 3: resolve stacks before grouping
+
+### Task 9: Add the position cache
+
+**Files:**
+- Create: `packages/worker/src/resolve/position-cache.ts`
+- Test: `packages/worker/src/__tests__/resolve-position-cache.test.ts`
+
+**Interfaces:**
+- Consumes: `RESOLVER_VERSION` from Task 6
+- Produces: `lookupPosition(key: PositionKey): Promise<CachedPosition | null>`, `storePosition(key: PositionKey, value: CachedPosition): Promise<void>`, `type PositionKey = { projectId: string; debugId: string; mapContentSha: string; line: number; column: number }`
+
+Since 2026-08-05, 509 production events carrying debug IDs shared 34 source maps, one of which is 2.25 MB. Fetching and parsing per event would repeat that work 509 times.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it, beforeEach } from 'vitest';
+import { lookupPosition, storePosition } from '../resolve/position-cache.js';
+
+describe('position cache', () => {
+  const key = {
+    projectId: '00000000-0000-0000-0000-000000000001',
+    debugId: 'c5cec566-6bbe-7c79-06b9-db1c71e746e5',
+    mapContentSha: 'abc123',
+    line: 17,
+    column: 78242,
+  };
+
+  it('returns null before anything is stored', async () => {
+    expect(await lookupPosition(key)).toBeNull();
+  });
+
+  it('round-trips a stored position', async () => {
+    await storePosition(key, {
+      originalFile: 'src/AssetDetails.vue',
+      originalFunction: 'deleteAsset',
+      originalLine: 142,
+    });
+    expect(await lookupPosition(key)).toEqual({
+      originalFile: 'src/AssetDetails.vue',
+      originalFunction: 'deleteAsset',
+      originalLine: 142,
+    });
+  });
+
+  it('treats a different resolver version as a different entry', async () => {
+    await storePosition(key, {
+      originalFile: 'src/Old.vue', originalFunction: 'old', originalLine: 1,
+    });
+    const other = await lookupPosition({ ...key, column: 99999 });
+    expect(other).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @opslane/worker test -- resolve-position-cache`
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement the cache**
+
+```typescript
+import { getPool } from '../db.js';
+import { RESOLVER_VERSION } from './envelope.js';
+
+export interface PositionKey {
+  projectId: string; debugId: string; mapContentSha: string;
+  line: number; column: number;
+}
+export interface CachedPosition {
+  originalFile: string; originalFunction: string; originalLine: number;
+}
+
+export async function lookupPosition(k: PositionKey): Promise<CachedPosition | null> {
+  const res = await getPool().query(
+    `SELECT original_file, original_function, original_line
+       FROM sourcemap_position_cache
+      WHERE project_id=$1 AND debug_id=$2 AND map_content_sha=$3
+        AND resolver_version=$4 AND generated_line=$5 AND generated_column=$6`,
+    [k.projectId, k.debugId, k.mapContentSha, RESOLVER_VERSION, k.line, k.column],
+  );
+  const row = res.rows[0];
+  if (!row) return null;
+  return {
+    originalFile: row.original_file,
+    originalFunction: row.original_function,
+    originalLine: row.original_line,
+  };
+}
+
+export async function storePosition(k: PositionKey, v: CachedPosition): Promise<void> {
+  await getPool().query(
+    `INSERT INTO sourcemap_position_cache
+       (project_id, debug_id, map_content_sha, resolver_version,
+        generated_line, generated_column, original_file, original_function, original_line)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+     ON CONFLICT DO NOTHING`,
+    [k.projectId, k.debugId, k.mapContentSha, RESOLVER_VERSION,
+     k.line, k.column, v.originalFile, v.originalFunction, v.originalLine],
+  );
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `pnpm --filter @opslane/worker test -- resolve-position-cache`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/worker/src/resolve/position-cache.ts packages/worker/src/__tests__/resolve-position-cache.test.ts
+git commit -m "feat(resolve): cache source-map positions per artifact"
+```
+
+---
+
+### Task 10: Add the stack_resolve job
+
+**Files:**
+- Create: `packages/worker/src/resolve/job.ts`
+- Modify: `packages/worker/src/index.ts` (job dispatch)
+- Modify: `packages/worker/src/index.ts:538`, `:1185` (remove on-demand resolution)
+- Test: `packages/worker/src/__tests__/resolve-job.test.ts`
+
+**Interfaces:**
+- Consumes: `lookupPosition`/`storePosition` (Task 9), `buildEnvelope` (Task 6), existing `resolveEventStack` from `resolve-stack.ts:103`
+- Produces: `runStackResolve(job: ClaimedJob): Promise<void>`, writing `error_event_resolutions`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+describe('stack_resolve job', () => {
+  it('writes a resolved envelope and marks the identity ready', async () => {
+    const { eventId, projectId } = await seedEventWithDebugId();
+    await runStackResolve({ id: 'job-1', projectId, eventId } as ClaimedJob);
+    const row = await queryOne(
+      `SELECT status, envelope FROM error_event_resolutions WHERE event_id=$1`, [eventId]);
+    expect(row.status).toBe('resolved');
+    expect(row.envelope.version).toBe(2);
+    expect(row.envelope.frames.length).toBeGreaterThan(0);
+  });
+
+  it('records no_map when the event carries no debug id', async () => {
+    const { eventId, projectId } = await seedEventWithoutDebugId();
+    await runStackResolve({ id: 'job-2', projectId, eventId } as ClaimedJob);
+    const row = await queryOne(
+      `SELECT status FROM error_event_resolutions WHERE event_id=$1`, [eventId]);
+    expect(row.status).toBe('no_map');
+  });
+
+  it('is idempotent across retries', async () => {
+    const { eventId, projectId } = await seedEventWithDebugId();
+    await runStackResolve({ id: 'job-3', projectId, eventId } as ClaimedJob);
+    await runStackResolve({ id: 'job-3', projectId, eventId } as ClaimedJob);
+    const { count } = await queryOne(
+      `SELECT count(*)::int AS count FROM error_event_resolutions WHERE event_id=$1`, [eventId]);
+    expect(count).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @opslane/worker test -- resolve-job`
+Expected: FAIL, `runStackResolve` not exported.
+
+- [ ] **Step 3: Implement the job**
+
+```typescript
+export async function runStackResolve(job: ClaimedJob): Promise<void> {
+  const event = await loadEvent(job.projectId, job.eventId);
+  if (!event.debug_meta?.images?.length) {
+    await recordResolution(job.projectId, job.eventId, 'no_map', null);
+    return;
+  }
+  const frames = await resolveFramesWithCache(event);
+  if (!frames) {
+    await recordResolution(job.projectId, job.eventId, 'no_map', null);
+    return;
+  }
+  await recordResolution(job.projectId, job.eventId, 'resolved', buildEnvelope(frames));
+}
+
+async function recordResolution(
+  projectId: string, eventId: string,
+  status: 'resolved' | 'no_map' | 'failed', envelope: EnvelopeV2 | null,
+): Promise<void> {
+  await getPool().query(
+    `INSERT INTO error_event_resolutions
+       (project_id, event_id, status, envelope, resolver_version)
+     VALUES ($1,$2,$3,$4,$5)
+     ON CONFLICT (project_id, event_id) DO UPDATE
+       SET status=EXCLUDED.status, envelope=EXCLUDED.envelope,
+           resolver_version=EXCLUDED.resolver_version, resolved_at=now()`,
+    [projectId, eventId, status, envelope, RESOLVER_VERSION],
+  );
+}
+```
+
+- [ ] **Step 3b: Route the new job types in the worker**
+
+`processJobInner` in `packages/worker/src/index.ts` dispatches on `job_type`. Add the
+four new types alongside the existing `investigate`, `fix`, `session_analysis`, and
+`route_map` cases:
+
+Add only the case whose handler exists at this task:
+
+```typescript
+case 'stack_resolve': return runStackResolve(job);
+```
+
+The other three job types get their cases in the tasks that create their handlers:
+`issue_inquiry` in Task 21, `product_context` in Task 17, and `digest_write` in
+Task 26. Adding them here would import modules that do not exist and break the
+worker build at this point in the sequence.
+
+A job type with no case is claimed, never handled, and leases out forever. Task 26,
+the last of the four, adds the test asserting that every type the Go side enqueues
+has a case, so a fifth type cannot be added without routing it.
+
+`claimJob` (`packages/worker/src/db.ts:562-584`) must also select the two new
+columns and put them on `ClaimedJob`:
+
+```typescript
+export interface ClaimedJob {
+  // ...existing fields
+  episodeId?: string;   // set for issue_inquiry and investigate
+  runId?: string;       // set for digest_write
+}
+```
+
+Without them every handler above receives `undefined` and fails at its first query.
+
+- [ ] **Step 4: Remove on-demand resolution from investigate and fix**
+
+Delete the `resolveStackForEvent` calls at `packages/worker/src/index.ts:538` and `:1185`. Those are its only two callers. Investigations now read the persisted envelope.
+
+- [ ] **Step 5: Run the worker suite**
+
+Run: `pnpm --filter @opslane/worker test`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/worker/src/resolve/job.ts packages/worker/src/index.ts packages/worker/src/__tests__/resolve-job.test.ts
+git commit -m "feat(resolve): resolve stacks in their own job before grouping"
+```
+
+---
+
+### Task 11: Add the raw fallback and the watchdog
+
+**Files:**
+- Create: `packages/ingestion/resolve/watchdog.go`
+- Test: `packages/ingestion/resolve/watchdog_test.go`
+
+**Interfaces:**
+- Consumes: `error_event_resolutions` (Task 5)
+- Produces: `func (w *Watchdog) Sweep(ctx context.Context) (settledRaw int, stuck int, err error)`
+
+An event whose map has not arrived must not wait forever. At the daily boundary it settles on its raw fingerprint; a later map upload can wake it sooner. Anything still pending past the boundary is reported.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestWatchdogSettlesStaleUnresolvedEventsOnRaw(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	eventID := seedPendingResolution(t, pool, projectID, time.Now().Add(-30*time.Hour))
+
+	w := &Watchdog{pool: pool, boundary: 24 * time.Hour}
+	settled, stuck, err := w.Sweep(ctx)
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if settled != 1 {
+		t.Errorf("settled = %d, want 1", settled)
+	}
+	if stuck != 0 {
+		t.Errorf("stuck = %d, want 0", stuck)
+	}
+	var status string
+	pool.QueryRow(ctx,
+		`SELECT status FROM error_event_resolutions WHERE event_id=$1`, eventID).Scan(&status)
+	if status != "no_map" {
+		t.Errorf("status = %q, want no_map", status)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./resolve -v`
+Expected: FAIL, package does not exist.
+
+- [ ] **Step 3: Implement the watchdog**
+
+```go
+package resolve
+
+// Sweep settles events whose source map never arrived. Waiting forever would
+// let a bug fragment indefinitely while looking smaller than it is.
+func (w *Watchdog) Sweep(ctx context.Context) (int, int, error) {
+	tag, err := w.pool.Exec(ctx,
+		`UPDATE error_event_resolutions
+		    SET status = 'no_map', resolved_at = now()
+		  WHERE status = 'pending'
+		    AND resolved_at < now() - $1::interval`,
+		w.boundary.String())
+	if err != nil {
+		return 0, 0, fmt.Errorf("settle stale: %w", err)
+	}
+	var stuck int
+	if err := w.pool.QueryRow(ctx,
+		`SELECT count(*) FROM error_event_resolutions
+		  WHERE status='failed' AND resolved_at < now() - $1::interval`,
+		w.boundary.String()).Scan(&stuck); err != nil {
+		return 0, 0, fmt.Errorf("count stuck: %w", err)
+	}
+	if stuck > 0 {
+		slog.Warn("resolution jobs stuck", "count", stuck)
+	}
+	return int(tag.RowsAffected()), stuck, nil
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./resolve -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/resolve/
+git commit -m "feat(resolve): settle on raw identity when a map never arrives"
+```
+
+---
+
+# Slice 4: attach observations to stable issues
+
+### Task 12: Bind aliases and settle one observation
+
+**Files:**
+- Create: `packages/ingestion/identity/settle.go`
+- Create: `packages/ingestion/identity/alias.go`
+- Test: `packages/ingestion/identity/settle_test.go`
+
+**Interfaces:**
+- Consumes: `CanonicalString`, `Hash`, `IdentityVersion` (Task 6); `error_event_resolutions` (Task 10)
+- Produces: `func Settle(ctx context.Context, pool *pgxpool.Pool, projectID, eventID string) (Result, error)` where `type Result struct { CanonicalIssueID string; State string }` and `State` is `settled` or `conflict`
+
+Normal settlement **attaches**; it never moves. This is the decision the whole slice rests on. Rewriting `error_groups.fingerprint` in place collides with `UNIQUE(project_id, fingerprint)` (`001_baseline.sql:95`) exactly when two issues should merge, and because `error_events.error_group_id` has no foreign key (`001_baseline.sql:63`), the events orphaned by the obvious recovery go quiet rather than error, which reads as a successful fix.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestSettleAttachesTwoFingerprintsToOneIssue(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+
+	// Two deploys, same source location, different bundle hash.
+	a := seedResolvedEvent(t, pool, projectID, "entry-index.AAA11111.js", "src/Assets.vue", "deleteAsset")
+	b := seedResolvedEvent(t, pool, projectID, "entry-index.BBB22222.js", "src/Assets.vue", "deleteAsset")
+
+	ra, err := Settle(ctx, pool, projectID, a)
+	if err != nil {
+		t.Fatalf("settle a: %v", err)
+	}
+	rb, err := Settle(ctx, pool, projectID, b)
+	if err != nil {
+		t.Fatalf("settle b: %v", err)
+	}
+	if ra.CanonicalIssueID != rb.CanonicalIssueID {
+		t.Errorf("same source location must settle to one issue: %s != %s",
+			ra.CanonicalIssueID, rb.CanonicalIssueID)
+	}
+	var issues int
+	pool.QueryRow(ctx, `SELECT count(*) FROM error_groups WHERE project_id=$1`, projectID).Scan(&issues)
+	if issues != 1 {
+		t.Errorf("issues = %d, want 1", issues)
+	}
+}
+
+func TestSettleRecordsConflictWithoutMerging(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+
+	// Two established issues, then an event whose raw and resolved aliases
+	// point at different ones.
+	issueA := seedIssueWithAlias(t, pool, projectID, "raw-1", "raw")
+	issueB := seedIssueWithAlias(t, pool, projectID, "res-1", "resolved")
+	eventID := seedEventWithFingerprints(t, pool, projectID, "raw-1", "res-1")
+
+	res, err := Settle(ctx, pool, projectID, eventID)
+	if err != nil {
+		t.Fatalf("settle: %v", err)
+	}
+	if res.State != "conflict" {
+		t.Errorf("state = %q, want conflict", res.State)
+	}
+	if issueA == issueB {
+		t.Fatal("test setup error")
+	}
+	var aliasCount int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM canonical_issue_fingerprints
+		  WHERE project_id=$1 AND canonical_issue_id IN ($2,$3)`,
+		projectID, issueA, issueB).Scan(&aliasCount)
+	if aliasCount != 2 {
+		t.Errorf("conflict must not rebind aliases: got %d, want 2", aliasCount)
+	}
+}
+
+func TestSettleIsIdempotent(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	eventID := seedResolvedEvent(t, pool, projectID, "a.js", "src/A.vue", "f")
+
+	first, _ := Settle(ctx, pool, projectID, eventID)
+	second, _ := Settle(ctx, pool, projectID, eventID)
+	if first.CanonicalIssueID != second.CanonicalIssueID {
+		t.Errorf("retry changed the issue: %s -> %s", first.CanonicalIssueID, second.CanonicalIssueID)
+	}
+	var occurrences int
+	pool.QueryRow(ctx,
+		`SELECT occurrence_count FROM error_groups WHERE id=$1`, first.CanonicalIssueID).Scan(&occurrences)
+	if occurrences != 1 {
+		t.Errorf("occurrence_count = %d, want 1 (retry must not double-count)", occurrences)
+	}
+}
+
+func TestSettleNeverReadsSampleEventID(t *testing.T) {
+	// Guard against the oscillation failure: queries.go:588 rewrites
+	// sample_event_id on every occurrence, so anything keyed on it computes a
+	// different answer depending on when it ran.
+	src, err := os.ReadFile("settle.go")
+	if err != nil {
+		t.Fatalf("read settle.go: %v", err)
+	}
+	if bytes.Contains(src, []byte("sample_event_id")) {
+		t.Error("settle.go must not reference sample_event_id")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./identity -v`
+Expected: FAIL, `Settle` undefined.
+
+- [ ] **Step 3: Implement settlement**
+
+```go
+// Settle binds an observation's fingerprints to a canonical issue. It only ever
+// attaches: no fingerprint is rewritten and no event is relocated. A confirmed
+// merge is a separate audited operation.
+func Settle(ctx context.Context, pool *pgxpool.Pool, projectID, eventID string) (Result, error) {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return Result{}, fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var rawFP string
+	var status string
+	var envelope *Envelope
+	if err := tx.QueryRow(ctx,
+		`SELECT i.raw_fingerprint, i.status, r.envelope
+		   FROM error_event_identities i
+		   LEFT JOIN error_event_resolutions r
+		     ON r.project_id = i.project_id AND r.event_id = i.event_id
+		  WHERE i.project_id = $1 AND i.event_id = $2
+		  FOR UPDATE OF i`,
+		projectID, eventID).Scan(&rawFP, &status, &envelope); err != nil {
+		return Result{}, fmt.Errorf("load identity: %w", err)
+	}
+	if status == "settled" {
+		var issueID string
+		tx.QueryRow(ctx,
+			`SELECT canonical_issue_id FROM error_event_identities
+			  WHERE project_id=$1 AND event_id=$2`, projectID, eventID).Scan(&issueID)
+		return Result{CanonicalIssueID: issueID, State: "settled"}, tx.Commit(ctx)
+	}
+
+	candidates := []alias{{fp: rawFP, kind: "raw"}}
+	if envelope != nil {
+		candidates = append(candidates, alias{fp: Hash(*envelope), kind: "resolved"})
+	}
+	// Sorted advisory locks prevent deadlock between concurrent settlers that
+	// touch the same pair of fingerprints in opposite order.
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].fp < candidates[j].fp })
+	for _, c := range candidates {
+		if _, err := tx.Exec(ctx,
+			`SELECT pg_advisory_xact_lock(hashtext($1))`, c.fp); err != nil {
+			return Result{}, fmt.Errorf("lock %s: %w", c.fp, err)
+		}
+	}
+
+	bound, err := lookupAliases(ctx, tx, projectID, candidates)
+	if err != nil {
+		return Result{}, err
+	}
+	distinct := distinctIssues(bound)
+	if len(distinct) > 1 {
+		if err := recordConflict(ctx, tx, projectID, eventID, distinct); err != nil {
+			return Result{}, err
+		}
+		// Mark the row terminal. Leaving it pending would let the loop reclaim
+		// it every tick and write a fresh conflict each time.
+		if _, err := tx.Exec(ctx,
+			`UPDATE error_event_identities SET status='conflict'
+			  WHERE project_id=$1 AND event_id=$2`, projectID, eventID); err != nil {
+			return Result{}, fmt.Errorf("mark conflict: %w", err)
+		}
+		return Result{State: "conflict"}, tx.Commit(ctx)
+	}
+
+	issueID := ""
+	if len(distinct) == 1 {
+		issueID = distinct[0]
+	} else {
+		if issueID, err = createIssue(ctx, tx, projectID, eventID); err != nil {
+			return Result{}, err
+		}
+	}
+	for _, c := range candidates {
+		if err := bindAlias(ctx, tx, projectID, c, issueID); err != nil {
+			return Result{}, err
+		}
+	}
+	if err := attachObservation(ctx, tx, projectID, eventID, issueID); err != nil {
+		return Result{}, err
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE error_event_identities
+		    SET status='settled', canonical_issue_id=$3, settled_at=now()
+		  WHERE project_id=$1 AND event_id=$2`,
+		projectID, eventID, issueID); err != nil {
+		return Result{}, fmt.Errorf("mark settled: %w", err)
+	}
+	return Result{CanonicalIssueID: issueID, State: "settled"}, tx.Commit(ctx)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./identity -v`
+Expected: PASS all four.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/identity/
+git commit -m "feat(identity): settle observations by binding aliases, never by moving"
+```
+
+---
+
+### Task 12A: Merge two issues on confirmation, audited
+
+**Files:**
+- Create: `packages/ingestion/identity/merge.go`
+- Test: `packages/ingestion/identity/merge_test.go`
+
+**Interfaces:**
+- Consumes: `canonical_issue_fingerprints`, `issue_alias_conflicts` (Task 5)
+- Produces: `func ConfirmMerge(ctx context.Context, pool *pgxpool.Pool, projectID, winnerID, loserID, confirmedBy, actor string) error`
+
+Task 12 records conflicts and merges nothing, which is correct for normal
+settlement. But conflicts then accumulate in a ledger nothing drains. This is the
+separate, audited operation that resolves one: it redirects the losing aliases,
+marks the loser merged, and rebuilds the winner's counters from `error_events`.
+
+V1 permits an automatic confirmed merge **only before either issue has started an
+investigation or a publication**. After that, a merge would silently rewrite history
+a customer has already been shown, so it stays a visible possible duplicate.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestConfirmMergeRedirectsAliasesAndRebuildsCounters(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	winner := seedIssueWithEvents(t, pool, projectID, 3)
+	loser  := seedIssueWithEvents(t, pool, projectID, 2)
+
+	if err := ConfirmMerge(ctx, pool, projectID, winner, loser, "human", "abhishek"); err != nil {
+		t.Fatalf("ConfirmMerge: %v", err)
+	}
+
+	var pointing int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM canonical_issue_fingerprints WHERE canonical_issue_id=$1`,
+		winner).Scan(&pointing)
+	if pointing < 2 {
+		t.Errorf("winner holds %d aliases, want the loser's redirected too", pointing)
+	}
+
+	var occ int
+	pool.QueryRow(ctx, `SELECT occurrence_count FROM error_groups WHERE id=$1`, winner).Scan(&occ)
+	if occ != 5 {
+		t.Errorf("occurrence_count = %d, want 5 rebuilt from error_events", occ)
+	}
+
+	var status string
+	pool.QueryRow(ctx, `SELECT status FROM error_groups WHERE id=$1`, loser).Scan(&status)
+	if status != "merged" {
+		t.Errorf("loser status = %q, want merged", status)
+	}
+
+	var audited int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM issue_merges WHERE winner_id=$1 AND loser_id=$2`,
+		winner, loser).Scan(&audited)
+	if audited != 1 {
+		t.Errorf("merge audit rows = %d, want 1; an unaudited merge is a silent rewrite", audited)
+	}
+
+	var openLoserEpisodes int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM issue_episodes WHERE canonical_issue_id=$1 AND closed_at IS NULL`,
+		loser).Scan(&openLoserEpisodes)
+	if openLoserEpisodes != 0 {
+		t.Errorf("loser has %d open episodes, want 0", openLoserEpisodes)
+	}
+}
+
+func TestConfirmMergeRefusesAfterInvestigationOrPublication(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	for _, blocker := range []string{"investigation", "publication"} {
+		winner := seedIssueWithEvents(t, pool, projectID, 2)
+		loser  := seedIssueWithEvents(t, pool, projectID, 2)
+		seedBlocker(t, pool, projectID, loser, blocker)
+		err := ConfirmMerge(ctx, pool, projectID, winner, loser, "model", "inquiry")
+		if err == nil {
+			t.Errorf("%s should block an automatic merge", blocker)
+		}
+	}
+}
+
+func TestRebuiltCountersMatchAbsoluteReconstruction(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	winner := seedIssueWithEvents(t, pool, projectID, 7)
+	loser  := seedIssueWithEvents(t, pool, projectID, 4)
+	if err := ConfirmMerge(ctx, pool, projectID, winner, loser, "human", "abhishek"); err != nil {
+		t.Fatalf("ConfirmMerge: %v", err)
+	}
+	var incremental, absolute int
+	pool.QueryRow(ctx, `SELECT occurrence_count FROM error_groups WHERE id=$1`, winner).Scan(&incremental)
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM error_events e
+		   JOIN error_event_identities i ON i.event_id = e.id
+		  WHERE i.canonical_issue_id = $1`, winner).Scan(&absolute)
+	if incremental != absolute {
+		t.Errorf("counter drift: stored %d, reconstructed %d", incremental, absolute)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./identity -run 'TestConfirmMerge|TestRebuilt' -v`
+Expected: FAIL, `ConfirmMerge` undefined.
+
+- [ ] **Step 3: Implement the merge**
+
+```go
+// ConfirmMerge is the only operation that may move an observation between
+// issues. Normal settlement attaches and never moves; this exists so a
+// confirmed duplicate can be resolved without leaving orphaned events.
+func ConfirmMerge(ctx context.Context, pool *pgxpool.Pool, projectID, winnerID, loserID, confirmedBy, actor string) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var blocked bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (
+		   SELECT 1 FROM error_group_jobs j
+		    JOIN issue_episodes ep ON ep.id = j.episode_id
+		   WHERE ep.canonical_issue_id IN ($1,$2) AND j.job_type = 'investigate')
+		 OR EXISTS (
+		   SELECT 1 FROM issue_publications p
+		    JOIN issue_episodes ep ON ep.id = p.episode_id
+		   WHERE ep.canonical_issue_id IN ($1,$2))`,
+		winnerID, loserID).Scan(&blocked); err != nil {
+		return fmt.Errorf("check blockers: %w", err)
+	}
+	if blocked && confirmedBy != "human" {
+		return fmt.Errorf("merge refused: an issue already investigated or published")
+	}
+
+	aliasTag, err := tx.Exec(ctx,
+		`UPDATE canonical_issue_fingerprints
+		    SET canonical_issue_id = $1, confirmed_by = $3, bound_at = now()
+		  WHERE canonical_issue_id = $2 AND project_id = $4`,
+		winnerID, loserID, confirmedBy, projectID)
+	if err != nil {
+		return fmt.Errorf("redirect aliases: %w", err)
+	}
+	aliasesMoved := int(aliasTag.RowsAffected())
+
+	eventTag, err := tx.Exec(ctx,
+		`UPDATE error_event_identities SET canonical_issue_id = $1
+		  WHERE canonical_issue_id = $2 AND project_id = $3`,
+		winnerID, loserID, projectID)
+	if err != nil {
+		return fmt.Errorf("move observations: %w", err)
+	}
+	eventsMoved := int(eventTag.RowsAffected())
+	// Absolute reconstruction, not arithmetic on the two counters. Rebuilding
+	// from error_events is what keeps the incremental path auditable.
+	if _, err := tx.Exec(ctx,
+		`UPDATE error_groups g SET
+		   occurrence_count = sub.n, first_seen = sub.first, last_seen = sub.last
+		  FROM (SELECT count(*) AS n, min(e.created_at) AS first, max(e.created_at) AS last
+		          FROM error_events e
+		          JOIN error_event_identities i ON i.event_id = e.id
+		         WHERE i.canonical_issue_id = $1) sub
+		 WHERE g.id = $1`, winnerID); err != nil {
+		return fmt.Errorf("rebuild counters: %w", err)
+	}
+	// The capture handle on the raw event row must follow the observation, or a
+	// reader coming through the old handle lands on a merged, silent issue.
+	if _, err := tx.Exec(ctx,
+		`UPDATE error_events SET error_group_id = $1
+		  WHERE error_group_id = $2 AND project_id = $3`,
+		winnerID, loserID, projectID); err != nil {
+		return fmt.Errorf("move capture handles: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE issue_episodes SET closed_at = now()
+		  WHERE canonical_issue_id = $1 AND closed_at IS NULL`, loserID); err != nil {
+		return fmt.Errorf("close loser episode: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE error_groups SET status = 'merged', merged_at = now() WHERE id = $1`,
+		loserID); err != nil {
+		return fmt.Errorf("mark loser merged: %w", err)
+	}
+	// The audit record. Without this row the operation is a silent rewrite of
+	// history and nothing can answer "why are these one issue now".
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO issue_merges
+		   (project_id, winner_id, loser_id, confirmed_by, actor, aliases_moved, events_moved)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+		projectID, winnerID, loserID, confirmedBy, actor, aliasesMoved, eventsMoved); err != nil {
+		return fmt.Errorf("record merge: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE issue_alias_conflicts SET status = 'resolved'
+		  WHERE project_id = $3
+		    AND left_issue_id IN ($1,$2) AND right_issue_id IN ($1,$2)`,
+		winnerID, loserID, projectID); err != nil {
+		return fmt.Errorf("close conflict: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./identity -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/identity/merge.go packages/ingestion/identity/merge_test.go
+git commit -m "feat(identity): resolve a confirmed duplicate with an audited merge"
+```
+
+---
+
+### Task 13: Run the settler as a multi-replica loop
+
+**Files:**
+- Create: `packages/ingestion/identity/loop.go`
+- Modify: `packages/ingestion/main.go` (start the loop)
+- Test: `packages/ingestion/identity/loop_test.go`
+
+**Interfaces:**
+- Consumes: `Settle` (Task 12)
+- Produces: `func (l *Loop) Start(ctx context.Context, interval time.Duration)`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestLoopSkipsObservationsWhoseResolutionIsStillPending(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	eventID := seedEventWithPendingResolution(t, pool, projectID)
+
+	if err := (&Loop{pool: pool}).Tick(ctx); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	var status string
+	pool.QueryRow(ctx,
+		`SELECT status FROM error_event_identities WHERE event_id=$1`, eventID).Scan(&status)
+	if status != "pending" {
+		t.Errorf("status = %q, want pending; settling before resolution loses the map", status)
+	}
+}
+
+func TestLoopSettlesEachObservationExactlyOnceUnderConcurrency(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	// Distinct raw fingerprints as well as distinct resolved ones. Seeding all
+	// forty with one raw key would bind them through the raw alias and produce
+	// a single issue, so the four-issue assertion below would prove nothing.
+	for i := 0; i < 40; i++ {
+		seedResolvedEvent(t, pool, projectID,
+			fmt.Sprintf("bundle-%d.js", i%4), fmt.Sprintf("src/F%d.vue", i%4), "f")
+	}
+
+	var wg sync.WaitGroup
+	for r := 0; r < 4; r++ { // four replicas
+		wg.Add(1)
+		go func() { defer wg.Done(); (&Loop{pool: pool}).Tick(ctx) }()
+	}
+	wg.Wait()
+
+	var pending, settled int
+	pool.QueryRow(ctx, `SELECT count(*) FROM error_event_identities WHERE status='pending'`).Scan(&pending)
+	pool.QueryRow(ctx, `SELECT count(*) FROM error_event_identities WHERE status='settled'`).Scan(&settled)
+	if pending != 0 || settled != 40 {
+		t.Errorf("pending=%d settled=%d, want 0 and 40", pending, settled)
+	}
+	// Four distinct source files must produce exactly four issues.
+	var issues int
+	pool.QueryRow(ctx, `SELECT count(*) FROM error_groups WHERE project_id=$1`, projectID).Scan(&issues)
+	if issues != 4 {
+		t.Errorf("issues = %d, want 4", issues)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./identity -run TestLoop -v`
+Expected: FAIL, `Loop` undefined.
+
+- [ ] **Step 3: Implement the loop**
+
+```go
+// Tick claims a bounded batch of pending identities. FOR UPDATE SKIP LOCKED
+// lets every replica make progress without blocking on each other.
+func (l *Loop) Tick(ctx context.Context) error {
+	// Claim by UPDATE, not by SELECT ... FOR UPDATE. Closing the rows of a
+	// SELECT releases its locks before the work runs, so two replicas would
+	// process the same batch. Marking the row 'settling' is the claim.
+	// Without this join the settler races the resolver and permanently settles a
+	// mapped event on its raw fingerprint, which is the exact fragmentation the
+	// rewrite exists to remove.
+	rows, err := l.pool.Query(ctx,
+		`UPDATE error_event_identities i
+		    SET status = 'settling', claimed_at = now()
+		  WHERE (i.project_id, i.event_id) IN (
+		          SELECT i2.project_id, i2.event_id
+		            FROM error_event_identities i2
+		            JOIN error_event_resolutions r
+		              ON r.project_id = i2.project_id AND r.event_id = i2.event_id
+		           WHERE i2.status = 'pending'
+		             AND r.status IN ('resolved','no_map','failed')
+		           ORDER BY i2.event_id
+		           LIMIT 100
+		           FOR UPDATE OF i2 SKIP LOCKED)
+		 RETURNING i.project_id::text, i.event_id::text`)
+	if err != nil {
+		return fmt.Errorf("claim batch: %w", err)
+	}
+	type ref struct{ project, event string }
+	var batch []ref
+	for rows.Next() {
+		var r ref
+		if err := rows.Scan(&r.project, &r.event); err != nil {
+			rows.Close()
+			return err
+		}
+		batch = append(batch, r)
+	}
+	rows.Close()
+
+	for _, r := range batch {
+		if _, err := Settle(ctx, l.pool, r.project, r.event); err != nil {
+			slog.Error("settle failed", "event_id", r.event, "error", err)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 3b: Reset abandoned claims**
+
+A worker that dies mid-settle leaves the row at `settling` forever, and Task 13 only
+claims `pending`. Add to the same tick:
+
+```go
+// Rows claimed but not finished within the lease are returned to the queue.
+// Settlement is idempotent, so re-running one is free.
+func (l *Loop) resetAbandoned(ctx context.Context) error {
+	_, err := l.pool.Exec(ctx,
+		`UPDATE error_event_identities
+		    SET status = 'pending', claimed_at = NULL
+		  WHERE status = 'settling' AND claimed_at < now() - interval '5 minutes'`)
+	return err
+}
+```
+
+```go
+func TestAbandonedClaimsReturnToTheQueue(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	eventID := seedStuckSettlingIdentity(t, pool, projectID, time.Now().Add(-10*time.Minute))
+
+	if err := (&Loop{pool: pool}).resetAbandoned(ctx); err != nil {
+		t.Fatalf("resetAbandoned: %v", err)
+	}
+	var status string
+	pool.QueryRow(ctx, `SELECT status FROM error_event_identities WHERE event_id=$1`,
+		eventID).Scan(&status)
+	if status != "pending" {
+		t.Errorf("status = %q, want pending; a dead worker must not strand an observation", status)
+	}
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./identity -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/identity/loop.go packages/ingestion/identity/loop_test.go packages/ingestion/main.go
+git commit -m "feat(identity): run settlement as a multi-replica claim loop"
+```
+
+---
+
+### Task 14: Open and close issue episodes
+
+**Files:**
+- Create: `packages/ingestion/identity/episode.go`
+- Test: `packages/ingestion/identity/episode_test.go`
+
+**Interfaces:**
+- Consumes: `Settle` (Task 12)
+- Produces: `func OpenOrGetEpisode(ctx, tx, projectID, issueID string) (string, error)`, `func CloseEpisode(ctx, tx, projectID, episodeID string) error`
+
+An episode is one continuous active period between resolutions. It makes "investigate once", "publish once", and "returned rather than new" enforceable without treating a recurrence as a new issue.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestEpisodeReopensAsReturnedAfterResolution(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	issueID := seedIssue(t, pool, projectID)
+
+	first := mustOpenEpisode(t, pool, projectID, issueID)
+	same := mustOpenEpisode(t, pool, projectID, issueID)
+	if first != same {
+		t.Errorf("an open episode must be reused, got %s then %s", first, same)
+	}
+
+	mustCloseEpisode(t, pool, projectID, first)
+	second := mustOpenEpisode(t, pool, projectID, issueID)
+	if second == first {
+		t.Error("a recurrence after resolution must open a new episode")
+	}
+
+	var seq int
+	pool.QueryRow(ctx, `SELECT sequence FROM issue_episodes WHERE id=$1`, second).Scan(&seq)
+	if seq != 2 {
+		t.Errorf("sequence = %d, want 2 (this is what renders as returned)", seq)
+	}
+}
+
+func TestOnlyOneEpisodeOpenPerIssue(t *testing.T) {
+	pool := testPool(t)
+	projectID := seedProject(t, pool)
+	issueID := seedIssue(t, pool, projectID)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); _, _ = openEpisodeRaw(pool, projectID, issueID) }()
+	}
+	wg.Wait()
+	var open int
+	pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM issue_episodes WHERE canonical_issue_id=$1 AND closed_at IS NULL`,
+		issueID).Scan(&open)
+	if open != 1 {
+		t.Errorf("open episodes = %d, want 1", open)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./identity -run TestEpisode -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement episodes**
+
+```go
+// OpenOrGetEpisode returns the issue's open episode, creating one if the issue
+// has none. The partial unique index idx_one_open_episode makes the race safe.
+func OpenOrGetEpisode(ctx context.Context, tx pgx.Tx, projectID, issueID string) (string, error) {
+	var id string
+	err := tx.QueryRow(ctx,
+		`INSERT INTO issue_episodes (project_id, canonical_issue_id, sequence)
+		 SELECT $1, $2, COALESCE(MAX(sequence), 0) + 1
+		   FROM issue_episodes WHERE canonical_issue_id = $2
+		 ON CONFLICT DO NOTHING
+		 RETURNING id::text`,
+		projectID, issueID).Scan(&id)
+	if err == nil {
+		return id, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return "", fmt.Errorf("open episode: %w", err)
+	}
+	if err := tx.QueryRow(ctx,
+		`SELECT id::text FROM issue_episodes
+		  WHERE project_id = $1 AND canonical_issue_id = $2 AND closed_at IS NULL`,
+		projectID, issueID).Scan(&id); err != nil {
+		return "", fmt.Errorf("read open episode: %w", err)
+	}
+	return id, nil
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./identity -v`
+Expected: PASS
+
+- [ ] **Step 4b: Close the round when the issue resolves**
+
+`OpenOrGetEpisode` has no counterpart caller, so without this step a resolved issue
+keeps its round open and a later recurrence attaches to the same one, which means
+A9 can never pass: nothing ever presents as returned.
+
+**Closure is Go's, and it happens on resolution only.** A verified fix is not a
+resolution: its card is the PR the founder still has to review, and Task 25 only
+considers episodes with `closed_at IS NULL`, so closing on a verified fix would make
+the fix unpublishable. The round closes when the issue actually reaches `resolved`.
+
+TypeScript cannot call this Go function, so nothing bridges runtimes. Instead the
+dispatcher sweep in Task 19A closes rounds whose issue has become resolved, which
+keeps `issue_episodes` single-writer:
+
+```go
+// closeResolvedRounds runs in the same tick as staleEpisodes.
+func (d *Dispatcher) closeResolvedRounds(ctx context.Context) error {
+	_, err := d.pool.Exec(ctx,
+		`UPDATE issue_episodes ep SET closed_at = now()
+		   FROM error_groups g
+		  WHERE g.id = ep.canonical_issue_id
+		    AND ep.closed_at IS NULL
+		    AND g.status = 'resolved'`)
+	return err
+}
+```
+
+Add a test:
+
+```go
+func TestResolutionClosesTheRoundSoRecurrenceReturns(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	issueID := seedIssue(t, pool, projectID)
+	first := mustOpenEpisode(t, pool, projectID, issueID)
+
+	mustResolveIssue(t, pool, projectID, issueID)
+	if err := (&Dispatcher{pool: pool}).closeResolvedRounds(ctx); err != nil {
+		t.Fatalf("closeResolvedRounds: %v", err)
+	}
+
+	var closed bool
+	pool.QueryRow(ctx,
+		`SELECT closed_at IS NOT NULL FROM issue_episodes WHERE id=$1`, first).Scan(&closed)
+	if !closed {
+		t.Fatal("resolving the issue must close its round")
+	}
+	second := mustOpenEpisode(t, pool, projectID, issueID)
+	if second == first {
+		t.Error("a recurrence after resolution must open a new round")
+	}
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/identity/episode.go packages/ingestion/identity/episode_test.go
+git commit -m "feat(identity): track work rounds as issue episodes"
+```
+
+---
+
+### Task 14A: Wire settlement to the episode and the filter
+
+**Files:**
+- Modify: `packages/ingestion/identity/settle.go`
+- Modify: `packages/ingestion/identity/loop.go`
+- Test: `packages/ingestion/identity/wiring_test.go`
+
+**Interfaces:**
+- Consumes: `Settle` (Task 12), `OpenOrGetEpisode` (Task 14)
+- Produces: settlement opens the work round and stamps it on the observation
+
+Evaluation is **not** here. An earlier draft called `filter.Evaluate` from this loop,
+which made Task 14A depend on Task 18 and therefore unable to compile in sequence.
+The filter runs from its own sweep in Task 19A instead.
+
+Tasks 12 and 14 build settlement and episodes; nothing calls the second from the
+first. Without this task an engineer can finish every identity task and observe no
+episodes, no decisions, and no downstream work. This is the first of three links
+that turn the stages into a pipeline.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestSettlementOpensAnEpisodeAndTriggersTheFilter(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	seedResolvedEvent(t, pool, projectID, "a.js", "src/A.vue", "f")
+	seedResolvedEvent(t, pool, projectID, "a.js", "src/A.vue", "f")
+
+	if err := (&Loop{pool: pool}).Tick(ctx); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+
+	var episodes int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM issue_episodes WHERE project_id=$1 AND closed_at IS NULL`,
+		projectID).Scan(&episodes)
+	if episodes != 1 {
+		t.Errorf("open episodes = %d, want 1", episodes)
+	}
+
+	var stamped int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM error_event_identities
+		  WHERE project_id=$1 AND status='settled' AND episode_id IS NOT NULL`,
+		projectID).Scan(&stamped)
+	if stamped != 2 {
+		t.Errorf("observations stamped with an episode = %d, want 2", stamped)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./identity -run TestSettlementOpens -v`
+Expected: FAIL, zero episodes.
+
+- [ ] **Step 3: Open the episode inside settlement**
+
+In `Settle`, after `attachObservation` and before marking the observation settled,
+call `OpenOrGetEpisode(ctx, tx, projectID, issueID)` and record the episode on the
+attached observation. The episode is part of the same transaction, so an issue can
+never exist without one.
+
+- [ ] **Step 4: Stamp the episode on the observation**
+
+`Settle` writes `error_event_identities.episode_id` in the same transaction. The
+filter counts observations by episode, so an unstamped observation would be counted
+against every round the issue has ever had.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./identity -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ingestion/identity/
+git commit -m "feat(identity): open a work round on settlement"
+```
+
+---
+
+# Slice 5: compact session facts and evidence lookup
+
+### Task 15: Fix the refused-request signal before building on it
+
+**Files:**
+- Modify: `packages/worker/src/friction/facts.ts:43`, `:88-91`, `:106-111`
+- Test: `packages/worker/src/__tests__/friction-facts.test.ts`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `WRITE_METHODS` includes `DELETE`; status `0` counts as a failure
+
+The severity signal this design leans on is invisible three ways today. `WRITE_METHODS` omits `DELETE`, so the flagship "customers cannot delete assets" case produces no refused-write signal at all. The SDK emits `status: 0` for transport refusals (`packages/sdk/src/network.ts:124`) and the bucketing counts only `2xx` and `>= 400`, so a connection the server never answered lands nowhere. And `sameOrigin` returns true when a URL will not parse.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+describe('failed write detection', () => {
+  it('counts a refused DELETE', () => {
+    const facts = extractSessionFacts(sessionWith([
+      { method: 'DELETE', url: '/api/assets/1', status: 400, sameOrigin: true },
+    ]));
+    expect(facts.failedWriteCount).toBe(1);
+  });
+
+  it('counts a transport refusal reported as status 0', () => {
+    const facts = extractSessionFacts(sessionWith([
+      { method: 'POST', url: '/api/assets', status: 0, sameOrigin: true },
+    ]));
+    expect(facts.failedWriteCount).toBe(1);
+  });
+
+  it('does not treat an unparseable URL as same-origin', () => {
+    const facts = extractSessionFacts(sessionWith([
+      { method: 'POST', url: '::::not-a-url', status: 500, sameOrigin: false },
+    ]));
+    expect(facts.failedWriteCount).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify all three fail**
+
+Run: `pnpm --filter @opslane/worker test -- friction-facts`
+Expected: FAIL on all three.
+
+- [ ] **Step 3: Fix the three defects**
+
+```typescript
+const WRITE_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
+// status 0 is the SDK's transport-refusal marker (sdk/src/network.ts:124):
+// the request never got an answer, which is a failure, not an unknown.
+function isFailure(status: number): boolean {
+  return status === 0 || status >= 400;
+}
+
+function sameOrigin(url: string, pageOrigin: string): boolean {
+  // `new URL('::::not-a-url', base)` does NOT throw: it resolves as a relative
+  // path and would count as same-origin. Reject anything that is not an
+  // absolute same-origin URL or a plain rooted path.
+  if (url.startsWith('/') && !url.startsWith('//')) return true;
+  try {
+    const parsed = new URL(url);
+    return parsed.origin === pageOrigin;
+  } catch {
+    return false;
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `pnpm --filter @opslane/worker test -- friction-facts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/worker/src/friction/facts.ts packages/worker/src/__tests__/friction-facts.test.ts
+git commit -m "fix(friction): count refused DELETEs and transport refusals as failed writes"
+```
+
+---
+
+### Task 16: Build the bounded evidence reader
+
+**Files:**
+- Create: `packages/worker/src/evidence/bundle.ts`
+- Test: `packages/worker/src/__tests__/evidence-bundle.test.ts`
+
+**Interfaces:**
+- Consumes: `error_event_resolutions` (Task 10), `issue_evidence_anchors` (Task 5), session facts (Task 15)
+- Produces: `loadEvidence(projectId: string, episodeId: string): Promise<EvidenceBundle>` where
+  `EvidenceBundle = { frames, failedRequests, writeRollups, productContext, replayPointers, availability, affectedUnits, relatedCandidates }`
+
+`affectedUnits` and `relatedCandidates` exist because Task 21 reads both: the first
+becomes `evaluated_units` on the stored decision, the second is the only set of
+issue IDs an inquiry is allowed to cite.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+describe('evidence bundle', () => {
+  it('reads frozen anchors, never sample_event_id', async () => {
+    const { episodeId, projectId, anchorEventId } = await seedEpisodeWithAnchors();
+    await moveSampleEventId(projectId); // simulate a later occurrence arriving
+    const bundle = await loadEvidence(projectId, episodeId);
+    expect(bundle.frames.sourceEventId).toBe(anchorEventId);
+  });
+
+  it('degrades to stated availability when the recording expired', async () => {
+    const { episodeId, projectId } = await seedEpisodeWithExpiredRecording();
+    const bundle = await loadEvidence(projectId, episodeId);
+    expect(bundle.availability.recording).toBe('expired');
+    expect(bundle.failedRequests).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @opslane/worker test -- evidence-bundle`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the reader**
+
+```typescript
+export async function loadEvidence(
+  projectId: string, episodeId: string,
+): Promise<EvidenceBundle> {
+  const anchors = await getPool().query(
+    `SELECT anchor_kind, event_id FROM issue_evidence_anchors
+      WHERE project_id=$1 AND episode_id=$2`, [projectId, episodeId]);
+  if (anchors.rowCount === 0) {
+    throw new Error(`no frozen anchors for episode ${episodeId}`);
+  }
+  const threshold = anchors.rows.find((r) => r.anchor_kind === 'threshold');
+  const frames = await loadResolvedFrames(projectId, threshold.event_id);
+  const facts = await loadSessionFacts(projectId, anchors.rows.map((r) => r.event_id));
+  return {
+    frames: { ...frames, sourceEventId: threshold.event_id },
+    failedRequests: facts.failedRequests,
+    writeRollups: facts.writeRollups,
+    productContext: await loadProductContext(projectId, frames.routes),
+    replayPointers: facts.replayPointers,
+    availability: {
+      recording: facts.recordingExpired ? 'expired' : 'available',
+      sourceMap: frames.status,
+    },
+    affectedUnits: await countAffectedUnits(projectId, episodeId),
+    relatedCandidates: await loadRelatedCandidates(projectId, episodeId),
+  };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter @opslane/worker test -- evidence-bundle`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/worker/src/evidence/ packages/worker/src/__tests__/evidence-bundle.test.ts
+git commit -m "feat(evidence): assemble a bounded bundle from frozen anchors"
+```
+
+---
+
+### Task 16A: Persist compact session facts
+
+**Files:**
+- Create: `packages/worker/src/facts/persist.ts`
+- Test: `packages/worker/src/__tests__/facts-persist.test.ts`
+
+**Interfaces:**
+- Consumes: `session_request_failures`, `session_write_rollups` (Task 5); the fixed
+  predicates from Task 15
+- Produces: `replaceSessionFacts(projectId: string, sessionId: string, facts: SessionFacts): Promise<void>`
+
+Task 15 fixes what counts as a failed write; nothing stores the result. The
+architecture keeps recordings in object storage and writes only the facts an
+investigation needs, so this is the write path that makes the evidence bundle
+possible. Decoded recordings in the audited sample ran 1.1 MB to 28 MB while the
+facts fit in a handful of rows.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+describe('session fact persistence', () => {
+  it('stores one row per failed request and rolls up successes', async () => {
+    const { projectId, sessionId } = await seedSession();
+    await replaceSessionFacts(projectId, sessionId, factsWith({
+      failures: [
+        { method: 'PUT', endpoint: '/api/assets/:id', status: 400, route: '/assets/:id/edit' },
+        { method: 'PUT', endpoint: '/api/assets/:id', status: 400, route: '/assets/:id/edit' },
+      ],
+      successes: [
+        { method: 'POST', endpoint: '/api/assets', statusClass: 2, route: '/assets/new', count: 5 },
+      ],
+    }));
+    const f = await query(`SELECT * FROM session_request_failures WHERE session_id=$1`, [sessionId]);
+    const r = await query(`SELECT * FROM session_write_rollups WHERE session_id=$1`, [sessionId]);
+    expect(f.rowCount).toBe(2);
+    expect(r.rowCount).toBe(1);
+    expect(r.rows[0].occurrence_count).toBe(5);
+  });
+
+  it('replaces the whole fact set when a late chunk arrives', async () => {
+    const { projectId, sessionId } = await seedSession();
+    await replaceSessionFacts(projectId, sessionId, factsWith({ failures: [failure()] }));
+    await replaceSessionFacts(projectId, sessionId, factsWith({ failures: [failure(), failure2()] }));
+    const f = await query(`SELECT * FROM session_request_failures WHERE session_id=$1`, [sessionId]);
+    expect(f.rowCount).toBe(2); // replaced, not appended
+  });
+
+  it('stores no request body, query string, or host', async () => {
+    const { projectId, sessionId } = await seedSession();
+    await replaceSessionFacts(projectId, sessionId, factsWith({
+      failures: [{ method: 'POST', endpoint: '/api/assets?token=secret',
+                   status: 400, route: '/assets/new' }],
+    }));
+    const f = await query(`SELECT endpoint_pattern FROM session_request_failures WHERE session_id=$1`, [sessionId]);
+    expect(f.rows[0].endpoint_pattern).not.toContain('token');
+    expect(f.rows[0].endpoint_pattern).not.toContain('?');
+  });
+
+  it('expires with the session', async () => {
+    const { projectId, sessionId } = await seedSession();
+    await replaceSessionFacts(projectId, sessionId, factsWith({ failures: [failure()] }));
+    await query(`DELETE FROM sessions WHERE id=$1`, [sessionId]);
+    const f = await query(`SELECT * FROM session_request_failures WHERE session_id=$1`, [sessionId]);
+    expect(f.rowCount).toBe(0); // ON DELETE CASCADE, no second sweeper
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm --filter @opslane/worker test -- facts-persist`
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement transactional replacement**
+
+```typescript
+/** One session's facts are whole-session truth at a rule version. A late chunk
+ *  produces a new truth, so the old set is replaced rather than merged. */
+export async function replaceSessionFacts(
+  projectId: string, sessionId: string, facts: SessionFacts,
+): Promise<void> {
+  const client = await getPool().connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `DELETE FROM session_request_failures
+        WHERE project_id=$1 AND session_id=$2 AND rule_version=$3`,
+      [projectId, sessionId, facts.ruleVersion]);
+    await client.query(
+      `DELETE FROM session_write_rollups
+        WHERE project_id=$1 AND session_id=$2 AND rule_version=$3`,
+      [projectId, sessionId, facts.ruleVersion]);
+    for (const f of facts.failures) {
+      await client.query(
+        `INSERT INTO session_request_failures
+           (project_id, session_id, request_id_hash, page_route, method,
+            endpoint_pattern, status, action_kind, action_selector, action_link,
+            occurred_at, rule_version)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+        [projectId, sessionId, f.requestIdHash, f.route, f.method,
+         stripQuery(f.endpoint), f.status, f.actionKind ?? null,
+         f.actionSelector ?? null, f.actionLink, f.occurredAt, facts.ruleVersion]);
+    }
+    for (const r of facts.successes) {
+      await client.query(
+        `INSERT INTO session_write_rollups
+           (project_id, session_id, page_route, method, endpoint_pattern,
+            status_class, occurrence_count, rule_version)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+        [projectId, sessionId, r.route, r.method, stripQuery(r.endpoint),
+         r.statusClass, r.count, facts.ruleVersion]);
+    }
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/** Query strings can carry tokens, so the pattern never keeps one. */
+function stripQuery(endpoint: string): string {
+  return endpoint.split('?')[0]!;
+}
+```
+
+Call it at the end of the session analysis job, replacing the current totals-only write.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `pnpm --filter @opslane/worker test -- facts-persist`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/worker/src/facts/ packages/worker/src/__tests__/facts-persist.test.ts
+git commit -m "feat(facts): persist compact session facts with cascading expiry"
+```
+
+---
+
+# Slice 6: LLM-built product understanding
+
+### Task 17: Build grounded route and action understanding
+
+**Files:**
+- Create: `packages/worker/src/product-context/job.ts`
+- Create: `packages/worker/src/product-context/schema.ts`
+- Test: `packages/worker/src/__tests__/product-context.test.ts`
+
+**Interfaces:**
+- Consumes: existing repository checkout tooling; `route_map` table
+- Produces: `runProductContext(job: ClaimedJob): Promise<void>`; `type RouteClaim = { route: string; purpose: string; actions: string[]; clientRefs: string[]; serverRefs: string[]; audience: string; confidence: number }`
+
+Mechanical discovery supplies registered routes, likely page files, and observed requests. The model then reads the code and records what each route is for. Every claim carries its code references, commit, prompt version, model, and confidence. Human rows stay authoritative. Missing understanding means unknown, never unimportant.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+describe('product context', () => {
+  it('records code references for every claim', async () => {
+    const claims = await runProductContextForFixture('assets-repo');
+    for (const claim of claims) {
+      expect(claim.clientRefs.length + claim.serverRefs.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('never overwrites a human-authored claim', async () => {
+    const { projectId, route } = await seedHumanClaim('/assets/:id/edit', 'Edits an asset');
+    await runProductContext({ projectId } as ClaimedJob);
+    const stored = await queryOne(
+      `SELECT purpose, source FROM route_map WHERE project_id=$1 AND pattern=$2`,
+      [projectId, route]);
+    expect(stored.source).toBe('human');
+    expect(stored.purpose).toBe('Edits an asset');
+  });
+
+  it('marks an unmapped route unknown rather than unimportant', async () => {
+    const claims = await runProductContextForFixture('sparse-repo');
+    const unmapped = claims.find((c) => c.route === '/internal/debug');
+    expect(unmapped?.confidence).toBe(0);
+    expect(unmapped?.purpose).toBe('unknown');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @opslane/worker test -- product-context`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the job with a strict output schema**
+
+```typescript
+export const ROUTE_CLAIM_SCHEMA = {
+  type: 'object',
+  required: ['route', 'purpose', 'actions', 'client_refs', 'server_refs', 'audience', 'confidence'],
+  properties: {
+    route: { type: 'string' },
+    purpose: { type: 'string' },
+    actions: { type: 'array', items: { type: 'string' } },
+    client_refs: { type: 'array', items: { type: 'string' } },
+    server_refs: { type: 'array', items: { type: 'string' } },
+    audience: { type: 'string', enum: ['customer', 'admin', 'standard', 'unknown'] },
+    confidence: { type: 'number', minimum: 0, maximum: 1 },
+  },
+  additionalProperties: false,
+} as const;
+
+export async function runProductContext(job: ClaimedJob): Promise<void> {
+  const discovered = await discoverRoutes(job.projectId);
+  const claims = await askModelForClaims(discovered, ROUTE_CLAIM_SCHEMA);
+  for (const claim of claims) {
+    if (!claim.client_refs.length && !claim.server_refs.length) {
+      // Stored as unknown with zero confidence, not dropped. "Missing
+      // understanding means unknown, never unimportant": a dropped route looks
+      // identical to one nobody has looked at, and ranking would treat it as
+      // ordinary rather than unexamined.
+      claim.purpose = 'unknown';
+      claim.confidence = 0;
+    }
+    await getPool().query(
+      `INSERT INTO route_map
+         (project_id, pattern, purpose, actions, client_refs, server_refs,
+          audience, confidence, commit_sha, prompt_version, model, source)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,'model')
+       ON CONFLICT (project_id, pattern) DO UPDATE
+         SET purpose=EXCLUDED.purpose, actions=EXCLUDED.actions,
+             client_refs=EXCLUDED.client_refs, server_refs=EXCLUDED.server_refs,
+             audience=EXCLUDED.audience, confidence=EXCLUDED.confidence,
+             commit_sha=EXCLUDED.commit_sha, prompt_version=EXCLUDED.prompt_version,
+             model=EXCLUDED.model
+         WHERE route_map.source <> 'human'`,
+      [job.projectId, claim.route, claim.purpose, claim.actions, claim.client_refs,
+       claim.server_refs, claim.audience, claim.confidence, job.commitSha,
+       PROMPT_VERSION, MODEL]);
+  }
+}
+```
+
+- [ ] **Step 4: Add the deploy trigger**
+
+`handler/webhook.go:57` rejects every GitHub event that is not `pull_request`, so a deploy cannot trigger this job today. Accept `push` on the default branch and enqueue a `product_context` job. Add the corresponding App event subscription.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `pnpm --filter @opslane/worker test -- product-context`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/worker/src/product-context/ packages/worker/src/__tests__/product-context.test.ts packages/ingestion/handler/webhook.go
+git commit -m "feat(product-context): build grounded route understanding on deploy"
+```
+
+---
+
+# Slice 7A: the cheap filter
+
+### Task 18: Evaluate reach, recency, and scope
+
+**Files:**
+- Create: `packages/ingestion/filter/evaluate.go`
+- Test: `packages/ingestion/filter/evaluate_test.go`
+
+**Interfaces:**
+- Consumes: `issue_episodes` (Task 14)
+- Produces: `func Evaluate(ctx context.Context, pool *pgxpool.Pool, projectID, episodeID string) (Decision, error)` where `Decision = { Outcome string; Reason string; Users7d, Anon7d int }` and `Outcome` is one of `open_inquiry`, `watch`, `inactive`, `out_of_scope`
+
+An affected unit is one distinct identified user, or one anonymous session where no identity exists. Occurrence count is not reach: one retry loop generates unlimited events and no additional people. The 30-day replay admits three to seven issues a day and holds 24 to 31 at exactly one unit.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestFilterOutcomes(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+
+	cases := []struct {
+		name    string
+		seed    func(t *testing.T) string // returns episodeID
+		want    string
+	}{
+		{"two identified users admit", func(t *testing.T) string {
+			return seedEpisodeWithUsers(t, pool, projectID, 2, 0, time.Now())
+		}, "open_inquiry"},
+		{"one user plus one anon session admit", func(t *testing.T) string {
+			return seedEpisodeWithUsers(t, pool, projectID, 1, 1, time.Now())
+		}, "open_inquiry"},
+		{"one unit holds", func(t *testing.T) string {
+			return seedEpisodeWithUsers(t, pool, projectID, 1, 0, time.Now())
+		}, "watch"},
+		{"200 occurrences from one user still holds", func(t *testing.T) string {
+			return seedEpisodeWithOccurrences(t, pool, projectID, 1, 200, time.Now())
+		}, "watch"},
+		{"quiet for eight days is inactive", func(t *testing.T) string {
+			return seedEpisodeWithUsers(t, pool, projectID, 5, 0, time.Now().Add(-8*24*time.Hour))
+		}, "inactive"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := Evaluate(ctx, pool, projectID, tc.seed(t))
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if d.Outcome != tc.want {
+				t.Errorf("outcome = %q, want %q (reason: %s)", d.Outcome, tc.want, d.Reason)
+			}
+		})
+	}
+}
+
+func TestFilterAppendsOnlyOnChange(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	ep := seedEpisodeWithUsers(t, pool, projectID, 1, 0, time.Now())
+
+	for i := 0; i < 3; i++ {
+		if _, err := Evaluate(ctx, pool, projectID, ep); err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+	}
+	var n int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM issue_decisions WHERE episode_id=$1`, ep).Scan(&n)
+	if n != 1 {
+		t.Errorf("decisions = %d, want 1 (unchanged outcome must not append)", n)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./filter -v`
+Expected: FAIL, package does not exist.
+
+- [ ] **Step 3: Implement the filter**
+
+```go
+package filter
+
+const RuleVersion = 1
+const admitUnits = 2
+const livenessWindow = 7 * 24 * time.Hour
+
+// Evaluate answers one factual question: has this happened recently, in scope,
+// to enough distinct people to deserve an AI review? It does not decide whether
+// the issue is a real defect. That is the inquiry's job.
+func Evaluate(ctx context.Context, pool *pgxpool.Pool, projectID, episodeID string) (Decision, error) {
+	var users7d, anon7d int
+	var lastSeen time.Time
+	var inScope bool
+	err := pool.QueryRow(ctx,
+		`SELECT
+		   -- Keyed on i.episode_id, NOT on the issue. A returned episode must
+		   -- count its own observations; joining through canonical_issue_id
+		   -- would hand it every event the issue ever had.
+		   (SELECT count(DISTINCT e.end_user_id) FROM error_events e
+		     JOIN error_event_identities i ON i.event_id = e.id
+		    WHERE i.episode_id = $1 AND e.end_user_id IS NOT NULL
+		      AND e.created_at > now() - interval '7 days'),
+		   (SELECT count(DISTINCT e.session_id) FROM error_events e
+		     JOIN error_event_identities i ON i.event_id = e.id
+		    WHERE i.episode_id = $1 AND e.end_user_id IS NULL
+		      AND e.created_at > now() - interval '7 days'),
+		   (SELECT max(g.last_seen) FROM error_groups g
+		     JOIN issue_episodes ep ON ep.canonical_issue_id = g.id WHERE ep.id = $1),
+		   (SELECT COALESCE(bool_or(rm.tier <> 'excluded'), true)
+		      FROM route_map rm
+		      JOIN error_events e2 ON e2.context->>'url' LIKE '%' || rm.pattern || '%'
+		      JOIN error_event_identities i2 ON i2.event_id = e2.id
+		     WHERE i2.episode_id = $1)`,
+		episodeID).Scan(&users7d, &anon7d, &lastSeen, &inScope)
+	if err != nil {
+		return Decision{}, fmt.Errorf("count reach: %w", err)
+	}
+
+	d := Decision{Users7d: users7d, Anon7d: anon7d}
+	switch {
+	case !inScope:
+		d.Outcome, d.Reason = "out_of_scope", "no observations in the project's action scope"
+	case time.Since(lastSeen) > livenessWindow:
+		d.Outcome, d.Reason = "inactive", fmt.Sprintf("no occurrence since %s", lastSeen.Format(time.RFC3339))
+	case users7d+anon7d >= admitUnits:
+		d.Outcome, d.Reason = "open_inquiry", fmt.Sprintf("%d affected units in seven days", users7d+anon7d)
+	default:
+		d.Outcome, d.Reason = "watch", fmt.Sprintf("%d affected unit in seven days, below %d", users7d+anon7d, admitUnits)
+	}
+	return d, appendIfChanged(ctx, pool, projectID, episodeID, d)
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./filter -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/filter/
+git commit -m "feat(filter): admit on two affected units in seven days"
+```
+
+---
+
+### Task 19: Replay the filter over 30 days of production
+
+**Files:**
+- Create: `packages/ingestion/cmd/filter-replay/main.go`
+
+**Interfaces:**
+- Consumes: `Evaluate` (Task 18)
+- Produces: a read-only report of daily admit and hold counts
+
+- [ ] **Step 1: Write the replay command**
+
+```go
+// filter-replay recomputes the cheap filter for each of the last 30 days from
+// error_events, so the rule can be judged before it gates anything.
+// Read-only: it opens the session with default_transaction_read_only.
+func main() {
+	// ... connect, SET default_transaction_read_only = on ...
+	for day := 29; day >= 0; day-- {
+		at := time.Now().AddDate(0, 0, -day)
+		counts := replayDay(ctx, pool, projectID, at)
+		fmt.Printf("%s  admit=%d  watch=%d  inactive=%d\n",
+			at.Format("2006-01-02"), counts.Admit, counts.Watch, counts.Inactive)
+	}
+}
+```
+
+- [ ] **Step 2: Run it against production**
+
+Run: `DATABASE_URL="$PROD_READONLY_DSN" go run ./cmd/filter-replay --project 5a64d496-0dd0-48a3-aebd-f2ad636e3b44`
+Expected: three to seven admitted per recent day, 24 to 31 watched at one unit.
+
+- [ ] **Step 3: Read the held list**
+
+Print the watched issues for the most recent day with their titles and counts. A person reads all of them and confirms none should have been investigated. Record the outcome in the cutover evidence file.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ingestion/cmd/filter-replay/
+git commit -m "feat(filter): add a read-only 30-day admission replay"
+```
+
+---
+
+### Task 19A: Sweep the filter, freeze evidence, enqueue the inquiry
+
+**Files:**
+- Create: `packages/ingestion/filter/dispatch.go`
+- Create: `packages/ingestion/identity/anchors.go` (`FreezeAnchors`, first called here)
+- Modify: `packages/ingestion/main.go`
+- Test: `packages/ingestion/filter/dispatch_test.go`
+- Test: `packages/ingestion/identity/anchors_test.go`
+
+`FreezeAnchors` pins three observations for the round: the one that crossed the bar,
+the round's first, and a recent distinct one. It reads `error_events` joined through
+`error_event_identities` on `episode_id`, and never `sample_event_id`, which
+`queries.go:588` rewrites on every occurrence.
+
+**Interfaces:**
+- Consumes: `filter.Evaluate` (Task 18), `FreezeAnchors` (Task 24), `error_group_jobs.episode_id` (Task 5)
+- Produces: `func (d *Dispatcher) Tick(ctx context.Context) (evaluated, enqueued int, err error)`
+
+Second of three links, and it does three things in order: evaluate every open episode
+that has new evidence or a stale rule version, freeze the evidence anchors for any
+episode the filter admits, then enqueue one inquiry job for it.
+
+**Anchors freeze here, not at acceptance.** The inquiry reads the evidence bundle to
+make its decision, and the bundle is built from frozen anchors. Freezing after the
+inquiry decides would make the inquiry depend on evidence that does not exist yet.
+The architecture puts the freeze in the admission transaction for exactly this
+reason.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestDispatcherFreezesAnchorsBeforeEnqueueingTheInquiry(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	ep := seedEpisodeWithEvents(t, pool, projectID, 3)
+
+	if _, _, err := (&Dispatcher{pool: pool}).Tick(ctx); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	var anchors int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM issue_evidence_anchors WHERE episode_id=$1`, ep).Scan(&anchors)
+	if anchors < 2 {
+		t.Fatalf("anchors = %d; the inquiry cannot build an evidence bundle without them", anchors)
+	}
+	if got := countJobs(t, pool, ep, "issue_inquiry"); got != 1 {
+		t.Errorf("inquiry jobs = %d, want 1", got)
+	}
+}
+
+func TestDispatcherEnqueuesOneInquiryPerAdmittedEpisode(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	admitted := seedDecision(t, pool, projectID, "open_inquiry")
+	watched := seedDecision(t, pool, projectID, "watch")
+
+	if _, _, err := (&Dispatcher{pool: pool}).Tick(ctx); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if got := countJobs(t, pool, admitted, "issue_inquiry"); got != 1 {
+		t.Errorf("admitted episode has %d inquiry jobs, want 1", got)
+	}
+	if got := countJobs(t, pool, watched, "issue_inquiry"); got != 0 {
+		t.Errorf("watched episode has %d inquiry jobs, want 0", got)
+	}
+}
+
+func TestDispatcherDoesNotReEnqueueWhileOneIsPending(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	ep := seedDecision(t, pool, projectID, "open_inquiry")
+	for i := 0; i < 3; i++ {
+		if _, _, err := (&Dispatcher{pool: pool}).Tick(ctx); err != nil {
+			t.Fatalf("Tick: %v", err)
+		}
+	}
+	if got := countJobs(t, pool, ep, "issue_inquiry"); got != 1 {
+		t.Errorf("inquiry jobs = %d, want 1", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./filter -run TestDispatcher -v`
+Expected: FAIL, `Dispatcher` undefined.
+
+- [ ] **Step 3: Implement the dispatcher**
+
+```go
+// Tick evaluates open episodes, then admits the ones that clear the bar. The
+// evaluation runs here rather than inside settlement so a slow filter never
+// holds an identity lock, and appendIfChanged makes a repeat evaluation free.
+func (d *Dispatcher) Tick(ctx context.Context) (int, int, error) {
+	// Close rounds whose issue resolved, so a later recurrence opens a new one
+	// and presents as returned rather than joining the old round.
+	if err := d.closeResolvedRounds(ctx); err != nil {
+		return 0, 0, err
+	}
+
+	episodes, err := d.staleEpisodes(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	evaluated := 0
+	for _, e := range episodes {
+		if _, err := Evaluate(ctx, d.pool, e.projectID, e.episodeID); err != nil {
+			slog.Error("evaluate failed", "episode_id", e.episodeID, "error", err)
+			continue
+		}
+		evaluated++
+	}
+
+	admitted, err := d.admittedWithoutJob(ctx)
+	if err != nil {
+		return evaluated, 0, err
+	}
+	enqueued := 0
+	for _, a := range admitted {
+		if err := d.admitOne(ctx, a.projectID, a.episodeID); err != nil {
+			slog.Error("admit failed", "episode_id", a.episodeID, "error", err)
+			continue
+		}
+		enqueued++
+	}
+	return evaluated, enqueued, nil
+}
+
+// admitOne freezes the evidence the inquiry will read and enqueues it, in one
+// transaction. uq_one_active_job_per_episode_type makes a concurrent replica a no-op.
+func (d *Dispatcher) admitOne(ctx context.Context, projectID, episodeID string) error {
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if err := identity.FreezeAnchors(ctx, tx, projectID, episodeID); err != nil { // identity is imported
+		return err
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO error_group_jobs (project_id, episode_id, job_type, status)
+		 VALUES ($1, $2, 'issue_inquiry', 'pending')
+		 ON CONFLICT (project_id, episode_id, job_type)
+		   WHERE status IN ('pending','claimed') DO NOTHING`,
+		projectID, episodeID); err != nil {
+		return fmt.Errorf("enqueue inquiry: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+```
+
+`staleEpisodes` selects open episodes on three conditions, and the third is easy to
+forget: an observation newer than the latest decision, a decision at an older
+`rule_version`, **or** a latest decision older than the liveness window. Without the
+third, an issue that simply stops occurring is never re-evaluated and never becomes
+`inactive`, because nothing new arrives to trigger a look. That is what makes a
+quiet issue go `inactive` and a rule change re-evaluate, both of which the
+architecture requires and neither of which happens on its own.
+
+Start it in `main.go` beside the identity loop and the acceptor, on the same
+advisory-lock pattern the priority sweeper uses (`priority/sweeper.go:22`, `:362`),
+with a fresh lock key so the two sweepers do not block each other.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./filter -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/filter/ packages/ingestion/identity/anchors.go packages/ingestion/identity/anchors_test.go packages/ingestion/main.go
+git commit -m "feat(filter): dispatch an inquiry when an episode clears the bar"
+```
+
+---
+
+# Slice 7B: retire the old readiness path
+
+### Task 20: Remove every runtime writer and reader of digest_readiness
+
+**Files:**
+- Modify: `packages/worker/src/db.ts:130-150` (`upsertDigestReadiness`), `:1277-1281` (direct UPDATE)
+- Modify: `packages/ingestion/db/queries.go:779-784` (ingest-transaction write)
+- Modify: `packages/ingestion/digest/build.go` (readiness join)
+- Test: `packages/ingestion/db/readiness_retired_test.go`
+
+**Interfaces:**
+- Consumes: `issue_decisions`, `issue_inquiry_decisions` (Tasks 5, 18, 21)
+- Produces: no runtime reference to `digest_readiness`
+
+The table has six writers across two runtimes, including one that bypasses its own helper and one inside the Go ingest transaction. That distribution is why "we considered this and held it back" has never been expressible.
+
+- [ ] **Step 1: Write the failing guard test**
+
+```go
+func TestNoRuntimeReferenceToDigestReadiness(t *testing.T) {
+	roots := []string{"../", "../../worker/src"}
+	var offenders []string
+	for _, root := range roots {
+		filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			if strings.Contains(path, "/migrations/") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			if ext := filepath.Ext(path); ext != ".go" && ext != ".ts" {
+				return nil
+			}
+			body, _ := os.ReadFile(path)
+			if bytes.Contains(body, []byte("digest_readiness")) {
+				offenders = append(offenders, path)
+			}
+			return nil
+		})
+	}
+	if len(offenders) > 0 {
+		t.Errorf("digest_readiness still referenced at runtime:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/ingestion && go test ./db -run TestNoRuntimeReference -v`
+Expected: FAIL, listing all six writers plus the digest reader.
+
+- [ ] **Step 3: Replace each reference**
+
+Delete `upsertDigestReadiness` and its four call sites. Delete the direct UPDATE at `db.ts:1277`. Delete the Go write in the requeue path at `queries.go:779`. Change `digest/build.go` to join `issue_decisions` and `issue_inquiry_decisions` for eligibility instead of `digest_readiness`.
+
+- [ ] **Step 4: Run the guard and both suites**
+
+Run: `cd packages/ingestion && go test ./... && cd ../.. && pnpm --filter @opslane/worker test`
+Expected: PASS. The table remains in the schema, inert, until a later cleanup migration drops it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A packages/ingestion packages/worker
+git commit -m "refactor(readiness): replace digest_readiness with explicit decisions"
+```
+
+---
+
+# Slice 8: inquiries
+
+### Task 21: Add the inquiry job with a strict decision schema
+
+**Files:**
+- Create: `packages/worker/src/inquiry/schema.ts`
+- Create: `packages/worker/src/inquiry/job.ts`
+- Test: `packages/worker/src/__tests__/inquiry-job.test.ts`
+
+**Interfaces:**
+- Consumes: `loadEvidence` (Task 16), `route_map` claims (Task 17), `issue_decisions` (Task 18)
+- Produces: `runInquiry(job: ClaimedJob): Promise<InquiryDecision>` where `InquiryDecision = { decision: 'investigate' | 'wait_for_more_evidence' | 'do_not_pursue'; reason: string; brief?: string; relatedIssues: string[] }`
+
+The inquiry answers what counts cannot: is this a genuine product problem, was the user blocked, is this third-party noise, is there enough evidence to spend a full investigation. It gets read-only repository tools and no write or PR tools. Every candidate gets a decision; silence is a failure. Uncertainty favours investigation, because a silent false negative costs more than a wasted investigation.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+describe('issue_inquiry', () => {
+  it('records an investigate decision and creates no job itself', async () => {
+    const ep = await seedQualifiedEpisode();
+    stubModel({ decision: 'investigate', reason: 'real failed write', brief: 'check delete path' });
+    await runInquiry({ projectId: ep.projectId, episodeId: ep.id } as ClaimedJob);
+    const d = await queryOne(
+      `SELECT decision, evidence_signature FROM issue_inquiry_decisions WHERE episode_id=$1`, [ep.id]);
+    expect(d.decision).toBe('investigate');
+    expect(d.evidence_signature).toBeTruthy();
+    // error_group_jobs has one writer, and it is Go. See Task 24.
+    const { count } = await queryOne(
+      `SELECT count(*)::int AS count FROM error_group_jobs
+        WHERE job_type='investigate' AND episode_id=$1`, [ep.id]);
+    expect(count).toBe(0);
+  });
+
+  it('creates no job for do_not_pursue but stores the decision', async () => {
+    const ep = await seedQualifiedEpisode();
+    stubModel({ decision: 'do_not_pursue', reason: 'browser extension noise' });
+    await runInquiry({ projectId: ep.projectId, episodeId: ep.id } as ClaimedJob);
+    const jobs = await queryOne(
+      `SELECT count(*)::int AS count FROM error_group_jobs
+        WHERE job_type='investigate' AND episode_id=$1`, [ep.id]);
+    expect(jobs.count).toBe(0);
+    const decision = await queryOne(
+      `SELECT decision, reason FROM issue_inquiry_decisions WHERE episode_id=$1`, [ep.id]);
+    expect(decision.decision).toBe('do_not_pursue');
+    expect(decision.reason).toBe('browser extension noise');
+  });
+
+  it('fails the job on silent or invalid model output', async () => {
+    const ep = await seedQualifiedEpisode();
+    stubModel({ reason: 'no decision field' });
+    await expect(runInquiry({ projectId: ep.projectId, episodeId: ep.id } as ClaimedJob))
+      .rejects.toThrow(/decision/);
+  });
+
+  it('stores one decision across retries', async () => {
+    const ep = await seedQualifiedEpisode();
+    stubModel({ decision: 'investigate', reason: 'r', brief: 'b' });
+    await runInquiry({ projectId: ep.projectId, episodeId: ep.id } as ClaimedJob);
+    await runInquiry({ projectId: ep.projectId, episodeId: ep.id } as ClaimedJob);
+    const d = await queryOne(
+      `SELECT count(*)::int AS count FROM issue_inquiry_decisions WHERE episode_id=$1`, [ep.id]);
+    expect(d.count).toBe(1); // uq_one_inquiry_per_evidence
+  });
+
+  it('cites only issue IDs it was given', async () => {
+    const ep = await seedQualifiedEpisode();
+    stubModel({ decision: 'investigate', reason: 'r', related_issues: ['not-a-supplied-id'] });
+    await expect(runInquiry({ projectId: ep.projectId, episodeId: ep.id } as ClaimedJob))
+      .rejects.toThrow(/unknown issue/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm --filter @opslane/worker test -- inquiry-job`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the schema and job**
+
+```typescript
+export const INQUIRY_PROMPT_VERSION = 1;
+
+export const INQUIRY_DECISION_SCHEMA = {
+  type: 'object',
+  required: ['decision', 'reason'],
+  properties: {
+    decision: { type: 'string', enum: ['investigate', 'wait_for_more_evidence', 'do_not_pursue'] },
+    reason: { type: 'string', minLength: 1 },
+    brief: { type: 'string' },
+    related_issues: { type: 'array', items: { type: 'string' } },
+  },
+  additionalProperties: false,
+} as const;
+
+export async function runInquiry(job: ClaimedJob): Promise<InquiryDecision> {
+  const evidence = await loadEvidence(job.projectId, job.episodeId);
+  const suppliedIds = new Set(evidence.relatedCandidates.map((c) => c.issueId));
+
+  const raw = await askModel({
+    schema: INQUIRY_DECISION_SCHEMA,
+    tools: readOnlyRepositoryTools(), // no write, no PR
+    input: evidence,
+  });
+  if (!raw?.decision) {
+    throw new Error('inquiry returned no decision; silence is a failure');
+  }
+  for (const id of raw.related_issues ?? []) {
+    if (!suppliedIds.has(id)) {
+      throw new Error(`inquiry cited unknown issue ${id}`);
+    }
+  }
+
+  const client = await getPool().connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `INSERT INTO issue_inquiry_decisions
+         (project_id, episode_id, decision, reason, brief, related_issues,
+          evaluated_units, evidence_signature, model, prompt_version)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+       ON CONFLICT (project_id, episode_id, prompt_version, evidence_signature)
+       DO NOTHING`,
+      [job.projectId, job.episodeId, raw.decision, raw.reason, raw.brief ?? null,
+       raw.related_issues ?? [], evidence.affectedUnits,
+       evidenceSignature(evidence), MODEL, INQUIRY_PROMPT_VERSION]);
+    // No investigation job here. Go's acceptor (Task 24) turns an `investigate`
+    // decision into the investigation, so `error_group_jobs` keeps one writer.
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+  return raw as InquiryDecision;
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `pnpm --filter @opslane/worker test -- inquiry-job`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/worker/src/inquiry/ packages/worker/src/__tests__/inquiry-job.test.ts
+git commit -m "feat(inquiry): gate investigation on a bounded AI review"
+```
+
+---
+
+### Task 22: Bound reopen the inquirying with an evidence growth gate
+
+**Files:**
+- Modify: `packages/worker/src/inquiry/job.ts`
+- Test: `packages/worker/src/__tests__/inquiry-reopen.test.ts`
+
+**Interfaces:**
+- Consumes: `issue_inquiry_decisions.evaluated_units` (Task 5)
+- Produces: `INQUIRY_REGROWTH = 1.5`; `shouldReopenInquiry(units: number, lastEvaluated: number): boolean`
+
+Waiting work re-runs when evidence changes, and counts change on every occurrence, so an episode parked in `wait_for_more_evidence` would reopen the inquiry continuously at model cost. This codebase already solved the same problem once: `packages/worker/src/friction/promotion.ts:29` sets `RE_ADJUDICATION_GROWTH = 1.5`, enforced at `:192`, with the comment "Re-judge only when evidence has grown by half again since the last verdict. Without this, a bucket over threshold is re-judged on every session." Tracking cost is not bounding it.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+describe('reopen the inquiry gate', () => {
+  it('does not reopen the inquiry on a single extra unit', () => {
+    // ceil(2 * 1.5) = 3, so two units growing to two stays below the bar.
+    expect(shouldReopenInquiry(2, 2)).toBe(false);
+  });
+
+  it('reopens the inquiry when evidence grows by half again', () => {
+    // 3 >= ceil(2 * 1.5) = 3. The boundary reopens.
+    expect(shouldReopenInquiry(3, 2)).toBe(true);
+    expect(shouldReopenInquiry(4, 2)).toBe(true);
+  });
+
+  it('always reopens the inquiry on a prompt version change', async () => {
+    // The stored prompt_version is the module constant, so simulate the bump by
+    // seeding a decision at an older version and running the sweep.
+    const ep = await seedWaitingEpisode({ units: 2, promptVersion: INQUIRY_PROMPT_VERSION - 1 });
+    await runInquirySweep(ep.projectId);
+    const { count } = await queryOne(
+      `SELECT count(*)::int AS count FROM issue_inquiry_decisions WHERE episode_id=$1`, [ep.id]);
+    expect(count).toBe(2);
+  });
+
+  it('does not reopen the inquiry a waiting episode whose counts barely moved', async () => {
+    const ep = await seedWaitingEpisode({ units: 4, promptVersion: 1 });
+    await addUnits(ep.id, 1); // 5 units, below ceil(4 * 1.5) = 6
+    await runInquirySweep(ep.projectId);
+    const { count } = await queryOne(
+      `SELECT count(*)::int AS count FROM issue_inquiry_decisions WHERE episode_id=$1`, [ep.id]);
+    expect(count).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @opslane/worker test -- inquiry-reopen`
+Expected: FAIL, `shouldReopenInquiry` not exported.
+
+- [ ] **Step 3: Implement the gate**
+
+```typescript
+/** Mirrors friction/promotion.ts:29. Without this, an episode over the bar is
+ *  re-judged on every occurrence. */
+export const INQUIRY_REGROWTH = 1.5;
+
+export function shouldReopenInquiry(units: number, lastEvaluated: number): boolean {
+  if (lastEvaluated <= 0) return true;
+  return units >= Math.ceil(lastEvaluated * INQUIRY_REGROWTH);
+}
+```
+
+Apply it in the sweep that requeues `wait_for_more_evidence` episodes: reopen the inquiry when `shouldReopenInquiry(currentUnits, lastDecision.evaluated_units)` is true, or when the prompt version changed, or on an explicit human request. A `do_not_pursue` episode reopens the inquiry only on material new evidence, a prompt-version change, or a human request.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter @opslane/worker test -- inquiry-reopen`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/worker/src/inquiry/job.ts packages/worker/src/__tests__/inquiry-reopen.test.ts
+git commit -m "feat(inquiry): bound reopen the inquirying with an evidence growth gate"
+```
+
+---
+
+### Task 23: Evaluate the inquiry against a fixed production set
+
+**Files:**
+- Create: `packages/worker/src/inquiry/__fixtures__/production-set.json`
+- Create: `packages/worker/scripts/inquiry-eval.ts`
+
+**Interfaces:**
+- Consumes: `runInquiry` (Task 21)
+- Produces: an evaluation report; no runtime behaviour
+
+- [ ] **Step 1: Assemble the fixed set**
+
+Six named cases from production, each with its evidence bundle captured to JSON: the asset-deletion cluster (seven fragments, 28 occurrences, nine identified users); the four Assets dead-click digest cards; stale release assets (577 occurrences, 42 identified users); browser-extension noise; one-user errors; and investigations that previously ended `needs_more_context`.
+
+- [ ] **Step 2: Run the evaluation**
+
+Run: `pnpm --filter @opslane/worker exec tsx scripts/inquiry-eval.ts`
+Expected: a table of decision, reason, tokens, cost, and latency per case.
+
+- [ ] **Step 3: Read every rejection**
+
+A person reads every `do_not_pursue` and every `wait_for_more_evidence`. Expected: the asset-deletion cluster and stale release assets are investigated; browser-extension noise is rejected with a specific reason; the dead-click cards are either investigated as one component defect or rejected with a reason that names the recovered behaviour.
+
+- [ ] **Step 4: Record acceptance by issue type**
+
+Write the results to the cutover evidence file: acceptance rate by type, reversals, any false negative found by reading, tokens, cost, and latency.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/worker/src/inquiry/__fixtures__/ packages/worker/scripts/inquiry-eval.ts
+git commit -m "test(inquiry): add a fixed production evaluation set"
+```
+
+---
+
+# Slice 9: hand accepted work to the investigator
+
+### Task 24: Turn an accepted inquiry into an investigation
+
+**Files:**
+- Create: `packages/ingestion/inquiry/accept.go`
+- Test: `packages/ingestion/inquiry/accept_test.go`
+
+`FreezeAnchors` already exists: Task 19A creates it, because Task 19A is where it is
+first called.
+
+**Interfaces:**
+- Consumes: `issue_inquiry_decisions` (Task 21), `issue_evidence_anchors` (Task 5)
+- Produces: `func (a *Acceptor) Tick(ctx context.Context) (accepted int, err error)`
+
+**Why this is Go and not TypeScript.** The inquiry job runs in the worker and calls
+the model, but creating the investigation job is a database write next to the
+counters Go already owns. Anchors were frozen earlier, at admission (Task 19A), so
+the inquiry could read them; this task reuses them rather than freezing again. A TypeScript transaction cannot call a
+Go function, and duplicating the anchor SQL in both runtimes would give
+`issue_evidence_anchors` and `error_group_jobs` two writers each, which the
+architecture forbids. So the runtimes hand off through Postgres, exactly like
+capture hands off to resolution: TypeScript writes only its decision, and this Go
+loop turns an `investigate` decision into frozen anchors and one investigation job,
+atomically.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestAcceptorFreezesAnchorsAndCreatesOneInvestigation(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	ep := seedEpisodeWithEvents(t, pool, projectID, 4)
+	// Admission froze these in Task 19A. The acceptor asserts they exist rather
+	// than creating them, so the test must reproduce that handoff.
+	seedFrozenAnchors(t, pool, projectID, ep)
+	seedInquiryDecision(t, pool, projectID, ep, "investigate")
+
+	a := &Acceptor{pool: pool}
+	n, err := a.Tick(ctx)
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("accepted = %d, want 1", n)
+	}
+
+	var anchors int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM issue_evidence_anchors WHERE episode_id=$1`, ep).Scan(&anchors)
+	if anchors < 2 {
+		t.Errorf("anchors = %d, want at least threshold and first", anchors)
+	}
+
+	// And an episode reaching acceptance WITHOUT anchors must fail loudly.
+	bare := seedEpisodeWithEvents(t, pool, projectID, 2)
+	seedInquiryDecision(t, pool, projectID, bare, "investigate")
+	if _, err := a.Tick(ctx); err == nil {
+		var jobs int
+		pool.QueryRow(ctx,
+			`SELECT count(*) FROM error_group_jobs
+			  WHERE episode_id=$1 AND job_type='investigate'`, bare).Scan(&jobs)
+		if jobs != 0 {
+			t.Error("an episode with no frozen anchors must not reach investigation")
+		}
+	}
+	for _, kind := range []string{"threshold", "first"} {
+		var exists bool
+		pool.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM issue_evidence_anchors
+			   WHERE episode_id=$1 AND anchor_kind=$2)`, ep, kind).Scan(&exists)
+		if !exists {
+			t.Errorf("missing %s anchor", kind)
+		}
+	}
+
+	var jobs int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM error_group_jobs
+		  WHERE episode_id=$1 AND job_type='investigate'`, ep).Scan(&jobs)
+	if jobs != 1 {
+		t.Errorf("investigation jobs = %d, want 1", jobs)
+	}
+}
+
+func TestAcceptorIgnoresNonInvestigateDecisions(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	for _, outcome := range []string{"wait_for_more_evidence", "do_not_pursue"} {
+		ep := seedEpisodeWithEvents(t, pool, projectID, 4)
+		seedInquiryDecision(t, pool, projectID, ep, outcome)
+		if _, err := (&Acceptor{pool: pool}).Tick(ctx); err != nil {
+			t.Fatalf("Tick: %v", err)
+		}
+		var jobs int
+		pool.QueryRow(ctx,
+			`SELECT count(*) FROM error_group_jobs
+			  WHERE episode_id=$1 AND job_type='investigate'`, ep).Scan(&jobs)
+		if jobs != 0 {
+			t.Errorf("%s created %d investigations, want 0", outcome, jobs)
+		}
+	}
+}
+
+func TestAcceptorIsIdempotentAcrossReplicas(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	ep := seedEpisodeWithEvents(t, pool, projectID, 4)
+	seedInquiryDecision(t, pool, projectID, ep, "investigate")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); _, _ = (&Acceptor{pool: pool}).Tick(ctx) }()
+	}
+	wg.Wait()
+
+	var jobs, anchors int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM error_group_jobs
+		  WHERE episode_id=$1 AND job_type='investigate'`, ep).Scan(&jobs)
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM issue_evidence_anchors WHERE episode_id=$1`, ep).Scan(&anchors)
+	if jobs != 1 {
+		t.Errorf("investigation jobs = %d, want 1 (uq_one_active_job_per_episode_type)", jobs)
+	}
+	if anchors > 3 {
+		t.Errorf("anchors = %d, want at most 3", anchors)
+	}
+}
+
+func TestAcceptorNeverReadsSampleEventID(t *testing.T) {
+	for _, f := range []string{"accept.go", "../identity/anchors.go"} {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("cannot read %s: %v (a missing file must fail, not pass)", f, err)
+		}
+		if bytes.Contains(src, []byte("sample_event_id")) {
+			t.Errorf("%s must not reference sample_event_id", f)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./inquiry -v`
+Expected: FAIL, package does not exist.
+
+- [ ] **Step 3: Implement the acceptor**
+
+```go
+package inquiry
+
+// Tick turns accepted inquiries into investigations. It claims decisions whose
+// episode has no investigation job yet, so a crash between claim and commit
+// simply leaves the row for the next tick.
+func (a *Acceptor) Tick(ctx context.Context) (int, error) {
+	// DISTINCT ON picks the LATEST decision per episode. Selecting any
+	// historical 'investigate' would resurrect a decision a later inquiry
+	// reversed. The uniqueness index, not the lock, is what makes concurrent
+	// replicas safe here.
+	rows, err := a.pool.Query(ctx,
+		`SELECT project_id, episode_id FROM (
+		   SELECT DISTINCT ON (d.episode_id)
+		          d.project_id::text AS project_id, d.episode_id::text AS episode_id,
+		          d.decision
+		     FROM issue_inquiry_decisions d
+		    ORDER BY d.episode_id, d.decided_at DESC, d.id DESC) latest
+		  WHERE latest.decision = 'investigate'
+		    AND NOT EXISTS (
+		          SELECT 1 FROM error_group_jobs j
+		           WHERE j.episode_id = latest.episode_id::uuid
+		             AND j.job_type = 'investigate')
+		  LIMIT 50`)
+	if err != nil {
+		return 0, fmt.Errorf("claim accepted inquiries: %w", err)
+	}
+	type ref struct{ project, episode string }
+	var batch []ref
+	for rows.Next() {
+		var r ref
+		if err := rows.Scan(&r.project, &r.episode); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		batch = append(batch, r)
+	}
+	rows.Close()
+
+	accepted := 0
+	for _, r := range batch {
+		if err := a.acceptOne(ctx, r.project, r.episode); err != nil {
+			slog.Error("accept inquiry failed", "episode_id", r.episode, "error", err)
+			continue
+		}
+		accepted++
+	}
+	return accepted, nil
+}
+
+func (a *Acceptor) acceptOne(ctx context.Context, projectID, episodeID string) error {
+	tx, err := a.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Anchors already exist from admission. Assert rather than create: an
+	// episode reaching acceptance without them means the dispatcher failed, and
+	// investigating on unfrozen evidence is the bug this whole path prevents.
+	var anchors int
+	if err := tx.QueryRow(ctx,
+		`SELECT count(*) FROM issue_evidence_anchors WHERE episode_id=$1`,
+		episodeID).Scan(&anchors); err != nil {
+		return fmt.Errorf("count anchors: %w", err)
+	}
+	if anchors == 0 {
+		return fmt.Errorf("episode %s accepted with no frozen anchors", episodeID)
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO error_group_jobs (project_id, episode_id, job_type, status)
+		 VALUES ($1, $2, 'investigate', 'pending')
+		 ON CONFLICT (project_id, episode_id, job_type)
+		   WHERE status IN ('pending','claimed') DO NOTHING`,
+		projectID, episodeID); err != nil {
+		return fmt.Errorf("enqueue investigation: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+```
+
+`FreezeAnchors` lives in `packages/ingestion/identity/anchors.go` and is called by
+the dispatcher in Task 19A. It pins the observation that crossed the bar, the
+episode's first observation, and a recent distinct one, reading `error_events`
+joined through `error_event_identities`, never `sample_event_id`.
+
+- [ ] **Step 3b: Start the acceptor**
+
+Add `go acceptor.Start(ctx, 1*time.Minute)` in `packages/ingestion/main.go` beside
+the identity loop and the filter dispatcher, guarded by its own advisory-lock key on
+the `priority/sweeper.go:22` pattern. A loop nobody starts is the defect this whole
+slice exists to remove; the boot log line proves it runs.
+
+- [ ] **Step 4: Point the investigator at frozen evidence and persist its outcome**
+
+Change the investigate job in `packages/worker/src/index.ts` to call
+`loadEvidence(projectId, episodeId)` from Task 16 instead of reading the group's
+sample event, and stamp `episode_id` on the row it writes.
+
+It must also persist `diagnosis_decisions.outcome` as exactly one of `verified_fix`,
+`needs_human`, or `unable_to_establish_cause`. Task 25's freeze selects on that
+column, so an investigation that finishes without writing it produces a digest that
+is permanently empty, and the failure looks like "no problems today" rather than
+like a bug.
+
+```typescript
+await client.query(
+  `UPDATE diagnosis_decisions SET outcome=$2, summary=$3, pr_url=$4
+    WHERE id=$1`,
+  [decisionId, terminalOutcome, summary, prUrl ?? null]);
+```
+
+Add a test asserting every terminal path writes one of the three values, and that
+none writes the customer phrase "Investigation report ready".
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./inquiry -v && pnpm --filter @opslane/worker test`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ingestion/inquiry/ packages/worker/src/index.ts
+git commit -m "feat(inquiry): turn accepted inquiries into anchored investigations"
+```
+
+---
+
+# Slice 10: author and deliver the daily message
+
+### Task 25: Freeze the candidate set in Go
+
+**Files:**
+- Create: `packages/ingestion/digest/freeze.go`
+- Test: `packages/ingestion/digest/freeze_test.go`
+
+**Interfaces:**
+- Consumes: `issue_publications`, `digest_runs` (Task 5)
+- Produces: `func FreezeCandidates(ctx, pool, projectID string, at time.Time) (runID string, candidates []Candidate, err error)`
+
+The AI cannot revive a stale issue or invent a candidate, because it never chooses the candidate set. Go does, and freezes it before the model sees anything.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestFreezeAllowsANewlyReadyActionOnAQuietProblem(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	// Problem last seen nine days ago, but a fix became ready an hour ago.
+	quietWithAction := seedTerminalEpisode(t, pool, projectID, time.Now().Add(-9*24*time.Hour), false)
+	seedReadyAction(t, pool, projectID, quietWithAction, "verified_fix", time.Now().Add(-1*time.Hour))
+
+	_, candidates, err := FreezeCandidates(ctx, pool, projectID, time.Now())
+	if err != nil {
+		t.Fatalf("FreezeCandidates: %v", err)
+	}
+	found := false
+	for _, c := range candidates {
+		if c.EpisodeID == quietWithAction {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("a newly ready fix must be publishable even when the problem went quiet")
+	}
+}
+
+func TestFreezeExcludesStaleAndAlreadyPublished(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+
+	fresh := seedTerminalEpisode(t, pool, projectID, time.Now().Add(-2*time.Hour), false)
+	stale := seedTerminalEpisode(t, pool, projectID, time.Now().Add(-9*24*time.Hour), false)
+	already := seedTerminalEpisode(t, pool, projectID, time.Now().Add(-2*time.Hour), true)
+
+	_, candidates, err := FreezeCandidates(ctx, pool, projectID, time.Now())
+	if err != nil {
+		t.Fatalf("FreezeCandidates: %v", err)
+	}
+	got := map[string]bool{}
+	for _, c := range candidates {
+		got[c.EpisodeID] = true
+	}
+	if !got[fresh] {
+		t.Error("a fresh terminal result must be a candidate")
+	}
+	if got[stale] {
+		t.Error("a problem last seen nine days ago must not be a candidate")
+	}
+	if got[already] {
+		t.Error("an episode with a digest receipt must not repeat")
+	}
+}
+
+func TestFreezeIsIdempotentPerWindow(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	at := time.Now()
+	first, _, _ := FreezeCandidates(ctx, pool, projectID, at)
+	second, _, _ := FreezeCandidates(ctx, pool, projectID, at)
+	if first != second {
+		t.Errorf("two freezes in one window must reuse the run: %s != %s", first, second)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./digest -run TestFreeze -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the freeze**
+
+```go
+// FreezeCandidates selects the day's publishable work and records it before any
+// model runs. idx_one_run_per_window makes a concurrent sweeper reuse the run.
+func FreezeCandidates(ctx context.Context, pool *pgxpool.Pool, projectID string, at time.Time) (string, []Candidate, error) {
+	// The frozen candidate carries everything the writer is allowed to use.
+	// Anything absent here is something the model would have to invent.
+	rows, err := pool.Query(ctx,
+		`SELECT ep.id::text, ep.sequence, g.id::text, g.title,
+		        d.outcome, d.summary, d.pr_url,
+		        (SELECT count(DISTINCT eau.end_user_id) FROM error_group_affected_users eau
+		          WHERE eau.error_group_id = g.id) AS affected_users,
+		        (SELECT array_agg(DISTINCT eu.account_name) FROM error_group_affected_users eau2
+		           JOIN end_users eu ON eu.id = eau2.end_user_id
+		          WHERE eau2.error_group_id = g.id AND eu.account_name IS NOT NULL) AS accounts,
+		        g.last_seen, rm.purpose
+		   FROM issue_episodes ep
+		   JOIN error_groups g ON g.id = ep.canonical_issue_id
+		   LEFT JOIN route_map rm ON rm.project_id = ep.project_id
+		                         AND g.page_url_normalized LIKE '%' || rm.pattern || '%'
+		   -- Latest decision per episode, not every decision ever written. A
+		   -- reversed inquiry or a superseded diagnosis must not resurrect.
+		   JOIN LATERAL (
+		     SELECT dd.outcome, dd.decided_at, dd.summary, dd.pr_url FROM diagnosis_decisions dd
+		      WHERE dd.episode_id = ep.id
+		      ORDER BY dd.decided_at DESC, dd.id DESC LIMIT 1) d ON true
+		   JOIN LATERAL (
+		     SELECT idq.decision FROM issue_inquiry_decisions idq
+		      WHERE idq.episode_id = ep.id
+		      ORDER BY idq.decided_at DESC, idq.id DESC LIMIT 1) s ON true
+		  WHERE ep.project_id = $1
+		    AND s.decision = 'investigate'
+		    AND d.outcome IN ('verified_fix','needs_human')
+		    AND ep.closed_at IS NULL
+		    -- Liveness, with the architecture's exception: a newly ready PR or
+		    -- approval request may appear even when the problem itself has gone
+		    -- quiet. Its card describes the action as current, not the problem.
+		    AND (g.last_seen >= $2 - interval '7 days'
+		         OR EXISTS (SELECT 1 FROM diagnosis_decisions dd
+		                     WHERE dd.episode_id = ep.id
+		                       AND dd.outcome IN ('verified_fix','needs_human')
+		                       AND dd.decided_at >= (SELECT COALESCE(max(window_to), 'epoch')
+		                                               FROM digest_runs
+		                                              WHERE project_id = $1 AND status = 'delivered')))
+		    -- Newly usable since the last delivered run, OR deferred by it and
+		    -- still unpublished. Without the second arm a deferred card is
+		    -- silently dropped forever: its diagnosis is now older than the
+		    -- window even though nobody has ever seen it.
+		    AND (d.decided_at >= (SELECT COALESCE(max(window_to), 'epoch')
+		                            FROM digest_runs
+		                           WHERE project_id = $1 AND status = 'delivered')
+		         OR EXISTS (SELECT 1 FROM digest_run_items dri
+		                     WHERE dri.episode_id = ep.id AND dri.outcome = 'deferred'))
+		    AND NOT EXISTS (SELECT 1 FROM issue_publications p
+		                     WHERE p.episode_id = ep.id AND p.channel = 'digest')
+		  ORDER BY g.last_seen DESC`,
+		projectID, at)
+	// ... scan into []Candidate, insert digest_runs with status 'frozen',
+	//     insert digest_run_items, return the run id ...
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./digest -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/digest/freeze.go packages/ingestion/digest/freeze_test.go
+git commit -m "feat(digest): freeze the candidate set before any model runs"
+```
+
+---
+
+### Task 25A: Schedule the daily run
+
+**Files:**
+- Create: `packages/ingestion/digest/scheduler.go`
+- Modify: `packages/ingestion/main.go`
+- Test: `packages/ingestion/digest/scheduler_test.go`
+
+**Interfaces:**
+- Consumes: `FreezeCandidates` (Task 25), the writer job (Task 26), `ValidateAndPublish` (Task 27)
+- Produces: `func (s *Scheduler) Tick(ctx context.Context) error`
+
+Third and last orchestration link. Tasks 25 through 27 build freeze, write, and
+publish, and nothing runs them on a schedule or moves a run between the stages.
+The run is the state machine: `frozen` becomes `written` becomes `validated`
+becomes `delivered`, and a failure at any point leaves the window unadvanced so the
+next tick retries the same frozen set.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestSchedulerFreezesOncePerDailyBoundary(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProjectWithBoundary(t, pool, "09:00", "America/Los_Angeles")
+	seedTerminalEpisode(t, pool, projectID, time.Now().Add(-2*time.Hour), false)
+
+	s := &Scheduler{pool: pool, now: func() time.Time { return boundaryTime(t, "09:01") }}
+	for i := 0; i < 3; i++ {
+		if err := s.Tick(ctx); err != nil {
+			t.Fatalf("Tick %d: %v", i, err)
+		}
+	}
+	var runs int
+	pool.QueryRow(ctx, `SELECT count(*) FROM digest_runs WHERE project_id=$1`, projectID).Scan(&runs)
+	if runs != 1 {
+		t.Errorf("runs = %d, want 1 (idx_one_run_per_window)", runs)
+	}
+}
+
+func TestSchedulerAdvancesTheRunThroughItsStates(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProjectWithBoundary(t, pool, "09:00", "UTC")
+	seedTerminalEpisode(t, pool, projectID, time.Now().Add(-2*time.Hour), false)
+	s := &Scheduler{pool: pool, now: func() time.Time { return boundaryTime(t, "09:01") }}
+
+	stubWriterReturnsValidPayload(t)
+	if err := s.Tick(ctx); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	var status string
+	pool.QueryRow(ctx, `SELECT status FROM digest_runs WHERE project_id=$1`, projectID).Scan(&status)
+	if status != "delivered" {
+		t.Errorf("status = %q, want delivered", status)
+	}
+}
+
+func TestAFailedRunRetriesTheSameFrozenSet(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProjectWithBoundary(t, pool, "09:00", "UTC")
+	ep := seedTerminalEpisode(t, pool, projectID, time.Now().Add(-2*time.Hour), false)
+	s := &Scheduler{pool: pool, now: func() time.Time { return boundaryTime(t, "09:01") }}
+
+	stubWriterReturnsInventedLink(t)
+	_ = s.Tick(ctx)
+	var runID, status string
+	pool.QueryRow(ctx, `SELECT id::text, status FROM digest_runs WHERE project_id=$1`, projectID).Scan(&runID, &status)
+	if status != "failed" {
+		t.Fatalf("status = %q, want failed", status)
+	}
+
+	// A later episode must not join the retried run: the set was frozen.
+	seedTerminalEpisode(t, pool, projectID, time.Now(), false)
+	stubWriterReturnsValidPayload(t)
+	if err := s.Tick(ctx); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	var items int
+	pool.QueryRow(ctx, `SELECT count(*) FROM digest_run_items WHERE run_id=$1`, runID).Scan(&items)
+	if items != 1 {
+		t.Errorf("frozen items = %d, want 1; the retry must not re-freeze", items)
+	}
+	_ = ep
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./digest -run TestScheduler -v`
+Expected: FAIL, `Scheduler` undefined.
+
+- [ ] **Step 3: Implement the scheduler**
+
+```go
+// Tick advances at most one run per project. Freezing is idempotent per window,
+// so a crash anywhere in the chain resumes from the last durable status rather
+// than rebuilding the candidate set.
+func (s *Scheduler) Tick(ctx context.Context) error {
+	projects, err := s.projectsPastBoundary(ctx)
+	if err != nil {
+		return err
+	}
+	for _, projectID := range projects {
+		// Normalised to the project's boundary, not the wall clock. The unique
+		// index is on (project_id, window_to); passing s.now() every five
+		// minutes would mint a new run each tick.
+		windowTo := boundaryFor(projectID, s.now())
+		runID, _, err := FreezeCandidates(ctx, s.pool, projectID, windowTo)
+		if err != nil {
+			slog.Error("freeze failed", "project_id", projectID, "error", err)
+			continue
+		}
+		status, err := s.runStatus(ctx, runID)
+		if err != nil {
+			continue
+		}
+		switch status {
+		case "frozen", "failed":
+			if err := s.enqueueWrite(ctx, projectID, runID); err != nil {
+				slog.Error("enqueue write failed", "run_id", runID, "error", err)
+			}
+		case "written":
+			if err := ValidateAndPublish(ctx, s.pool, runID); err != nil {
+				slog.Error("publish failed", "run_id", runID, "error", err)
+			}
+		}
+	}
+	return nil
+}
+```
+
+Start it in `main.go` on the advisory-lock pattern from `priority/sweeper.go:22`,
+with its own key, ticking every five minutes. The boundary check makes a tick
+outside the window a cheap no-op, which is the same shape as the existing digest
+sweep.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./digest -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/digest/scheduler.go packages/ingestion/digest/scheduler_test.go packages/ingestion/main.go
+git commit -m "feat(digest): schedule and advance the daily run"
+```
+
+---
+
+### Task 26: Write the cards with the model
+
+**Files:**
+- Create: `packages/worker/src/digest-writer/job.ts`
+- Create: `packages/worker/src/digest-writer/schema.ts`
+- Test: `packages/worker/src/__tests__/digest-writer.test.ts`
+
+**Interfaces:**
+- Consumes: frozen candidates (Task 25)
+- Produces: `writeDigest(runId: string): Promise<DigestPayload>` where every input candidate appears in `included` or `deferred`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+describe('digest writer', () => {
+  it('accounts for every candidate', async () => {
+    const run = await seedFrozenRun(5);
+    const payload = await writeDigest(run.id);
+    const seen = new Set([
+      ...payload.included.map((c) => c.episodeId),
+      ...payload.deferred.map((d) => d.episodeId),
+    ]);
+    expect(seen.size).toBe(5);
+  });
+
+  it('rejects a card citing an episode that was not frozen', async () => {
+    const run = await seedFrozenRun(2);
+    stubModel({ included: [{ episodeId: 'not-frozen', copy: 'x', action: 'y' }], deferred: [] });
+    await expect(writeDigest(run.id)).rejects.toThrow(/unknown episode/);
+  });
+
+  it('rejects a card whose count does not match stored observations', async () => {
+    const run = await seedFrozenRun(1, { users: 9 });
+    stubModel({ included: [{ episodeId: run.episodes[0], copy: '40 customers affected', action: 'Review the fix PR', claimedUsers: 40 }], deferred: [] });
+    await expect(writeDigest(run.id)).rejects.toThrow(/unsupported count/);
+  });
+
+  it('advances the run to written and records every outcome', async () => {
+    const run = await seedFrozenRun(3);
+    await writeDigest(run.id);
+    const r = await queryOne(`SELECT status, payload FROM digest_runs WHERE id=$1`, [run.id]);
+    expect(r.status).toBe('written');
+    expect(r.payload).toBeTruthy();
+    const { pending } = await queryOne(
+      `SELECT count(*)::int AS pending FROM digest_run_items
+        WHERE run_id=$1 AND outcome IS NULL`, [run.id]);
+    expect(pending).toBe(0);
+  });
+
+  it('labels a second episode as returned', async () => {
+    const run = await seedFrozenRunWithReturnedEpisode();
+    const payload = await writeDigest(run.id);
+    expect(payload.included[0].label).toBe('returned');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm --filter @opslane/worker test -- digest-writer`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the writer**
+
+```typescript
+export const DIGEST_PROMPT_VERSION = 1;
+
+export async function writeDigest(runId: string): Promise<DigestPayload> {
+  const { candidates, projectId } = await loadFrozenRun(runId);
+  const allowed = new Set(candidates.map((c) => c.episodeId));
+
+  const raw = await askModel({ schema: DIGEST_PAYLOAD_SCHEMA, input: candidates });
+
+  // The model may translate facts into product language. It may not change
+  // counts, account names, PR URLs, issue URLs, or investigation state.
+  for (const card of raw.included) {
+    if (!allowed.has(card.episodeId)) {
+      throw new Error(`unknown episode ${card.episodeId}`);
+    }
+    const truth = candidates.find((c) => c.episodeId === card.episodeId)!;
+    if (card.claimedUsers != null && card.claimedUsers !== truth.affectedUsers) {
+      throw new Error(
+        `unsupported count for ${card.episodeId}: claimed ${card.claimedUsers}, stored ${truth.affectedUsers}`);
+    }
+    card.label = truth.episodeSequence > 1 ? 'returned' : 'new';
+  }
+  const accounted = new Set([
+    ...raw.included.map((c) => c.episodeId),
+    ...raw.deferred.map((d) => d.episodeId),
+  ]);
+  for (const c of candidates) {
+    if (!accounted.has(c.episodeId)) {
+      throw new Error(`candidate ${c.episodeId} was neither included nor deferred`);
+    }
+  }
+
+  // Persist and advance. Returning the payload without storing it would leave
+  // the run stuck at `frozen`, and the scheduler would re-enqueue the write
+  // every tick forever.
+  const client = await getPool().connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `UPDATE digest_runs SET payload=$2, status='written' WHERE id=$1 AND status IN ('frozen','failed')`,
+      [runId, raw]);
+    for (const card of raw.included) {
+      await client.query(
+        `UPDATE digest_run_items SET outcome='included', reason=NULL
+          WHERE run_id=$1 AND episode_id=$2`, [runId, card.episodeId]);
+    }
+    for (const d of raw.deferred) {
+      await client.query(
+        `UPDATE digest_run_items SET outcome='deferred', reason=$3
+          WHERE run_id=$1 AND episode_id=$2`, [runId, d.episodeId, d.reason]);
+    }
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+  return raw;
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `pnpm --filter @opslane/worker test -- digest-writer`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/worker/src/digest-writer/ packages/worker/src/__tests__/digest-writer.test.ts
+git commit -m "feat(digest): author cards with the model over a frozen candidate set"
+```
+
+---
+
+### Task 27: Validate and deliver once
+
+**Files:**
+- Create: `packages/ingestion/digest/validate.go`
+- Test: `packages/ingestion/digest/validate_test.go`
+
+**Interfaces:**
+- Consumes: `writeDigest` output (Task 26)
+- Produces: `func ValidateAndPublish(ctx, pool, runID string) error`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestValidateRejectsInventedLinks(t *testing.T) {
+	pool := testPool(t)
+	runID := seedWrittenRun(t, pool, withCard(card{PRURL: "https://github.com/other/repo/pull/1"}))
+	err := ValidateAndPublish(context.Background(), pool, runID)
+	if err == nil || !strings.Contains(err.Error(), "link") {
+		t.Errorf("expected a link rejection, got %v", err)
+	}
+}
+
+func TestPublishIsIdempotentAcrossConcurrentSweepers(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	runID := seedWrittenRun(t, pool, withCard(validCard()))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); _ = ValidateAndPublish(ctx, pool, runID) }()
+	}
+	wg.Wait()
+
+	var outbox, receipts int
+	pool.QueryRow(ctx, `SELECT count(*) FROM outbound_events WHERE payload->>'run_id'=$1`, runID).Scan(&outbox)
+	pool.QueryRow(ctx, `SELECT count(*) FROM issue_publications WHERE channel='digest'`).Scan(&receipts)
+	if outbox != 1 {
+		t.Errorf("outbox events = %d, want 1", outbox)
+	}
+	if receipts != 1 {
+		t.Errorf("publication receipts = %d, want 1", receipts)
+	}
+}
+
+func TestFailedRunDoesNotAdvanceTheWindow(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	runID := seedWrittenRun(t, pool, withCard(card{PRURL: "https://evil.example/pull/1"}))
+	_ = ValidateAndPublish(ctx, pool, runID)
+
+	var status string
+	pool.QueryRow(ctx, `SELECT status FROM digest_runs WHERE id=$1`, runID).Scan(&status)
+	if status != "failed" {
+		t.Errorf("status = %q, want failed", status)
+	}
+	var receipts int
+	pool.QueryRow(ctx, `SELECT count(*) FROM issue_publications WHERE channel='digest'`).Scan(&receipts)
+	if receipts != 0 {
+		t.Errorf("a failed run must write no receipts, got %d", receipts)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./digest -run 'TestValidate|TestPublish|TestFailedRun' -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement validation and the publish transaction**
+
+Validation rejects unknown episode IDs, stale candidates, links whose host or repository does not match the project's own, counts unsupported by stored observations, duplicate actions, and malformed output. One transaction then writes the run status, chosen items, deferred reasons, rendered payload, publication receipts, outbox event, and deliveries. A failure leaves the window unadvanced so the next sweep retries the same frozen run.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./digest -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/digest/validate.go packages/ingestion/digest/validate_test.go
+git commit -m "feat(digest): validate AI output and publish exactly once"
+```
+
+---
+
+### Task 28: Read a week of generated messages
+
+**Files:**
+- Create: `packages/ingestion/cmd/digest-eval/main.go`
+
+**Interfaces:**
+- Consumes: Tasks 25 through 27
+- Produces: seven rendered digests for human reading
+
+This is the A1 and A9 evidence and cannot be automated.
+
+- [ ] **Step 1: Generate seven daily messages from production snapshots**
+
+Run: `DATABASE_URL="$PROD_READONLY_DSN" go run ./cmd/digest-eval --project 5a64d496-0dd0-48a3-aebd-f2ad636e3b44 --days 7`
+
+- [ ] **Step 2: The founder reads all seven**
+
+For every card, they name the action without opening the dashboard. Any "so what?" fails the evaluation and sends the copy or the bar back for change.
+
+- [ ] **Step 3: Confirm the returned label reads correctly**
+
+Find at least one episode with sequence greater than one and confirm the card presents it as returned rather than new. This is A9's rendering proof, which the recurrence integration test does not cover.
+
+- [ ] **Step 4: Record the outcome**
+
+Append the seven messages and the founder's per-card actions to the cutover evidence file.
+
+---
+
+### Task 28A: Show pipeline state in the inbox
+
+**Files:**
+- Modify: `packages/ingestion/handler/read_api.go`
+- Modify: `packages/dashboard/src/` (issue list and detail)
+- Test: `packages/ingestion/handler/inbox_test.go`
+
+**Interfaces:**
+- Consumes: `issue_decisions` (Task 18), `issue_inquiry_decisions` (Task 21),
+  `issue_episodes` (Task 14)
+- Produces: `GET /api/v1/issues` returns a `state` and a `reason` per issue
+
+Section 7 of the architecture had no task. Without it the digest becomes selective
+while nothing preserves completeness, which is the trade the whole design rests on:
+the message is short **because** the inbox is complete.
+
+The two held-back lists are different and must render separately. `Watching` means
+the problem has not reached enough people to look into. `Reviewed, not pursuing`
+means Opslane looked and declined. A founder auditing the system cares far more
+about the second, and burying it inside thirty low-count issues hides it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestInboxSeparatesWatchedFromDeclined(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	projectID := seedProject(t, pool)
+	watched  := seedEpisodeWithDecision(t, pool, projectID, "watch", "1 affected unit in seven days")
+	declined := seedEpisodeWithInquiry(t, pool, projectID, "do_not_pursue", "browser extension noise")
+
+	issues := listIssues(t, ctx, pool, projectID)
+	byID := map[string]issueView{}
+	for _, i := range issues {
+		byID[i.EpisodeID] = i
+	}
+	if got := byID[watched].State; got != "watching" {
+		t.Errorf("watched state = %q, want watching", got)
+	}
+	if got := byID[declined].State; got != "reviewed_not_pursuing" {
+		t.Errorf("declined state = %q, want reviewed_not_pursuing", got)
+	}
+	if byID[declined].Reason != "browser extension noise" {
+		t.Errorf("declined issue must carry the inquiry reason, got %q", byID[declined].Reason)
+	}
+}
+
+func TestEveryLiveIssueHasAStateAndReason(t *testing.T) {
+	pool := testPool(t)
+	projectID := seedProject(t, pool)
+	seedAssortedEpisodes(t, pool, projectID, 20)
+	for _, i := range listIssues(t, context.Background(), pool, projectID) {
+		if i.State == "" {
+			t.Errorf("issue %s has no state", i.EpisodeID)
+		}
+		if i.Reason == "" {
+			t.Errorf("issue %s has no reason; silence is the defect this replaces", i.EpisodeID)
+		}
+	}
+}
+
+func TestInboxShowsCapturesThatHaveNoRoundYet(t *testing.T) {
+	pool := testPool(t)
+	projectID := seedProject(t, pool)
+	// A captured observation whose identity has not settled has no episode.
+	// Listing only episodes would hide it, and "Processing" would never appear.
+	seedPendingIdentity(t, pool, projectID)
+
+	issues := listIssues(t, context.Background(), pool, projectID)
+	if len(issues) != 1 {
+		t.Fatalf("issues = %d, want 1", len(issues))
+	}
+	if issues[0].State != "processing" {
+		t.Errorf("state = %q, want processing", issues[0].State)
+	}
+}
+
+func TestInboxHidesNoLiveIssue(t *testing.T) {
+	pool := testPool(t)
+	projectID := seedProject(t, pool)
+	seedAssortedEpisodes(t, pool, projectID, 20)
+	var live int
+	pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM issue_episodes WHERE project_id=$1 AND closed_at IS NULL`,
+		projectID).Scan(&live)
+	if got := len(listIssues(t, context.Background(), pool, projectID)); got != live {
+		t.Errorf("inbox shows %d of %d live issues", got, live)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./handler -run 'TestInbox|TestEveryLive' -v`
+Expected: FAIL
+
+- [ ] **Step 3: Derive the state from the latest decisions**
+
+```go
+// inboxState maps pipeline records onto the customer vocabulary. Storage names
+// never reach the response.
+func inboxState(identity, filterDecision, inquiryDecision, diagnosisOutcome, groupStatus string) (state, reason string) {
+	switch {
+	case identity == "pending":
+		return "processing", "working out which problem this belongs to"
+	case groupStatus == "resolved":
+		return "resolved", "closed"
+	case inquiryDecision == "do_not_pursue":
+		return "reviewed_not_pursuing", "" // caller fills the stored reason
+	case inquiryDecision == "wait_for_more_evidence":
+		return "waiting_for_evidence", ""
+	case inquiryDecision == "investigate" && diagnosisOutcome == "verified_fix":
+		return "fix_ready", "a change is verified and waiting for your review"
+	case inquiryDecision == "investigate" && diagnosisOutcome == "needs_human":
+		return "needs_you", "" // caller fills the stored reason
+	case inquiryDecision == "investigate" && diagnosisOutcome == "unable_to_establish_cause":
+		return "reviewed_not_pursuing", "we could not establish a cause"
+	case inquiryDecision == "investigate":
+		return "investigating", "tracing the cause"
+	case filterDecision == "open_inquiry":
+		return "reviewing_evidence", "deciding whether this is worth investigating"
+	case filterDecision == "inactive":
+		return "inactive", "stopped occurring before it advanced"
+	default:
+		return "watching", "" // caller fills the stored reason
+	}
+}
+```
+
+The list query unions open episodes with pending identities that have no episode
+yet, so a just-captured observation appears as `processing` rather than vanishing
+until settlement. The endpoint returns `state`, `reason`, the cited evidence
+references, the decision time, and links to the observations and available recordings. The dashboard
+renders `watching` and `reviewed_not_pursuing` as two lists, with a control on the
+second to request another look.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd packages/ingestion && DATABASE_URL="$DATABASE_URL" go test ./handler -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/handler/ packages/dashboard/src/
+git commit -m "feat(inbox): show what Opslane is watching and why it did not advance"
+```
+
+---
+
+# Slice 11: cut over production
+
+### Task 29: Generate and read the cutover report
+
+**Files:**
+- Create: `packages/ingestion/cmd/cutover-report/main.go`
+
+**Interfaces:**
+- Consumes: `Settle` (Task 12), `Evaluate` (Task 18)
+- Produces: a read-only report of proposed identity changes, the held list, and inquiry candidates
+
+- [ ] **Step 1: Write the read-only report**
+
+The command opens its session with `SET default_transaction_read_only = on`, replays identity over 30 days, and prints every proposed many-to-one identity change with the titles and messages of the issues being combined.
+
+- [ ] **Step 2: Run it against production**
+
+Run: `DATABASE_URL="$PROD_READONLY_DSN" go run ./cmd/cutover-report --project 5a64d496-0dd0-48a3-aebd-f2ad636e3b44`
+
+- [ ] **Step 3: Read every many-to-one change by hand**
+
+A wrong merge is indistinguishable from a successful fix: if three of four merged fragments stop after a fix and one does not, occurrences fall and it reads as success. Only confirmed clusters enter the alias backfill. Uncertain clusters stay split.
+
+- [ ] **Step 4: Read the held and rejected lists again**
+
+Under the final action-scope query, confirm nothing in the held list should have been investigated and nothing in the inquiry's rejections was a false negative.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ingestion/cmd/cutover-report/
+git commit -m "feat(cutover): add the read-only pre-cutover report"
+```
+
+---
+
+### Task 30: Execute the maintenance window
+
+**Files:**
+- Create: `packages/ingestion/db/migrations/055_cutover_backfill.sql`
+- Create: `scripts/cutover-smoke.sh`
+
+**Interfaces:**
+- Consumes: every prior task
+- Produces: production running the new pipeline
+
+- [ ] **Step 1: Write the backfill**
+
+Adopt existing visible `error_groups` rows as canonical issues, open an active episode for each, bind confirmed aliases from the report, link recent observations, and seed digest publication receipts so old issues do not announce themselves again as new. Uncertain clusters stay split.
+
+- [ ] **Step 2: Write the smoke script**
+
+`scripts/cutover-smoke.sh` must assert, in order: an event is accepted and returns a capture handle; its resolution row reaches a terminal status; its identity settles to a canonical issue; the filter writes a decision; a qualified episode reaches an inquiry decision; an accepted episode creates exactly one investigation; a digest run freezes, validates, and delivers. This script is the only gate before the rollback window closes.
+
+- [ ] **Step 3: Run the full repository gate**
+
+```bash
+pnpm install --frozen-lockfile
+pnpm -r build
+pnpm test
+(cd packages/ingestion && go build ./... && go test ./...)
+docker compose config --quiet
+```
+
+Expected: PASS with `DATABASE_URL` and storage configured, and **zero** skipped Go database or storage tests. Remove stale `dist/` output first, since it survives between runs and a local build otherwise proves nothing about a clean checkout.
+
+- [ ] **Step 4: Execute the window**
+
+1. Let active jobs finish.
+2. Stop ingestion and the worker.
+3. Snapshot Postgres.
+4. Apply migrations 054 and 055.
+5. Deploy both runtimes.
+6. Run `scripts/cutover-smoke.sh`.
+7. Resume traffic.
+
+The browser SDK buffers up to 100 events and retries with backoff capped at 30 seconds, extended to roughly 45 by jitter, with a best-effort unload flush limited to 60 KiB. A short outage is mostly survivable, not lossless: overflow, prolonged failure, or navigation can still drop events.
+
+- [ ] **Step 5: Know the rollback boundary**
+
+Before traffic resumes, restore the snapshot and the old images. After new canonical data arrives, recovery is a forward fix, because old binaries cannot read the new sources of truth safely.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ingestion/db/migrations/055_cutover_backfill.sql scripts/cutover-smoke.sh
+git commit -m "feat(cutover): add the backfill and the live smoke gate"
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** Every architecture section maps to at least one task.
+
+| Architecture section | Tasks |
+| --- | --- |
+| 1. Store observations | 8 |
+| 1. Stack resolution | 9, 10, 11 |
+| 1. Session facts | 15, 16A |
+| 1. Product understanding | 17 |
+| 2. One problem, one issue | 12, 12A, 13, 14 |
+| 3. Cheap filter | 18, 19 |
+| 4. Inquiry | 21, 22, 23 |
+| 5. Investigation | 24 |
+| 6. Daily message | 25, 25A, 26, 27, 28 |
+| 7. Inbox | 28A |
+| Stored state and ownership | 5, 20 |
+| Asynchrony and orchestration | 14A, 19A, 24, 25A |
+| Verification | 19, 23, 28, 29 |
+| Direct cutover | 29, 30 |
+
+Acceptance criteria: A1 (28), A2 (3, 12, 12A, 25), A3 (1, 25), A4 (26), A5 (2, 26),
+A6 (4, 30), A7 (18, 20, 21, 28A), A8 (27), A9 (14, 26, 28).
+
+**The pipeline is wired end to end.** Three tasks exist only to connect stages,
+because an earlier draft built every stage and no track between them. Task 14A makes
+settlement open a work round and evaluate it. Task 19A turns an admitted decision
+into an inquiry job. Task 24 turns an accepted inquiry into frozen anchors and an
+investigation. Task 25A schedules the daily run and advances it through its states.
+Task 30's smoke asserts that whole chain, so it now has an implementation behind it.
+
+**Cross-runtime handoffs go through Postgres, never through a shared transaction.**
+Go captures, settles, filters, dispatches, accepts, and publishes. TypeScript
+resolves stacks, runs the inquiry, investigates, and writes the digest. Each new
+state has exactly one writer. Where the two runtimes must cooperate, one writes a
+row and the other's loop claims it.
+
+**Known gaps carried forward.** Two open questions from the design record are not
+closed by any task. The reopen gate in Task 22 compares an evidence signature whose
+exact composition is left to the implementer beyond "counts, route map version, and
+failure kinds"; a wrong choice makes inquiries either too chatty or too sticky, and
+the Task 23 evaluation is what would catch it. And Task 30's live smoke has its
+assertions listed but no written script; it is the last gate before the rollback
+window closes and deserves review before the window is scheduled.
+
+**Placeholder scan.** No task contains TBD, "handle edge cases", or a step without
+its content. Task 25's `FreezeCandidates` and Task 27's validation carry a described
+tail rather than full code; both are scan-and-insert bodies whose queries and
+rejection lists are stated in full.
+
+**Type consistency.** `Envelope`, `Frame`, and `GeneratedPos` (Task 6) are used
+unchanged in Tasks 10 and 12. `Decision` (Task 18) and `InquiryDecision` (Task 21)
+are distinct types over distinct tables. `episode_id` is the join key from Task 14
+onward, added to `error_group_jobs` by the migration in Task 5 before Tasks 19A, 21,
+and 24 write it. Every `ON CONFLICT` in the plan names a constraint the migration
+creates.

--- a/docs/superpowers/specs/2026-08-14-digest-signal-quality-design.md
+++ b/docs/superpowers/specs/2026-08-14-digest-signal-quality-design.md
@@ -1,0 +1,523 @@
+# Digest signal quality: design
+
+Status: draft for review
+Date: 2026-08-14
+Supersedes parts of: `2026-08-07-daily-digest-design.md` (purpose section stands; section order and card content change)
+
+## Summary in plain words
+
+Opslane sends a daily Slack message about problems in your product. Right now
+that message is mostly noise. It asks the reader to review four code fixes for
+errors that have not happened in ten days, two of which happened exactly once
+ever. It counts 58 things as needing a decision when half of them affect nobody
+and half have not been seen in a week. It never mentions the three fixes that
+are blocked waiting for the reader's approval.
+
+This document proposes a bar that problems must clear before Opslane spends
+money investigating them, a second bar before anything reaches the daily
+message, and a rule that removes dead items. It also corrects impact wording
+that currently claims more than the data supports.
+
+Terms used below: an **error** is a crash, meaning something threw an exception
+in the browser. **Friction** is when nothing crashed but the person struggled
+anyway, such as clicking a control that does nothing. An **incident** is either
+one, stored in the same table. A **visit** is one recorded browsing session.
+
+## Problem
+
+Four fix PRs are open and awaiting review in AMFJ 2. Their last occurrence
+dates are 2026-07-28, 2026-07-28, 2026-07-31 and 2026-08-04. Two of the four
+have an occurrence count of 1. One affects zero identifiable customers. Opslane
+investigated a `DOMException` that fired a single time, wrote a patch, and asked
+the owner to review it.
+
+That is not a digest bug. It is what the pipeline was told to do. In
+`packages/ingestion/db/queries.go:707`, a new error group in an in-scope
+environment calls `enqueueFirst()` on its first event. No occurrence count, no
+affected-user count, no impact check. **Investigation is unconditional.**
+
+There is a bar, but it sits one stage too late and is set very low.
+`impactBarEligible` (`packages/worker/src/db.ts:251`) is
+`identifiedUsers >= 1 || recentAnonSessions >= 3`, evaluated at
+`packages/worker/src/index.ts:731` **after** the investigation has run, to decide
+whether to auto-create a fix job. Below the bar the group is parked as
+`investigated` and still marked digest-eligible. So we pay for every
+investigation regardless, and one identified user is enough to earn a PR.
+
+Two corrections to the evidence above, both material. That bar shipped on
+2026-08-12 in C3 (#348), so all four PRs predate it. And it would not stop most
+of them today: two of the four have `affected_users_count = 1`, which clears
+`identifiedUsers >= 1` on its own. The single-occurrence
+`rl: The request took too long` error would still be investigated and still get
+a PR under current code.
+
+Friction is gated earlier and harder. `PROMOTION_THRESHOLD_USERS = 5`
+(`packages/worker/src/friction/promotion.ts:26`) blocks standalone bucket
+promotion below five distinct eligible users. The bar is not absolute:
+same-session fold candidates are adjudicated eagerly, anonymous signals can
+fold, and a later signal can inherit an already-accepted generation without
+crossing the threshold again (`promotion.ts:82`, `promotion.ts:126`). Even so,
+friction earns its place and errors do not.
+
+The consequences compound:
+
+| Measurement (AMFJ 2, prod, 2026-08-14) | Value |
+| --- | --- |
+| Open incidents | 478 |
+| Still occurring within 7 days | 296 |
+| With any impact measurement at all | 51 |
+| Where a customer did not recover | 27 |
+| With 5 or more failed visits | 4 |
+| With 20 or more failed visits | 1 |
+
+Of the 58 counted as needing a decision, 28 have a priority score of zero
+(no affected users) and 28 have not been seen in over 7 days. Their reason
+codes: `insufficient_context` 26, `unfixable_infra` 15,
+`unfixable_third_party` 7, `unfixable_no_app_frames` 5, `budget_exhausted` 2,
+`low_confidence_fix` 1. So 27 of 58 are already labelled unfixable by our own
+pipeline, and 26 are cases where Opslane failed to investigate, which is our
+backlog rather than the reader's.
+
+Three further defects, each independently sufficient to make the message
+untrustworthy:
+
+**Dead items never expire.** The receipt query in
+`packages/ingestion/digest/build.go:64` filters on
+`dr.updated_at >= $2 AND dr.updated_at < $3`, the readiness row's timestamp. It
+never checks whether the incident is still happening. A background job touching
+readiness is enough to put a two-week-dead group in today's message.
+
+**A request for approval is disguised as a status update.**
+`packages/ingestion/digest/build.go:186` maps status to a receipt sentence and
+ends with `default: return "report_ready"`, rendered as "Investigation report
+ready." That default swallows `awaiting_approval`. AMFJ 2 has 4 friction
+incidents in `awaiting_approval`, 3 of them digest-eligible, where Opslane has
+finished investigating and is blocked on the owner saying yes. The digest has
+never asked.
+
+**The counter and the cards disagree about time.**
+`buildTriageAndHeldBack` (`build.go:289`) has no window at all and counts every
+non-resolved group for all time, while the cards are windowed. The reader sees
+a lifetime backlog number next to a windowed list.
+
+## Goals
+
+- Raise the ratio of items worth acting on to items shown, measured on real
+  AMFJ data.
+- Stop spending investigation budget on incidents that have not earned it.
+- Say only what the data supports about customer impact.
+- Surface the approval requests that are currently invisible.
+
+## Non-goals
+
+- **Merging friction and errors internally.** Their differences are
+  principled. Friction needs a user threshold because one dead click is
+  meaningless, and friction needs approval because changing a control's
+  behaviour is a product decision. Only the reader-facing presentation merges.
+- **Task-completion measurement.** Knowing whether a customer finished what
+  they came to do requires naming the flows that matter and instrumenting
+  them. That is its own project. See the honest caveat.
+- **A new notification channel, digest archive table, or per-user
+  preferences.** Unchanged from the v1 design's non-goals.
+- **Re-ranking the dashboard.** This document changes what is pushed to Slack,
+  not the incident feed.
+
+## The frame every decision is tested against
+
+The reader is a founder or product engineer with no time. They want problems
+that are high impact, that they can act on, and that are relevant to their
+product. If the message does not clear that bar they will use Sentry instead,
+which is free and already open. **They do not care whether a problem is
+classified as friction or as an error. They want bugs and papercuts gone.**
+
+Two consequences that shape everything below. First, the digest presents one
+ranked list with no friction or error sections, and the kind is never a heading.
+Second, an empty digest is a valid and desirable outcome, because "nothing
+needed you today" is what makes the non-empty days believable.
+
+## User requirements
+
+| # | Requirement | Verified by |
+| --- | --- | --- |
+| R1 | An error is not investigated until it clears an admission bar | Unit test on the enqueue path; prod replay showing the two single-occurrence PRs are not created |
+| R2 | An incident that has stopped occurring never appears in the digest | Digest build test seeding a group with an old `last_seen` and a fresh readiness row |
+| R3 | An incident awaiting the reader's approval renders as an explicit ask, not as a report | Formatter test asserting the `awaiting_approval` receipt state and its action |
+| R4 | The digest never states a customer failed; it states what was observed | Formatter test asserting the wording, plus review of every impact string |
+| R5 | Counters describe the same window as the cards, or are removed | Digest build test comparing counter scope to card scope |
+| R6 | Incident links resolve to a real dashboard URL | Live smoke against a deployed stack with `DASHBOARD_URL` set |
+| R7 | Reader-facing copy never names the kind as a section or category | Formatter test over a mixed friction and error payload |
+| R8 | A digest with nothing qualifying sends a short "nothing needed you" message | Digest build test with an empty qualifying set |
+
+## System overview
+
+```mermaid
+sequenceDiagram
+    participant E as Event ingest
+    participant A as Admission bar (new)
+    participant W as Worker
+    participant D as Digest build
+    participant S as Slack
+
+    E->>A: new or recurring incident
+    A-->>E: below bar, record only
+    A->>W: cleared bar, enqueue investigation
+    W->>W: investigate, maybe fix
+    W->>D: readiness projection
+    D->>D: gate 1 occurred inside the window
+    D->>D: gate 2 union: awaiting reader, or unrecovered impact, or unmeasured and wide
+    D->>D: rank by people affected, customers named separately
+    D->>S: cards with one action each, or the nothing-needed-you line
+```
+
+Two gates, in different places, doing different jobs. The admission bar governs
+spend and PR quality. The digest gates govern the reader's attention. Neither
+can substitute for the other: an item admitted for investigation may still be
+uninteresting today, and a costly item that we cannot patch still deserves the
+reader's attention.
+
+## Component design
+
+### 1. Admission bar for errors
+
+Errors currently enqueue on first event. Friction already requires five distinct
+users. Aligning them is the single change that removes the most waste, because
+it operates before any money is spent.
+
+The unit should be affected people rather than occurrence count. A count of 518
+from one customer is not 518 problems, and today's largest error group has
+exactly that shape: 518 occurrences and `affected_users_count = 0`.
+
+**Reuse the existing population definition rather than inventing one.**
+`getGroupImpactBar` (`db.ts:272`) already counts identified users, plus
+sessions in the last 7 days whose events are *all* anonymous
+(`bool_and(ee.end_user_id IS NULL)`). That second term is anonymous-only
+sessions, not all sessions, which matters: counting all sessions would let one
+identified user qualify by retrying 20 times. Admission uses the same two
+counts with higher constants:
+
+```go
+// Same population as impactBarEligible (worker db.ts:251): identified users,
+// plus 7-day sessions whose events are all anonymous. Only the constants
+// differ. Reusing the definition keeps one notion of "how many people".
+const (
+    admitIdentifiedUsers  = 5   // matches PROMOTION_THRESHOLD_USERS
+    admitAnonOnlySessions = 20  // placeholder; M1 sets this from replay
+)
+```
+
+**Both enqueue paths must be gated, not just the new-group path.** Gating only
+`isNew` at `queries.go:707` is bypassed by the dormant-group branch at
+`queries.go:726`, which enqueues unconditionally when a group is still `new`
+and has no jobs. A held group is by construction in exactly that state, so the
+next event would admit it regardless. The check belongs in one helper called
+from both branches.
+
+**The recount must include the event currently being written.** The enqueue
+decision runs in the same transaction that inserts the event, links it to the
+group, and updates the affected-user rollup (`queries.go:622`, `queries.go:665`),
+so the counts already reflect this event by the time admission is evaluated.
+That ordering is load-bearing rather than incidental: recounting before the
+rollup write leaves a group sitting at exactly 4 users forever, because the
+fifth user's own event is the one that would never be counted. The admission
+helper is called after the rollup update, and a test pins the boundary case of a
+group crossing on the Nth distinct user.
+
+**The count must be scoped to eligible environments.** Error groups are keyed by
+project and fingerprint, while action scope is evaluated per event
+(`queries.go:679`), and `error_group_affected_users` carries no environment
+column. Without an environment-scoped recount, staging traffic can satisfy the
+bar and let a single production occurrence through. Admission counts only
+events in environments that are in the project's action scope.
+
+**Held groups are visible but inert, and that is a real behaviour change.** A
+group below the bar is recorded and grouped, and still appears in the incidents
+API, but it has no job, no `digest_readiness` row, and no `issue.created`
+notification. Two consequences to accept deliberately. Per-issue Slack alerts stop firing on
+first sight of a new error. And when an old group later crosses the bar, receipt
+selection keys on the new readiness timestamp while `buildTopNewIssues` still
+keys on the original `first_seen` (`build.go:414`), so a late-admitted group can
+miss both surfaces. Milestone 2 covers the second by treating admission time,
+not `first_seen`, as the novelty clock.
+
+**Requeue is not folded into this check.** The existing requeue path preserves
+non-retriable failure states, archived dismissal, and release ordering
+(`queries.go:731`), and resets `digest_readiness` to `pending` only after a job
+row is actually inserted. Admission gates the *first* investigation. A regressed
+group that already completed a lifecycle keeps its existing requeue rules, and
+readiness is never reset unless a job was inserted.
+
+**Open decision.** Whether a first occurrence should ever bypass the bar for a
+severe crash on a checkout-shaped route. The current impact bar sits at the
+opposite extreme, admitting anything with one identified user, so moving
+straight to 5 is a large jump for rare-but-severe failures. Doing the exception
+properly needs `route_map` tier coverage that is unverified for AMFJ. Recommend
+shipping without it and measuring what it misses in M1's replay.
+
+### 2. The two digest gates, stated precisely
+
+**Liveness has exactly one definition in this document: the incident occurred
+inside the digest window.** One predicate added to the receipt query in
+`build.go`:
+
+```sql
+AND g.last_seen >= $2   -- the window start, the same bound the readiness filter uses
+```
+
+Nothing else defines liveness. The 7-day and 14-day figures elsewhere are not
+alternative definitions: 7 days is the measurement horizon used to describe the
+current backlog, and the 14 days in M4 is the separate question of when an
+already-open fix PR is withdrawn.
+
+This is the whole fix for the four dead PRs. It is small because the defect is
+not subtle: the query filters on when our own bookkeeping row changed and never
+on whether the problem is real today.
+
+**The second gate widens the input.** Only 51 of 296 live incidents carry any
+impact measurement, so a gate that *required* measured impact would drop 83% of
+the input and could render an empty digest on a day when real problems exist.
+It is a union of three admitting clauses. An incident reaches the digest when
+any of these holds:
+
+1. It is waiting on the reader (`awaiting_approval`, or a fix PR open for
+   review).
+2. It has measured impact with at least one unrecovered visit.
+3. It has no impact measurement at all, and clears the reach bar on identified
+   users or anonymous-only sessions.
+
+Clause 3 is what keeps an unmeasured but widespread problem visible, and it is
+also why ranking falls back to reach rather than to impact. The only incidents
+excluded outright are those with measured impact where every visit recovered,
+because the measurement we do have says nobody was stuck. That is the
+"all 5 visits recovered" dead-click case from today's digest.
+
+**Empty is a real outcome and has an owner.** When no incident satisfies any
+clause, `Build` produces a payload with no cards, and the formatter renders a
+single line saying nothing needed the reader today. This is the R8 path, it
+lives in `formatSlackDigestV2` alongside the existing quiet-day branch
+(`slack_digest.go:121`), and M2 owns it.
+
+### 3. Approval as a first-class receipt state
+
+`receiptState` gains an explicit branch before the default:
+
+```go
+case "awaiting_approval":
+    return "approval_pending"
+```
+
+with the sentence "Ready to fix this. Needs your OK." and an approve action on
+the card. The `default` branch stays for genuinely unknown states, but it now
+logs, so the next state that falls through is visible rather than silently
+rendered as a report.
+
+This is the highest-value single change in the document. Three fixes are
+already waiting; the work is done and unclaimed.
+
+### 4. Impact wording
+
+`impact_visits_recovered` counts sessions whose recording contains an event at
+least 60 seconds after the last hit (`priority/sweeper.go:251`,
+`impactRecoveryMs = 60_000`). It does not observe intent and never checks
+whether the person achieved anything.
+
+On the one case we could audit, that proxy is wrong often. For the stale-deploy
+group: 262 sessions, 158 recovered, 104 scored as failed. Only 14 of those 104
+belong to an identifiable customer, and 6 of those 14 had the same customer
+start a new session within 10 minutes. On the followable sample, roughly 43% of
+"failures" are people who reloaded and carried on. That is the expected shape,
+since a failed bundle load prompts a reload and a reload starts a new session.
+
+One further distortion: the rollup inner-joins sessions to scrubbed chunks
+(`sweeper.go:238`), so a session with no usable recording leaves both the
+numerator and the denominator. The ratio is therefore over recorded sessions
+only, and never over everyone who hit the problem.
+
+So the digest describes the observation, not the inference:
+
+> 41 customers hit a stale bundle across 262 visits. In 104 the session stopped
+> within a minute.
+
+and never "104 customers failed". Session stitching (Milestone 3) upgrades the
+claim once the same-customer-returned check is materialised.
+
+### 5. Ranking and presentation
+
+One list. Rank by customers affected, with anonymous sessions counted
+separately and never merged into a customer number. Name the customers we can
+identify: for AMFJ every identified user carries an `account_name` that is a
+Jira site (484 users, 483 distinct, all `*.atlassian.net`), so naming is real
+rather than aspirational.
+
+Each card carries exactly one primary action, derived from state rather than
+from kind: review a fix PR, approve a fix, make a decision, or read what we
+found. The reason codes decide the ask, never admission. `unfixable_no_app_frames`
+means our pipeline cannot write a patch. It does not mean the reader does not
+need to know: that class covers stale deploy, which is 104 of the 157 failed
+visits we can measure across the whole product.
+
+**Open decision.** Whether an unfixable-but-costly item appears daily, or only
+when it crosses a threshold. Recommend threshold-triggered, because a card that
+appears every day with no action becomes wallpaper.
+
+### 6. The merged counter stops being rendered
+
+An earlier draft deleted `buildTriageAndHeldBack`. That is wrong.
+`DigestTriageCounts` and `HeldBackCount` are fields on the notification payload
+contract (`notify/event.go:72`), the formatter reads them for the header and
+footer (`slack_digest.go:117`), and digest tests assert them
+(`build_test.go:643`). Deleting the builder leaves a nil pointer that renders as
+a confident zero, and drops artifact-belt failure reporting with it.
+
+What changes is the rendered line, not the data. The merged sentence
+"N fix PRs awaiting review, M issues need a decision" is removed, because its
+two halves describe opposite requests: `needs_human` means Opslane gave up and
+is handing work over, `awaiting_approval` means Opslane wants to take work away.
+Adding them yields a figure that cannot guide anything. The counts stay in the
+payload for the dashboard and for held-back reporting, and anything that needs
+the reader becomes a card.
+
+`buildTriageAndHeldBack` also gains the window it never had (`build.go:289`), so
+the retained counts describe the same period as the cards.
+
+## Milestones
+
+**M1, admission bar.** Errors gated on identified users or anonymous-only sessions before
+enqueue. Exit criterion: replaying the last 30 days of AMFJ events creates no
+investigation job for either single-occurrence group, and still creates one for
+the 518-occurrence group and for stale deploy. `admitDistinctSessions` fixed
+from that replay.
+
+**M2, digest gates and copy.** Liveness predicate, the three-clause admission
+union, approval receipt state, the merged counter's removal from the rendered
+output, impact wording, one unsectioned list, and the empty-digest line. Exit criterion, against a digest rendered from a restored prod snapshot: no
+incident whose `last_seen` precedes the window start, the three pending
+approvals named as approvals, and no string asserting that a customer failed. A
+separate run seeded with nothing qualifying must render the nothing-needed-you
+line rather than a header with no body.
+
+**M3, session stitching.** A failed visit is re-scored as recovered when the
+same identified customer starts a session within 10 minutes. Exit criterion: the
+stale-deploy group's failed count drops by roughly the audited proportion, and
+the digest sentence upgrades from "the session stopped" to "did not come back".
+
+**M4, expiry of dead work.** A fix PR whose incident has not occurred in 14
+days is withdrawn or marked stale rather than presented as work. Gated on M1
+landing, since M1 stops the supply.
+
+## Testing and validation
+
+Runs in CI: the admission bar, the liveness predicate, the receipt state
+mapping, counter removal, and every copy assertion. All are pure functions or
+single-query behaviours with existing test harnesses in
+`packages/ingestion/digest` and `packages/worker/src/__tests__`.
+
+Needs a live run: R6, because `BuildIncidentURL` (`notify/url.go:11`) returns an
+empty string for an unset base and `slackDigestLink` then silently degrades to
+plain text. That failure is invisible to unit tests and is currently live in
+production, where `DASHBOARD_URL` is absent from the ECS task definition. Also
+needs a live run: the M1 replay, which requires prod-shaped data.
+
+Not provable in CI: whether the resulting digest is worth a founder's time. The
+proxy is that a reader can name the action for every card without opening the
+dashboard.
+
+### Contract and test impact
+
+The frozen `POST /api/v1/events` contract is not affected. Admission is an
+internal gate: a held event still returns 202 with stable event and group IDs
+(`error_event.go:297`), and `wire_compat_test.go` does not assert job creation.
+The contract would only break if we made identity or session ID required, or
+rejected below-bar events, and we do neither.
+
+Tests that will need updating, because they assert a job is created on first
+event: `db/error_group_ingestion_test.go`, `db/notifications_publish_test.go`,
+the action-scope and requeue suites, and the single-event pipeline e2e. These
+are the correct tests to change, since the behaviour they pin is the behaviour
+this document removes. `digest/build_test.go` needs the retained-but-windowed
+triage counts rather than deleted ones.
+
+## Risks
+
+**The bar hides a real outage on an uninstrumented page.** A severe break on a
+route where `identify()` never runs produces few identified users. The session
+fallback is the mitigation, and its value is set from replay rather than guessed.
+Worst case is a delayed investigation, not a lost one: the group stays `new`
+with no job, so the gated dormant-group branch at `queries.go:726` admits it on
+the first event after it crosses either bar. This is the first-investigation
+path, not the requeue path, which handles only groups that already completed a
+lifecycle.
+
+**Ranking by customers rewards good instrumentation rather than real severity.**
+Mitigated by counting anonymous sessions in the ranking while never calling them
+customers in the copy. A line reading "1 customer and 379 anonymous visits" is
+itself a useful signal that instrumentation has a gap.
+
+**Session stitching over-corrects.** A customer who returns may be retrying and
+failing again. M3 makes the claim weaker rather than stronger, and the wording
+stays observational.
+
+**Per-issue alerts go quiet for held groups.** Admission stops
+`issue.created` from firing on a new error's first sight, which is a
+user-visible change to the Slack stream, not only to the digest. That is
+intended under the frame, since a first-sight alert for a one-off error is the
+same noise in a different envelope. It is called out because a reader who
+watches the alert channel will notice the change before they notice the
+improvement.
+
+**The digest goes quiet when it should not.** Three gates compose here: the
+admission bar, the liveness predicate, and the second-gate union. Each is
+individually defensible and together they could produce silence on a day with
+real problems. The union's clause 3 is the specific guard, since it admits
+unmeasured incidents on reach alone, and the M2 exit criterion checks the
+snapshot renders a non-empty digest for a day we know had real items. If the
+digest is empty for a week while the dashboard is not, the gates are wrong.
+
+**A held group looks investigated-but-idle in the dashboard.** It has no job and
+no readiness row while sitting in `new`. The incidents API still lists it, so
+nothing disappears, but the UI needs a state that reads as "watching, not enough
+signal yet" rather than as a stalled investigation.
+
+**Unsolved: measurement coverage.** Only 51 of 296 live incidents have any
+impact measurement, because impact requires a session recording to determine
+recovery. For 83% of live incidents we cannot say whether anyone was blocked,
+and ranking falls back to reach, which is what event-count tools already do. The
+differentiator is capped by recording coverage, not by ranking logic. Nothing in
+this document fixes that, and it should be the next investigation.
+
+## Alternatives considered
+
+**Filter harder in the digest, leave the pipeline alone.** Rejected. The four
+junk PRs already exist by the time the digest runs. Filtering hides the waste
+without stopping it, and the reader still sees the pipeline working on trivia
+whenever they open the dashboard.
+
+**Gate on occurrence count instead of distinct users.** Rejected. The largest
+error group has 518 occurrences and no identifiable customers, and a single
+noisy retry loop can manufacture any occurrence count. Users and anonymous-only
+sessions measure spread, which is what "does this matter" actually asks.
+
+**Raise the existing impact bar instead of adding an admission bar.** The
+cheapest option by far: `impactBarEligible` already exists, already has the
+right population, and moving it from `1 user or 3 anonymous sessions` to
+something higher is a two-constant change with no new gating path, no
+environment recount, and no held-group state. Rejected as insufficient on its
+own, because the bar runs *after* the investigation at `index.ts:731`, so it
+controls which investigations become PRs and never controls how many
+investigations we pay for. It is a good complement, not a substitute, and M1
+should tune both constants from the same replay.
+
+**Suppress unfixable classes entirely.** Rejected after measurement. Stale
+deploy is the single largest source of measurable customer harm in AMFJ, and it
+has a real fix that is not a code patch. Conflating "our pipeline cannot write
+the patch" with "the reader does not need to know" discards the biggest problem
+in the product.
+
+**Keep the friction and error sections and improve each.** Rejected on the
+frame. The reader wants bugs and papercuts gone and does not think in our
+taxonomy. Two sections force them to learn our internal model before they can
+read their own list.
+
+**Raise `friction_autonomy` to `auto_fix` instead of asking.** Not rejected,
+deferred to the reader. It removes the approval step entirely and is a smaller
+change than adding an approval state. It is out of scope here because it is a
+product decision about how much autonomy Opslane gets, not a digest decision.

--- a/docs/superpowers/specs/2026-08-15-pipeline-and-digest-design.md
+++ b/docs/superpowers/specs/2026-08-15-pipeline-and-digest-design.md
@@ -1,0 +1,395 @@
+# Pipeline identity and the daily digest
+
+Status: draft for review
+Date: 2026-08-15
+Supersedes: `2026-08-14-digest-signal-quality-design.md`, which treated the digest
+as the problem. The digest is the last 20%.
+
+## Problem
+
+AMFJ 2 receives about **50 error events a day** and creates **50 to 65 new issues
+a day**. More issues than errors. Measured 8 to 15 August 2026 in production.
+
+That is not growth. It is the same bugs fragmenting. 483 open issues are roughly
+163 real bugs, and the two largest problems in the product have never appeared in
+a digest because each is shattered into pieces too small to notice:
+
+| Bug | Customers | Issues it is split across |
+| --- | --- | --- |
+| Dead clicks on a form field, `/assets` | 74 | 10 |
+| `Error deleting Assets` | 9 | 7 |
+
+In one of those delete sessions a customer worked on `/assets` for 80 minutes,
+attempted two saves, and completed none. Session `60238832`, customer
+`soundcu.atlassian.net`, full recording, classified active with 10 clicks and 10
+keystrokes.
+
+### Three causes of fragmentation
+
+**Bundle filename hashes.** A crash's identity includes its top stack lines, which
+contain the bundle filename. Vite writes a content hash there, so every deploy
+changes it. The seven delete issues share function, line and column and differ
+only here:
+
+```
+entry-index.CaWHNXv4.js:17:78242
+entry-index.DXhxKZv7.js:17:78242
+entry-index.CmiI5RcM.js:17:78242
+```
+
+The normaliser meant to strip this (`grouping/fingerprint.go:20`) requires a
+hyphen before the hash. This bundler writes a dot, so it never fires.
+
+**Compiled CSS class hashes.** A dead click's identity includes the element's path
+in the page. Atlaskit compiles styles into hashed class names such as `_11c81d4k`,
+which change when its styles rebuild. Three of the four live form-field issues on
+`/assets` differ only in these.
+
+**Positional selectors, already fixed.** `friction/fingerprint.ts:27` strips
+`:nth-of-type` and its siblings, with a comment naming this exact failure. Correct
+fix, incomplete coverage.
+
+### Finished work sits waiting
+
+An issue reaches the digest only if a readiness flag permits it, and the sole
+writer of that flag is an investigation completing (`worker/src/db.ts:137`). A
+one-shot migration stamped 376 issues `backfill_unverified` and left no path out.
+
+**Of 482 live issues, 10 can reach the digest.** Thirteen more are quarantined and
+hold 196 customers between them. Going forward the same hole recurs: 43 issues
+created on 14 August have no flag at all.
+
+Separately, `digest/build.go:186` maps issue state to a sentence and ends in a
+catch-all returning "Investigation report ready." Dead-click states fall through
+it, so three issues where the fix is written and awaiting the owner's approval
+render as passive reports.
+
+### Links do not work
+
+`DASHBOARD_URL` is absent from the production task definition. `BuildIncidentURL`
+(`notify/url.go:11`) returns an empty string for an unset base, and the formatter
+falls back to plain text. Every "Issue page" in every digest sent to date is dead
+text. On per-issue alerts the button is omitted entirely.
+
+## Goals
+
+- One bug produces one issue, across deploys and style rebuilds.
+- Cheap analysis runs over every issue; expensive analysis runs over a shortlist.
+- Every issue carries a recorded decision, including a decision not to act.
+- The digest states only what the data supports.
+
+## Non-goals
+
+**Rescuing the 376 parked issues.** New rules apply going forward. Old issues stop
+receiving events and go quiet on their own. Reconciling them would mean deciding
+which of two investigated issues survives and what happens to an open PR, and that
+complexity buys nothing a customer sees.
+
+**Un-merging, parent-child clusters, and two-issues-both-with-PRs.** Rare, and the
+existing reopen rules (`queries.go:341`) already handle the common cases.
+
+**Per-customer fairness in the job queue.** Job claiming is global FIFO with no
+project in the ordering (`worker/src/db.ts:524`). AMFJ 2 is 960 of 968 issues and
+78,421 of 78,421 analysed sessions, so one customer is effectively all the load
+and this has never been exercised.
+
+**Rewriting grouping.** Two mechanical fixes cover every observed cause.
+
+**Task-completion measurement.** Knowing whether a customer achieved what they
+came for needs the customer to name their flows. Its own project.
+
+## User requirements
+
+| # | Requirement | Verified by |
+| --- | --- | --- |
+| R1 | A bug keeps one identity across a deploy | Replay two events from different builds with identical resolved frames; assert one group |
+| R2 | A bug keeps one identity across a style rebuild | Unit test on selector canonicalisation with two Atlaskit class hashes |
+| R3 | Stack unscrambling runs whether or not we investigate | Integration test: an issue below the investigation bar still gets resolved frames |
+| R4 | Every issue carries a recorded decision, including "held" | Query after a sweep: zero live issues with no readiness row |
+| R5 | An issue that stopped occurring never reaches the digest | Digest build test: old `last_seen`, fresh readiness row, absent from output |
+| R6 | An issue awaiting approval renders as an ask | Formatter test asserting the state and its action |
+| R7 | Incident links resolve | Live smoke against a deployed stack with `DASHBOARD_URL` set |
+| R8 | Cards name the customers we can identify | Formatter test over a payload carrying account names |
+| R9 | A card can state that a save failed | Integration test joining session facts to an issue |
+| R10 | Scout accept rate is observable per detector | Metric emitted per adjudication run; dashboard tile |
+
+## System overview
+
+```mermaid
+sequenceDiagram
+    participant SDK
+    participant Ingest as Ingest (Go, in request)
+    participant Resolve as Unscramble (worker job)
+    participant Sweep as Cheap sweeps (Go, continuous)
+    participant Scout as Scout (daily, model)
+    participant Slack
+
+    SDK->>Ingest: error event
+    Ingest->>Ingest: provisional identity, store, count
+    Ingest-->>Resolve: enqueue
+    Resolve->>Resolve: source map to real file and line
+    Resolve-->>Sweep: resolved frames written
+    Sweep->>Sweep: settle identity, merge if key changed
+    Sweep->>Sweep: count customers, sessions, failed saves, repeats
+    Sweep->>Sweep: decide: investigate / hold / not actionable
+    Note over Sweep: everything above runs for every issue
+    Sweep-->>Scout: ~15 survivors of ~125 daily deltas
+    Scout->>Scout: confirm merges, read cause, write cards
+    Scout->>Slack: digest
+```
+
+The rule: everything above the Note runs for every issue regardless of size. That
+is what makes it safe to be selective below it. Today selectivity means blindness,
+because counting and investigating are entangled.
+
+### Three chains
+
+Keyed differently, volumes two orders of magnitude apart, so separate budgets.
+
+**Issues**, about 125 a day to consider, triggered by an error arriving.
+
+**Sessions**, 10,000 to 17,000 a day, triggered by a session closing. A model never
+reads one. They are counted and the counts attach to issues.
+
+**Codebase**, triggered by a deploy. Today it is triggered by unmapped routes on
+error groups (`priority/sweeper.go:289`), so it only learns about parts of the
+product that break, and never refreshes when code changes.
+
+The chains meet twice. Dead clicks become an issue at five distinct users, which
+works. Issue counting reads session facts, which does not exist and is one join.
+That join is soft: counting uses whatever facts exist and recomputes when more
+arrive, so it never blocks on a queue eighty times its size.
+
+## Component design
+
+### 1. Identity settles late
+
+**What.** The event gets a provisional identity in the request so it has a home
+and the occurrence count ticks. An unscrambling job then produces real source
+frames, and identity is recomputed from those.
+
+**Why.** Source files do not change when you deploy; bundle filenames do. Today we
+make a permanent identity decision synchronously, at the moment we know least,
+using the least stable representation available. Resolution cannot move into the
+request because source maps are capped at 32 MiB and fetching one per event would
+sink ingest latency. It can move out of investigation.
+
+```go
+// Settled identity uses resolved frames when present. The provisional key stays
+// as the fallback: if source maps never arrive, nothing breaks, we just do not
+// get the improvement.
+func settledKey(platform, errorType, message string, resolved []ResolvedFrame) string {
+    if len(resolved) == 0 {
+        return "" // keep provisional
+    }
+    parts := make([]string, 0, len(resolved))
+    for _, f := range resolved[:min(len(resolved), hashedFrameCount)] {
+        parts = append(parts, fmt.Sprintf("%s:%d", f.OriginalFile, f.OriginalLine))
+    }
+    return hash(platform, errorType, normalizeMessage(message), parts)
+}
+```
+
+### 2. Unscrambling moves out of investigation
+
+**What.** A worker job type that resolves an event's stack and writes
+`stack_trace_resolved`.
+
+**Why.** It is currently called only from the investigate and fix jobs
+(`worker/src/index.ts:538`, `:1185`). That creates a trap for the admission bar in
+component 4: hold an investigation back, the stack is never resolved, the bug
+keeps fragmenting, each fragment looks smaller, and it never qualifies. Same cost,
+same asynchrony, different owner.
+
+### 3. Click identity strips generated class hashes
+
+**What.** One more rule in `canonicalizeSelector`.
+
+**Why.** The function already strips positional pseudo-classes for exactly this
+reason. Compiled class hashes are the same category of ingredient: they change for
+reasons unrelated to the bug.
+
+```ts
+function canonicalizeSelector(selector: string | null): string {
+  return (selector ?? '')
+    .replace(/#react-select-(\d+)-[\w-]+/g, '#react-select-$1')
+    .replace(/:nth-of-type\(\s*[^)]*\)/g, '')
+    // Compiled style hashes (Atlaskit `_11c81d4k`) change when styles rebuild,
+    // splitting one defect across many findings. Same reason as the above.
+    .replace(/\._[a-z0-9]{6,}/g, '')
+}
+```
+
+**Unverified.** The `_[a-z0-9]{6,}` shape is inferred from four observed selectors
+(`_11c81d4k`, `_10m98stt`, `_2rko12b0`, `_ymio1r31`). Before shipping, sample the
+distinct selectors in `friction_signals` and confirm the pattern does not also
+match a hand-written class.
+
+### 4. Readiness becomes an owned state
+
+**What.** The decide step writes one of three outcomes: investigate, held, or not
+actionable.
+
+**Why.** Today readiness is a side effect of investigations completing, and its
+absence is silence. Silence is what made 376 issues unreachable with no way back,
+and what leaves 43 of yesterday's issues with no flag at all. "Held" is the state
+that does not exist and needs to.
+
+### 5. Recompute by rules version
+
+**What.** Every derived value records which rules version produced it and when.
+Sweeps select rows where the version moved or the input is newer than the output.
+
+**Why.** It makes identity changeable rather than permanent, which is what makes
+"fix mechanical causes at source" safe. Change a rule, bump the version, affected
+events regroup on the next pass. No migration, no backfill script.
+
+**This pattern already exists twice**: `session_analysis.rule_version` and
+`ROUTE_MAP_PROMPT_VERSION`. Nothing acts on either when it changes.
+
+### 6. The scout authors the digest
+
+**What.** One daily pass over the delta. The cheap layer narrows about 125 issues
+to roughly 15 by dropping dead ones, dropping zero-reach ones, and proposing
+duplicates. The scout confirms merges, reads causes, and writes cards.
+
+**Why author rather than template.** A template renders the rows it is given. It
+cannot notice that eleven of today's new issues are the same dead click that
+already has ten fragments. Merging needs judgment and must happen before anything
+is written, so the merger and the writer are one pass.
+
+**The number that keeps it honest is accept rate**, and your own data already
+shows where the line sits:
+
+| Detector | Judged | Accepted | Rate |
+| --- | --- | --- | --- |
+| Dead click | 1,078 | 303 | 28% |
+| Rage click | 197 | 40 | 20% |
+| Form abandon | 984 | **2** | **0.2%** |
+
+Form abandon is a broken filter, not a bad prompt. Switch its adjudication off
+until the detector is fixed. Sustained below roughly 20% means fix the filter;
+near 100% means the cheap layer already decided and the model is ceremony.
+
+## Milestones
+
+**M1, links and states.** Set `DASHBOARD_URL`. Add an explicit approval state
+before the catch-all in `receiptState`. Add a liveness predicate to the receipt
+query.
+
+*Exit:* a digest rendered from a restored prod snapshot contains no issue whose
+`last_seen` precedes the window start, names the three pending approvals as
+approvals, and every link resolves against a deployed stack.
+
+**M2, identity.** Unscrambling as its own job. Settled identity from resolved
+frames. Class hashes stripped from click identity. Rules versions acted on.
+
+*Exit:* replaying 30 days of AMFJ events produces one issue for the delete bug
+rather than seven, and one for the `/assets` form field rather than three. New
+issues per day drops below 20.
+
+**M3, decisions and facts.** Readiness as an owned state with a held outcome. A
+bar before investigating. Session facts joined to issues.
+
+*Exit:* zero live issues with no readiness row. Replaying 30 days creates no
+investigation job for either single-occurrence error. A card can state a failed
+save count drawn from `session_analysis`.
+
+**M4, the scout.** Daily pass authors the digest. Accept rate emitted per
+detector.
+
+*Exit:* a digest generated end to end from a prod snapshot, three to five cards,
+every card naming customers, and the accept-rate metric visible.
+
+Gate M2 on M1 shipping, since M1 is config and copy and needs no coordination.
+Gate M3 on M2, because a bar over fragmented issues holds back the wrong things.
+
+## Testing and validation
+
+**In CI.** Identity rules are pure functions and get table tests: two builds with
+identical resolved frames, two Atlaskit hashes, a hand-written class that must
+survive. The liveness predicate, the receipt state mapping, the readiness
+outcomes, and every copy assertion are single-query or pure and use the existing
+harnesses in `packages/ingestion/digest` and `packages/worker/src/__tests__`.
+
+**Needs a live run.** R7, because `BuildIncidentURL` returns empty for an unset
+base and the formatter degrades silently to plain text, which no unit test sees
+and which is live in production today. Also the M2 and M3 replays, which need
+prod-shaped data.
+
+**Not provable in CI.** Whether the digest is worth a founder's time. The proxy is
+that a reader can name the action for every card without opening the dashboard.
+
+## Risks and mitigations
+
+**The class-hash rule matches a real class name.** Blast radius is two distinct
+bugs merging into one, which is the failure mode that hides a bug rather than
+merely adding noise. Mitigated by sampling distinct selectors before shipping and
+by keeping the rule anchored to a leading underscore.
+
+**Source maps arrive after the event.** The plugin uploads at build time so maps
+normally precede errors, but a fast error after a deploy can beat its own map. The
+resolution job retries, and identity tolerates settling minutes late because
+nothing has looked at the issue yet.
+
+**The bar starves an uninstrumented page.** Only 4.9% of sessions carry an
+identity, so a break where `identify()` never runs looks customer-free. Mitigated
+by counting anonymous-only sessions alongside identified customers, and by the
+fact that a held issue is admitted on the first event after it crosses either
+threshold.
+
+**The digest goes quiet when it should not.** Three gates compose. Mitigated by
+the M4 exit criterion checking a known-busy day renders a non-empty digest.
+
+**Unsolved: we cannot tell a wrong merge from a successful fix.** Merging is the
+only operation here that hides a real bug inside another. If three of four merged
+fragments stop after a fix and one does not, occurrences drop and it reads as
+success. The cheapest guard is checking whether a bug actually stops after its fix
+deploys. It is a follow-up, not a launch item, and until it exists the scout
+should refuse marginal merges.
+
+## Alternatives considered
+
+**Patch the asset-hash regex to accept a dot.** One line, fixes AMFJ immediately.
+Rejected as the primary fix because it treats a symptom: the next bundler
+convention breaks it again, and it does nothing for the CDN-host and
+browser-stack-format variants visible in the same six rows. Kept as a cheap
+addition, not a substitute.
+
+**Let everything fragment and have the scout merge at digest time.** Rejected. The
+issue list stays at 483 and only the message looks clean, so the dashboard, the
+counts, and every threshold stay wrong. Merging is also the operation most likely
+to hide a bug, so doing it thousands of times a week rather than for the residue
+is the wrong risk profile.
+
+**Move raw error events to object storage with derived columns in Postgres.**
+Rejected on measurement. `error_events` is 18 MB across 7,734 rows, against 249 MB
+for session chunk metadata. Almost every diagnosis behind this document came from
+querying raw stack traces and JSON context directly, and that stops if they become
+blobs. Revisit past roughly a hundred million events.
+
+**Adopt the friction bar of five distinct users for errors unchanged.** Rejected
+as written. Errors already have a bar: `impactBarEligible` at
+`worker/src/db.ts:251` requires one identified user or three recent anonymous
+sessions. But it runs after the investigation (`index.ts:731`). So it governs
+which investigations become PRs, and never what we pay to investigate. Move that
+bar earlier rather than adding a second one.
+
+**A workflow engine.** Rejected. The dependencies are a straight line, not a
+graph, and a line is expressible as "is my input newer than my output". Adding a
+queue also needs an architectural decision under the project's own guardrails, and
+nothing here requires one.
+
+## The honest caveat
+
+**We cannot say whether a customer got their work done.** The number we have is
+whether a recording continued for 60 seconds after the problem
+(`priority/sweeper.go:253`, `impactRecoveryMs = 60_000` at `:34`). On the one case we could audit, the stale-deploy
+group, 104 sessions scored as failed, only 14 belonged to an identifiable
+customer, and 6 of those 14 started a new session within ten minutes. Roughly 43%
+of the failures we could follow were people who reloaded and carried on.
+
+So impact language stays observational, and the recovery number stays out of the
+digest until either session stitching lands or the customer names the flows that
+matter. Everything here ranks on reach and on whether a save failed, both of which
+survive scrutiny.

--- a/docs/superpowers/specs/2026-08-15-pipeline-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-15-pipeline-architecture-design.md
@@ -1,0 +1,669 @@
+# Pipeline quality: from observations to customer action
+
+Status: accepted v1 architecture; implementation pending
+
+Date: 2026-08-16
+
+Companion: `2026-08-16-pipeline-implementation-plan.md`
+
+Supersedes: `2026-08-15-pipeline-and-digest-design.md` and the pipeline portions of
+`2026-08-14-digest-signal-quality-design.md`
+
+## Purpose
+
+Opslane collects errors, session recordings, and repository code. Its job is not to
+forward that material to a customer. Its job is to reduce it to a few trustworthy
+actions: a verified fix to review, a specific decision only the customer can make,
+or no message when nothing needs attention.
+
+The pipeline therefore has two filters:
+
+1. Cheap rules remove observations that have not earned an AI review.
+2. the inquiry applies the product judgment that counts and thresholds cannot provide.
+
+Only problems that survive both filters receive a full investigation. A separate
+daily AI pass writes the customer's message from completed work. Mechanical code
+owns facts, identity, counters, validation, deduplication, and delivery. AI owns
+product interpretation, judgment, investigation, and writing.
+
+This document defines that architecture. Its companion defines the build order.
+
+## Production baseline
+
+The measurements below come from read-only queries against AMFJ 2. The latest
+snapshot was taken on 2026-08-16 around 05:15 UTC.
+
+| Production fact | Current value |
+| --- | ---: |
+| Error events in one day | 27 |
+| Error events in seven days | 301 |
+| Error events in 30 days | 7,753 |
+| Sessions analyzed in seven days | 78,803 |
+| Failed writes in seven days | 97 across 62 sessions |
+| 5xx responses in seven days | 45 across 36 sessions |
+| Live error rows | 72 rows for 38 distinct titles |
+| Live friction rows | 409, of which 391 are hidden candidates |
+| Identified end users | 490 across 489 named accounts |
+
+The latest digest, dated 2026-08-15, contained four cards. All four described dead
+clicks around select or dropdown controls on Assets pages. Together they covered 30
+visits, 27 of which continued successfully. Every card said `report_ready`; none
+gave the reader a clear action. The same payload counted 85 held-back items and no
+top new issue.
+
+Three production examples anchor the design:
+
+**Asset deletion is fragmented.** Seven live rows titled `Error deleting Assets`
+contain 28 occurrences across nine identified users. Five fragments independently
+produced a `code_fix` diagnosis, and several point to
+`server/app/routes/api/resources/asset.py`. One customer problem has paid for
+several investigations and still has no single outcome.
+
+**Dead clicks need judgment.** The latest digest presented four related findings.
+Counts alone cannot tell whether the controls blocked users, recorded harmless
+clicks on internal DOM nodes, or exposed one shared component defect.
+
+**Stale release assets have broad reach.** One live issue contains 577 occurrences
+across 42 identified users. It clearly deserves review, even if the right answer is
+an operational change rather than a code patch.
+
+The current pipeline also wastes investigation work. Production holds 234 completed
+investigation jobs and 31 completed fix jobs. Among 58 structured diagnosis
+decisions, 39 need more context, 13 identify a code fix, five are not actionable,
+and one is incomplete. The system investigates too early and with evidence split
+across unstable issue identities.
+
+## What the customer should receive
+
+The inbox shows every settled issue that still matters, including low-volume issues
+that Opslane is watching. The daily message contains only completed work or a clear
+request for the customer.
+
+A useful card answers four questions:
+
+1. What broke in the customer's product?
+2. Who or how many people encountered it?
+3. What did Opslane establish?
+4. What should the reader do now?
+
+For example:
+
+> **Customers cannot delete assets**
+>
+> Asset deletion failed 28 times across nine customer accounts and was last seen
+> on August 13.
+>
+> We traced the failures to the asset deletion path and verified a change.
+>
+> **Action:** Review the fix PR.
+
+If Opslane cannot write a safe fix, the card asks for the specific human decision.
+If nothing needs attention, the digest says so. It does not manufacture content.
+
+### Acceptance criteria
+
+| # | The customer experience passes when |
+| --- | --- |
+| A1 | Every card has an action the reader can name. |
+| A2 | One unresolved problem appears once, not once per deploy or fragment. |
+| A3 | A problem card occurred inside the seven-day liveness window. A newly created approval or fix may appear without claiming that the problem is still occurring. |
+| A4 | Cards name affected accounts when the SDK supplied them. |
+| A5 | Cards use product language, not stack traces or internal workflow states. |
+| A6 | Every link and requested action works. |
+| A7 | The inbox distinguishes work that lacks reach from work AI reviewed and declined, and shows the reason for each decision. |
+| A8 | Every number comes from stored observations under a written definition. |
+| A9 | A problem fixed and later seen again is presented as returned, not new. |
+
+## End-to-end flow
+
+```text
+Errors and recordings
+        |
+        v
+Store raw input, resolve stacks, and extract session facts
+        |
+        v
+Group observations under stable issues
+        |
+        v
+Cheap rules: watch, inactive, or send to inquiry
+        |                              ^
+        |                              |
+        +-------------------- product understanding
+                               built by an LLM from
+                               repository code and sessions
+        |
+        v
+inquiry: investigate, wait, or do not pursue
+        |
+        v
+AI investigation: verified fix or specific needs_human result
+        |
+        v
+Daily factual selection -> daily AI writing -> validation -> delivery
+```
+
+The inbox reads live state throughout this flow. It is not a delivery channel and
+does not wait for the daily message.
+
+### Who decides what
+
+| Work | Owner | Decision |
+| --- | --- | --- |
+| Store an error or recording | Mechanical | Preserve the observation. |
+| Resolve a stack | Mechanical | Recover stable source locations or use the raw fallback. |
+| Group observations | Mechanical | Bind exact, versioned fingerprints to a stable issue. |
+| Count reach and recency | Mechanical | Compute identified users, anonymous sessions, and last occurrence. |
+| Apply the cheap filter | Mechanical | Watch, mark inactive, or send to an inquiry. |
+| Explain routes and actions | LLM | Build grounded product understanding from code and sessions. |
+| Review a qualified issue | inquiry | Investigate, wait, or do not pursue. |
+| Find and fix the cause | AI investigator | Produce a verified fix or a specific human request. |
+| Choose and explain today's work | Daily AI pass | Include, defer, order, and write customer-facing cards. |
+| Check and send the message | Mechanical | Validate facts and references, record receipts, and deliver once. |
+
+## 1. Store observations and prepare facts
+
+The request path records facts; it makes no lasting product decision.
+
+### Errors
+
+One transaction stores the immutable error event, a provisional capture bucket, the
+end-user and session links, a pending identity record, and a stack-resolution job.
+It creates no stable issue, inquiry job, investigation, or notification.
+
+The response preserves the current `group_id` and `error_group_id` fields, but
+`docs/contracts/events.md` will define them as provisional capture handles. No SDK
+uses either field as a stable issue identifier, and the current suppression path
+already returns an empty value.
+
+Concurrent matching requests share a provisional bucket through a unique raw key;
+every request keeps its own event row. The bucket is an ingestion aid, not the
+customer's issue. V1 retains one small bucket row per distinct raw fingerprint and
+monitors its count and age. A later error-event retention policy may prune buckets
+with their source events.
+
+### Stack resolution
+
+The worker resolves one event at a time before grouping. Source-map work no longer
+depends on an investigation.
+
+TypeScript writes a versioned structured frame envelope. Go alone normalizes that
+envelope, serializes the identity string, and hashes it. A shared golden fixture
+asserted in both languages prevents a path separator, anonymous-function marker, or
+prefix change from silently re-keying every issue.
+
+Resolved identity uses `original_file + original_function`. An anonymous frame
+falls back to `original_file + original_line`. Generated positions, original
+positions, and `original_function` remain available for audit and investigation.
+Source snippets never enter the identity key.
+
+`sourcemap_position_cache` keys by project, debug ID, source-map content hash,
+resolver version, generated line, and generated column. Since 2026-08-05, 509 events
+with debug IDs shared 34 source maps, including one 2.25 MB map. The cache resolves
+each artifact position once instead of fetching the map for every event.
+
+An event without a debug ID uses its raw fingerprint immediately. An event whose map
+has not arrived waits until the next daily boundary; a later upload wakes it sooner.
+Object-store failures retry. Exhausted work falls back to the raw fingerprint, and a
+watchdog reports stuck jobs.
+
+The production replay established that this path is viable. Since 2026-08-05, 720
+JavaScript events had stacks, 509 carried a debug ID, and every one of those 509 IDs
+matched an uploaded map. Thus roughly seven events in ten can use resolved identity;
+the rest keep the current raw behavior.
+
+### Session facts
+
+The worker decodes each retained recording and replaces one compact fact set
+transactionally. It stores:
+
+- detailed failed requests;
+- aggregate successful writes;
+- normalized routes;
+- exact click-to-request links when the recording establishes the link; and
+- rule and source versions.
+
+It does not copy a general event timeline into Postgres. Complete decoded recordings
+in the audited sample ranged from 1.1 MB to 28 MB, whereas the useful facts fit in a
+small record. Raw recordings remain in object storage.
+
+Late chunks replace the derived facts. Facts expire with their scrubbed recording by
+foreign-key cascade. V1 has no separate archive of expired session facts.
+
+### Product understanding
+
+Understanding a product is AI work, not a mechanical rule.
+
+Mechanical discovery supplies registered routes, likely page files, observed
+requests, and likely handlers. An LLM then reads the relevant repository code and
+records what each route is for, which user actions it supports, which client and
+server code implements those actions, and the likely audience.
+
+For `/assets/:id/edit`, mechanical evidence may find the Vue route and observed
+`PUT /api/assets/:id` calls. The LLM reads the form, client function, and server
+handler and records that the page edits an asset and that a failed PUT means the save
+did not complete.
+
+This work runs when a repository connects, after relevant deploys, and when sessions
+reveal an unknown route or action. Each claim records its code references, observed
+requests, commit, prompt version, model, confidence, and source. Human corrections
+remain authoritative. Conflicting evidence lowers confidence or requests review.
+Missing understanding means unknown, never unimportant.
+
+Product understanding helps inquiries, investigations, ranking, and customer language.
+It does not bypass the v1 mechanical filter.
+
+## 2. Keep one problem under one issue
+
+A fingerprint labels an observation. A separate alias table binds fingerprints to a
+stable issue. No fingerprint is rewritten to impersonate another fingerprint.
+
+```text
+event -> exact fingerprint -------> stable issue
+               raw alias ---------> same issue
+          resolved alias ---------> same issue
+```
+
+`canonical_issue_fingerprints` is the sole identity lookup. The physical
+`error_groups` table remains the stable-issue table to avoid a repository-wide
+rename, but `error_groups.fingerprint` loses identity meaning after cutover.
+
+A Go settlement loop claims pending identities with `FOR UPDATE SKIP LOCKED`. For
+each observation it:
+
+1. chooses the resolved fingerprint when available;
+2. looks up the resolved and raw aliases;
+3. attaches to the one known issue or creates an issue;
+4. binds unknown aliases when they do not conflict;
+5. records disagreement instead of merging;
+6. updates counts from the attached observation; and
+7. marks the observation settled.
+
+Normal settlement only attaches new observations. A separate, audited merge may
+redirect aliases and rebuild counts from source events. V1 permits an automatic
+confirmed merge only before either issue starts investigation or publication. A
+inquiry may flag likely duplicates, but it cannot silently rewrite identity. Later
+conflicts remain visible as possible duplicates.
+
+`sample_event_id` never participates in settlement or investigation evidence. The
+current ingest path rewrites it on every event, so any decision based on it changes
+with arrival order.
+
+Other existing grouping paths remain explicit:
+
+- suppression stays before capture;
+- curated family fingerprints enter as primary fingerprints;
+- Python and stackless JavaScript settle on versioned raw fingerprints; and
+- available JavaScript source maps always use the resolved path.
+
+Friction has no stack, so it enters stable grouping directly. V1 may bind
+high-confidence aliases but does not attempt perfect click identity.
+
+## 3. Apply the cheap filter
+
+The cheap filter runs after identity settles. It answers one factual question:
+
+> Has this issue happened recently, inside the customer's permitted scope, to enough
+> distinct people or sessions to deserve an AI review?
+
+It does not decide whether the issue is a real defect, actionable, fixable, or worth
+mentioning to the customer.
+
+The v1 rule is:
+
+```text
+identity still pending                  -> wait
+no observations in action scope         -> watch: outside scope
+no occurrence in the last seven days    -> inactive
+two affected units in seven days        -> send to inquiry
+otherwise                               -> watch: below threshold
+```
+
+An affected unit is one distinct identified user or, when no identity exists, one
+anonymous session. An occurrence count is not reach: one retry loop can generate any
+number of events. Route importance and `priority_score` may order work, but they do
+not turn one affected unit into two.
+
+The 30-day replay sends roughly three to seven issues per recent day to inquiries and
+leaves 24 to 31 at one affected unit. The implementation reruns that replay against
+the final action-scope query before cutover.
+
+Every decision is append-only and records the counts, reason, rule version, and
+time. A watched issue remains visible and accumulates evidence. New evidence or a
+rule-version change runs the filter again.
+
+The database keeps one internal row for each round of work on an issue. The product
+does not expose this term. An unresolved issue stays in the same round even if it
+goes quiet and later becomes active. Resolution closes the round. A later recurrence
+opens a new round and appears to the customer as returned. This internal scope makes
+"investigate once" and "publish once" enforceable without treating the returned
+problem as a new issue.
+
+Passing the filter is durable, but digest liveness is independent. A qualified issue
+that stops occurring may finish its investigation, but it cannot enter a later
+digest as current work.
+
+## 4. Open an inquiry and apply judgment
+
+An inquiry opens as soon as an issue clears the cheap filter. It is a bounded AI review,
+not the full investigation.
+
+The inquiry receives:
+
+- the stable issue and current work round;
+- affected-user and anonymous-session counts;
+- first, threshold-crossing, and recent representative observations;
+- resolved frames and exact request failures;
+- route and action understanding;
+- recording availability and exact replay links; and
+- read-only access to relevant repository code.
+
+The inquiry answers the questions rules cannot:
+
+- Does this describe a genuine product problem or expected behavior?
+- Did the user appear blocked, degraded, or unaffected?
+- Is this browser-extension, framework, or third-party noise?
+- Do several issues appear related?
+- Is there enough evidence to spend a full investigation?
+- What should the investigator examine first?
+
+The inquiry returns one structured decision:
+
+```text
+investigate
+wait_for_more_evidence
+do_not_pursue
+```
+
+The record includes a plain-language reason, evidence references, possible related
+issue IDs, an investigation brief, model, prompt version, and time. Every candidate
+gets a decision. Silence is a failure.
+
+One new occurrence does not trigger another inquiry. After
+`wait_for_more_evidence`, the issue returns to the inquiry stage when the number of distinct
+affected people or anonymous sessions has grown by at least half since the last
+review, rounded up. For example, a review at five affected people becomes eligible
+again at eight. The issue may return sooner when the evidence changes materially:
+a new failing request, resolved code location, route or action, or distinct recording
+pattern can change the decision even when the count does not.
+
+A change to product understanding requeues only issues on the affected route or
+action. A prompt-version change makes work eligible for a controlled batch; it does
+not enqueue every issue in the capture path. A human may always request another
+review.
+
+`do_not_pursue` remains visible in a separate inbox list. It returns to the inquiry stage
+only after material new evidence, a relevant product-understanding change, a
+controlled prompt-version re-evaluation, or a human request. Uncertainty favors
+investigation rather than a silent false negative.
+
+An inquiry does not compute counts, alter source facts, publish messages, or hide issues.
+They may recommend that likely duplicates be reviewed together, but only the audited
+identity operation may merge them.
+
+The current dead-click digest illustrates this interface. Counts found repeated
+clicks across Assets routes. An inquiry must read the session behavior and shared select
+code to decide whether these are harmless recovered clicks, one component defect, or
+several distinct problems. The database cannot make that decision from selectors.
+
+## 5. Investigate accepted problems
+
+Only a inquiry's `investigate` decision creates a full investigation job.
+
+The job freezes the observation that crossed the threshold, the issue's first
+observation in the current round, and a recent distinct observation. The investigator
+therefore receives stable evidence even as later events arrive. It never reads the
+mutable `sample_event_id`.
+
+The worker checks out the trigger observation's reachable `commit_sha`; otherwise it
+uses the default branch head and records the commit it actually inspected. One
+evidence reader supplies resolved frames, compact session facts, product
+understanding, replay pointers, and evidence availability. Repository access remains
+available throughout the investigation.
+
+The existing agent loop traces the route, client request, server handler, and related
+code. It may inspect a recording when facts and code leave ambiguity. If it proposes
+a patch, deterministic builds, tests, and fix verification decide whether the patch
+is safe. Failed verification returns evidence to the agent while budget remains.
+
+The job ends with one useful result:
+
+```text
+verified_fix
+needs_human
+unable_to_establish_cause
+```
+
+A verified fix carries its diff, verification evidence, and PR state. `needs_human`
+names the decision or external action required. `unable_to_establish_cause` states
+which evidence was missing and may run again when that evidence arrives. The system
+never converts it to the customer phrase "Investigation report ready."
+
+One unique job per work round prevents duplicate investigations. Retries reclaim the
+same job and evidence anchors rather than starting another investigation.
+
+## 6. Write the daily message with AI
+
+The daily message has a factual selection step, an AI writing step, and a mechanical
+delivery step.
+
+### Factual selection
+
+At the project's daily boundary, Go freezes a candidate set. A problem result must:
+
+- have settled identity;
+- have passed the inquiry stage;
+- have a useful terminal investigation result or an outstanding customer action;
+- have become usable since the last committed digest run;
+- have occurred inside the trailing seven-day liveness window;
+- remain unresolved; and
+- lack a digest receipt for the current round of work.
+
+A newly created PR, approval request, or other customer action may also qualify when
+the action became ready since the last committed run. Its card describes the action
+as current; it does not claim that the underlying problem is still occurring. This
+query protects freshness and publish-once semantics. The daily AI cannot revive a
+stale issue or invent a candidate.
+
+### AI writing
+
+The daily AI receives the frozen candidates, current counts, named accounts,
+product understanding, investigation outcomes, and valid actions. It may include,
+defer, order, and explain candidates. It may summarize related findings together
+when the evidence supports that relationship, without changing their stored
+identities.
+
+The structured result accounts for every input candidate:
+
+```text
+included: cards with issue IDs, copy, and one action
+deferred: issue IDs with plain-language reasons
+```
+
+Deferred work remains in the inbox and may return at the next boundary while it is
+still current. The prompt favors a short, useful message; a configurable safety cap
+prevents an unbounded payload.
+
+The AI may translate facts into product language. It may not change counts, account
+names, PR URLs, issue URLs, or investigation state. It cites the candidate IDs and
+evidence used for each card.
+
+### Validation and delivery
+
+Mechanical validation rejects unknown IDs, stale candidates, invented links,
+unsupported numbers, duplicate actions, and malformed output. A transaction then
+stores the run, chosen items, deferred reasons, rendered payload, publication
+receipts, outbox event, and deliveries.
+
+The existing outbox remains at-least-once at the remote boundary because a
+destination may accept a request whose response is lost. Postgres prevents
+intentional duplicate publication.
+
+An unresolved issue appears in one digest. Resolution closes that round of work. If
+the same issue later returns and clears the filters again, the message labels it
+returned.
+
+## 7. Show useful state in the inbox
+
+The inbox exposes the pipeline without its storage vocabulary:
+
+| Customer state | Meaning |
+| --- | --- |
+| Processing | Opslane stored the observation and is still working out which problem it belongs to. |
+| Watching | The problem is current but has not affected enough people to look into yet. |
+| Reviewing evidence | Opslane is deciding whether this is worth investigating. |
+| Waiting for evidence | Opslane looked and named the evidence it still needs. |
+| Reviewed, not pursuing | Opslane looked and decided against investigating. |
+| Investigating | The full agent is tracing the cause or testing a fix. |
+| Fix ready | Opslane verified a change and has a PR or approval request. |
+| Needs you | Opslane found a specific decision or external action. |
+| Inactive | The issue stopped occurring before it advanced. |
+| Resolved | A person or verified fix closed the issue. |
+
+The inbox renders `Watching` and `Reviewed, not pursuing` as separate lists. The
+first means the problem has not reached enough people or sessions to look into. The
+second means Opslane looked and declined to investigate. Rejected work shows the
+decision reason, cited evidence, review time, and a way to request another review.
+Every watched or rejected issue links to its observations and available recordings.
+The digest remains selective because the inbox preserves completeness.
+
+## Stored state and write ownership
+
+Storage names belong here, not in the customer explanation.
+
+| Stored state | Sole writer | Retention |
+| --- | --- | --- |
+| `error_events` | Capture transaction | Existing error-event policy |
+| `error_capture_buckets` | Capture transaction | V1 retains and monitors; later follows event retention |
+| `error_event_resolutions` | Resolution job | Follows the event |
+| `sourcemap_position_cache` | Resolution job | Versioned artifact cache |
+| `error_event_identities` | Identity settlement | Follows the event |
+| `canonical_issue_fingerprints` | Identity settlement or audited merge | Stable identity history |
+| `error_groups` | Identity and issue lifecycle logic | Canonical issue record |
+| `issue_episodes` | Issue lifecycle logic | Internal work rounds |
+| `issue_decisions` | Cheap filter | Append-only |
+| `issue_inquiry_decisions` | Inquiry job | Append-only and versioned; records reviewed affected-unit count and evidence signature |
+| `issue_evidence_anchors` | Filter/inquiry handoff | Follows the work round |
+| `route_map` and product claims | Repository-understanding job or human | Versioned; human rows authoritative |
+| compact session facts | Session analysis | Expires with the recording |
+| `diagnosis_decisions` | Investigation job | Existing issue history |
+| `issue_publications` | Publication transaction | Delivery audit |
+| `digest_runs` and `digest_run_items` | Daily publication transaction | Delivery audit |
+
+`canonical_issue_fingerprints` is the sole hot-path identity lookup. The new decision
+tables replace every runtime use of `digest_readiness`; that table may remain inert
+until a cleanup migration removes it.
+
+## Asynchrony, retries, and concurrency
+
+Postgres remains the durable queue. The design introduces no Redis, BullMQ, or
+workflow engine.
+
+Each job records its input version and may be retried safely. Live work outranks
+bounded reprocessing. Version changes drain stale rows in batches instead of
+blocking capture.
+
+Workers use:
+
+- row locks for one observation or work round;
+- sorted advisory locks for fingerprint keys;
+- unique constraints for one inquiry, investigation, and publication per work round;
+- `FOR UPDATE SKIP LOCKED` for multi-replica claims; and
+- absolute rollup reconstruction tests to check incremental counters.
+
+Model timeouts and invalid structured output retry the same durable job. Exhausted
+inquiry work remains visible as waiting for review. Exhausted investigation work ends
+as `unable_to_establish_cause` with the failure recorded. A digest-generation failure
+does not advance the window or write publication receipts; the next sweep retries the
+same frozen run.
+
+## The production examples through the new flow
+
+| Example | Stable grouping | Cheap filter | inquiry | Investigation | Customer result |
+| --- | --- | --- | --- | --- | --- |
+| Asset deletion | Seven fragments and their aliases converge on one issue when evidence agrees. | Nine users pass. | Confirms a real failed product action and directs the agent to the delete path. | One investigation combines all evidence and verifies a fix or states the required decision. | One card, one action, no repeated alert. |
+| Assets dead clicks | Exact signals remain auditable; likely relationships are presented to the inquiry. | Repeated sessions may pass. | Reads recovered behavior and shared control code; investigates only a supported defect. | Traces the common select control when accepted. | One supported card or no card, not four vague reports. |
+| Stale release assets | One stable issue already contains broad evidence. | Forty-two users pass. | Recognizes a current release-delivery problem even if no source patch fits. | Establishes the cache or asset-retention action. | A specific `needs_human` card while the problem remains current. |
+
+## Verification
+
+Mechanical claims have deterministic tests:
+
+- Go and TypeScript agree on the resolved-frame fixture and fingerprint.
+- Concurrent capture, settlement, filtering, the inquiry stage, and publication remain
+  idempotent.
+- Missing maps and expired recordings degrade to explicit fallbacks.
+- One unresolved work round gets one investigation and one digest receipt.
+- A resolved issue that returns gets a new round and a returned label.
+- One new occurrence cannot re-run a waiting inquiry; 50% growth or materially new evidence can.
+- Digest validation rejects unsupported counts, IDs, and links.
+
+AI quality needs fixed fixtures and human evaluation:
+
+- Replay production candidates through the inquiry; inspect every rejection and every
+  proposed relationship.
+- Run the investigator once over the unified asset-deletion evidence and compare it
+  with the fragmented production investigations.
+- Generate a week of daily messages from production snapshots. The founder must name
+  the action for every card. Any "so what?" fails the evaluation.
+- Track inquiry acceptance, reversal, investigation yield, verified-fix yield, digest
+  inclusion, customer action, latency, tokens, and cost by model and prompt version.
+
+Pipeline changes also require the repository's live smoke: apply migrations, seed a
+disposable project, rebuild ingestion and worker, send events, and observe capture,
+resolution, identity, filtering, the inquiry stage, investigation, and digest delivery reach
+their expected states with zero skipped database or storage tests.
+
+## Direct cutover
+
+V1 has one production user, so it uses one coordinated cutover rather than shadow
+identity, dual writes, or per-project activation flags.
+
+Before the window, a read-only report replays identity, the cheap filter, and inquiry
+candidates over 30 days. A person reads every proposed many-to-one identity change
+and the held and rejected lists.
+
+During the window:
+
+1. Let active jobs finish.
+2. Stop ingestion and the worker.
+3. Snapshot Postgres.
+4. Apply the migration and backfill.
+5. Deploy both runtimes.
+6. Run the end-to-end smoke.
+7. Resume traffic.
+
+The browser SDK buffers up to 100 events in memory and retries with exponential
+backoff whose base caps at 30 seconds; jitter can extend a delay to 45 seconds. Its
+best-effort unload flush is limited to 60 KiB. A short outage is mostly survivable,
+not lossless: overflow, prolonged failure, or navigation can still drop events.
+
+Before traffic resumes, rollback restores the snapshot and old images. After new
+canonical data arrives, recovery is a forward fix because old binaries cannot read
+the new sources of truth safely.
+
+## Non-goals and later work
+
+**Critical-action overrides.** V1 does not let one occurrence bypass the cheap
+filter because a route appears important. Product understanding first needs measured
+accuracy and coverage.
+
+**Perfect dead-click identity.** Generated classes and privacy-safe selectors make
+click identity weaker than resolved error identity. An inquiry can judge related
+findings in v1. Capturing a control's accessible name could improve grouping, but it
+changes the SDK privacy trade and belongs in a separate design.
+
+**Pricing policy.** Inquiries, repository understanding, investigations, and daily
+writing add model cost. V1 records tokens and cost by job, model, and prompt. Product
+pricing and free-tier limits follow measured usage; they do not change the pipeline's
+correctness.
+
+**Persisted general timelines.** Error investigations use compact facts, source
+events, code, and optional replay access. V1 does not copy full replay timelines into
+Postgres.
+
+**Tracing as a requirement.** Traces may later contribute evidence through the same
+evidence reader. V1 does not wait for tracing.
+
+**Automatic splitting after a wrong merge.** V1 prevents speculative merges and
+keeps an audited merge path. It does not add a second automatic clustering system.

--- a/docs/superpowers/specs/2026-08-16-pipeline-design-record.md
+++ b/docs/superpowers/specs/2026-08-16-pipeline-design-record.md
@@ -1,0 +1,287 @@
+# Pipeline quality: the decision record
+
+Status: draft for review
+Date: 2026-08-16
+
+Detail lives in two companions and is not repeated here:
+`2026-08-15-pipeline-architecture-design.md` (how it works) and
+`2026-08-16-pipeline-implementation-plan.md` (how it gets built).
+
+This document exists so a reviewer can disagree before code is written. It carries
+the decisions, what proves each requirement, what was rejected, and what is still
+open.
+
+## Problem
+
+On 2026-08-15 the daily message contained four cards. All four described dead clicks
+on select controls on Assets pages, covering 30 visits of which 27 continued
+successfully. Every card said `report_ready`. None told the reader what to do. The
+same payload reported 85 held-back items and no top new issue.
+
+Behind that message, production holds 234 completed investigation jobs and 31
+completed fix jobs. Of 58 structured diagnosis decisions, 39 need more context and 13
+identify a code fix. The system investigates early, on evidence split across unstable
+identities, and then cannot say anything useful.
+
+Three cases show the shape of it:
+
+- **Asset deletion is fragmented.** Seven live rows titled `Error deleting Assets`
+  hold 28 occurrences across nine identified users. Five fragments independently
+  produced a `code_fix` diagnosis. One customer problem paid for several
+  investigations and produced no single outcome.
+- **Dead clicks need judgment no count can supply.** Whether those four cards are one
+  component defect, harmless recovered clicks, or several problems cannot be decided
+  from selectors and counts.
+- **Stale release assets have real reach.** One issue holds 577 occurrences across 42
+  identified users and deserves review even though the fix is operational rather than
+  a patch.
+
+## Goals
+
+- One real problem is one issue, across deploys and fragments.
+- Nothing reaches the customer without a nameable action or an explicit request.
+- Every issue has a recorded decision, including the decision not to advance.
+- Every number in the message traces to stored observations under a written
+  definition.
+
+## Non-goals
+
+**Critical-action overrides in v1.** One occurrence on an apparently important route
+does not bypass the filter. Product understanding needs measured accuracy first.
+
+**Perfect dead-click identity.** Generated class names and privacy-safe selectors
+make click identity weaker than resolved error identity. Inquiries judge related
+findings instead. Capturing a control's accessible name would help and changes the
+SDK privacy trade, so it belongs in its own design.
+
+**Pricing policy.** The model tier adds cost. V1 records tokens and cost by job,
+model, and prompt version. What that means for a free tier follows measurement.
+
+**Shadow identity, dual writes, and per-project flags.** With one production customer,
+a coordinated cutover is simpler than reconciling two definitions of an issue.
+
+## The one structural decision
+
+Everything else follows from splitting the admission decision in two.
+
+A **cheap mechanical filter** answers a factual question: has this happened recently,
+in scope, to enough distinct people to deserve a look? It runs over everything, costs
+nothing, and is auditable. It explicitly does not decide whether something is a real
+defect.
+
+An **inquiry** then answers what counts cannot: is this a genuine product problem,
+was the user blocked, is this third-party noise, is there enough evidence to spend a
+full investigation. It gets read-only repository access, so it can look at the shared
+select component rather than guessing from a selector string.
+
+Only work surviving both gets a full investigation. A separate daily pass writes the
+customer's message from completed work.
+
+The division of labour is the point: mechanical code owns facts, identity, counters,
+validation, deduplication and delivery. The model owns interpretation, judgment,
+investigation and writing. Neither crosses.
+
+## Requirements and their proofs
+
+Each criterion names the slice that delivers it and the evidence that settles it.
+Slice numbers refer to the implementation plan.
+
+| # | Requirement | Verified by | Slice |
+| --- | --- | --- | --- |
+| A1 | Every card has an action the reader can name | A week of digests generated from production snapshots; the founder names the action for every card. Any "so what?" fails | 10 |
+| A2 | One unresolved problem appears once, not once per deploy or fragment | Shared golden fixture, two-build integration test, 30-day production replay | 3, 4, 10 |
+| A3 | A problem card occurred inside the seven-day liveness window | Frozen candidate-query tests; a new approval or fix may appear without claiming the problem is current | 0, 10 |
+| A4 | Cards name affected accounts when the SDK supplied them | Card rendering test against `end_users.account_name` | 10 |
+| A5 | Cards use product language, not stack traces or internal states | Validator rejects internal vocabulary; human evaluation of a week of output | 10 |
+| A6 | Every link and requested action works | Live link smoke against a deployed stack | 0, 11 |
+| A7 | The inbox shows what Opslane is watching and why it did not advance | Inbox and decision-query tests; every candidate has a stored decision | 7A, 8 |
+| A8 | Every number comes from stored observations under a written definition | Frozen-run validator rejects unsupported counts, IDs, and links | 10 |
+| A9 | A problem fixed and later seen again is presented as returned, not new | Resolution and recurrence integration test, **plus** the production evaluation reading the card's words | 10 |
+
+Two notes on this table.
+
+**A4 is now satisfiable and was not always.** The baseline shows 490 identified end
+users across 489 named accounts, so the SDK is supplying account names. An earlier
+draft treated this as blocked on an SDK integration ticket. It is not.
+
+**A9 needs the production evaluation, not only the integration test.** The mechanical
+test proves a new work round opens. A9 is a claim about what the card says, which
+only a human reading the output settles. That addition is the one change this record
+makes to the companion's verification.
+
+## System overview
+
+```mermaid
+flowchart TD
+  SDK[Errors and recordings] --> CAP[Capture: store, no judgment]
+  CAP --> RES[Resolve stacks]
+  RES --> ID[Settle identity via aliases]
+  ID --> FILT{Cheap filter}
+  FILT -->|watch / inactive| INBOX[Inbox]
+  FILT -->|2 units in 7 days| INQ{Inquiry}
+  PU[Product understanding<br/>LLM reads the repo] -.-> INQ
+  INQ -->|wait / do not pursue| INBOX
+  INQ -->|investigate| INV[AI investigation]
+  INV --> SEL[Daily factual selection in Go]
+  SEL --> WRITE[Daily AI writing]
+  WRITE --> VAL[Mechanical validation]
+  VAL --> SLACK[Delivery]
+  INV --> INBOX
+```
+
+The inbox reads live state throughout and is not a delivery channel. That is what
+lets the daily message be selective without hiding anything.
+
+## The decisions worth arguing about
+
+**Identity is a binding, not a rewrite.** A separate alias table maps fingerprints to
+a stable issue, and `canonical_issue_fingerprints` is the sole lookup. Normal
+settlement only attaches new observations. This dissolves two failure modes rather
+than mitigating them. Rewriting `error_groups.fingerprint` in place would collide
+with its unique constraint exactly when two issues should merge. And because
+`error_events.error_group_id` has no foreign key, the events orphaned by the obvious
+recovery would go quiet rather than error, which reads as a successful fix. A confirmed merge remains a separate audited operation that does rebuild counts.
+
+**Nothing reads `sample_event_id`.** Ingest rewrites it on every event, so any
+decision keyed on it changes with arrival order. Identity would oscillate instead of
+settling, and each oscillation would look like ordinary activity.
+
+**Go alone computes the fingerprint.** TypeScript resolves frames and writes a
+versioned envelope; Go normalizes, serializes and hashes it. A shared golden fixture
+asserted in both runtimes is what stops a path separator or anonymous-function marker
+from silently re-keying every issue in the system. That failure would present as mass
+fragmentation, not as a bug.
+
+**Reach is affected units, not occurrences.** One identified user, or one anonymous
+session where no identity exists. A retry loop generates unlimited events and no
+additional reach. Route weight may order work; it cannot turn one unit into two.
+
+**Uncertainty favours investigation.** A inquiry that is unsure investigates. A silent
+false negative costs more than a wasted investigation, because the customer never
+learns what was dropped.
+
+**Recordings stay in object storage.** Decoded recordings in the audited sample ran
+1.1 MB to 28 MB while the useful facts fit in a small record. Postgres gets compact
+failed-request rows and success rollups; the recording stays where it is and the
+facts expire with it by cascade.
+
+## Milestones
+
+Twelve slices, two deploys. Slice 0 ships alone because it is configuration and copy
+and repairs three criteria immediately. Slices 1 through 10 accumulate in one release
+candidate, each leaving the repository buildable but none deployable on its own,
+because Slice 2 stops the request creating issues and nothing creates them again until
+7A. Slice 11 deploys the batch in one window.
+
+| Slice | Delivers | Exit |
+| --- | --- | --- |
+| 0 | Digest liveness, links, wording, one safe grouping rule | A generated digest where every link resolves and no card is stale |
+| 1 | Inert schema and shared contracts | Golden fixture asserted in both runtimes; no runtime path uses the tables |
+| 2 | Capture without judgment | Request creates no issue, investigation, or notification |
+| 3 | Stack resolution before grouping | Cached and uncached output match the fixture; missing maps fall back |
+| 4 | Observations attached to stable issues | Concurrent settlement idempotent; no test settles from `sample_event_id` |
+| 5 | Compact session facts and evidence lookup | Expired recordings degrade to stated availability, not job failure |
+| 6 | LLM-built product understanding | Claims cite code references; human corrections win |
+| 7A | The cheap filter | 30-day replay produces a held list a person reads |
+| 7B | Retire the old readiness path | No runtime writer or reader of `digest_readiness` remains |
+| 8 | inquiries | Only inquiry-approved work is investigated; every qualified issue has a visible decision |
+| 9 | Accepted work reaches the investigator | Frozen anchors; one investigation per work round |
+| 10 | Daily message authored and delivered | The founder names an action for every card across a week |
+| 11 | Production cutover | Live smoke passes before traffic resumes |
+
+## Testing and validation
+
+Mechanical claims get deterministic tests: cross-runtime fixture agreement, idempotent
+concurrent capture and settlement, fallback behaviour for missing maps and expired
+recordings, one investigation and one receipt per work round, and validator rejection
+of unsupported numbers and invented links.
+
+Model behaviour cannot be tested that way, so it gets fixed fixtures and human reading.
+The inquiry evaluation runs a named production set: the asset-deletion cluster, the four
+dead-click cards, stale release assets, browser-extension noise, one-user errors, and
+investigations that previously ended `needs_more_context`. A person reads every
+rejection. The digest evaluation is a week of generated messages the founder reads.
+
+The full repository gate runs before the cutover candidate is accepted, with
+`DATABASE_URL` and storage configured, stale `dist/` removed, and zero skipped Go
+storage tests confirmed.
+
+## Risks
+
+**A wrong merge is indistinguishable from a successful fix.** If three of four merged
+fragments stop after a fix and one does not, occurrences fall and it reads as success.
+The pre-cutover human read of every many-to-one change is the only guard, and it does
+not scale past one customer.
+
+**The rollback window closes when traffic resumes.** Restoring the snapshot works
+until the first new canonical record arrives. After that, recovery is forward-only,
+so the live smoke inside the window carries all of the rollback risk.
+
+**The outage is bounded but not lossless.** The SDK buffers 100 events and retries
+with backoff capped at 30 seconds, extended to about 45 by jitter, with a best-effort
+unload flush limited to 60 KiB. Overflow, prolonged failure, or navigation still drop
+events.
+
+**Model cost is tracked but not bounded.** See the open questions.
+
+**Nothing improves for the customer between Slice 0 and Slice 11.** The whole benefit
+lands at cutover.
+
+## Alternatives considered
+
+**Rewrite the fingerprint in place when identity settles.** Rejected: it collides with
+`UNIQUE(project_id, fingerprint)` precisely when two issues should merge, and the
+obvious recovery orphans events invisibly.
+
+**Keep resolution inside investigation, where it already runs.** Rejected: it creates
+a trap. Hold an investigation back and the stack never resolves, so the bug keeps
+fragmenting, each fragment looks smaller, and it never qualifies.
+
+**One admission decision instead of two.** A single mechanical bar is cheap but cannot
+tell a component defect from recovered clicks. A single model pass over everything can,
+but runs over every issue at model cost. The split runs the cheap test over everything
+and the expensive one over three to seven issues a day.
+
+**Let the model decide admission outright.** Rejected: it runs over every issue, so it
+must be cheap, and a skipped bug needs an explainable reason. A model may propose
+merges and recommend investigation; it may not silently decide what is looked at.
+
+**Deploy every slice.** Rejected: Slices 2 through 7A would each need compatibility
+shims that then need removing. The maintenance window is cheaper.
+
+**Shadow mode.** Rejected: it would validate identity against live traffic, which has
+real value, at the cost of two live definitions of an issue and a reconciliation
+problem at the end.
+
+**A workflow engine for the async chain.** Rejected: the dependencies are a line, not a
+graph, and a line is expressible as "is my input newer than my output". Postgres stays
+the queue.
+
+**One row per timeline event from recordings.** Rejected on measurement: the useful
+facts are small and the recordings are not, so the recordings stay in object storage.
+
+## The honest caveat
+
+This design is built for one production customer and says so throughout. The direct
+cutover, the human read of every merge cluster and every inquiry rejection, and the
+forward-only recovery after traffic resumes are all choices that stop working at ten
+customers. That is a deliberate trade for delivery speed, not an oversight. The second
+customer arrives with a migration problem attached, and the inquiry evaluation becomes
+the first thing that cannot be done by reading.
+
+## Open questions
+
+1. **Reopening an inquiry has no growth gate.** Waiting work re-runs when evidence changes, and
+   counts change on every occurrence, so an issue parked in `wait_for_more_evidence`
+   can reopen the inquiry continuously. This codebase already solved the same problem once:
+   `friction/promotion.ts:29` sets `RE_ADJUDICATION_GROWTH = 1.5`, enforced at `:192`, with the comment
+   "Re-judge only when evidence has grown by half again since the last verdict. Without
+   this, a bucket over threshold is re-judged on every session." The inquiry needs the
+   equivalent. Tracking cost is not bounding it.
+2. **There are two held-back lists and the inbox describes one.** The filter watches 24
+   to 31 issues at a single affected unit; the inquiry separately returns
+   `do_not_pursue`. "Not enough people yet" and "a model judged this not a real problem"
+   are different, and the second is the one a founder needs to audit. Should they render
+   distinctly?
+3. **What exactly does the live smoke cover?** It is the last gate before the rollback
+   window closes, and it currently has no stated contents.

--- a/docs/superpowers/specs/2026-08-16-pipeline-implementation-plan.md
+++ b/docs/superpowers/specs/2026-08-16-pipeline-implementation-plan.md
@@ -1,0 +1,818 @@
+# Pipeline quality: build order and production cutover
+
+Status: accepted build plan; implementation pending
+
+Date: 2026-08-16
+
+Architecture: `2026-08-15-pipeline-architecture-design.md`
+
+## Purpose
+
+The architecture defines how raw observations become customer action. This document
+defines how to build it without creating a second, accidental architecture in the
+task list.
+
+The order follows the data:
+
+```text
+capture -> stack resolution -> stable grouping -> cheap filter -> inquiry
+        -> investigation -> daily AI writing -> mechanical delivery
+```
+
+Repository understanding and session facts feed the inquiry and investigation after
+stable grouping exists.
+
+## Delivery strategy
+
+The work uses two production deploys, not one deploy per slice.
+
+- **Slice 0 deploys alone.** It repairs current digest liveness, links, wording, and
+  one safe grouping rule.
+- **Slices 1 through 10, including 7A and 7B, accumulate in one release
+  candidate.** Each leaves the repository buildable and tested, but the
+  intermediate runtimes do not deploy.
+- **Slice 11 deploys the accumulated rewrite** during one maintenance window.
+
+This plan deliberately avoids shadow identity, dual writes, compatibility modes,
+and per-project activation flags. One live customer makes a coordinated cutover
+simpler than reconciling two definitions of an issue.
+
+## Rules for every slice
+
+Each slice must:
+
+1. implement one architecture section;
+2. keep one writer for each new state transition;
+3. add deterministic tests for mechanical behavior;
+4. add fixed-fixture and schema tests for AI behavior;
+5. preserve the public event contract;
+6. leave the full repository buildable; and
+7. state whether the result can deploy.
+
+No frozen fixture under `test-fixtures/wire/` may change. New grouping fixtures live
+outside that directory. Postgres remains the queue.
+
+## Dependency map
+
+```mermaid
+graph LR
+  S0[0 current digest repairs]
+  S1[1 schema and contracts]
+  S2[2 capture]
+  S3[3 stack resolution]
+  S4[4 stable grouping]
+  S5[5 session facts]
+  S6[6 product understanding]
+  S7A[7A cheap filter]
+  S7B[7B retire old readiness]
+  S8[8 inquiries]
+  S9[9 investigation handoff]
+  S10[10 daily AI message]
+  S11[11 production cutover]
+
+  S1 --> S2 --> S3 --> S4 --> S7A --> S8 --> S9 --> S10 --> S11
+  S7A --> S7B --> S10
+  S1 --> S5 --> S8
+  S1 --> S6 --> S8
+  S0 -. independent .-> S11
+```
+
+## Slice 0: repair the current customer message
+
+This slice improves the current product without depending on the rewrite.
+
+### Changes
+
+- Set `DASHBOARD_URL` in the production task definition.
+- Filter digest cards by issue occurrence time, not `digest_readiness.updated_at`.
+- Render `awaiting_approval` and draft-PR states as requests.
+- Make `reAssetToken` in `packages/ingestion/grouping/fingerprint.go` accept a dot
+  before a content hash as well as a hyphen.
+
+The regex change reduced 71 groups to 63 over a 466-event production sample. No
+merged group contained more than one observed message. That is useful evidence, not
+proof that two distinct bugs can never share a message; the later identity audit
+remains required.
+
+### Files
+
+- `packages/ingestion/digest/build.go`
+- `packages/ingestion/notify/slack_digest.go`
+- `packages/ingestion/grouping/fingerprint.go`
+- focused tests beside those packages
+- the production ECS task definition in the deploy repository
+
+### Exit
+
+Generate a digest from a known production day. Every problem card occurred inside
+the liveness window, every approval reads as a request without claiming the problem
+is current, every link works, and the grouping replay matches the measured 71-to-63
+result.
+
+### Deployment
+
+Deploy this slice alone.
+
+## Slice 1: add inert storage and shared contracts
+
+This slice creates the storage needed by the full flow. No runtime reads or writes
+the new path yet.
+
+### Migration
+
+Add idempotent migration `054_pipeline_quality.sql`, unless another migration claims
+054 first. It adds:
+
+- `error_capture_buckets`;
+- `error_event_resolutions`;
+- `sourcemap_position_cache`;
+- `error_event_identities`;
+- `canonical_issue_fingerprints`;
+- `issue_episodes` for internal rounds of work;
+- `issue_decisions` for the cheap filter;
+- `issue_inquiry_decisions`;
+- `issue_evidence_anchors`;
+- `issue_publications`;
+- `digest_runs`; and
+- `digest_run_items`.
+
+Extend `route_map` with structured actions, code references, observed requests,
+commit, confidence, model, prompt version, and update time. Preserve its existing
+`source='human'` override rule.
+
+Add the job types needed for stack resolution, inquirying, and daily writing to the
+existing `error_group_jobs` queue. Do not add another queue table.
+
+`issue_decisions` records `watch`, `open_inquiry`, or `inactive` plus its factual
+reason and counts. `issue_inquiry_decisions` records `investigate`,
+`wait_for_more_evidence`, or `do_not_pursue` plus its grounded explanation. Each
+inquiry decision also records the distinct affected-unit count, evidence signature,
+relevant product-understanding version, and prompt version used for the review.
+
+### Contracts
+
+Add one version-2 resolved-frame fixture outside `test-fixtures/wire/`. TypeScript
+must produce the exact structured envelope. Go must produce the exact canonical
+string and hash from that envelope.
+
+Document `group_id` and `error_group_id` in `docs/contracts/events.md` as provisional
+capture handles. The HTTP shape remains unchanged.
+
+Define and validate the structured AI outputs:
+
+- inquiry: `investigate`, `wait_for_more_evidence`, or `do_not_pursue`;
+- investigation: `verified_fix`, `needs_human`, or
+  `unable_to_establish_cause`; and
+- daily writing: all frozen candidates appear in `included` or `deferred`.
+
+Each record carries its model, prompt version, evidence version, and source IDs.
+
+### Invariants
+
+Database tests pin:
+
+- one capture bucket per project, identity version, and raw fingerprint;
+- one active fingerprint binding;
+- one open work round per issue;
+- one inquiry and one investigation job per work round and version;
+- one publication receipt per work round and channel; and
+- one daily run per project and local date.
+
+### Exit
+
+Migrations reapply cleanly. Go and TypeScript pass the same golden fixture. No
+runtime query references a new table.
+
+### Deployment
+
+Do not deploy independently.
+
+## Slice 2: make ingestion capture without judging
+
+Refactor `InsertErrorEventAndGroup` in `packages/ingestion/db/queries.go` into one
+capture transaction.
+
+### Transaction
+
+The transaction writes:
+
+- the immutable error event;
+- its provisional capture bucket;
+- a pending identity row;
+- the session pin;
+- the end-user link; and
+- one stack-resolution job when needed.
+
+It stops creating stable issues, investigation jobs, readiness rows, and outbound
+events in the request.
+
+Suppression remains before capture. Curated family fingerprints remain explicit in
+the pending identity input. Python and stackless JavaScript carry a raw fallback.
+
+The handler returns the existing response shape with the provisional handle. A
+failed transaction leaves no partial event, bucket, link, or job.
+
+### Tests
+
+- Concurrent identical errors share a bucket and retain distinct events.
+- A transaction failure rolls back every write.
+- Suppressed events preserve current behavior.
+- Python and stackless events carry a usable fallback.
+- Frozen wire fixtures remain byte-for-byte unchanged.
+
+### Exit
+
+The endpoint passes its contract and concurrency tests. On this branch, no stable
+issue appears until later slices; this state is buildable but not deployable.
+
+## Slice 3: resolve stacks before grouping
+
+Move source-map resolution out of the investigate and fix paths into its own worker
+job.
+
+### Worker work
+
+- Resolve one event into the version-2 frame envelope.
+- Store generated and original positions plus `original_function`.
+- Read and write `sourcemap_position_cache` by artifact content and generated
+  position.
+- Wake waiting jobs when a matching map uploads.
+- Fall back at the next daily boundary when a map never arrives.
+- Retry object-store failures and report stuck jobs.
+
+Remove on-demand resolution from the existing investigate and fix handlers in
+`packages/worker/src/index.ts`. Those handlers later consume persisted resolutions.
+
+### Go work
+
+Add one pure serializer and hasher for the version-2 envelope. It uses original file
+and function, with original line as the anonymous-function fallback.
+
+### Tests
+
+- Cached and uncached resolution produce identical envelopes.
+- TypeScript output and Go hashing match the shared fixture.
+- A missing debug ID settles immediately on the raw fallback.
+- A late source-map upload wakes waiting work.
+- Exhausted resolution records its fallback rather than blocking forever.
+
+### Production replay
+
+Replay the population measured since 2026-08-05: 720 JavaScript events with stacks,
+509 debug IDs, and a 100% uploaded-map match for those IDs. Report any changed
+denominator before cutover.
+
+### Exit
+
+Every captured event reaches a persisted resolution or an explicit raw fallback
+without starting an investigation.
+
+## Slice 4: attach observations to stable issues
+
+Add a Go settlement sweep that claims eligible rows with
+`FOR UPDATE SKIP LOCKED`.
+
+### Settlement
+
+For each observation:
+
+1. choose the resolved fingerprint when present;
+2. look up resolved and raw aliases in `canonical_issue_fingerprints`;
+3. attach to one known issue or create one;
+4. bind non-conflicting aliases;
+5. record conflicts without merging;
+6. update issue counts from the event; and
+7. mark identity settled.
+
+Lock candidate fingerprint keys in sorted order. `canonical_issue_fingerprints` is
+the sole identity lookup. Stop treating `error_groups.fingerprint` as identity.
+
+Add a separate confirmed-merge operation. It redirects aliases, records binding
+history, reattaches source observations, and rebuilds counts. Automatic confirmation
+is allowed only before investigation or publication.
+
+### Tests
+
+- Concurrent events settle idempotently.
+- Conflicting aliases remain separate and visible.
+- Retry after partial worker failure produces one attachment.
+- Confirmed merge reconstructs absolute counts correctly.
+- No settlement or test reads `sample_event_id`.
+- Friction enters grouping directly without stack resolution.
+
+### Production replay
+
+Produce a read-only report showing:
+
+- every many-to-one issue change;
+- the seven `Error deleting Assets` fragments;
+- deployment-hash fragmentation;
+- raw and resolved alias conflicts; and
+- before-and-after issue and occurrence counts.
+
+### Exit
+
+A logical error across two builds lands on one stable issue, while uncertain
+relationships remain split.
+
+## Slice 5: finish compact session facts and evidence lookup
+
+Extend the existing session-analysis path rather than creating a second replay
+processor.
+
+### Changes
+
+- Store detailed failed-request rows.
+- Store successful-write rollups.
+- Preserve exact click-to-request links only when the recording establishes them.
+- Replace one session's fact set transactionally after late chunks.
+- Cascade fact deletion with recording expiry.
+- Build one evidence reader keyed by a work round and fixed anchors.
+
+The evidence reader returns resolved frames, source events, failed requests, success
+rollups, product understanding, replay availability, and repository coordinates. It
+does not expose a copied general timeline or `sample_event_id`.
+
+### Tests
+
+- Late chunks replace rather than append duplicate facts.
+- Expired and missing recordings return explicit availability.
+- Direct click links survive; timing-only proximity does not become causation.
+- Facts disappear with their recording.
+- Evidence remains bounded for 1.1 MB and 28 MB source recordings.
+
+### Production check
+
+Reproduce the seven-day totals: 97 failed writes across 62 sessions and 45 5xx
+responses across 36 sessions. Trace the `/assets/:id/edit`, `/onboarding`, and
+`/issue-context` examples from facts back to their retained recordings.
+
+### Exit
+
+One call returns all durable evidence available for an issue without decoding every
+recording during investigation.
+
+## Slice 6: let an LLM build product understanding
+
+Expand the existing `route_map` job in `packages/worker/src/route-map.ts`.
+
+### Discovery
+
+Mechanical discovery supplies:
+
+- routes registered in the repository;
+- likely route and page files;
+- normalized routes observed in sessions;
+- observed requests; and
+- likely client and server handlers.
+
+Run discovery when a repository connects, after a new deploy, and when a session
+reveals an unknown route.
+
+### LLM work
+
+The LLM reads the relevant files with existing read-only repository tools and
+returns, for each route:
+
+- name and purpose;
+- supported user actions;
+- audience;
+- code references;
+- observed request relationships;
+- confidence; and
+- evidence it could not reconcile.
+
+The worker validates that every cited path exists and every requested route belongs
+to the discovery input. It upserts only non-human rows. Missing or conflicting
+evidence produces unknown or review-needed, never unimportant.
+
+### Tests
+
+- Structured-output validation rejects extra routes and nonexistent paths.
+- Human route rows survive every AI refresh.
+- A changed commit reprocesses affected routes only.
+- An unknown route never receives a low-importance default.
+- A fixture for `/assets/:id/edit` links the page, save action, client PUT, and server
+  handler from grounded code.
+
+### Observability
+
+Record model, prompt version, commit, tokens, cost, latency, coverage, unknown count,
+and human corrections.
+
+### Exit
+
+The production route report explains known Assets routes from code and observed
+requests, and every claim links to its evidence.
+
+## Slice 7A: implement the cheap filter
+
+Add internal work rounds and an append-only decision sweep in Go.
+
+### Rule
+
+For each settled issue:
+
+```text
+outside action scope                   -> watch
+no occurrence in seven days            -> inactive
+two affected users or anonymous sessions -> send to inquiry
+otherwise                              -> watch
+```
+
+The count uses identified users plus wholly anonymous sessions. It does not use raw
+occurrence count, route weight, `impact`, or `priority_score`.
+
+When a current round first clears the bar, one transaction records the decision,
+freezes first, threshold-crossing, and recent evidence anchors, and creates one inquiry
+job. Later events update counts but do not create duplicate inquiry jobs.
+
+Resolution closes the round. A later occurrence opens a new round and can clear the
+filter again. Quiet unresolved work stays in the same round and may reactivate.
+
+### Tests
+
+- The second affected unit crosses the bar in the same transaction that counts it.
+- Repeated events from one session remain one affected unit.
+- Identified and anonymous counts do not double-count one session.
+- Out-of-scope events never cross the bar.
+- Watched work advances when evidence grows.
+- Quiet work becomes inactive.
+- A resolved issue that returns opens a new round.
+- Concurrent sweeps create one inquiry job.
+
+### Production replay
+
+Rerun the 30-day result against the final action-scope query. The earlier replay sent
+three to seven issues per recent day to inquiries and watched 24 to 31 at one affected
+unit. A person reads the complete watch and inquiry lists.
+
+### Exit
+
+Every current issue has a recorded factual decision. Passing the filter creates a
+inquiry job, never an investigation job.
+
+## Slice 7B: retire the old readiness path
+
+Move runtime state ownership from `digest_readiness` to the new factual, inquiry,
+investigation, and publication records. This is separate from implementing the cheap
+filter because the old table has six writers across two runtimes.
+
+### Changes
+
+- Remove the TypeScript readiness helper and its four call sites.
+- Remove the direct update in `packages/worker/src/db.ts` that bypasses the helper.
+- Remove the Go ingest write, if Slice 2 did not already delete it.
+- Update requeue, inbox, and current digest reads to derive state from the new
+  records.
+- Render low-reach `Watching` work separately from `Waiting for evidence` and
+  `Reviewed, not pursuing` work. Show the latest inquiry reason, cited evidence,
+  review time, and re-review action for AI rejections.
+- Retire readiness migration and backfill scripts from runtime operations.
+- Leave `digest_readiness` present but inert until a later cleanup migration.
+
+Do not create a compatibility projection or a second writer. Slices after 7B read
+the new source of truth directly.
+
+### Tests
+
+- A repository search finds no runtime write to `digest_readiness`.
+- Inbox state derives from the latest factual and inquiry decisions. Low-reach work,
+  requests for more evidence, and AI rejections render as distinct states.
+- Requeue preserves terminal investigation and publication behavior.
+- The current digest test harness runs from the new records until Slice 10 replaces
+  its renderer.
+- Reapplying old migrations does not restore runtime ownership.
+
+### Exit
+
+No running path reads or writes `digest_readiness`. The table contains legacy data
+only.
+
+## Slice 8: add the inquiry stage
+
+Add a `issue_inquiry` worker path beside the existing investigate path.
+
+### Input
+
+The worker loads the stable issue, current round, factual decision, fixed evidence
+anchors, current counts, resolved frames, failed requests, product understanding,
+recording availability, and relevant repository files.
+
+The input is bounded and versioned. The inquiry may use existing read-only repository
+tools; it does not receive write or PR tools.
+
+### Output and transaction
+
+Validate and store one decision:
+
+- `investigate` with an investigation brief;
+- `wait_for_more_evidence` with the missing evidence; or
+- `do_not_pursue` with a specific reason.
+
+The same transaction creates one investigate job only for `investigate`. It records
+possible related issues without merging them.
+
+Use the existing friction rule as the v1 growth policy: re-run
+`wait_for_more_evidence` when the distinct affected people or anonymous sessions
+reach `ceil(previous_review_count * 1.5)`. Keep the policy in neutral worker code;
+the inquiry must not depend on the friction module. A single additional occurrence or
+an increased raw occurrence count does not requeue the inquiry.
+
+Materially different evidence may requeue waiting work before the count threshold.
+The evidence signature covers failed-request identity, resolved code locations,
+route and action, and representative recording patterns. A product-understanding
+change affects only work on the changed route or action. A prompt-version change
+makes work eligible for an explicit, rate-limited batch instead of requeueing it in
+the capture path.
+
+Re-run `do_not_pursue` only after materially different evidence, a relevant
+product-understanding change, a controlled prompt-version re-evaluation, or a human
+request.
+
+### Tests
+
+- Invalid or silent output fails the job.
+- Every decision cites only supplied evidence and issue IDs.
+- A retry stores one decision and one investigation job.
+- A review at five affected units does not run again at six or seven and becomes
+  eligible at eight.
+- Raw occurrence growth does not requeue waiting work.
+- Materially different evidence can requeue waiting work before 50% growth.
+- A product-understanding change requeues only affected routes or actions.
+- A prompt-version change requires an explicit batch and never requeues from
+  capture.
+- Rejected work renders separately from low-reach work and creates no investigation.
+- Possible duplicates do not alter identity.
+
+### Evaluation
+
+Run a fixed production set containing:
+
+- the asset-deletion cluster;
+- the four Assets dead-click digest cards;
+- stale release assets;
+- browser-extension noise;
+- one-user errors; and
+- investigations that previously ended `needs_more_context`.
+
+A person reads every inquiry rejection. Measure acceptance by issue type, reversal,
+false-negative findings, tokens, cost, and latency. Uncertainty should favor
+investigation.
+
+### Exit
+
+Only inquiry-approved work creates investigations, and every mechanically qualified
+issue has a visible AI decision.
+
+## Slice 9: hand accepted work to the existing investigator
+
+Refactor the current investigate and fix paths to consume the inquiry's brief and fixed
+evidence rather than a mutable sample event.
+
+### Changes
+
+- Add the current work-round ID to jobs and diagnosis decisions.
+- Preserve the inquiry decision and evidence anchors through retries and fix jobs.
+- Check out the trigger event's reachable commit; record the actual fallback commit.
+- Consume persisted source-map resolution.
+- Use the common evidence reader.
+- Return `verified_fix`, `needs_human`, or `unable_to_establish_cause`.
+- Keep deterministic verification as the authority on proposed patches.
+
+Remove the current post-investigation impact gate. The cheap filter and inquiry now
+decide whether investigation runs; fix verification and project autonomy decide
+whether a PR can advance.
+
+### Tests
+
+- A rejected inquiry decision cannot start investigation.
+- One accepted work round gets one investigation under retries and concurrency.
+- The investigator uses the frozen commit and anchors.
+- Expired recordings degrade without failing the job.
+- Failed verification returns evidence to the agent until budget ends.
+- Terminal outcomes contain a specific action or missing-evidence statement.
+
+### Production evaluation
+
+Run one investigation over the unified asset-deletion evidence and compare it with
+the fragmented production results. It should read all nine-user evidence once and
+produce one coherent outcome.
+
+### Exit
+
+An accepted issue reaches one useful terminal result. The customer never receives
+the internal phrase `report_ready`.
+
+## Slice 10: author and deliver the daily message
+
+Replace the current template-first digest path with a frozen factual selection, one
+AI writing job, and mechanical validation and delivery.
+
+### Freeze candidates in Go
+
+At the project's daily boundary, create one `digest_runs` row and candidate
+`digest_run_items`. Problem-result candidates must be inquiry-approved, useful,
+unresolved, newly usable since the last committed run, seen inside the trailing
+seven-day liveness window, and unpublished for this work round. A newly created PR,
+approval request, or other customer action may qualify without claiming that its
+underlying problem is still occurring.
+
+Freezing records the window, cutoff, source versions, issue IDs, counts, named
+accounts, investigation outcomes, and valid actions. Do not advance the window yet.
+
+### Write in TypeScript
+
+The worker claims the daily-writing job and asks the model to account for every
+candidate as included or deferred. Included cards contain one action and cite their
+source issue IDs. Deferred items contain a reason.
+
+The writer may combine related findings in prose, but it cannot merge issue records.
+It may translate technical evidence into product language, but it cannot change
+counts, account names, links, PR state, or factual eligibility.
+
+### Validate and publish in Go
+
+Check every ID, count, account, URL, action, freshness predicate, and disposition
+against the frozen run. Reject unsupported output.
+
+One transaction then stores the final items and deferred reasons, marks the run
+complete, writes work-round publication receipts, creates the outbox event, and
+creates deliveries. Only that commit advances the digest window.
+
+An empty candidate set or a model-authored empty message sends the configured
+"nothing needs your attention" text without inventing cards.
+
+### Tests
+
+- An unresolved issue appears in at most one digest.
+- A returned issue may appear again and carries the returned label.
+- Stale issues cannot enter a run, even when old bookkeeping changes.
+- The writer must account for every candidate.
+- Unknown IDs, wrong counts, invented URLs, and duplicate actions fail validation.
+- A model or delivery retry does not advance the window or duplicate receipts.
+- Concurrent sweepers produce one run.
+- Named accounts and links survive end to end.
+
+### Production evaluation
+
+Generate a week of messages from production snapshots. For the 2026-08-15 input,
+the result must not present four vague Assets dead-click cards unless evidence proves
+four distinct actionable problems. The founder must name the action for every card.
+
+The evaluation also includes a resolved issue followed by a later occurrence. Its
+customer-facing card must say that the problem returned and must not describe it as
+new. Use a production case when one exists in the snapshot; otherwise preserve a
+production-shaped recurrence fixture for this check.
+
+### Exit
+
+The daily message satisfies every acceptance criterion in the architecture document,
+including the valid empty-message case.
+
+## Slice 11: cut over production
+
+Slices 1 through 10 ship together.
+
+### Read-only report
+
+Before the window, run the final code against 30 days of production data and report:
+
+- all proposed identity merges and conflicts;
+- before-and-after issue counts;
+- the cheap filter's watch, inactive, and inquiry lists;
+- inquiry decisions and reasons;
+- expected investigations;
+- expected daily candidates;
+- capture-bucket count and oldest row; and
+- projected model calls, tokens, and cost.
+
+A person reads every many-to-one identity change and every inquiry rejection. Confirm
+the asset-deletion, dead-click, and stale-release examples explicitly.
+
+### Backfill
+
+The backfill:
+
+- adopts existing visible `error_groups` rows as stable issues;
+- leaves uncertain clusters split;
+- binds confirmed raw aliases;
+- links recent source observations;
+- opens one work round for each unresolved issue seen in seven days;
+- marks quiet unresolved issues inactive;
+- recomputes the cheap filter from source observations;
+- seeds publication receipts from prior outbound events so old issues do not
+  announce themselves again; and
+- leaves `digest_readiness` inert.
+
+Do not rewrite old fingerprints or manufacture historical inquiry decisions.
+
+### Maintenance window
+
+1. Let active jobs finish.
+2. Stop ingestion and worker tasks.
+3. Snapshot Postgres.
+4. Apply the migration and backfill.
+5. Deploy ingestion and worker images.
+6. Run the live smoke against the seeded smoke project.
+7. Resume traffic.
+
+### Required live smoke
+
+The smoke must:
+
+1. send two logically matching events from distinct sessions;
+2. observe both capture receipts;
+3. confirm source resolution or the explicit fallback;
+4. confirm both events settle on one issue;
+5. confirm the second affected unit sends the issue to an inquiry;
+6. confirm the inquiry records a decision;
+7. confirm accepted work reaches a terminal investigation result;
+8. create a daily run;
+9. validate and render its message; and
+10. confirm one outbox event and one delivery reach terminal state.
+
+Use the repository's required disposable ports and storage credentials. Treat a
+green test run with skipped database or storage tests as failure.
+
+### Rollback
+
+Before traffic resumes, restore the snapshot and old images. After new stable-issue
+data arrives, recovery is a forward fix; old binaries cannot safely interpret the
+new sources of truth.
+
+The SDK buffers up to 100 events in memory and retries with exponential backoff. The
+base delay caps at 30 seconds, jitter can extend it to 45 seconds, and best-effort
+unload delivery is limited to 60 KiB. The window should therefore be short, but the
+plan does not claim it is lossless.
+
+## Verification matrix
+
+| Acceptance | Architecture claim | Proof |
+| --- | --- | --- |
+| A2 | One logical error survives a deploy as one issue | Shared fixture, two-build integration test, production replay |
+| A2 | Go and TypeScript cannot drift on identity | Golden envelope, canonical string, and hash in both runtimes |
+| A2, A8 | Capture stays atomic under concurrency | Database race and rollback tests |
+| A2 | Missing source maps cannot block forever | Fallback and watchdog tests |
+| A7 | Low-volume issues remain visible | Inbox and decision-query tests |
+| A1, A7 | Only AI-approved work is investigated | Inquiry-to-investigation transaction tests |
+| A7 | AI cannot silently reject work | Decision completeness constraint, separate rejected-work view, and evaluation report |
+| A1, A5, A6 | Product understanding stays grounded | Existing-path validation and human-override tests |
+| A8 | Investigation uses stable evidence | Frozen-anchor and commit tests |
+| A3 | One unresolved issue publishes once | Receipt, retry, and concurrent-sweeper tests |
+| A9 | A returned issue publishes again and reads as returned, not new | Resolution and recurrence integration test, renderer assertion, and production evaluation |
+| A4, A8 | Digest facts are true | Frozen-run validator tests |
+| A1, A4, A5, A6 | The customer receives actionable cards | One-week production evaluation and live link smoke |
+
+During implementation, run the smallest package checks for each slice. Before the
+cutover candidate is accepted, run the full repository gate with `DATABASE_URL` and
+storage configured, remove stale `dist/` output when workspace dependencies change,
+and confirm zero skipped Go storage tests.
+
+## Main risks and controls
+
+**Cross-language fingerprint drift.** A tiny serialization difference fragments
+every issue. The shared golden fixture lands before runtime use.
+
+**A false merge hides a bug.** Exact aliases bind automatically; conflicts remain
+split. A person reads every cutover merge, and later merges use the audited operation.
+
+**The cheap filter sends the wrong population to AI.** The production replay exposes
+every watched and advanced issue. The rule stays factual and reversible.
+
+**A inquiry rejects a real problem.** Every rejection has evidence and a reason, stays
+visible, and can run again. The pre-cutover evaluation reads every rejection;
+uncertainty favors investigation.
+
+**Product understanding hallucinates purpose.** The worker accepts only discovered
+routes and existing code references. Claims carry provenance and confidence; human
+corrections win; unknown stays unknown.
+
+**Model failure stalls work.** Durable jobs retry. Exhausted work remains visible
+with an explicit failure. Digest windows advance only after a committed message.
+
+**The `digest_readiness` migration has many writers.** The code search and tests must
+remove all six runtime paths before cutover. The old table remains inert until later
+cleanup.
+
+**Model cost surprises the product.** Every AI job records tokens and cost. Pricing
+policy follows measured usage; it does not weaken correctness or add a second path.
+
+**The rollback window closes after traffic resumes.** The end-to-end smoke runs
+inside the window. After resume, fixes move forward.
+
+## Explicit follow-ups, not v1 blockers
+
+**Better dead-click identity.** Capturing accessible control names may improve
+grouping but changes the SDK's privacy contract. V1 keeps current capture and uses
+inquiry judgment without silently merging issues.
+
+**Pricing and free-tier policy.** V1 measures actual model use for product
+understanding, inquiries, investigations, and daily writing. Packaging and limits follow
+that evidence.
+
+**Critical-action overrides.** V1 does not bypass the two-unit rule from inferred
+route importance.
+
+**Persisted full timelines and tracing.** Both may later contribute evidence through
+the same reader. Neither blocks the first version.

--- a/packages/ingestion/db/migrations/044_actionable_receipts_contracts.sql
+++ b/packages/ingestion/db/migrations/044_actionable_receipts_contracts.sql
@@ -2,14 +2,20 @@
 -- The runner has no ledger and autocommits per statement: each statement is
 -- guarded so any prefix of this file can re-run safely, forever.
 
+-- 054 later widens this constraint with the rewritten pipeline's terminal
+-- outcomes. The runner replays every file on every boot, so this guard must
+-- accept BOTH definitions or each boot would re-narrow what 054 widened (and
+-- fail outright once a row holds a new outcome).
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM pg_constraint
     WHERE conrelid = 'diagnosis_decisions'::regclass
       AND conname = 'diagnosis_decisions_outcome_check'
       AND convalidated
-      AND pg_get_constraintdef(oid) =
-        'CHECK ((outcome = ANY (ARRAY[''code_fix''::text, ''not_actionable''::text, ''needs_more_context''::text, ''incomplete''::text])))'
+      AND pg_get_constraintdef(oid) IN (
+        'CHECK ((outcome = ANY (ARRAY[''code_fix''::text, ''not_actionable''::text, ''needs_more_context''::text, ''incomplete''::text])))',
+        'CHECK ((outcome = ANY (ARRAY[''code_fix''::text, ''not_actionable''::text, ''needs_more_context''::text, ''incomplete''::text, ''verified_fix''::text, ''needs_human''::text, ''unable_to_establish_cause''::text])))'
+      )
   ) THEN
     ALTER TABLE diagnosis_decisions DROP CONSTRAINT IF EXISTS diagnosis_decisions_outcome_check;
     ALTER TABLE diagnosis_decisions ADD CONSTRAINT diagnosis_decisions_outcome_check

--- a/packages/ingestion/db/migrations/054_pipeline_quality.sql
+++ b/packages/ingestion/db/migrations/054_pipeline_quality.sql
@@ -134,16 +134,18 @@ CREATE TABLE IF NOT EXISTS digest_runs (
   project_id  UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
   window_from TIMESTAMPTZ NOT NULL,
   window_to   TIMESTAMPTZ NOT NULL,
-  run_date    DATE NOT NULL DEFAULT ((now() AT TIME ZONE 'utc')::date),
+  -- The project-local calendar date of the daily boundary. No default: the
+  -- freezer must stamp it explicitly, because the server's clock date and the
+  -- project's local date disagree across the UTC boundary.
+  run_date    DATE NOT NULL,
   status      TEXT NOT NULL CHECK (status IN ('frozen','written','validated','delivered','failed')),
   payload     JSONB,
   created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_one_run_per_window
   ON digest_runs (project_id, window_to);
--- The freezer stamps the project-local calendar date of the boundary; the
--- volatile default only covers rows that predate this column.
-ALTER TABLE digest_runs ADD COLUMN IF NOT EXISTS run_date DATE NOT NULL DEFAULT ((now() AT TIME ZONE 'utc')::date);
+-- One run per project and local date regardless of status: a failed run is
+-- retried by reclaiming the same frozen row, never by inserting a second run.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_one_run_per_local_date
   ON digest_runs (project_id, run_date);
 
@@ -174,41 +176,28 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_one_job_per_episode_type_version
 CREATE UNIQUE INDEX IF NOT EXISTS uq_one_inquiry_per_evidence
   ON issue_inquiry_decisions (project_id, episode_id, prompt_version, evidence_signature);
 
-ALTER TABLE route_map ADD COLUMN IF NOT EXISTS purpose TEXT;
+-- route_map already has purpose, source (DEFAULT 'llm'), created_at, and
+-- updated_at from migration 040; only the structured-understanding columns
+-- below are new.
 ALTER TABLE route_map ADD COLUMN IF NOT EXISTS actions TEXT[] NOT NULL DEFAULT '{}';
 ALTER TABLE route_map ADD COLUMN IF NOT EXISTS client_refs TEXT[] NOT NULL DEFAULT '{}';
 ALTER TABLE route_map ADD COLUMN IF NOT EXISTS server_refs TEXT[] NOT NULL DEFAULT '{}';
 ALTER TABLE route_map ADD COLUMN IF NOT EXISTS observed_requests TEXT[] NOT NULL DEFAULT '{}';
 ALTER TABLE route_map ADD COLUMN IF NOT EXISTS audience TEXT NOT NULL DEFAULT 'unknown';
 ALTER TABLE route_map ADD COLUMN IF NOT EXISTS confidence REAL NOT NULL DEFAULT 0;
--- Base insert semantics stay: name and tier remain NOT NULL with no default.
-ALTER TABLE route_map ALTER COLUMN tier DROP DEFAULT;
-ALTER TABLE route_map ALTER COLUMN name DROP DEFAULT;
 ALTER TABLE route_map ADD COLUMN IF NOT EXISTS commit_sha TEXT;
 ALTER TABLE route_map ADD COLUMN IF NOT EXISTS prompt_version INTEGER;
 ALTER TABLE route_map ADD COLUMN IF NOT EXISTS model TEXT;
-ALTER TABLE route_map ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'mechanical';
 
+-- error_group_id is already nullable (001_baseline: friction jobs), and
+-- project-scoped jobs (route_map, session_analysis, setup_pr) legitimately
+-- carry no group, episode, or run. No scope CHECK belongs here.
 ALTER TABLE error_group_jobs
   ADD COLUMN IF NOT EXISTS run_id UUID REFERENCES digest_runs(id) ON DELETE CASCADE;
-
-ALTER TABLE error_group_jobs ALTER COLUMN error_group_id DROP NOT NULL;
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_one_active_write_job_per_run
   ON error_group_jobs (project_id, run_id, job_type)
   WHERE run_id IS NOT NULL AND status IN ('pending','claimed');
-
--- error_group_id lost NOT NULL above; every job still needs at least one scope.
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint
-    WHERE conrelid = 'error_group_jobs'::regclass
-      AND conname = 'error_group_jobs_scope_check'
-  ) THEN
-    ALTER TABLE error_group_jobs ADD CONSTRAINT error_group_jobs_scope_check
-      CHECK (error_group_id IS NOT NULL OR episode_id IS NOT NULL OR run_id IS NOT NULL);
-  END IF;
-END $$;
 
 ALTER TABLE diagnosis_decisions
   ADD COLUMN IF NOT EXISTS episode_id UUID REFERENCES issue_episodes(id) ON DELETE SET NULL;

--- a/packages/ingestion/db/migrations/054_pipeline_quality.sql
+++ b/packages/ingestion/db/migrations/054_pipeline_quality.sql
@@ -1,0 +1,233 @@
+-- 054_pipeline_quality.sql -- asynchronous identity, filtering, inquiry, and publication.
+-- Inert until the runtime paths land. IDEMPOTENCY IS MANDATORY.
+
+CREATE TABLE IF NOT EXISTS error_capture_buckets (
+  project_id       UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  raw_fingerprint  TEXT NOT NULL,
+  identity_version INTEGER NOT NULL,
+  first_seen       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, identity_version, raw_fingerprint)
+);
+
+CREATE TABLE IF NOT EXISTS error_event_resolutions (
+  project_id       UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  event_id         UUID NOT NULL REFERENCES error_events(id) ON DELETE CASCADE,
+  status           TEXT NOT NULL CHECK (status IN ('resolved','no_map','failed','pending')),
+  envelope         JSONB,
+  resolver_version INTEGER NOT NULL,
+  resolved_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, event_id)
+);
+
+CREATE TABLE IF NOT EXISTS sourcemap_position_cache (
+  project_id        UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  debug_id          TEXT NOT NULL,
+  map_content_sha   TEXT NOT NULL,
+  resolver_version  INTEGER NOT NULL,
+  generated_line    INTEGER NOT NULL,
+  generated_column  INTEGER NOT NULL,
+  original_file     TEXT,
+  original_function TEXT,
+  original_line     INTEGER,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, debug_id, map_content_sha, resolver_version,
+               generated_line, generated_column)
+);
+
+CREATE TABLE IF NOT EXISTS issue_episodes (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id         UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  canonical_issue_id UUID NOT NULL REFERENCES error_groups(id) ON DELETE CASCADE,
+  sequence           INTEGER NOT NULL,
+  opened_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  closed_at          TIMESTAMPTZ,
+  UNIQUE (project_id, canonical_issue_id, sequence)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_one_open_episode
+  ON issue_episodes (canonical_issue_id) WHERE closed_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS error_event_identities (
+  project_id           UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  event_id             UUID NOT NULL REFERENCES error_events(id) ON DELETE CASCADE,
+  -- 'settling' is the claim marker. A crash leaves it here, which is why the
+  -- later identity loop includes a reset sweep.
+  status               TEXT NOT NULL CHECK (status IN ('pending','settling','settled','conflict')),
+  claimed_at           TIMESTAMPTZ,
+  canonical_issue_id   UUID REFERENCES error_groups(id) ON DELETE SET NULL,
+  raw_fingerprint      TEXT NOT NULL,
+  resolved_fingerprint TEXT,
+  identity_version     INTEGER NOT NULL,
+  episode_id           UUID REFERENCES issue_episodes(id) ON DELETE SET NULL,
+  settled_at           TIMESTAMPTZ,
+  PRIMARY KEY (project_id, event_id)
+);
+CREATE INDEX IF NOT EXISTS idx_identities_pending
+  ON error_event_identities (project_id, status) WHERE status = 'pending';
+
+CREATE TABLE IF NOT EXISTS canonical_issue_fingerprints (
+  project_id         UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  fingerprint        TEXT NOT NULL,
+  fingerprint_kind   TEXT NOT NULL CHECK (fingerprint_kind IN ('raw','resolved','friction')),
+  canonical_issue_id UUID NOT NULL REFERENCES error_groups(id) ON DELETE CASCADE,
+  identity_version   INTEGER NOT NULL,
+  confirmed_by       TEXT NOT NULL CHECK (confirmed_by IN ('exact','model','human')),
+  bound_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, identity_version, fingerprint)
+);
+CREATE INDEX IF NOT EXISTS idx_alias_by_issue
+  ON canonical_issue_fingerprints (canonical_issue_id);
+
+CREATE TABLE IF NOT EXISTS issue_decisions (
+  id           BIGSERIAL PRIMARY KEY,
+  project_id   UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  episode_id   UUID NOT NULL REFERENCES issue_episodes(id) ON DELETE CASCADE,
+  decision     TEXT NOT NULL CHECK (decision IN ('open_inquiry','watch','inactive')),
+  reason       TEXT NOT NULL,
+  users_7d     INTEGER NOT NULL,
+  anon_7d      INTEGER NOT NULL,
+  rule_version INTEGER NOT NULL,
+  decided_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_decisions_latest
+  ON issue_decisions (project_id, episode_id, decided_at DESC, id DESC);
+
+CREATE TABLE IF NOT EXISTS issue_inquiry_decisions (
+  id                 BIGSERIAL PRIMARY KEY,
+  project_id         UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  episode_id         UUID NOT NULL REFERENCES issue_episodes(id) ON DELETE CASCADE,
+  decision           TEXT NOT NULL CHECK (decision IN ('investigate','wait_for_more_evidence','do_not_pursue')),
+  reason             TEXT NOT NULL,
+  brief              TEXT,
+  related_issues     UUID[] NOT NULL DEFAULT '{}',
+  evaluated_units    INTEGER NOT NULL,
+  evidence_signature TEXT NOT NULL,
+  -- The route/action understanding version this review read; NULL means no
+  -- product understanding existed yet for the issue's surface.
+  product_understanding_version INTEGER,
+  model              TEXT NOT NULL,
+  prompt_version     INTEGER NOT NULL,
+  decided_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_inquiry_latest
+  ON issue_inquiry_decisions (project_id, episode_id, decided_at DESC, id DESC);
+
+CREATE TABLE IF NOT EXISTS issue_evidence_anchors (
+  project_id  UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  episode_id  UUID NOT NULL REFERENCES issue_episodes(id) ON DELETE CASCADE,
+  anchor_kind TEXT NOT NULL CHECK (anchor_kind IN ('threshold','first','recent')),
+  event_id    UUID NOT NULL REFERENCES error_events(id) ON DELETE CASCADE,
+  frozen_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, episode_id, anchor_kind)
+);
+
+CREATE TABLE IF NOT EXISTS issue_publications (
+  project_id   UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  episode_id   UUID NOT NULL REFERENCES issue_episodes(id) ON DELETE CASCADE,
+  channel      TEXT NOT NULL CHECK (channel IN ('immediate','post_triage','digest')),
+  published_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, episode_id, channel)
+);
+
+CREATE TABLE IF NOT EXISTS digest_runs (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id  UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  window_from TIMESTAMPTZ NOT NULL,
+  window_to   TIMESTAMPTZ NOT NULL,
+  run_date    DATE NOT NULL DEFAULT ((now() AT TIME ZONE 'utc')::date),
+  status      TEXT NOT NULL CHECK (status IN ('frozen','written','validated','delivered','failed')),
+  payload     JSONB,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_one_run_per_window
+  ON digest_runs (project_id, window_to);
+-- The freezer stamps the project-local calendar date of the boundary; the
+-- volatile default only covers rows that predate this column.
+ALTER TABLE digest_runs ADD COLUMN IF NOT EXISTS run_date DATE NOT NULL DEFAULT ((now() AT TIME ZONE 'utc')::date);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_one_run_per_local_date
+  ON digest_runs (project_id, run_date);
+
+CREATE TABLE IF NOT EXISTS digest_run_items (
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  run_id     UUID NOT NULL REFERENCES digest_runs(id) ON DELETE CASCADE,
+  episode_id UUID NOT NULL REFERENCES issue_episodes(id) ON DELETE CASCADE,
+  outcome    TEXT CHECK (outcome IS NULL OR outcome IN ('included','deferred')),
+  reason     TEXT,
+  PRIMARY KEY (run_id, episode_id)
+);
+
+ALTER TABLE error_group_jobs
+  ADD COLUMN IF NOT EXISTS episode_id UUID REFERENCES issue_episodes(id) ON DELETE CASCADE;
+ALTER TABLE error_group_jobs
+  ADD COLUMN IF NOT EXISTS input_version INTEGER;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_one_active_job_per_episode_type
+  ON error_group_jobs (project_id, episode_id, job_type)
+  WHERE status IN ('pending','claimed');
+
+-- One inquiry and one investigation job per work round and input version.
+-- Retries reclaim the same row; only a new input version may enqueue again.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_one_job_per_episode_type_version
+  ON error_group_jobs (project_id, episode_id, job_type, input_version)
+  WHERE episode_id IS NOT NULL AND input_version IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_one_inquiry_per_evidence
+  ON issue_inquiry_decisions (project_id, episode_id, prompt_version, evidence_signature);
+
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS purpose TEXT;
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS actions TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS client_refs TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS server_refs TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS observed_requests TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS audience TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS confidence REAL NOT NULL DEFAULT 0;
+-- Base insert semantics stay: name and tier remain NOT NULL with no default.
+ALTER TABLE route_map ALTER COLUMN tier DROP DEFAULT;
+ALTER TABLE route_map ALTER COLUMN name DROP DEFAULT;
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS commit_sha TEXT;
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS prompt_version INTEGER;
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS model TEXT;
+ALTER TABLE route_map ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'mechanical';
+
+ALTER TABLE error_group_jobs
+  ADD COLUMN IF NOT EXISTS run_id UUID REFERENCES digest_runs(id) ON DELETE CASCADE;
+
+ALTER TABLE error_group_jobs ALTER COLUMN error_group_id DROP NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_one_active_write_job_per_run
+  ON error_group_jobs (project_id, run_id, job_type)
+  WHERE run_id IS NOT NULL AND status IN ('pending','claimed');
+
+-- error_group_id lost NOT NULL above; every job still needs at least one scope.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'error_group_jobs'::regclass
+      AND conname = 'error_group_jobs_scope_check'
+  ) THEN
+    ALTER TABLE error_group_jobs ADD CONSTRAINT error_group_jobs_scope_check
+      CHECK (error_group_id IS NOT NULL OR episode_id IS NOT NULL OR run_id IS NOT NULL);
+  END IF;
+END $$;
+
+ALTER TABLE diagnosis_decisions
+  ADD COLUMN IF NOT EXISTS episode_id UUID REFERENCES issue_episodes(id) ON DELETE SET NULL;
+
+-- outcome predates this migration. Preserve legacy values for existing rows and
+-- old binaries while admitting the rewritten pipeline's terminal outcomes.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'diagnosis_decisions'::regclass
+      AND conname = 'diagnosis_decisions_outcome_check'
+      AND convalidated
+      AND pg_get_constraintdef(oid) =
+        'CHECK ((outcome = ANY (ARRAY[''code_fix''::text, ''not_actionable''::text, ''needs_more_context''::text, ''incomplete''::text, ''verified_fix''::text, ''needs_human''::text, ''unable_to_establish_cause''::text])))'
+  ) THEN
+    ALTER TABLE diagnosis_decisions DROP CONSTRAINT IF EXISTS diagnosis_decisions_outcome_check;
+    ALTER TABLE diagnosis_decisions ADD CONSTRAINT diagnosis_decisions_outcome_check
+      CHECK (outcome IN ('code_fix','not_actionable','needs_more_context','incomplete',
+                         'verified_fix','needs_human','unable_to_establish_cause'));
+  END IF;
+END $$;
+

--- a/packages/ingestion/db/migrations_test.go
+++ b/packages/ingestion/db/migrations_test.go
@@ -216,6 +216,58 @@ func TestMigrations_RollForwardFromPreviousSchema(t *testing.T) {
 	}
 }
 
+func TestMigration054CreatesPipelineTables(t *testing.T) {
+	admin := testPool(t)
+	psql := findPsql(t)
+	pool, dsn := disposableDB(t, admin)
+	for _, file := range migrationFiles(t) {
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("migration %s: %v", file, err)
+		}
+	}
+
+	want := []string{
+		"error_capture_buckets", "error_event_resolutions", "sourcemap_position_cache",
+		"error_event_identities", "canonical_issue_fingerprints", "issue_episodes",
+		"issue_decisions", "issue_inquiry_decisions", "issue_evidence_anchors",
+		"issue_publications", "digest_runs", "digest_run_items",
+	}
+	for _, table := range want {
+		var exists bool
+		err := pool.QueryRow(context.Background(),
+			`SELECT EXISTS (SELECT 1 FROM information_schema.tables
+			  WHERE table_schema = 'public' AND table_name = $1)`, table).Scan(&exists)
+		if err != nil {
+			t.Fatalf("query %s: %v", table, err)
+		}
+		if !exists {
+			t.Errorf("table %s missing", table)
+		}
+	}
+}
+
+func TestMigration054IsReapplySafe(t *testing.T) {
+	admin := testPool(t)
+	psql := findPsql(t)
+	_, dsn := disposableDB(t, admin)
+	files := migrationFiles(t)
+	for _, file := range files {
+		if filepath.Base(file) == "054_pipeline_quality.sql" {
+			break
+		}
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("migration %s: %v", file, err)
+		}
+	}
+
+	path := "migrations/054_pipeline_quality.sql"
+	for i := 0; i < 2; i++ {
+		if err := applyMigration(t, psql, dsn, path); err != nil {
+			t.Fatalf("apply %d: %v", i+1, err)
+		}
+	}
+}
+
 func TestDefaultBranchNullableMigrationPreservesExistingRows(t *testing.T) {
 	admin := testPool(t)
 	files := migrationFiles(t)

--- a/packages/ingestion/digest/build.go
+++ b/packages/ingestion/digest/build.go
@@ -62,6 +62,7 @@ var (
 		 WHERE g.project_id = $1
 		   AND dr.status = 'eligible'
 		   AND dr.updated_at >= $2 AND dr.updated_at < $3
+		   AND g.last_seen >= now() - interval '7 days'
 		   AND g.status IN ('pr_created','pr_draft','needs_human','investigated','insight','awaiting_approval')`
 
 	receiptCountsQuery = `
@@ -185,8 +186,12 @@ type receiptQueryRow struct {
 
 func receiptState(status string, hasSavedDiff bool) string {
 	switch status {
-	case "pr_created", "pr_draft":
+	case "pr_created":
 		return "pr_open"
+	case "pr_draft":
+		return "pr_draft"
+	case "awaiting_approval":
+		return "awaiting_approval"
 	case "needs_human":
 		if hasSavedDiff {
 			return "attempt_failed_with_diff"
@@ -204,11 +209,11 @@ func publishable(item notify.ReceiptItem, hasValidatedDiagnosis bool) bool {
 		return false
 	}
 	switch item.ReceiptState {
-	case "pr_open":
+	case "pr_open", "pr_draft":
 		return item.PRURL != ""
 	case "attempt_failed_with_diff":
 		return item.HasSavedDiff
-	case "attempt_failed_no_diff", "report_ready":
+	case "attempt_failed_no_diff", "report_ready", "awaiting_approval":
 		return hasValidatedDiagnosis
 	default:
 		return false

--- a/packages/ingestion/digest/build.go
+++ b/packages/ingestion/digest/build.go
@@ -92,7 +92,7 @@ func (s *Sweeper) Build(ctx context.Context, projectID string, now time.Time) (n
 	if err != nil {
 		return notify.EventPayload{}, fmt.Errorf("digest timezone %q: %w", timezone, err)
 	}
-	from, to := digestWindow(now)
+	from, to := s.windowFor(ctx, projectID, now)
 	receiptItems, receiptOverflow, receiptBeltFailures, err := s.buildReceiptItems(ctx, projectID, from, to)
 	if err != nil {
 		return notify.EventPayload{}, err

--- a/packages/ingestion/digest/build.go
+++ b/packages/ingestion/digest/build.go
@@ -62,7 +62,7 @@ var (
 		 WHERE g.project_id = $1
 		   AND dr.status = 'eligible'
 		   AND dr.updated_at >= $2 AND dr.updated_at < $3
-		   AND g.last_seen >= now() - interval '7 days'
+		   AND g.last_seen >= $4
 		   AND g.status IN ('pr_created','pr_draft','needs_human','investigated','insight','awaiting_approval')`
 
 	receiptCountsQuery = `
@@ -224,14 +224,15 @@ func (s *Sweeper) buildReceiptItems(ctx context.Context, projectID string, from,
 	// Counts run over every qualifying row, before the publishable filter and
 	// the LIMIT, so they stay exact even when nothing is renderable.
 	var total, sqlBeltFailures int
-	if err := s.pool.QueryRow(ctx, receiptCountsQuery, projectID, from, to).Scan(&total, &sqlBeltFailures); err != nil {
+	liveSince := to.Add(-receiptLivenessWindow)
+	if err := s.pool.QueryRow(ctx, receiptCountsQuery, projectID, from, to, liveSince).Scan(&total, &sqlBeltFailures); err != nil {
 		return nil, 0, 0, fmt.Errorf("digest receipt counts: %w", err)
 	}
 	if sqlBeltFailures > 0 {
 		slog.Warn("eligible digest receipts failed the artifact belt", "project_id", projectID, "count", sqlBeltFailures)
 	}
 
-	rows, err := s.pool.Query(ctx, receiptItemsQuery, projectID, from, to)
+	rows, err := s.pool.Query(ctx, receiptItemsQuery, projectID, from, to, liveSince)
 	if err != nil {
 		return nil, 0, 0, fmt.Errorf("digest receipt items: %w", err)
 	}
@@ -253,6 +254,7 @@ func (s *Sweeper) buildReceiptItems(ctx context.Context, projectID string, from,
 			row.item.ImpactClass = *impactClass
 		}
 		row.item.ReceiptState = receiptState(row.status, row.item.HasSavedDiff)
+		row.item.HasValidatedDiagnosis = row.hasValidatedDiagnosis
 		row.item.Title = narrative.SanitizeExcerpt(row.item.Title, excerptMax)
 		if row.hasValidatedDiagnosis {
 			row.item.RootCauseExcerpt = narrative.SanitizeExcerpt(row.rootCause, excerptMax)

--- a/packages/ingestion/digest/build_test.go
+++ b/packages/ingestion/digest/build_test.go
@@ -596,8 +596,12 @@ func TestBuildReceiptItemsExcludesStaleProblems(t *testing.T) {
 		return groupID
 	}
 
-	staleID := seedEligibleGroup(now.Add(-10 * 24 * time.Hour))
-	freshID := seedEligibleGroup(now.Add(-2 * time.Hour))
+	// Seeded either side of the boundary itself, not merely far from it: 10d
+	// vs 2h passes for any cutoff between them, so it would not notice the
+	// interval being retuned to 3 or 9 days.
+	staleID := seedEligibleGroup(now.Add(-receiptLivenessWindow - time.Hour))
+	freshID := seedEligibleGroup(now.Add(-receiptLivenessWindow + time.Hour))
+	longGoneID := seedEligibleGroup(now.Add(-30 * 24 * time.Hour))
 	payload, err := New(pool, "https://dash.example").Build(ctx, f.ProjectID, now)
 	if err != nil {
 		t.Fatal(err)
@@ -607,10 +611,13 @@ func TestBuildReceiptItemsExcludesStaleProblems(t *testing.T) {
 		ids[item.IncidentID] = true
 	}
 	if ids[staleID] {
-		t.Error("stale problem (last seen 10 days ago) must not appear")
+		t.Error("problem seen just outside the liveness window must not appear")
 	}
 	if !ids[freshID] {
-		t.Error("fresh problem must appear")
+		t.Error("problem seen just inside the liveness window must appear")
+	}
+	if ids[longGoneID] {
+		t.Error("problem seen 30 days ago must not appear")
 	}
 }
 
@@ -833,6 +840,7 @@ func TestReceiptStateSurfacesApproval(t *testing.T) {
 	cases := map[string]string{
 		"awaiting_approval": "awaiting_approval",
 		"pr_draft":          "pr_draft",
+		"pr_created":        "pr_open",
 		"investigated":      "report_ready",
 	}
 	for groupStatus, want := range cases {

--- a/packages/ingestion/digest/build_test.go
+++ b/packages/ingestion/digest/build_test.go
@@ -571,6 +571,49 @@ func TestBuildDigestUsesProjectLocalDate(t *testing.T) {
 	}
 }
 
+func TestBuildReceiptItemsExcludesStaleProblems(t *testing.T) {
+	pool := testPool(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	f := seedDigestFixture(t, pool, now)
+	ctx := context.Background()
+
+	seedEligibleGroup := func(lastSeen time.Time) string {
+		t.Helper()
+		var groupID string
+		if err := pool.QueryRow(ctx, `INSERT INTO error_groups
+			(project_id,environment_id,fingerprint,title,kind,status,first_seen,last_seen,
+			 occurrence_count,affected_users_count,pr_created_at,pr_url)
+			VALUES ($1,$2,$3,'Receipt liveness','error','pr_created',$4,$4,1,1,$5,$6)
+			RETURNING id`, f.ProjectID, f.EnvID, "liveness-"+uuid.NewString(), lastSeen,
+			now.Add(-time.Hour), "https://github.example/pr/1").Scan(&groupID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := pool.Exec(ctx, `INSERT INTO digest_readiness
+			(incident_id,project_id,status,reason,updated_at)
+			VALUES ($1,$2,'eligible','fix_pr_opened',$3)`, groupID, f.ProjectID, now.Add(-time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+		return groupID
+	}
+
+	staleID := seedEligibleGroup(now.Add(-10 * 24 * time.Hour))
+	freshID := seedEligibleGroup(now.Add(-2 * time.Hour))
+	payload, err := New(pool, "https://dash.example").Build(ctx, f.ProjectID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := make(map[string]bool, len(payload.Digest.ReceiptItems))
+	for _, item := range payload.Digest.ReceiptItems {
+		ids[item.IncidentID] = true
+	}
+	if ids[staleID] {
+		t.Error("stale problem (last seen 10 days ago) must not appear")
+	}
+	if !ids[freshID] {
+		t.Error("fresh problem must appear")
+	}
+}
+
 func TestBuildReceiptItemsPriorityWindowCapAndGate(t *testing.T) {
 	pool := testPool(t)
 	now := time.Now().UTC().Truncate(time.Second)
@@ -709,7 +752,8 @@ func TestBuildReceiptItemsStatesAndValidatedProse(t *testing.T) {
 		prURL              string
 	}
 	seeds := []receiptSeed{
-		{status: "pr_draft", wantState: "pr_open", prURL: "https://github.example/pr/1"},
+		{status: "pr_draft", wantState: "pr_draft", prURL: "https://github.example/pr/1"},
+		{status: "awaiting_approval", wantState: "awaiting_approval", decision: true},
 		{status: "needs_human", wantState: "attempt_failed_with_diff", withDiff: true, decision: true},
 		{status: "needs_human", wantState: "attempt_failed_no_diff", decision: true},
 		{status: "investigated", wantState: "report_ready", decision: true},
@@ -769,18 +813,31 @@ func TestBuildReceiptItemsStatesAndValidatedProse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(payload.Digest.ReceiptItems) != 4 || payload.Digest.HeldBackCount != 2 {
+	if len(payload.Digest.ReceiptItems) != 5 || payload.Digest.HeldBackCount != 2 {
 		t.Fatalf("items/held = %d/%d", len(payload.Digest.ReceiptItems), payload.Digest.HeldBackCount)
 	}
 	for _, item := range payload.Digest.ReceiptItems {
 		if item.ReceiptState != wants[item.IncidentID] {
 			t.Errorf("%s state = %s, want %s", item.IncidentID, item.ReceiptState, wants[item.IncidentID])
 		}
-		if item.ReceiptState == "pr_open" && item.RootCauseExcerpt != "" {
+		if (item.ReceiptState == "pr_open" || item.ReceiptState == "pr_draft") && item.RootCauseExcerpt != "" {
 			t.Errorf("unvalidated PR prose rendered: %q", item.RootCauseExcerpt)
 		}
-		if item.ReceiptState != "pr_open" && (item.RootCauseExcerpt == "" || strings.Contains(item.RootCauseExcerpt, "https://") || strings.ContainsAny(item.RootCauseExcerpt, "*`")) {
+		if item.ReceiptState != "pr_open" && item.ReceiptState != "pr_draft" && (item.RootCauseExcerpt == "" || strings.Contains(item.RootCauseExcerpt, "https://") || strings.ContainsAny(item.RootCauseExcerpt, "*`")) {
 			t.Errorf("validated prose missing or dirty: %q", item.RootCauseExcerpt)
+		}
+	}
+}
+
+func TestReceiptStateSurfacesApproval(t *testing.T) {
+	cases := map[string]string{
+		"awaiting_approval": "awaiting_approval",
+		"pr_draft":          "pr_draft",
+		"investigated":      "report_ready",
+	}
+	for groupStatus, want := range cases {
+		if got := receiptState(groupStatus, false); got != want {
+			t.Errorf("receiptState(%q) = %q, want %q", groupStatus, got, want)
 		}
 	}
 }

--- a/packages/ingestion/digest/digest.go
+++ b/packages/ingestion/digest/digest.go
@@ -32,6 +32,8 @@ const (
 	// cannot stall the whole sweep. Due-ness is derived, so a timeout just
 	// means the next tick retries.
 	perProjectTimeout = 30 * time.Second
+	// Ceiling on the catch-up window after a missed run. See windowFor.
+	maxWindowLookback = 7 * 24 * time.Hour
 )
 
 type Sweeper struct {
@@ -89,8 +91,58 @@ func capped[T any](items []T) ([]T, bool) {
 	return items[:listCap], true
 }
 
-func digestWindow(now time.Time) (time.Time, time.Time) {
-	return now.Add(-24 * time.Hour), now
+// windowFor returns the reporting window: everything since the previous
+// digest's window end, so a late, early, or missed run neither drops nor
+// repeats items.
+//
+// A fixed trailing 24h anchored on run time cannot do this, because the run
+// time moves. Prod showed both failure modes: the 08-10 and 08-11 digests
+// overlapped by 8h25m (items reported twice), and the 08-13 sweep outage left
+// 09:00:01-16:35:54 on 08-13 covered by no digest at all.
+//
+// Falls back to a trailing 24h when there is no usable prior window: the first
+// digest for a project, or a stored value that cannot be trusted.
+func (s *Sweeper) windowFor(ctx context.Context, projectID string, now time.Time) (time.Time, time.Time) {
+	fallback := now.Add(-24 * time.Hour)
+	var stored *string
+	err := s.pool.QueryRow(ctx, `
+		SELECT payload->'digest'->'window'->>'to'
+		  FROM outbound_events
+		 WHERE project_id = $1 AND event_type = 'digest.daily'
+		 ORDER BY created_at DESC
+		 LIMIT 1`, projectID).Scan(&stored)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return fallback, now
+	}
+	if err != nil {
+		slog.Warn("digest: previous window lookup failed; using a trailing 24h", "project_id", projectID, "error", err)
+		return fallback, now
+	}
+	if stored == nil {
+		return fallback, now
+	}
+	previous, parseErr := time.Parse(time.RFC3339Nano, *stored)
+	if parseErr != nil {
+		slog.Warn("digest: previous window end is unparseable; using a trailing 24h", "project_id", projectID, "value", *stored)
+		return fallback, now
+	}
+	previous = previous.UTC()
+	// A stored end at or after now means a clock moved backwards. Reporting a
+	// negative window would silently emit an empty digest, so take the 24h.
+	if !previous.Before(now) {
+		slog.Warn("digest: previous window end is not in the past; using a trailing 24h", "project_id", projectID, "previous", previous, "now", now)
+		return fallback, now
+	}
+	// Bound the catch-up after a long outage. Without this, a sweep that has
+	// been down for weeks builds an unbounded window, and exceeding
+	// perProjectTimeout would make the digest fail every tick instead of
+	// publishing a large one -- turning a gap into a permanent outage.
+	if oldest := now.Add(-maxWindowLookback); previous.Before(oldest) {
+		slog.Warn("digest: previous window end is older than the lookback cap; truncating",
+			"project_id", projectID, "previous", previous, "capped_to", oldest)
+		return oldest, now
+	}
+	return previous, now
 }
 
 // Start runs the sweep until cancellation. It is safe to start unconditionally:

--- a/packages/ingestion/digest/digest.go
+++ b/packages/ingestion/digest/digest.go
@@ -34,6 +34,13 @@ const (
 	perProjectTimeout = 30 * time.Second
 	// Ceiling on the catch-up window after a missed run. See windowFor.
 	maxWindowLookback = 7 * 24 * time.Hour
+	// How recently a problem must have occurred to earn a digest card. This is
+	// about the problem still happening, not about the readiness bookkeeping in
+	// the reporting window. It equals maxWindowLookback today by coincidence of
+	// judgement, not by requirement: a catch-up window may legitimately reach
+	// back further than a problem stays worth reporting. Change them
+	// independently.
+	receiptLivenessWindow = 7 * 24 * time.Hour
 )
 
 type Sweeper struct {
@@ -105,11 +112,21 @@ func capped[T any](items []T) ([]T, bool) {
 func (s *Sweeper) windowFor(ctx context.Context, projectID string, now time.Time) (time.Time, time.Time) {
 	fallback := now.Add(-24 * time.Hour)
 	var stored *string
+	// Only a digest that actually reached a destination may move the watermark.
+	// outbound_events records the attempt; outbound_deliveries records the
+	// outcome. Resuming from an undelivered event would skip every issue in a
+	// message nobody received, and because the next window starts after it,
+	// those issues would never be reported again -- the same permanent gap this
+	// function exists to close, reintroduced through a Slack outage.
 	err := s.pool.QueryRow(ctx, `
-		SELECT payload->'digest'->'window'->>'to'
-		  FROM outbound_events
-		 WHERE project_id = $1 AND event_type = 'digest.daily'
-		 ORDER BY created_at DESC
+		SELECT e.payload->'digest'->'window'->>'to'
+		  FROM outbound_events e
+		 WHERE e.project_id = $1 AND e.event_type = 'digest.daily'
+		   AND EXISTS (
+		     SELECT 1 FROM outbound_deliveries d
+		      WHERE d.event_id = e.id AND d.status = 'delivered'
+		   )
+		 ORDER BY e.created_at DESC
 		 LIMIT 1`, projectID).Scan(&stored)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return fallback, now
@@ -119,6 +136,11 @@ func (s *Sweeper) windowFor(ctx context.Context, projectID string, now time.Time
 		return fallback, now
 	}
 	if stored == nil {
+		// A digest.daily row whose payload carries no window.to: written before
+		// the field existed, or by hand. Warn like the other fallbacks so a
+		// renamed json tag degrades loudly instead of silently reverting every
+		// project to a trailing 24h.
+		slog.Warn("digest: previous digest recorded no window end; using a trailing 24h", "project_id", projectID)
 		return fallback, now
 	}
 	previous, parseErr := time.Parse(time.RFC3339Nano, *stored)

--- a/packages/ingestion/digest/digest_test.go
+++ b/packages/ingestion/digest/digest_test.go
@@ -2,12 +2,120 @@ package digest
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// seedPriorDigest writes a published digest whose stored window ends at
+// windowEnd, which is the watermark the next run must resume from.
+func seedPriorDigest(t *testing.T, pool *pgxpool.Pool, projectID string, windowEnd time.Time, dedupSuffix string) {
+	t.Helper()
+	payload := fmt.Sprintf(`{"digest":{"window":{"from":%q,"to":%q}}}`,
+		windowEnd.Add(-24*time.Hour).Format(time.RFC3339Nano),
+		windowEnd.Format(time.RFC3339Nano))
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO outbound_events (project_id, event_type, dedup_key, payload)
+		 VALUES ($1,'digest.daily',$2,$3::jsonb)`,
+		projectID, "digest.daily:"+projectID+":"+dedupSuffix, payload); err != nil {
+		t.Fatalf("seed prior digest: %v", err)
+	}
+}
+
+func clearDigestEvents(t *testing.T, pool *pgxpool.Pool, projectID string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`DELETE FROM outbound_events WHERE project_id=$1 AND event_type='digest.daily'`, projectID); err != nil {
+		t.Fatalf("clear digest events: %v", err)
+	}
+}
+
+// The window must resume from the previous digest's end rather than a fixed
+// trailing 24h. Anchoring on run time both drops and repeats items whenever the
+// send time moves, which prod showed on 2026-08-13.
+func TestWindowForResumesFromPreviousDigest(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	f := seedDigestFixture(t, pool, now)
+	s := New(pool, "https://dash.example")
+
+	t.Run("first digest falls back to a trailing 24h", func(t *testing.T) {
+		from, to := s.windowFor(ctx, f.ProjectID, now)
+		if !to.Equal(now) || !from.Equal(now.Add(-24*time.Hour)) {
+			t.Fatalf("window = %s..%s; want %s..%s", from, to, now.Add(-24*time.Hour), now)
+		}
+	})
+
+	t.Run("closes the gap a late run would leave", func(t *testing.T) {
+		clearDigestEvents(t, pool, f.ProjectID)
+		// The real 2026-08-13 shape: previous digest ended 7h35m ago, so a
+		// trailing 24h would re-report 16h and a shorter window would drop time.
+		previousEnd := now.Add(-7*time.Hour - 35*time.Minute)
+		seedPriorDigest(t, pool, f.ProjectID, previousEnd, "gap-case")
+		from, to := s.windowFor(ctx, f.ProjectID, now)
+		if !from.Equal(previousEnd) || !to.Equal(now) {
+			t.Fatalf("window = %s..%s; want %s..%s", from, to, previousEnd, now)
+		}
+	})
+
+	t.Run("does not re-report an already covered span", func(t *testing.T) {
+		clearDigestEvents(t, pool, f.ProjectID)
+		// Previous digest ended 30h ago. A trailing 24h would start *after* it,
+		// silently skipping 6h; resuming from the watermark covers them.
+		previousEnd := now.Add(-30 * time.Hour)
+		seedPriorDigest(t, pool, f.ProjectID, previousEnd, "overlap-case")
+		from, _ := s.windowFor(ctx, f.ProjectID, now)
+		if !from.Equal(previousEnd) {
+			t.Fatalf("from = %s; want %s", from, previousEnd)
+		}
+	})
+
+	t.Run("caps an unbounded catch-up after a long outage", func(t *testing.T) {
+		clearDigestEvents(t, pool, f.ProjectID)
+		seedPriorDigest(t, pool, f.ProjectID, now.Add(-60*24*time.Hour), "cap-case")
+		from, _ := s.windowFor(ctx, f.ProjectID, now)
+		if want := now.Add(-maxWindowLookback); !from.Equal(want) {
+			t.Fatalf("from = %s; want the cap %s", from, want)
+		}
+	})
+
+	t.Run("ignores a watermark that is not in the past", func(t *testing.T) {
+		clearDigestEvents(t, pool, f.ProjectID)
+		seedPriorDigest(t, pool, f.ProjectID, now.Add(2*time.Hour), "future-case")
+		from, _ := s.windowFor(ctx, f.ProjectID, now)
+		if want := now.Add(-24 * time.Hour); !from.Equal(want) {
+			t.Fatalf("from = %s; want the 24h fallback %s", from, want)
+		}
+	})
+
+	t.Run("ignores an unparseable watermark", func(t *testing.T) {
+		clearDigestEvents(t, pool, f.ProjectID)
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO outbound_events (project_id, event_type, dedup_key, payload)
+			 VALUES ($1,'digest.daily',$2,'{"digest":{"window":{"to":"not-a-time"}}}'::jsonb)`,
+			f.ProjectID, "digest.daily:"+f.ProjectID+":junk-case"); err != nil {
+			t.Fatal(err)
+		}
+		from, _ := s.windowFor(ctx, f.ProjectID, now)
+		if want := now.Add(-24 * time.Hour); !from.Equal(want) {
+			t.Fatalf("from = %s; want the 24h fallback %s", from, want)
+		}
+	})
+
+	t.Run("is scoped to the project", func(t *testing.T) {
+		clearDigestEvents(t, pool, f.ProjectID)
+		other := seedDigestFixture(t, pool, now)
+		seedPriorDigest(t, pool, other.ProjectID, now.Add(-3*time.Hour), "other-project")
+		from, _ := s.windowFor(ctx, f.ProjectID, now)
+		if want := now.Add(-24 * time.Hour); !from.Equal(want) {
+			t.Fatalf("from = %s; another project's watermark leaked in", from)
+		}
+	})
+}
 
 func seedDestination(t *testing.T, pool *pgxpool.Pool, projectID string, eventTypes []string) string {
 	t.Helper()

--- a/packages/ingestion/digest/digest_test.go
+++ b/packages/ingestion/digest/digest_test.go
@@ -10,18 +10,60 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// seedPriorDigest writes a published digest whose stored window ends at
-// windowEnd, which is the watermark the next run must resume from.
+// seedPriorDigest writes a DELIVERED digest whose stored window ends at
+// windowEnd, which is the watermark the next run must resume from. Delivery is
+// part of the fixture because only a delivered digest may move the watermark;
+// see seedUndeliveredDigest for the other half.
 func seedPriorDigest(t *testing.T, pool *pgxpool.Pool, projectID string, windowEnd time.Time, dedupSuffix string) {
 	t.Helper()
+	seedPriorDigestWithStatus(t, pool, projectID, windowEnd, dedupSuffix, "delivered")
+}
+
+// seedUndeliveredDigest writes a digest that was built and enqueued but never
+// reached a destination, e.g. a Slack outage that exhausted its retries.
+func seedUndeliveredDigest(t *testing.T, pool *pgxpool.Pool, projectID string, windowEnd time.Time, dedupSuffix string) {
+	t.Helper()
+	seedPriorDigestWithStatus(t, pool, projectID, windowEnd, dedupSuffix, "failed")
+}
+
+func seedPriorDigestWithStatus(t *testing.T, pool *pgxpool.Pool, projectID string, windowEnd time.Time, dedupSuffix, status string) {
+	t.Helper()
+	ctx := context.Background()
 	payload := fmt.Sprintf(`{"digest":{"window":{"from":%q,"to":%q}}}`,
 		windowEnd.Add(-24*time.Hour).Format(time.RFC3339Nano),
 		windowEnd.Format(time.RFC3339Nano))
-	if _, err := pool.Exec(context.Background(),
+	var eventID string
+	if err := pool.QueryRow(ctx,
 		`INSERT INTO outbound_events (project_id, event_type, dedup_key, payload)
-		 VALUES ($1,'digest.daily',$2,$3::jsonb)`,
-		projectID, "digest.daily:"+projectID+":"+dedupSuffix, payload); err != nil {
+		 VALUES ($1,'digest.daily',$2,$3::jsonb) RETURNING id`,
+		projectID, "digest.daily:"+projectID+":"+dedupSuffix, payload).Scan(&eventID); err != nil {
 		t.Fatalf("seed prior digest: %v", err)
+	}
+	destID := seedDestination(t, pool, projectID, []string{"digest.daily"})
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO outbound_deliveries (event_id, destination_id, status) VALUES ($1,$2,$3)`,
+		eventID, destID, status); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+}
+
+// seedPriorDigestPayload writes a delivered digest carrying an arbitrary
+// payload, for the guard branches that never reach a parse.
+func seedPriorDigestPayload(t *testing.T, pool *pgxpool.Pool, projectID, payload, dedupSuffix string) {
+	t.Helper()
+	ctx := context.Background()
+	var eventID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO outbound_events (project_id, event_type, dedup_key, payload)
+		 VALUES ($1,'digest.daily',$2,$3::jsonb) RETURNING id`,
+		projectID, "digest.daily:"+projectID+":"+dedupSuffix, payload).Scan(&eventID); err != nil {
+		t.Fatalf("seed prior digest payload: %v", err)
+	}
+	destID := seedDestination(t, pool, projectID, []string{"digest.daily"})
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO outbound_deliveries (event_id, destination_id, status) VALUES ($1,$2,'delivered')`,
+		eventID, destID); err != nil {
+		t.Fatalf("seed delivery: %v", err)
 	}
 }
 
@@ -78,8 +120,53 @@ func TestWindowForResumesFromPreviousDigest(t *testing.T) {
 		clearDigestEvents(t, pool, f.ProjectID)
 		seedPriorDigest(t, pool, f.ProjectID, now.Add(-60*24*time.Hour), "cap-case")
 		from, _ := s.windowFor(ctx, f.ProjectID, now)
-		if want := now.Add(-maxWindowLookback); !from.Equal(want) {
+		// A literal, not maxWindowLookback: asserting against the same constant
+		// the code reads would keep this green if the cap were redefined.
+		if want := now.Add(-7 * 24 * time.Hour); !from.Equal(want) {
 			t.Fatalf("from = %s; want the cap %s", from, want)
+		}
+	})
+
+	t.Run("uses a watermark just inside the cap verbatim", func(t *testing.T) {
+		clearDigestEvents(t, pool, f.ProjectID)
+		previousEnd := now.Add(-7*24*time.Hour + time.Hour)
+		seedPriorDigest(t, pool, f.ProjectID, previousEnd, "just-inside-cap")
+		from, _ := s.windowFor(ctx, f.ProjectID, now)
+		if !from.Equal(previousEnd) {
+			t.Fatalf("from = %s; want the stored watermark %s untruncated", from, previousEnd)
+		}
+	})
+
+	t.Run("ignores a digest that recorded no window end", func(t *testing.T) {
+		clearDigestEvents(t, pool, f.ProjectID)
+		// payload->'digest'->>'to' is SQL NULL here. Reachable from any row
+		// written before the window field existed. The guard must not deref it.
+		seedPriorDigestPayload(t, pool, f.ProjectID, `{"digest":{}}`, "no-window-case")
+		from, to := s.windowFor(ctx, f.ProjectID, now)
+		if !from.Equal(now.Add(-24*time.Hour)) || !to.Equal(now) {
+			t.Fatalf("window = %s..%s; want the trailing 24h fallback", from, to)
+		}
+	})
+
+	t.Run("an undelivered digest does not move the watermark", func(t *testing.T) {
+		clearDigestEvents(t, pool, f.ProjectID)
+		// Slack was down and the deliveries exhausted their retries. Nobody read
+		// this digest, so resuming after it would bury every issue it covered.
+		seedUndeliveredDigest(t, pool, f.ProjectID, now.Add(-2*time.Hour), "undelivered-case")
+		from, _ := s.windowFor(ctx, f.ProjectID, now)
+		if !from.Equal(now.Add(-24 * time.Hour)) {
+			t.Fatalf("from = %s; an undelivered digest must not be treated as reported", from)
+		}
+	})
+
+	t.Run("prefers the newest delivered digest over a newer undelivered one", func(t *testing.T) {
+		clearDigestEvents(t, pool, f.ProjectID)
+		delivered := now.Add(-30 * time.Hour)
+		seedPriorDigest(t, pool, f.ProjectID, delivered, "delivered-older")
+		seedUndeliveredDigest(t, pool, f.ProjectID, now.Add(-2*time.Hour), "undelivered-newer")
+		from, _ := s.windowFor(ctx, f.ProjectID, now)
+		if !from.Equal(delivered) {
+			t.Fatalf("from = %s; want the last delivered watermark %s", from, delivered)
 		}
 	})
 

--- a/packages/ingestion/digest/publishable_test.go
+++ b/packages/ingestion/digest/publishable_test.go
@@ -1,0 +1,57 @@
+package digest
+
+import (
+	"testing"
+
+	"github.com/opslane/opslane/packages/ingestion/notify"
+)
+
+// publishable is the Go belt beneath the SQL projection, and its whole purpose
+// is to disagree with the SQL if the two ever drift. Driving it through Build
+// cannot test that: the SQL filters the same rows out first, so every arm here
+// would stay green with the belt deleted. These call it directly.
+func TestPublishableRequiresAnArtifactPerState(t *testing.T) {
+	const prURL = "https://github.example/pr/1"
+	tests := []struct {
+		name      string
+		item      notify.ReceiptItem
+		validated bool
+		want      bool
+	}{
+		{"open PR with a URL publishes", notify.ReceiptItem{ReceiptState: "pr_open", PRURL: prURL}, false, true},
+		{"open PR without a URL is held back", notify.ReceiptItem{ReceiptState: "pr_open"}, true, false},
+		{"draft PR with a URL publishes", notify.ReceiptItem{ReceiptState: "pr_draft", PRURL: prURL}, false, true},
+		{"draft PR without a URL is held back", notify.ReceiptItem{ReceiptState: "pr_draft"}, true, false},
+		{"failed attempt publishes on a saved diff", notify.ReceiptItem{ReceiptState: "attempt_failed_with_diff", HasSavedDiff: true}, false, true},
+		{"failed attempt without a diff is held back", notify.ReceiptItem{ReceiptState: "attempt_failed_with_diff"}, true, false},
+		{"failed attempt with no diff needs a diagnosis", notify.ReceiptItem{ReceiptState: "attempt_failed_no_diff"}, true, true},
+		{"failed attempt with no diff and no diagnosis is held back", notify.ReceiptItem{ReceiptState: "attempt_failed_no_diff"}, false, false},
+		{"report needs a diagnosis", notify.ReceiptItem{ReceiptState: "report_ready"}, true, true},
+		{"report without a diagnosis is held back", notify.ReceiptItem{ReceiptState: "report_ready"}, false, false},
+		{"approval needs a diagnosis", notify.ReceiptItem{ReceiptState: "awaiting_approval"}, true, true},
+		{"approval without a diagnosis is held back", notify.ReceiptItem{ReceiptState: "awaiting_approval"}, false, false},
+		{"an unknown state never publishes", notify.ReceiptItem{ReceiptState: "future_state", PRURL: prURL, HasSavedDiff: true}, true, false},
+		{"placeholder prose is held back whatever the state", notify.ReceiptItem{ReceiptState: "pr_open", PRURL: prURL, RootCauseExcerpt: "TBD"}, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := publishable(tt.item, tt.validated); got != tt.want {
+				t.Errorf("publishable(%q, validated=%v) = %v, want %v",
+					tt.item.ReceiptState, tt.validated, got, tt.want)
+			}
+		})
+	}
+}
+
+// Every state receiptState can return must render a sentence, or the card is
+// silently dropped at slack_digest.go with only a warning.
+func TestEveryReceiptStateIsRenderable(t *testing.T) {
+	for _, status := range []string{"pr_created", "pr_draft", "awaiting_approval", "needs_human", "investigated", "insight"} {
+		for _, savedDiff := range []bool{false, true} {
+			state := receiptState(status, savedDiff)
+			if state == "" {
+				t.Errorf("status %q (savedDiff=%v) produced an empty receipt state", status, savedDiff)
+			}
+		}
+	}
+}

--- a/packages/ingestion/digest/window_build_test.go
+++ b/packages/ingestion/digest/window_build_test.go
@@ -1,0 +1,69 @@
+package digest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The window fix is only worth anything if Build uses it. Every other window
+// test calls windowFor directly, so replacing the call in Build with a fixed
+// trailing 24h would leave them all green while the reported gap came back.
+// This drives the whole path: a prior delivered digest, an item that falls in
+// the recovered gap, and the published payload.
+func TestBuildCoversTheGapLeftByALateRun(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	f := seedDigestFixture(t, pool, now)
+
+	// The previous digest stopped 30h ago, so 30h..24h ago belongs to no
+	// digest under a trailing 24h and is exactly what must be recovered.
+	previousEnd := now.Add(-30 * time.Hour)
+	clearDigestEvents(t, pool, f.ProjectID)
+	seedPriorDigest(t, pool, f.ProjectID, previousEnd, "build-gap-case")
+
+	// Ready 28h ago: inside the recovered gap, outside a trailing 24h. Last
+	// seen recently so the liveness bound cannot be what admits or drops it.
+	var groupID string
+	if err := pool.QueryRow(ctx, `INSERT INTO error_groups
+		(project_id,environment_id,fingerprint,title,kind,status,first_seen,last_seen,
+		 occurrence_count,affected_users_count,pr_created_at,pr_url)
+		VALUES ($1,$2,$3,'Recovered from the gap','error','pr_created',$4,$5,3,2,$6,$7)
+		RETURNING id`, f.ProjectID, f.EnvID, "gap-"+uuid.NewString(),
+		now.Add(-40*time.Hour), now.Add(-time.Hour), now.Add(-28*time.Hour),
+		"https://github.example/pr/gap").Scan(&groupID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO digest_readiness
+		(incident_id,project_id,status,reason,updated_at)
+		VALUES ($1,$2,'eligible','fix_pr_opened',$3)`,
+		groupID, f.ProjectID, now.Add(-28*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := New(pool, "https://dash.example").Build(ctx, f.ProjectID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	from, err := time.Parse(time.RFC3339Nano, payload.Digest.Window.From)
+	if err != nil {
+		t.Fatalf("published window.from %q: %v", payload.Digest.Window.From, err)
+	}
+	if !from.UTC().Equal(previousEnd) {
+		t.Errorf("published window.from = %s; want the previous watermark %s", from.UTC(), previousEnd)
+	}
+
+	var found bool
+	for _, item := range payload.Digest.ReceiptItems {
+		if item.IncidentID == groupID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("an item ready 28h ago was not reported; the gap a late run leaves is still open")
+	}
+}

--- a/packages/ingestion/grouping/fingerprint.go
+++ b/packages/ingestion/grouping/fingerprint.go
@@ -17,7 +17,7 @@ var (
 	reQuoted     = regexp.MustCompile(`"[^"]*"`)
 	reSpaces     = regexp.MustCompile(`\s+`)
 	reURL        = regexp.MustCompile(`https?://[^/\s]+`)
-	reAssetToken = regexp.MustCompile(`([A-Za-z0-9_.]+)-([A-Za-z0-9_]+)\.(js|mjs|cjs|css|map)(\?[^\s:'")]*)?(:\d+:\d+)?`)
+	reAssetToken = regexp.MustCompile(`([A-Za-z0-9_.]+)[-.]([A-Za-z0-9_]+)\.(js|mjs|cjs|css|map)(\?[^\s:'")]*)?(:\d+:\d+)?`)
 	// reDebugQuery strips a query string left dangling on a substituted token.
 	// The token delimits the match, so this cannot eat the trailing :line:col.
 	reDebugQuery = regexp.MustCompile(`(<debug:[^>]*>)\?[^\s:)]*`)

--- a/packages/ingestion/grouping/fingerprint.go
+++ b/packages/ingestion/grouping/fingerprint.go
@@ -10,13 +10,25 @@ import (
 
 // Pre-compiled regexps for message normalization.
 var (
-	reHex        = regexp.MustCompile(`0x[0-9a-fA-F]+`)
-	reUUID       = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
-	rePathNum    = regexp.MustCompile(`/\d+`)
-	reNum        = regexp.MustCompile(`\b\d+\b`)
-	reQuoted     = regexp.MustCompile(`"[^"]*"`)
-	reSpaces     = regexp.MustCompile(`\s+`)
-	reURL        = regexp.MustCompile(`https?://[^/\s]+`)
+	reHex     = regexp.MustCompile(`0x[0-9a-fA-F]+`)
+	reUUID    = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+	rePathNum = regexp.MustCompile(`/\d+`)
+	reNum     = regexp.MustCompile(`\b\d+\b`)
+	reQuoted  = regexp.MustCompile(`"[^"]*"`)
+	reSpaces  = regexp.MustCompile(`\s+`)
+	reURL     = regexp.MustCompile(`https?://[^/\s]+`)
+	// The separator class covers both bundle spellings: webpack's
+	// index-<hash>.js and Vite's entry-index.<hash>.js. Both normalize to the
+	// dash form, so the same bundle keeps one identity across either.
+	//
+	// KNOWN LIMITATION. looksLikeHash below is the only thing separating a
+	// content hash from an ordinary name, and it cannot: app.polyfills_es2015.js
+	// and app.polyfills_es2018.js both offer an 8+ character token with a digit,
+	// so they collapse into one issue. The same already happens for the dash
+	// spelling (app-feature1.js), so widening did not introduce the class, only
+	// its reach. A filename cannot answer this question; resolving the frame to
+	// its original source can. Until then, prefer widening only when a real
+	// customer bundle needs it.
 	reAssetToken = regexp.MustCompile(`([A-Za-z0-9_.]+)[-.]([A-Za-z0-9_]+)\.(js|mjs|cjs|css|map)(\?[^\s:'")]*)?(:\d+:\d+)?`)
 	// reDebugQuery strips a query string left dangling on a substituted token.
 	// The token delimits the match, so this cannot eat the trailing :line:col.

--- a/packages/ingestion/grouping/fingerprint_test.go
+++ b/packages/ingestion/grouping/fingerprint_test.go
@@ -54,6 +54,24 @@ func TestFingerprint_CollapsesContentHash(t *testing.T) {
 	}
 }
 
+func TestFingerprintCollapsesDotSeparatedHashes(t *testing.T) {
+	stack1 := "at handler (entry-index.CaWHNXv4.js:17:78242)"
+	stack2 := "at handler (entry-index.DXhxKZv7.js:17:78242)"
+	a := Fingerprint("javascript", "TypeError", "boom", stack1)
+	b := Fingerprint("javascript", "TypeError", "boom", stack2)
+	if a != b {
+		t.Errorf("dot-separated hashes must collapse: %s != %s", a, b)
+	}
+}
+
+func TestFingerprintKeepsLibraryNames(t *testing.T) {
+	a := Fingerprint("javascript", "TypeError", "boom", "at f (vue.runtime.esm.js:1:1)")
+	b := Fingerprint("javascript", "TypeError", "boom", "at f (vue.runtime.prod.js:1:1)")
+	if a == b {
+		t.Error("distinct library files must not collapse")
+	}
+}
+
 func TestFingerprint_StripsHost(t *testing.T) {
 	a := Fingerprint("javascript", "Error", "Unable to preload CSS for https://app.example.com/assets/main-AbC12345.css", "")
 	b := Fingerprint("javascript", "Error", "Unable to preload CSS for /assets/main-Zx9Yq077.css", "")

--- a/packages/ingestion/identity/canonical.go
+++ b/packages/ingestion/identity/canonical.go
@@ -1,0 +1,58 @@
+package identity
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
+
+const IdentityVersion = 2
+
+// ResolverVersion is the envelope contract version. It must equal
+// RESOLVER_VERSION in packages/worker/src/resolve/envelope.ts.
+const ResolverVersion = 2
+
+const maxIdentityFrames = 5
+
+type GeneratedPos struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+type Frame struct {
+	OriginalFile     string       `json:"original_file"`
+	OriginalFunction string       `json:"original_function"`
+	OriginalLine     int          `json:"original_line"`
+	Generated        GeneratedPos `json:"generated"`
+}
+
+type Envelope struct {
+	Version int     `json:"version"`
+	Frames  []Frame `json:"frames"`
+}
+
+// CanonicalString serializes an envelope into the identity key input.
+// Anonymous functions include their original line so unrelated callbacks in
+// the same file do not merge.
+func CanonicalString(env Envelope) string {
+	frames := env.Frames
+	if len(frames) > maxIdentityFrames {
+		frames = frames[:maxIdentityFrames]
+	}
+	parts := make([]string, 0, len(frames)+1)
+	parts = append(parts, fmt.Sprintf("v%d", env.Version))
+	for _, frame := range frames {
+		file := strings.ReplaceAll(frame.OriginalFile, "\\", "/")
+		if frame.OriginalFunction == "" || frame.OriginalFunction == "<anonymous>" {
+			parts = append(parts, fmt.Sprintf("%s#L%d", file, frame.OriginalLine))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s#%s", file, frame.OriginalFunction))
+	}
+	return strings.Join(parts, "|")
+}
+
+func Hash(env Envelope) string {
+	sum := sha256.Sum256([]byte(CanonicalString(env)))
+	return fmt.Sprintf("%x", sum[:16])
+}

--- a/packages/ingestion/identity/canonical_test.go
+++ b/packages/ingestion/identity/canonical_test.go
@@ -1,0 +1,30 @@
+package identity
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestCanonicalStringMatchesFixture(t *testing.T) {
+	raw, err := os.ReadFile("../../../test-fixtures/grouping/resolved-envelope-v2.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var fixture struct {
+		Version           int     `json:"version"`
+		Frames            []Frame `json:"frames"`
+		ExpectedCanonical string  `json:"expected_canonical"`
+		ExpectedHash      string  `json:"expected_hash"`
+	}
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	envelope := Envelope{Version: fixture.Version, Frames: fixture.Frames}
+	if got := CanonicalString(envelope); got != fixture.ExpectedCanonical {
+		t.Errorf("CanonicalString =\n  %q\nwant\n  %q", got, fixture.ExpectedCanonical)
+	}
+	if got := Hash(envelope); got != fixture.ExpectedHash {
+		t.Errorf("Hash = %q, want %q", got, fixture.ExpectedHash)
+	}
+}

--- a/packages/ingestion/identity/canonical_test.go
+++ b/packages/ingestion/identity/canonical_test.go
@@ -20,6 +20,15 @@ func TestCanonicalStringMatchesFixture(t *testing.T) {
 	if err := json.Unmarshal(raw, &fixture); err != nil {
 		t.Fatalf("parse fixture: %v", err)
 	}
+	// Pin the constants to the fixture: regenerating the fixture for a new
+	// resolver version without bumping ResolverVersion (or vice versa) must
+	// fail here, or the two runtimes drift silently.
+	if fixture.Version != ResolverVersion {
+		t.Fatalf("fixture version %d != ResolverVersion %d", fixture.Version, ResolverVersion)
+	}
+	if IdentityVersion != ResolverVersion {
+		t.Fatalf("IdentityVersion %d != ResolverVersion %d; the v2 contract keeps them aligned", IdentityVersion, ResolverVersion)
+	}
 	envelope := Envelope{Version: fixture.Version, Frames: fixture.Frames}
 	if got := CanonicalString(envelope); got != fixture.ExpectedCanonical {
 		t.Errorf("CanonicalString =\n  %q\nwant\n  %q", got, fixture.ExpectedCanonical)

--- a/packages/ingestion/narrative/narrative.go
+++ b/packages/ingestion/narrative/narrative.go
@@ -92,12 +92,16 @@ func ReceiptLine(state string) (string, bool) {
 	switch state {
 	case "pr_open":
 		return "Fix PR ready for review.", true
+	case "pr_draft":
+		return "A draft fix PR needs your review.", true
+	case "awaiting_approval":
+		return "A fix is written and needs your approval.", true
 	case "attempt_failed_with_diff":
 		return "Fix attempt failed its checks; saved diff and report on the issue page.", true
 	case "attempt_failed_no_diff":
 		return "Fix attempt failed before producing a change; investigation report on the issue page.", true
 	case "report_ready":
-		return "Investigation report ready.", true
+		return "We could not establish a cause. Details in the issue.", true
 	default:
 		return "", false
 	}

--- a/packages/ingestion/narrative/narrative.go
+++ b/packages/ingestion/narrative/narrative.go
@@ -67,9 +67,16 @@ func (impact Impact) Valid() bool {
 }
 
 // PageReceiptLine returns the incident page's location-free receipt sentence.
-// "pr_open_draft" is a page-line key, not a receipt state: the API's
-// receipt_state stays 'pr_open' (the frozen vocabulary), but a draft PR's
-// page line must not claim ready-for-review next to the draft warning card.
+// "pr_open_draft" is a page-line key, not a receipt state: the incident API's
+// receipt_state stays 'pr_open', matching the four-value union pinned in
+// shared/src/types.ts, but a draft PR's page line must not claim
+// ready-for-review next to the draft warning card.
+//
+// This vocabulary is NOT the digest's. ReceiptLine below renders six states,
+// including pr_draft and awaiting_approval, which this function never sees
+// because read_api maps both back into the four-value set. The two surfaces
+// therefore word the same incident differently on purpose. Adding a state to
+// one does not add it to the other, and nothing in the compiler will say so.
 func PageReceiptLine(state string) (string, bool) {
 	switch state {
 	case "pr_open":
@@ -89,12 +96,19 @@ func PageReceiptLine(state string) (string, bool) {
 
 // ReceiptLine returns the fixed sentence for a known receipt state.
 //
-// hasCause reports whether the same card also states an investigation cause.
-// Only report_ready reads it, and it must: the digest admits a report_ready
-// item only when its diagnosis was validated (digest.publishable), so an
-// unconditional "we could not establish a cause" lands precisely on the items
-// that did establish one, directly above the cause itself.
-func ReceiptLine(state string, hasCause bool) (string, bool) {
+// hasValidatedDiagnosis is the same fact digest.publishable admits a
+// report_ready item on, carried on the item rather than re-derived here. Only
+// report_ready reads it, and it must: the digest admits a report_ready item
+// only when its diagnosis was validated, so an unconditional "we could not
+// establish a cause" lands precisely on the items that did establish one.
+//
+// Do not infer this from the rendered cause excerpt. A validated diagnosis
+// whose group carries no root_cause sanitizes to an empty excerpt, and the
+// card would then deny a cause the item was admitted for having.
+//
+// The page equivalent is PageReceiptLine above. The two deliberately differ in
+// vocabulary and wording; see the note there before changing either.
+func ReceiptLine(state string, hasValidatedDiagnosis bool) (string, bool) {
 	switch state {
 	case "pr_open":
 		return "Fix PR ready for review.", true
@@ -107,7 +121,7 @@ func ReceiptLine(state string, hasCause bool) (string, bool) {
 	case "attempt_failed_no_diff":
 		return "Fix attempt failed before producing a change; investigation report on the issue page.", true
 	case "report_ready":
-		if hasCause {
+		if hasValidatedDiagnosis {
 			return "Cause found; no fix opened yet. Details in the issue.", true
 		}
 		return "We could not establish a cause. Details in the issue.", true

--- a/packages/ingestion/narrative/narrative.go
+++ b/packages/ingestion/narrative/narrative.go
@@ -88,7 +88,13 @@ func PageReceiptLine(state string) (string, bool) {
 }
 
 // ReceiptLine returns the fixed sentence for a known receipt state.
-func ReceiptLine(state string) (string, bool) {
+//
+// hasCause reports whether the same card also states an investigation cause.
+// Only report_ready reads it, and it must: the digest admits a report_ready
+// item only when its diagnosis was validated (digest.publishable), so an
+// unconditional "we could not establish a cause" lands precisely on the items
+// that did establish one, directly above the cause itself.
+func ReceiptLine(state string, hasCause bool) (string, bool) {
 	switch state {
 	case "pr_open":
 		return "Fix PR ready for review.", true
@@ -101,6 +107,9 @@ func ReceiptLine(state string) (string, bool) {
 	case "attempt_failed_no_diff":
 		return "Fix attempt failed before producing a change; investigation report on the issue page.", true
 	case "report_ready":
+		if hasCause {
+			return "Cause found; no fix opened yet. Details in the issue.", true
+		}
 		return "We could not establish a cause. Details in the issue.", true
 	default:
 		return "", false

--- a/packages/ingestion/narrative/narrative_test.go
+++ b/packages/ingestion/narrative/narrative_test.go
@@ -73,9 +73,11 @@ func TestPageReceiptLine(t *testing.T) {
 func TestReceiptLine(t *testing.T) {
 	wants := map[string]string{
 		"pr_open":                  "Fix PR ready for review.",
+		"pr_draft":                 "A draft fix PR needs your review.",
+		"awaiting_approval":        "A fix is written and needs your approval.",
 		"attempt_failed_with_diff": "Fix attempt failed its checks; saved diff and report on the issue page.",
 		"attempt_failed_no_diff":   "Fix attempt failed before producing a change; investigation report on the issue page.",
-		"report_ready":             "Investigation report ready.",
+		"report_ready":             "We could not establish a cause. Details in the issue.",
 	}
 	for state, want := range wants {
 		got, ok := narrative.ReceiptLine(state)

--- a/packages/ingestion/narrative/narrative_test.go
+++ b/packages/ingestion/narrative/narrative_test.go
@@ -98,11 +98,12 @@ func TestReceiptLineDoesNotDenyAnEstablishedCause(t *testing.T) {
 	if !ok {
 		t.Fatal("report_ready with a cause must render")
 	}
+	const want = "Cause found; no fix opened yet. Details in the issue."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
 	if strings.Contains(strings.ToLower(got), "could not establish") {
 		t.Errorf("card states a cause and denies one in the same breath: %q", got)
-	}
-	if got == "" {
-		t.Error("empty receipt line")
 	}
 }
 

--- a/packages/ingestion/narrative/narrative_test.go
+++ b/packages/ingestion/narrative/narrative_test.go
@@ -80,13 +80,29 @@ func TestReceiptLine(t *testing.T) {
 		"report_ready":             "We could not establish a cause. Details in the issue.",
 	}
 	for state, want := range wants {
-		got, ok := narrative.ReceiptLine(state)
+		got, ok := narrative.ReceiptLine(state, false)
 		if !ok || got != want || strings.Contains(got, "://") {
 			t.Errorf("%s: got %q, %v", state, got, ok)
 		}
 	}
-	if _, ok := narrative.ReceiptLine("future"); ok {
+	if _, ok := narrative.ReceiptLine("future", false); ok {
 		t.Fatal("unknown receipt state accepted")
+	}
+}
+
+// A report_ready card that states a cause must not also deny one. The digest
+// publishes report_ready only when the diagnosis was validated, so this is the
+// branch every published card of that state actually takes.
+func TestReceiptLineDoesNotDenyAnEstablishedCause(t *testing.T) {
+	got, ok := narrative.ReceiptLine("report_ready", true)
+	if !ok {
+		t.Fatal("report_ready with a cause must render")
+	}
+	if strings.Contains(strings.ToLower(got), "could not establish") {
+		t.Errorf("card states a cause and denies one in the same breath: %q", got)
+	}
+	if got == "" {
+		t.Error("empty receipt line")
 	}
 }
 

--- a/packages/ingestion/notify/event.go
+++ b/packages/ingestion/notify/event.go
@@ -84,20 +84,26 @@ type DigestTriageCounts struct {
 
 // ReceiptItem is one digest card. Kind is error, friction, or cluster.
 type ReceiptItem struct {
-	Kind               string   `json:"kind"`
-	IncidentID         string   `json:"incident_id"`
-	Title              string   `json:"title"`
-	OccurrenceCount    int64    `json:"occurrence_count"`
-	ImpactClass        string   `json:"impact_class,omitempty"`
-	ImpactVisits       *int64   `json:"impact_visits,omitempty"`
-	ImpactRecovered    *int64   `json:"impact_visits_recovered,omitempty"`
-	ReceiptState       string   `json:"receipt_state"`
-	PRURL              string   `json:"pr_url,omitempty"`
-	SessionURL         string   `json:"session_url,omitempty"`
-	RootCauseExcerpt   string   `json:"root_cause_excerpt,omitempty"`
-	MitigationExcerpt  string   `json:"mitigation_excerpt,omitempty"`
-	HasSavedDiff       bool     `json:"has_saved_diff,omitempty"`
-	ClusterIncidentIDs []string `json:"cluster_incident_ids,omitempty"`
+	Kind              string `json:"kind"`
+	IncidentID        string `json:"incident_id"`
+	Title             string `json:"title"`
+	OccurrenceCount   int64  `json:"occurrence_count"`
+	ImpactClass       string `json:"impact_class,omitempty"`
+	ImpactVisits      *int64 `json:"impact_visits,omitempty"`
+	ImpactRecovered   *int64 `json:"impact_visits_recovered,omitempty"`
+	ReceiptState      string `json:"receipt_state"`
+	PRURL             string `json:"pr_url,omitempty"`
+	SessionURL        string `json:"session_url,omitempty"`
+	RootCauseExcerpt  string `json:"root_cause_excerpt,omitempty"`
+	MitigationExcerpt string `json:"mitigation_excerpt,omitempty"`
+	HasSavedDiff      bool   `json:"has_saved_diff,omitempty"`
+	// HasValidatedDiagnosis is the same fact digest.publishable admits the item
+	// on. Copy shows it directly rather than inferring it from
+	// RootCauseExcerpt: a validated diagnosis whose group carries no root_cause
+	// sanitizes to an empty excerpt, and the card would then deny a cause the
+	// item was admitted for having.
+	HasValidatedDiagnosis bool     `json:"has_validated_diagnosis,omitempty"`
+	ClusterIncidentIDs    []string `json:"cluster_incident_ids,omitempty"`
 }
 
 type DigestWindow struct {

--- a/packages/ingestion/notify/slack_digest.go
+++ b/packages/ingestion/notify/slack_digest.go
@@ -154,8 +154,12 @@ func digestReceiptCardBlocks(payload EventPayload, item ReceiptItem, receiptLine
 	}
 
 	links := make([]string, 0, 3)
-	if item.ReceiptState == "pr_open" && item.PRURL != "" {
-		links = append(links, slackDigestLink(item.PRURL, "Review fix PR"))
+	if (item.ReceiptState == "pr_open" || item.ReceiptState == "pr_draft") && item.PRURL != "" {
+		label := "Review fix PR"
+		if item.ReceiptState == "pr_draft" {
+			label = "Review draft PR"
+		}
+		links = append(links, slackDigestLink(item.PRURL, label))
 	}
 	if item.SessionURL != "" {
 		links = append(links, slackDigestLink(item.SessionURL, "Watch recording"))

--- a/packages/ingestion/notify/slack_digest.go
+++ b/packages/ingestion/notify/slack_digest.go
@@ -106,7 +106,7 @@ func formatSlackDigestV2(payload EventPayload) ([]byte, string, error) {
 			slog.Warn("digest receipt kind is not renderable", "incident_id", item.IncidentID, "kind", item.Kind)
 			continue
 		}
-		line, ok := narrative.ReceiptLine(item.ReceiptState)
+		line, ok := narrative.ReceiptLine(item.ReceiptState, item.RootCauseExcerpt != "")
 		if !ok {
 			slog.Warn("digest receipt state is not renderable", "incident_id", item.IncidentID, "state", item.ReceiptState)
 			continue

--- a/packages/ingestion/notify/slack_digest.go
+++ b/packages/ingestion/notify/slack_digest.go
@@ -106,7 +106,7 @@ func formatSlackDigestV2(payload EventPayload) ([]byte, string, error) {
 			slog.Warn("digest receipt kind is not renderable", "incident_id", item.IncidentID, "kind", item.Kind)
 			continue
 		}
-		line, ok := narrative.ReceiptLine(item.ReceiptState, item.RootCauseExcerpt != "")
+		line, ok := narrative.ReceiptLine(item.ReceiptState, item.HasValidatedDiagnosis)
 		if !ok {
 			slog.Warn("digest receipt state is not renderable", "incident_id", item.IncidentID, "state", item.ReceiptState)
 			continue

--- a/packages/ingestion/notify/slack_digest_test.go
+++ b/packages/ingestion/notify/slack_digest_test.go
@@ -210,6 +210,9 @@ func TestFormatSlackDigestV2Golden(t *testing.T) {
 					ImpactClass: "blocked", ImpactVisits: &visits, ImpactRecovered: &recovered,
 					ReceiptState: "pr_open", PRURL: "https://github.example/pr/1",
 					SessionURL: "https://dash.example/sessions/s1", RootCauseExcerpt: "Cart was nil."},
+				{Kind: "error", IncidentID: "draft", Title: "Draft fix", ReceiptState: "pr_draft",
+					PRURL: "https://github.example/pr/draft"},
+				{Kind: "friction", IncidentID: "approval", Title: "Approval needed", ReceiptState: "awaiting_approval"},
 				{Kind: "error", IncidentID: "diff", Title: "Saved diff", ReceiptState: "attempt_failed_with_diff"},
 				{Kind: "error", IncidentID: "no-diff", Title: "No diff", ReceiptState: "attempt_failed_no_diff"},
 				{Kind: "friction", IncidentID: "report", Title: "Checkout friction", OccurrenceCount: 2,
@@ -228,9 +231,11 @@ func TestFormatSlackDigestV2Golden(t *testing.T) {
 		"12 crashes across 3 visits, no visit recovered",
 		"2 friction signals; recording impact unavailable",
 		"Fix PR ready for review.",
+		"A draft fix PR needs your review.",
+		"A fix is written and needs your approval.",
 		"Fix attempt failed its checks; saved diff and report on the issue page.",
 		"Fix attempt failed before producing a change; investigation report on the issue page.",
-		"Investigation report ready.", "Review fix PR", "Watch recording", "Issue page", "Investigation: Cart was nil.",
+		"We could not establish a cause. Details in the issue.", "Review fix PR", "https://github.example/pr/draft", "Watch recording", "Issue page", "Investigation: Cart was nil.",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("v2 digest missing %q: %s", want, s)

--- a/packages/ingestion/notify/slack_digest_test.go
+++ b/packages/ingestion/notify/slack_digest_test.go
@@ -217,6 +217,8 @@ func TestFormatSlackDigestV2Golden(t *testing.T) {
 				{Kind: "error", IncidentID: "no-diff", Title: "No diff", ReceiptState: "attempt_failed_no_diff"},
 				{Kind: "friction", IncidentID: "report", Title: "Checkout friction", OccurrenceCount: 2,
 					ReceiptState: "report_ready"},
+				{Kind: "error", IncidentID: "caused", Title: "Cause established", OccurrenceCount: 3,
+					ReceiptState: "report_ready", HasValidatedDiagnosis: true},
 			},
 			Watching: DigestWatching{Sessions: 20, Users: 7},
 		},
@@ -235,7 +237,11 @@ func TestFormatSlackDigestV2Golden(t *testing.T) {
 		"A fix is written and needs your approval.",
 		"Fix attempt failed its checks; saved diff and report on the issue page.",
 		"Fix attempt failed before producing a change; investigation report on the issue page.",
-		"We could not establish a cause. Details in the issue.", "Review fix PR", "https://github.example/pr/draft", "Watch recording", "Issue page", "Investigation: Cart was nil.",
+		"We could not establish a cause. Details in the issue.",
+		"Cause found; no fix opened yet. Details in the issue.",
+		"Review fix PR", "Review draft PR",
+		"<https://github.example/pr/draft|Review draft PR>",
+		"Watch recording", "Issue page", "Investigation: Cart was nil.",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("v2 digest missing %q: %s", want, s)

--- a/packages/worker/src/__tests__/resolve-envelope.test.ts
+++ b/packages/worker/src/__tests__/resolve-envelope.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { buildEnvelope } from '../resolve/envelope.js';
+
+interface EnvelopeFixture {
+  frames: Parameters<typeof buildEnvelope>[0];
+}
+
+describe('resolved envelope v2', () => {
+  it('produces exactly the shape Go expects', () => {
+    const fixture = JSON.parse(
+      readFileSync('../../test-fixtures/grouping/resolved-envelope-v2.json', 'utf8'),
+    ) as EnvelopeFixture;
+
+    const built = buildEnvelope(fixture.frames);
+
+    expect(built.version).toBe(2);
+    expect(built.frames).toEqual(fixture.frames);
+    expect(Object.keys(built.frames[0]!)).toEqual([
+      'original_file',
+      'original_function',
+      'original_line',
+      'generated',
+    ]);
+  });
+});

--- a/packages/worker/src/__tests__/resolve-envelope.test.ts
+++ b/packages/worker/src/__tests__/resolve-envelope.test.ts
@@ -1,20 +1,31 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { buildEnvelope } from '../resolve/envelope.js';
+import { buildEnvelope, RESOLVER_VERSION } from '../resolve/envelope.js';
 
 interface EnvelopeFixture {
+  version: number;
   frames: Parameters<typeof buildEnvelope>[0];
 }
 
-describe('resolved envelope v2', () => {
-  it('produces exactly the shape Go expects', () => {
-    const fixture = JSON.parse(
-      readFileSync('../../test-fixtures/grouping/resolved-envelope-v2.json', 'utf8'),
-    ) as EnvelopeFixture;
+const fixture = JSON.parse(
+  readFileSync(
+    new URL('../../../../test-fixtures/grouping/resolved-envelope-v2.json', import.meta.url),
+    'utf8',
+  ),
+) as EnvelopeFixture;
 
+describe('resolved envelope v2', () => {
+  it('pins RESOLVER_VERSION to the fixture contract', () => {
+    // Bumping RESOLVER_VERSION without regenerating the fixture (or vice
+    // versa) must fail here, or Go and TypeScript drift silently.
+    expect(RESOLVER_VERSION).toBe(fixture.version);
+    expect(RESOLVER_VERSION).toBe(2);
+  });
+
+  it('produces exactly the shape Go expects', () => {
     const built = buildEnvelope(fixture.frames);
 
-    expect(built.version).toBe(2);
+    expect(built.version).toBe(fixture.version);
     expect(built.frames).toEqual(fixture.frames);
     expect(Object.keys(built.frames[0]!)).toEqual([
       'original_file',
@@ -22,5 +33,21 @@ describe('resolved envelope v2', () => {
       'original_line',
       'generated',
     ]);
+  });
+
+  it('normalizes what the fixture cannot show: backslashes and empty functions', () => {
+    // The fixture's frames are already normalized, so the equality test above
+    // would pass for an identity function. These inputs would not.
+    const built = buildEnvelope([
+      {
+        original_file: 'src\\shared\\http\\client.ts',
+        original_function: '',
+        original_line: 61,
+        generated: { line: 17, column: 9120 },
+      },
+    ]);
+
+    expect(built.frames[0]!.original_file).toBe('src/shared/http/client.ts');
+    expect(built.frames[0]!.original_function).toBe('<anonymous>');
   });
 });

--- a/packages/worker/src/resolve/envelope.ts
+++ b/packages/worker/src/resolve/envelope.ts
@@ -1,3 +1,8 @@
+// The v2 resolved-frame envelope: the cross-language identity contract.
+// Go (packages/ingestion/identity) alone canonicalizes and hashes envelopes;
+// this module is the only writer shape. Nothing persists v2 envelopes yet —
+// the v1 reader in resolve-stack.ts (framesFromEnvelope) cannot parse this
+// shape and is rewired when stack resolution moves to its own job (Slice 3).
 export const RESOLVER_VERSION = 2;
 
 export interface GeneratedPos {
@@ -5,7 +10,9 @@ export interface GeneratedPos {
   column: number;
 }
 
-export interface ResolvedFrame {
+// Named V2 to avoid colliding with the v1 ResolvedFrame in source-map.ts,
+// which uses camelCase fields and carries source snippets.
+export interface ResolvedFrameV2 {
   original_file: string;
   original_function: string;
   original_line: number;
@@ -14,10 +21,10 @@ export interface ResolvedFrame {
 
 export interface EnvelopeV2 {
   version: 2;
-  frames: ResolvedFrame[];
+  frames: ResolvedFrameV2[];
 }
 
-export function buildEnvelope(frames: ResolvedFrame[]): EnvelopeV2 {
+export function buildEnvelope(frames: ResolvedFrameV2[]): EnvelopeV2 {
   return {
     version: RESOLVER_VERSION,
     frames: frames.map((frame) => ({

--- a/packages/worker/src/resolve/envelope.ts
+++ b/packages/worker/src/resolve/envelope.ts
@@ -1,0 +1,33 @@
+export const RESOLVER_VERSION = 2;
+
+export interface GeneratedPos {
+  line: number;
+  column: number;
+}
+
+export interface ResolvedFrame {
+  original_file: string;
+  original_function: string;
+  original_line: number;
+  generated: GeneratedPos;
+}
+
+export interface EnvelopeV2 {
+  version: 2;
+  frames: ResolvedFrame[];
+}
+
+export function buildEnvelope(frames: ResolvedFrame[]): EnvelopeV2 {
+  return {
+    version: RESOLVER_VERSION,
+    frames: frames.map((frame) => ({
+      original_file: frame.original_file.replace(/\\/g, '/'),
+      original_function: frame.original_function || '<anonymous>',
+      original_line: frame.original_line,
+      generated: {
+        line: frame.generated.line,
+        column: frame.generated.column,
+      },
+    })),
+  };
+}

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -33,6 +33,9 @@ export interface ReceiptItem {
   root_cause_excerpt?: string;
   mitigation_excerpt?: string;
   has_saved_diff?: boolean;
+  /** Whether the item's diagnosis was validated. Digest copy reads this
+   *  directly rather than inferring a cause from root_cause_excerpt. */
+  has_validated_diagnosis?: boolean;
   cluster_incident_ids?: string[];
 }
 

--- a/test-e2e/digest-contract.test.ts
+++ b/test-e2e/digest-contract.test.ts
@@ -241,7 +241,13 @@ describe('daily digest contract (Slack webhook delivery)', () => {
       'No fix PRs awaiting review, 1 issue needs a decision.',
     );
     expect(firstHits[0]!.body).toContain('Rage clicks in digest contract');
-    expect(firstHits[0]!.body).toContain('Investigation report ready.');
+    // The seeded issue carries a validated diagnosis, which is the only reason
+    // it is in the digest at all, so the card must say a cause was found. The
+    // old copy here was 'Investigation report ready.', which said nothing
+    // actionable; the copy it was briefly replaced with denied the cause the
+    // very next line goes on to state.
+    expect(firstHits[0]!.body).toContain('Cause found; no fix opened yet. Details in the issue.');
+    expect(firstHits[0]!.body).not.toContain('We could not establish a cause');
     expect(firstHits[0]!.body).not.toContain('older issues still awaiting your review');
 
     const patchResponse = await fetch(destinationsUrl(`/${destination.id}`), {

--- a/test-fixtures/grouping/resolved-envelope-v2.json
+++ b/test-fixtures/grouping/resolved-envelope-v2.json
@@ -1,0 +1,25 @@
+{
+  "version": 2,
+  "frames": [
+    {
+      "original_file": "src/modules/assets/AssetDetails.vue",
+      "original_function": "deleteAsset",
+      "original_line": 142,
+      "generated": { "line": 17, "column": 78242 }
+    },
+    {
+      "original_file": "node_modules/vue/dist/runtime-core.esm-bundler.js",
+      "original_function": "callWithErrorHandling",
+      "original_line": 158,
+      "generated": { "line": 17, "column": 41003 }
+    },
+    {
+      "original_file": "src/shared/http/client.ts",
+      "original_function": "<anonymous>",
+      "original_line": 61,
+      "generated": { "line": 17, "column": 9120 }
+    }
+  ],
+  "expected_canonical": "v2|src/modules/assets/AssetDetails.vue#deleteAsset|node_modules/vue/dist/runtime-core.esm-bundler.js#callWithErrorHandling|src/shared/http/client.ts#L61",
+  "expected_hash": "b829f635d173a2031fb42486d87034e3"
+}


### PR DESCRIPTION
## What this contains

This branch carries two slices of the pipeline rewrite plan
(`docs/superpowers/specs/2026-08-16-pipeline-implementation-plan.md`):

**Slice 0 (first six commits): digest repairs.** Liveness-window filtering,
watermark-on-delivery, approval-state wording, and the digest e2e contract
pins. Independent of the rewrite; deployable on its own.

**Slice 1 (last two commits): inert storage and the shared identity contract.**

- Migration `054_pipeline_quality.sql`: the twelve pipeline tables (capture
  buckets, event resolutions, sourcemap position cache, event identities,
  canonical fingerprints, episodes, cheap-filter and inquiry decisions,
  evidence anchors, publication receipts, digest runs/items), route_map
  structured-understanding columns, and episode/run/input-version scoping on
  the existing `error_group_jobs` queue. Uniqueness invariants (one open
  round per issue, one job per round and version, one receipt per round and
  channel, one run per project and local date) are enforced by the schema.
- Cross-language identity contract: TypeScript builds the v2 resolved-frame
  envelope (`packages/worker/src/resolve/envelope.ts`), Go alone
  canonicalizes and hashes it (`packages/ingestion/identity`), and one golden
  fixture outside `test-fixtures/wire/` pins both, including version pins so
  either side regenerating alone fails tests.
- `docs/contracts/events.md` documents `group_id`/`error_group_id` as
  provisional capture handles; the HTTP shape is unchanged.

**No runtime path reads or writes the new tables.** A live event through the
built stack leaves all twelve empty with zero scan-counter movement. Per the
plan, Slices 1-10 accumulate on this branch and deploy together at Slice 11;
Slice 0 alone is independently deployable.

## Review and verification

A medium code review found and I fixed, among smaller items: a scope CHECK
that would have aborted the migration on any real database (error_group_id
has been nullable since baseline; route_map/session/setup jobs carry no
group), and migration 044's exact-string idempotency guard re-narrowing the
widened outcome constraint on every boot replay. The 044 guard now accepts
both definitions; a full-chain replay with a `verified_fix` row present
converges cleanly.

Local gate: `pnpm install --frozen-lockfile`, `pnpm -r build`, `pnpm test`
(with `DATABASE_URL`), `go build ./... && go test ./...` (zero skips, storage
env set), `docker compose config --quiet`. One known local-only failure: the
SDK WebKit browser-matrix test needs GTK4/GStreamer system libraries this
host cannot install; the branch touches no SDK file and the test is
identical on main — CI is the authority for it.

Slice 1 was also verified black-box against 27 approved acceptance criteria
(migrations applied via the deploy path on disposable databases, invariants
driven by real inserts, fixture parity cross-checked with an independent
sha256, inertness proven on the live stack); all 27 pass.