### PR TITLE
Pipeline rewrite Slice 5: session facts and evidence lookup

### DIFF
--- a/packages/ingestion/db/migrations/054_pipeline_quality.sql
+++ b/packages/ingestion/db/migrations/054_pipeline_quality.sql
@@ -202,6 +202,39 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_one_active_write_job_per_run
 ALTER TABLE diagnosis_decisions
   ADD COLUMN IF NOT EXISTS episode_id UUID REFERENCES issue_episodes(id) ON DELETE SET NULL;
 
+-- Compact facts derived from scrubbed recordings. Failures stay exact enough
+-- to investigate; successful writes are rolled up. Query strings, hosts,
+-- bodies, input values, and DOM text do not belong in either table. Retention
+-- deletes the owning session and cascades these facts with it.
+CREATE TABLE IF NOT EXISTS session_request_failures (
+  project_id       UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  session_id       TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  request_id_hash  TEXT NOT NULL,
+  page_route       TEXT NOT NULL,
+  method           TEXT NOT NULL,
+  endpoint_pattern TEXT NOT NULL,
+  status           INTEGER NOT NULL,
+  action_kind      TEXT CHECK (action_kind IS NULL OR action_kind IN ('click','form_submit')),
+  action_selector  TEXT,
+  action_link      TEXT NOT NULL CHECK (action_link IN ('direct','none')),
+  occurred_at      TIMESTAMPTZ NOT NULL,
+  rule_version     INTEGER NOT NULL,
+  PRIMARY KEY (project_id, session_id, request_id_hash, rule_version)
+);
+
+CREATE TABLE IF NOT EXISTS session_write_rollups (
+  project_id       UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  session_id       TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  page_route       TEXT NOT NULL,
+  method           TEXT NOT NULL,
+  endpoint_pattern TEXT NOT NULL,
+  status_class     INTEGER NOT NULL,
+  occurrence_count INTEGER NOT NULL,
+  rule_version     INTEGER NOT NULL,
+  PRIMARY KEY (project_id, session_id, page_route, method,
+               endpoint_pattern, status_class, rule_version)
+);
+
 -- outcome predates this migration. Preserve legacy values for existing rows and
 -- old binaries while admitting the rewritten pipeline's terminal outcomes.
 DO $$ BEGIN
@@ -219,4 +252,3 @@ DO $$ BEGIN
                          'verified_fix','needs_human','unable_to_establish_cause'));
   END IF;
 END $$;
-

--- a/packages/ingestion/db/migrations_test.go
+++ b/packages/ingestion/db/migrations_test.go
@@ -231,6 +231,7 @@ func TestMigration054CreatesPipelineTables(t *testing.T) {
 		"error_event_identities", "canonical_issue_fingerprints", "issue_episodes",
 		"issue_decisions", "issue_inquiry_decisions", "issue_evidence_anchors",
 		"issue_publications", "digest_runs", "digest_run_items",
+		"session_request_failures", "session_write_rollups",
 	}
 	for _, table := range want {
 		var exists bool

--- a/packages/worker/src/__tests__/evidence-bundle.test.ts
+++ b/packages/worker/src/__tests__/evidence-bundle.test.ts
@@ -1,0 +1,254 @@
+import pg from 'pg';
+import { afterAll, describe, expect, it } from 'vitest';
+import { closePool } from '../db.js';
+import { loadEvidence } from '../evidence/bundle.js';
+import { replaceSessionFacts } from '../facts/persist.js';
+
+const DATABASE_URL = process.env['DATABASE_URL'];
+const describeDb = DATABASE_URL ? describe : describe.skip;
+
+describeDb('evidence bundle', () => {
+  const pool = new pg.Pool({ connectionString: DATABASE_URL });
+  const orgIds: string[] = [];
+
+  async function seedProject(): Promise<{ projectId: string; environmentId: string }> {
+    const orgId = (await pool.query<{ id: string }>(
+      `INSERT INTO orgs (name) VALUES ($1) RETURNING id`,
+      [`evidence-${crypto.randomUUID()}`],
+    )).rows[0]!.id;
+    orgIds.push(orgId);
+    const projectId = (await pool.query<{ id: string }>(
+      `INSERT INTO projects (org_id, name, github_repo) VALUES ($1, 'evidence', '') RETURNING id`,
+      [orgId],
+    )).rows[0]!.id;
+    const environmentId = (await pool.query<{ id: string }>(
+      `INSERT INTO environments (project_id, name) VALUES ($1, 'production') RETURNING id`,
+      [projectId],
+    )).rows[0]!.id;
+    return { projectId, environmentId };
+  }
+
+  async function seedIssue(projectId: string): Promise<{ issueId: string; episodeId: string }> {
+    const issueId = (await pool.query<{ id: string }>(
+      `INSERT INTO error_groups
+         (project_id, fingerprint, title, first_seen, last_seen, status, page_url_normalized)
+       VALUES ($1,$2,'Asset deletion failed',now(),now(),'candidate','/assets/:id/edit')
+       RETURNING id`,
+      [projectId, `fingerprint-${crypto.randomUUID()}`],
+    )).rows[0]!.id;
+    const episodeId = (await pool.query<{ id: string }>(
+      `INSERT INTO issue_episodes (project_id, canonical_issue_id, sequence)
+       VALUES ($1,$2,1) RETURNING id`,
+      [projectId, issueId],
+    )).rows[0]!.id;
+    return { issueId, episodeId };
+  }
+
+  async function seedEvent(args: {
+    projectId: string;
+    environmentId: string;
+    issueId: string;
+    episodeId: string;
+    sessionId: string | null;
+    endUserId?: string | null;
+    anchorKind?: 'threshold' | 'first' | 'recent';
+  }): Promise<string> {
+    const eventId = (await pool.query<{ id: string }>(
+      `INSERT INTO error_events
+         (project_id, environment_id, error_group_id, timestamp, error_type,
+          error_message, stack_trace_raw, context, session_id, end_user_id, commit_sha)
+       VALUES ($1,$2,$3,now(),'TypeError','delete failed','at deleteAsset (app.js:1:2)',
+               '{"url":"https://app.example.com/assets/42/edit"}'::jsonb,$4,$5,$6)
+       RETURNING id`,
+      [args.projectId, args.environmentId, args.issueId, args.sessionId,
+        args.endUserId ?? null, 'a'.repeat(40)],
+    )).rows[0]!.id;
+    await pool.query(
+      `INSERT INTO error_event_identities
+         (project_id,event_id,status,canonical_issue_id,raw_fingerprint,
+          identity_version,episode_id,settled_at)
+       VALUES ($1,$2,'settled',$3,'raw',2,$4,now())`,
+      [args.projectId, eventId, args.issueId, args.episodeId],
+    );
+    if (args.anchorKind) {
+      await pool.query(
+        `INSERT INTO issue_evidence_anchors (project_id,episode_id,anchor_kind,event_id)
+         VALUES ($1,$2,$3,$4)`,
+        [args.projectId, args.episodeId, args.anchorKind, eventId],
+      );
+    }
+    return eventId;
+  }
+
+  async function seedSession(projectId: string, environmentId: string): Promise<string> {
+    const sessionId = `evidence-${crypto.randomUUID()}`;
+    await pool.query(
+      `INSERT INTO sessions
+         (id,project_id,environment_id,started_at,last_chunk_at,chunk_count,status)
+       VALUES ($1,$2,$3,now(),now(),1,'analyzed')`,
+      [sessionId, projectId, environmentId],
+    );
+    await pool.query(
+      `INSERT INTO session_analysis
+         (session_id,project_id,environment_id,session_started_at,coverage,
+          activity_class,rule_version)
+       VALUES ($1,$2,$3,now(),'complete','active',4)`,
+      [sessionId, projectId, environmentId],
+    );
+    return sessionId;
+  }
+
+  afterAll(async () => {
+    for (const orgId of orgIds) {
+      const projects = await pool.query<{ id: string }>(`SELECT id FROM projects WHERE org_id=$1`, [orgId]);
+      for (const { id } of projects.rows) {
+        await pool.query(`DELETE FROM sessions WHERE project_id=$1`, [id]);
+        await pool.query(`DELETE FROM error_events WHERE project_id=$1`, [id]);
+        await pool.query(`DELETE FROM error_groups WHERE project_id=$1`, [id]);
+        await pool.query(`DELETE FROM environments WHERE project_id=$1`, [id]);
+        await pool.query(`DELETE FROM projects WHERE id=$1`, [id]);
+      }
+      await pool.query(`DELETE FROM orgs WHERE id=$1`, [orgId]);
+    }
+    await pool.end();
+    await closePool();
+  });
+
+  it('reads frozen anchors and never follows sample_event_id', async () => {
+    const { projectId, environmentId } = await seedProject();
+    const { issueId, episodeId } = await seedIssue(projectId);
+    const anchorSessionId = await seedSession(projectId, environmentId);
+    const anchorEventId = await seedEvent({
+      projectId, environmentId, issueId, episodeId, sessionId: anchorSessionId,
+      anchorKind: 'threshold',
+    });
+    await pool.query(
+      `INSERT INTO error_event_resolutions
+         (project_id,event_id,status,envelope,resolver_version)
+       VALUES ($1,$2,'resolved',$3::jsonb,2)`,
+      [projectId, anchorEventId, JSON.stringify({
+        version: 2,
+        frames: [{
+          original_file: 'src/assets/delete.ts', original_function: 'deleteAsset',
+          original_line: 42, generated: { line: 1, column: 2 },
+        }],
+      })],
+    );
+    await replaceSessionFacts(projectId, anchorSessionId, {
+      entryPath: '/assets/:id/edit', clickCount: 1, inputEventCount: 0, pageEventCount: 1,
+      failedRequest4xxCount: 1, failedRequest5xxCount: 0,
+      unattributedFailedRequestCount: 0, successfulWriteCount: 0, failedWriteCount: 1,
+      firstEventMs: null, lastEventMs: null, ruleVersion: 4,
+      failures: [{
+        requestIdHash: 'anchor-request', pageRoute: '/assets/:id/edit', method: 'DELETE',
+        endpointPattern: '/api/assets/:id', status: 400, actionKind: 'click',
+        actionSelector: '[data-testid="delete"]', actionLink: 'direct',
+        occurredAt: '2026-08-18T00:00:00.000Z',
+      }],
+      successes: [{
+        pageRoute: '/assets/:id/edit', method: 'POST', endpointPattern: '/api/audit',
+        statusClass: 2, count: 3,
+      }],
+    });
+    await pool.query(
+      `INSERT INTO route_map
+         (project_id,pattern,name,purpose,tier,source,actions,client_refs,
+          server_refs,audience,confidence,commit_sha,prompt_version,model)
+       VALUES ($1,'/assets/:id/edit','Asset editor','Edits an asset','standard','model',
+               ARRAY['delete asset'],ARRAY['src/assets/edit.ts'],ARRAY['api/assets.ts'],
+               'standard',0.9,$2,1,'test-model')`,
+      [projectId, 'a'.repeat(40)],
+    );
+    const relatedIssueId = (await pool.query<{ id: string }>(
+      `INSERT INTO error_groups
+         (project_id,fingerprint,title,first_seen,last_seen,status,page_url_normalized)
+       VALUES ($1,$2,'Related asset failure',now(),now(),'candidate','/assets/:id/edit')
+       RETURNING id`,
+      [projectId, `related-${crypto.randomUUID()}`],
+    )).rows[0]!.id;
+    const movingSessionId = await seedSession(projectId, environmentId);
+    const movingEventId = await seedEvent({
+      projectId, environmentId, issueId, episodeId, sessionId: movingSessionId,
+    });
+    await pool.query(`UPDATE error_groups SET sample_event_id=$1 WHERE id=$2`, [movingEventId, issueId]);
+
+    const bundle = await loadEvidence(projectId, episodeId);
+
+    expect(bundle.frames.sourceEventId).toBe(anchorEventId);
+    expect(bundle.frames.envelope?.frames[0]?.original_file).toBe('src/assets/delete.ts');
+    expect(bundle.failedRequests).toHaveLength(1);
+    expect(bundle.failedRequests[0]?.sessionId).toBe(anchorSessionId);
+    expect(bundle.writeRollups[0]).toMatchObject({
+      sessionId: anchorSessionId, endpointPattern: '/api/audit', occurrenceCount: 3,
+    });
+    expect(bundle.productContext[0]).toMatchObject({
+      route: '/assets/:id/edit', purpose: 'Edits an asset', clientRefs: ['src/assets/edit.ts'],
+    });
+    expect(bundle.affectedUnits).toBe(2);
+    expect(bundle.relatedCandidates.map((candidate) => candidate.issueId)).toContain(relatedIssueId);
+    expect(bundle.replayPointers.map((pointer) => pointer.eventId)).toEqual([anchorEventId]);
+    expect(JSON.stringify(bundle)).not.toContain(movingEventId);
+  });
+
+  it('degrades to stated availability when the recording expired', async () => {
+    const { projectId, environmentId } = await seedProject();
+    const { issueId, episodeId } = await seedIssue(projectId);
+    const eventId = await seedEvent({
+      projectId, environmentId, issueId, episodeId,
+      sessionId: `expired-${crypto.randomUUID()}`, anchorKind: 'threshold',
+    });
+    await pool.query(
+      `INSERT INTO error_event_resolutions
+         (project_id,event_id,status,envelope,resolver_version)
+       VALUES ($1,$2,'no_map',NULL,2)`,
+      [projectId, eventId],
+    );
+
+    const bundle = await loadEvidence(projectId, episodeId);
+
+    expect(bundle.availability.recording).toBe('expired');
+    expect(bundle.availability.sourceMap).toBe('no_map');
+    expect(bundle.failedRequests).toEqual([]);
+    expect(bundle.replayPointers).toEqual([]);
+  });
+
+  it('does not revive facts from an older analyzer rule', async () => {
+    const { projectId, environmentId } = await seedProject();
+    const { issueId, episodeId } = await seedIssue(projectId);
+    const sessionId = await seedSession(projectId, environmentId);
+    await seedEvent({
+      projectId, environmentId, issueId, episodeId, sessionId, anchorKind: 'threshold',
+    });
+    await replaceSessionFacts(projectId, sessionId, {
+      entryPath: '/assets', clickCount: 0, inputEventCount: 0, pageEventCount: 1,
+      failedRequest4xxCount: 1, failedRequest5xxCount: 0,
+      unattributedFailedRequestCount: 0, successfulWriteCount: 0, failedWriteCount: 1,
+      firstEventMs: null, lastEventMs: null, ruleVersion: 3,
+      failures: [{
+        requestIdHash: 'old-rule', pageRoute: '/assets', method: 'POST',
+        endpointPattern: '/api/assets', status: 400, actionKind: null,
+        actionSelector: null, actionLink: 'none', occurredAt: '2026-08-18T00:00:00.000Z',
+      }],
+      successes: [],
+    });
+
+    const bundle = await loadEvidence(projectId, episodeId);
+
+    expect(bundle.failedRequests).toEqual([]);
+  });
+
+  it('states when an anchored observation never had a recording', async () => {
+    const { projectId, environmentId } = await seedProject();
+    const { issueId, episodeId } = await seedIssue(projectId);
+    await seedEvent({
+      projectId, environmentId, issueId, episodeId,
+      sessionId: null, anchorKind: 'threshold',
+    });
+
+    const bundle = await loadEvidence(projectId, episodeId);
+
+    expect(bundle.availability.recording).toBe('missing');
+    expect(bundle.availability.sourceMap).toBe('missing');
+    expect(bundle.replayPointers).toEqual([]);
+  });
+});

--- a/packages/worker/src/__tests__/facts-persist.test.ts
+++ b/packages/worker/src/__tests__/facts-persist.test.ts
@@ -53,7 +53,9 @@ describeDb('session fact persistence', () => {
     return sessionId;
   }
 
-  function factsWith(overrides: Partial<SessionFacts> = {}): SessionFacts & { ruleVersion: number } {
+  function factsWith(
+    overrides: Partial<SessionFacts & { ruleVersion: number }> = {},
+  ): SessionFacts & { ruleVersion: number } {
     return {
       entryPath: '/assets', clickCount: 0, inputEventCount: 0, pageEventCount: 1,
       failedRequest4xxCount: 0, failedRequest5xxCount: 0,
@@ -114,21 +116,41 @@ describeDb('session fact persistence', () => {
     expect(stored.rows.map((row) => row.request_id_hash)).toEqual(['new-1', 'new-2']);
   });
 
-  it('never stores an endpoint host or query string', async () => {
+  it('rejects an endpoint carrying a host or query string instead of re-normalizing it', async () => {
+    // Persist trusts the extractor's normalization: re-normalizing here is not
+    // idempotent for every input and can collapse two distinct extractor keys
+    // onto one primary key. Un-normalized input is a caller bug and must fail
+    // loudly, and nothing may be written for the session.
     const sessionId = await seedSession();
-    await replaceSessionFacts(projectId, sessionId, factsWith({
+    await expect(replaceSessionFacts(projectId, sessionId, factsWith({
       failures: [{
         ...failure('secret'),
         endpointPattern: 'https://app.example.com/api/assets/42?token=secret',
       }],
+    }))).rejects.toThrow(/normalized path/);
+
+    const stored = await pool.query(
+      `SELECT 1 FROM session_request_failures WHERE project_id=$1 AND session_id=$2`,
+      [projectId, sessionId],
+    );
+    expect(stored.rowCount).toBe(0);
+  });
+
+  it('replaces rows left by an older rule version', async () => {
+    const sessionId = await seedSession();
+    await replaceSessionFacts(projectId, sessionId, factsWith({
+      failures: [failure('old-rules')], ruleVersion: 4,
+    }));
+    await replaceSessionFacts(projectId, sessionId, factsWith({
+      failures: [failure('new-rules')], ruleVersion: 5,
     }));
 
-    const stored = await pool.query<{ endpoint_pattern: string }>(
-      `SELECT endpoint_pattern FROM session_request_failures
+    const stored = await pool.query<{ request_id_hash: string; rule_version: number }>(
+      `SELECT request_id_hash, rule_version FROM session_request_failures
        WHERE project_id=$1 AND session_id=$2`,
       [projectId, sessionId],
     );
-    expect(stored.rows[0]?.endpoint_pattern).toBe('/api/assets/:id');
+    expect(stored.rows).toEqual([{ request_id_hash: 'new-rules', rule_version: 5 }]);
   });
 
   it('expires facts with the session', async () => {

--- a/packages/worker/src/__tests__/facts-persist.test.ts
+++ b/packages/worker/src/__tests__/facts-persist.test.ts
@@ -1,0 +1,145 @@
+import pg from 'pg';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { closePool } from '../db.js';
+import { replaceSessionFacts } from '../facts/persist.js';
+import type { SessionFacts } from '../friction/facts.js';
+
+const DATABASE_URL = process.env['DATABASE_URL'];
+const describeDb = DATABASE_URL ? describe : describe.skip;
+
+describeDb('session fact persistence', () => {
+  const pool = new pg.Pool({ connectionString: DATABASE_URL });
+  const sessionIds: string[] = [];
+  let orgId: string;
+  let projectId: string;
+  let environmentId: string;
+
+  beforeAll(async () => {
+    orgId = (await pool.query<{ id: string }>(
+      `INSERT INTO orgs (name) VALUES ($1) RETURNING id`,
+      [`facts-persist-${crypto.randomUUID()}`],
+    )).rows[0]!.id;
+    projectId = (await pool.query<{ id: string }>(
+      `INSERT INTO projects (org_id, name, github_repo) VALUES ($1, 'facts', '') RETURNING id`,
+      [orgId],
+    )).rows[0]!.id;
+    environmentId = (await pool.query<{ id: string }>(
+      `INSERT INTO environments (project_id, name) VALUES ($1, 'production') RETURNING id`,
+      [projectId],
+    )).rows[0]!.id;
+  });
+
+  afterEach(async () => {
+    await pool.query(`DELETE FROM sessions WHERE id = ANY($1::text[])`, [sessionIds]);
+    sessionIds.length = 0;
+  });
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM environments WHERE id = $1`, [environmentId]);
+    await pool.query(`DELETE FROM projects WHERE id = $1`, [projectId]);
+    await pool.query(`DELETE FROM orgs WHERE id = $1`, [orgId]);
+    await pool.end();
+    await closePool();
+  });
+
+  async function seedSession(): Promise<string> {
+    const sessionId = `facts-${crypto.randomUUID()}`;
+    sessionIds.push(sessionId);
+    await pool.query(
+      `INSERT INTO sessions (id, project_id, environment_id, started_at, status)
+       VALUES ($1,$2,$3,now(),'analyzed')`,
+      [sessionId, projectId, environmentId],
+    );
+    return sessionId;
+  }
+
+  function factsWith(overrides: Partial<SessionFacts> = {}): SessionFacts & { ruleVersion: number } {
+    return {
+      entryPath: '/assets', clickCount: 0, inputEventCount: 0, pageEventCount: 1,
+      failedRequest4xxCount: 0, failedRequest5xxCount: 0,
+      unattributedFailedRequestCount: 0, successfulWriteCount: 0, failedWriteCount: 0,
+      firstEventMs: null, lastEventMs: null, failures: [], successes: [],
+      ruleVersion: 4,
+      ...overrides,
+    };
+  }
+
+  const failure = (requestIdHash: string) => ({
+    requestIdHash,
+    pageRoute: '/assets/:id/edit',
+    method: 'PUT',
+    endpointPattern: '/api/assets/:id',
+    status: 400,
+    actionKind: 'click' as const,
+    actionSelector: '[data-testid="save"]',
+    actionLink: 'direct' as const,
+    occurredAt: '2026-08-18T00:00:00.000Z',
+  });
+
+  it('stores one row per failed request and rolls up successful writes', async () => {
+    const sessionId = await seedSession();
+    await replaceSessionFacts(projectId, sessionId, factsWith({
+      failures: [failure('failure-1'), failure('failure-2')],
+      successes: [{
+        pageRoute: '/assets/new', method: 'POST', endpointPattern: '/api/assets',
+        statusClass: 2, count: 5,
+      }],
+    }));
+
+    const failures = await pool.query(
+      `SELECT * FROM session_request_failures WHERE project_id=$1 AND session_id=$2`,
+      [projectId, sessionId],
+    );
+    const rollups = await pool.query<{ occurrence_count: number }>(
+      `SELECT occurrence_count FROM session_write_rollups WHERE project_id=$1 AND session_id=$2`,
+      [projectId, sessionId],
+    );
+    expect(failures.rowCount).toBe(2);
+    expect(rollups.rowCount).toBe(1);
+    expect(rollups.rows[0]?.occurrence_count).toBe(5);
+  });
+
+  it('replaces the whole fact set when a late chunk arrives', async () => {
+    const sessionId = await seedSession();
+    await replaceSessionFacts(projectId, sessionId, factsWith({ failures: [failure('old')] }));
+    await replaceSessionFacts(projectId, sessionId, factsWith({
+      failures: [failure('new-1'), failure('new-2')],
+    }));
+
+    const stored = await pool.query<{ request_id_hash: string }>(
+      `SELECT request_id_hash FROM session_request_failures
+       WHERE project_id=$1 AND session_id=$2 ORDER BY request_id_hash`,
+      [projectId, sessionId],
+    );
+    expect(stored.rows.map((row) => row.request_id_hash)).toEqual(['new-1', 'new-2']);
+  });
+
+  it('never stores an endpoint host or query string', async () => {
+    const sessionId = await seedSession();
+    await replaceSessionFacts(projectId, sessionId, factsWith({
+      failures: [{
+        ...failure('secret'),
+        endpointPattern: 'https://app.example.com/api/assets/42?token=secret',
+      }],
+    }));
+
+    const stored = await pool.query<{ endpoint_pattern: string }>(
+      `SELECT endpoint_pattern FROM session_request_failures
+       WHERE project_id=$1 AND session_id=$2`,
+      [projectId, sessionId],
+    );
+    expect(stored.rows[0]?.endpoint_pattern).toBe('/api/assets/:id');
+  });
+
+  it('expires facts with the session', async () => {
+    const sessionId = await seedSession();
+    await replaceSessionFacts(projectId, sessionId, factsWith({ failures: [failure('expiring')] }));
+    await pool.query(`DELETE FROM sessions WHERE id=$1 AND project_id=$2`, [sessionId, projectId]);
+
+    const stored = await pool.query(
+      `SELECT 1 FROM session_request_failures WHERE project_id=$1 AND session_id=$2`,
+      [projectId, sessionId],
+    );
+    expect(stored.rowCount).toBe(0);
+  });
+});

--- a/packages/worker/src/__tests__/index.test.ts
+++ b/packages/worker/src/__tests__/index.test.ts
@@ -117,11 +117,12 @@ vi.mock('../friction/facts.js', () => ({
     entryPath: null, clickCount: 0, inputEventCount: 0, pageEventCount: 0,
     failedRequest4xxCount: 0, failedRequest5xxCount: 0,
     unattributedFailedRequestCount: 0, successfulWriteCount: 0, failedWriteCount: 0,
-    firstEventMs: null, lastEventMs: null,
+    firstEventMs: null, lastEventMs: null, failures: [], successes: [],
   })),
   deriveCoverage: vi.fn(() => 'no_replay'),
   classifyActivity: vi.fn(() => 'unknown'),
 }));
+vi.mock('../facts/persist.js', () => ({ replaceSessionFacts: vi.fn() }));
 vi.mock('../friction/persist.js', () => ({ writeFrictionSignals: vi.fn() }));
 vi.mock('../friction/promotion.js', () => ({ processFrictionOutcomes: vi.fn() }));
 vi.mock('../friction/adjudicator.js', () => ({
@@ -141,6 +142,7 @@ const { gatherFrictionEvidence } = await import('../friction/friction-evidence.j
 const { investigateFriction } = await import('../friction/investigate-friction.js');
 const { readChunksBounded } = await import('../friction/chunk-reader.js');
 const { analyzeSession } = await import('../friction/analyzer.js');
+const { replaceSessionFacts } = await import('../facts/persist.js');
 const { writeFrictionSignals } = await import('../friction/persist.js');
 const { processFrictionOutcomes } = await import('../friction/promotion.js');
 const { processRouteMapJob } = await import('../route-map.js');
@@ -1191,6 +1193,12 @@ describe('session_analysis handler', () => {
     expect(db.upsertSessionAnalysis).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: 'session-1', coverage: 'no_replay', activityClass: 'unknown', ruleVersion: 2,
     }));
+    expect(replaceSessionFacts).toHaveBeenCalledWith('proj-1', 'session-1', expect.objectContaining({
+      ruleVersion: 2, failures: [], successes: [],
+    }));
+    expect(vi.mocked(replaceSessionFacts).mock.invocationCallOrder[0]!).toBeLessThan(
+      vi.mocked(db.upsertSessionAnalysis).mock.invocationCallOrder[0]!,
+    );
     expect(writeFrictionSignals).toHaveBeenCalledWith(session, [], 2);
     expect(db.setSessionAnalysisStatus).toHaveBeenLastCalledWith('session-1', 'proj-1', 'analyzed', 2, job);
     expect(db.updateGroupAndCreateFixJob).not.toHaveBeenCalled();

--- a/packages/worker/src/evidence/bundle.ts
+++ b/packages/worker/src/evidence/bundle.ts
@@ -274,9 +274,7 @@ export async function loadEvidence(projectId: string, episodeId: string): Promis
                 observed_requests, audience, confidence, commit_sha,
                 prompt_version, model, source
            FROM route_map
-          WHERE project_id=$1
-            AND COALESCE(NULLIF(regexp_replace(pattern, '^https?://[^/]*', '', 'i'), ''), '/')
-                =ANY($2::text[])
+          WHERE project_id=$1 AND pattern=ANY($2::text[])
           ORDER BY pattern`,
         [projectId, routes],
       );

--- a/packages/worker/src/evidence/bundle.ts
+++ b/packages/worker/src/evidence/bundle.ts
@@ -1,0 +1,376 @@
+import { getPool } from '../db.js';
+import type { EnvelopeV2 } from '../resolve/envelope.js';
+import { normalizePageUrl } from '../friction/urlnorm.js';
+
+const MAX_FRAMES = 20;
+const MAX_FAILED_REQUESTS = 100;
+const MAX_WRITE_ROLLUPS = 100;
+const MAX_RELATED_CANDIDATES = 10;
+
+type ResolutionStatus = 'resolved' | 'no_map' | 'failed' | 'pending' | 'missing';
+type RecordingAvailability = 'available' | 'partial' | 'expired' | 'missing';
+
+export interface ResolvedFrameEvidence {
+  sourceEventId: string;
+  status: ResolutionStatus;
+  resolverVersion: number | null;
+  envelope: EnvelopeV2 | null;
+  commitSha: string | null;
+}
+
+export interface FailedRequestEvidence {
+  sessionId: string;
+  requestIdHash: string;
+  pageRoute: string;
+  method: string;
+  endpointPattern: string;
+  status: number;
+  actionKind: 'click' | 'form_submit' | null;
+  actionSelector: string | null;
+  actionLink: 'direct' | 'none';
+  occurredAt: string;
+  ruleVersion: number;
+}
+
+export interface WriteRollupEvidence {
+  sessionId: string;
+  pageRoute: string;
+  method: string;
+  endpointPattern: string;
+  statusClass: number;
+  occurrenceCount: number;
+  ruleVersion: number;
+}
+
+export interface ProductContextEvidence {
+  route: string;
+  name: string;
+  purpose: string;
+  tier: string;
+  actions: string[];
+  clientRefs: string[];
+  serverRefs: string[];
+  observedRequests: string[];
+  audience: string;
+  confidence: number;
+  commitSha: string | null;
+  promptVersion: number | null;
+  model: string | null;
+  source: string;
+}
+
+export interface ReplayPointer {
+  anchorKind: 'threshold' | 'first' | 'recent';
+  eventId: string;
+  sessionId: string;
+  anchorMs: number;
+}
+
+export interface RelatedCandidate {
+  issueId: string;
+  title: string;
+  route: string;
+}
+
+export interface EvidenceBundle {
+  frames: ResolvedFrameEvidence;
+  failedRequests: FailedRequestEvidence[];
+  writeRollups: WriteRollupEvidence[];
+  productContext: ProductContextEvidence[];
+  replayPointers: ReplayPointer[];
+  availability: {
+    recording: RecordingAvailability;
+    sourceMap: ResolutionStatus;
+  };
+  affectedUnits: number;
+  relatedCandidates: RelatedCandidate[];
+}
+
+interface AnchorRow {
+  anchor_kind: ReplayPointer['anchorKind'];
+  event_id: string;
+  session_id: string | null;
+  event_at: Date | string;
+  commit_sha: string | null;
+  retained_session_id: string | null;
+  resolution_status: Exclude<ResolutionStatus, 'missing'> | null;
+  envelope: unknown;
+  resolver_version: number | null;
+  route_url: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function envelopeV2(value: unknown): EnvelopeV2 | null {
+  if (!isRecord(value) || value['version'] !== 2 || !Array.isArray(value['frames'])) return null;
+  const frames: EnvelopeV2['frames'] = [];
+  for (const raw of value['frames'].slice(0, MAX_FRAMES)) {
+    if (!isRecord(raw) || !isRecord(raw['generated'])) return null;
+    const originalFile = raw['original_file'];
+    const originalFunction = raw['original_function'];
+    const originalLine = raw['original_line'];
+    const generatedLine = raw['generated']['line'];
+    const generatedColumn = raw['generated']['column'];
+    if (
+      typeof originalFile !== 'string' || typeof originalFunction !== 'string'
+      || typeof originalLine !== 'number' || typeof generatedLine !== 'number'
+      || typeof generatedColumn !== 'number'
+    ) return null;
+    frames.push({
+      original_file: originalFile,
+      original_function: originalFunction,
+      original_line: originalLine,
+      generated: { line: generatedLine, column: generatedColumn },
+    });
+  }
+  return { version: 2, frames };
+}
+
+function iso(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function recordingAvailability(anchors: AnchorRow[]): RecordingAvailability {
+  const referenced = new Set(
+    anchors.map((anchor) => anchor.session_id).filter((id): id is string => id !== null),
+  );
+  if (referenced.size === 0) return 'missing';
+  const retained = new Set(
+    anchors.map((anchor) => anchor.retained_session_id).filter((id): id is string => id !== null),
+  );
+  if (retained.size === 0) return 'expired';
+  return retained.size === referenced.size ? 'available' : 'partial';
+}
+
+/**
+ * Assemble the durable, bounded evidence for one work round. Every source row
+ * is reached through issue_evidence_anchors; the mutable group sample is not
+ * part of this read path.
+ */
+export async function loadEvidence(projectId: string, episodeId: string): Promise<EvidenceBundle> {
+  const pool = getPool();
+  const anchorsResult = await pool.query<AnchorRow>(
+    `SELECT a.anchor_kind, a.event_id, e.session_id, e.timestamp AS event_at,
+            e.commit_sha,
+            CASE WHEN s.status <> 'deleting' THEN s.id END AS retained_session_id,
+            r.status AS resolution_status, r.envelope, r.resolver_version,
+            e.context->>'url' AS route_url
+       FROM issue_evidence_anchors a
+       JOIN error_events e
+         ON e.id=a.event_id AND e.project_id=a.project_id
+       LEFT JOIN sessions s
+         ON s.id=e.session_id AND s.project_id=a.project_id
+       LEFT JOIN error_event_resolutions r
+         ON r.event_id=a.event_id AND r.project_id=a.project_id
+      WHERE a.project_id=$1 AND a.episode_id=$2
+      ORDER BY CASE a.anchor_kind WHEN 'threshold' THEN 0 WHEN 'first' THEN 1 ELSE 2 END`,
+    [projectId, episodeId],
+  );
+  if (anchorsResult.rowCount === 0) {
+    throw new Error(`no frozen anchors for episode ${episodeId}`);
+  }
+  const anchors = anchorsResult.rows;
+  const threshold = anchors.find((anchor) => anchor.anchor_kind === 'threshold');
+  if (!threshold) throw new Error(`no threshold anchor for episode ${episodeId}`);
+
+  const retainedSessionIds = [...new Set(
+    anchors
+      .map((anchor) => anchor.retained_session_id)
+      .filter((id): id is string => id !== null),
+  )];
+
+  const failuresResult = retainedSessionIds.length === 0
+    ? { rows: [] as Array<{
+        session_id: string; request_id_hash: string; page_route: string; method: string;
+        endpoint_pattern: string; status: number; action_kind: FailedRequestEvidence['actionKind'];
+        action_selector: string | null; action_link: FailedRequestEvidence['actionLink'];
+        occurred_at: Date | string; rule_version: number;
+      }> }
+    : await pool.query<{
+        session_id: string; request_id_hash: string; page_route: string; method: string;
+        endpoint_pattern: string; status: number; action_kind: FailedRequestEvidence['actionKind'];
+        action_selector: string | null; action_link: FailedRequestEvidence['actionLink'];
+        occurred_at: Date | string; rule_version: number;
+      }>(
+        `SELECT f.session_id, f.request_id_hash, f.page_route, f.method,
+                f.endpoint_pattern, f.status, f.action_kind, f.action_selector,
+                f.action_link, f.occurred_at, f.rule_version
+           FROM session_request_failures f
+          WHERE f.project_id=$1 AND f.session_id=ANY($2::text[])
+            AND f.rule_version=(
+              SELECT analysis.rule_version FROM session_analysis analysis
+               WHERE analysis.project_id=f.project_id AND analysis.session_id=f.session_id)
+          ORDER BY f.occurred_at DESC, f.request_id_hash
+          LIMIT $3`,
+        [projectId, retainedSessionIds, MAX_FAILED_REQUESTS],
+      );
+
+  const rollupsResult = retainedSessionIds.length === 0
+    ? { rows: [] as Array<{
+        session_id: string; page_route: string; method: string; endpoint_pattern: string;
+        status_class: number; occurrence_count: number; rule_version: number;
+      }> }
+    : await pool.query<{
+        session_id: string; page_route: string; method: string; endpoint_pattern: string;
+        status_class: number; occurrence_count: number; rule_version: number;
+      }>(
+        `SELECT w.session_id, w.page_route, w.method, w.endpoint_pattern,
+                w.status_class, w.occurrence_count, w.rule_version
+           FROM session_write_rollups w
+          WHERE w.project_id=$1 AND w.session_id=ANY($2::text[])
+            AND w.rule_version=(
+              SELECT analysis.rule_version FROM session_analysis analysis
+               WHERE analysis.project_id=w.project_id AND analysis.session_id=w.session_id)
+          ORDER BY w.occurrence_count DESC, w.session_id, w.page_route, w.method
+          LIMIT $3`,
+        [projectId, retainedSessionIds, MAX_WRITE_ROLLUPS],
+      );
+
+  const failedRequests = failuresResult.rows.map((row): FailedRequestEvidence => ({
+    sessionId: row.session_id,
+    requestIdHash: row.request_id_hash,
+    pageRoute: row.page_route,
+    method: row.method,
+    endpointPattern: row.endpoint_pattern,
+    status: row.status,
+    actionKind: row.action_kind,
+    actionSelector: row.action_selector,
+    actionLink: row.action_link,
+    occurredAt: iso(row.occurred_at),
+    ruleVersion: row.rule_version,
+  }));
+  const writeRollups = rollupsResult.rows.map((row): WriteRollupEvidence => ({
+    sessionId: row.session_id,
+    pageRoute: row.page_route,
+    method: row.method,
+    endpointPattern: row.endpoint_pattern,
+    statusClass: row.status_class,
+    occurrenceCount: row.occurrence_count,
+    ruleVersion: row.rule_version,
+  }));
+
+  const routes = [...new Set([
+    ...anchors.map((anchor) => anchor.route_url ? normalizePageUrl(anchor.route_url) : ''),
+    ...failedRequests.map((failure) => failure.pageRoute),
+    ...writeRollups.map((rollup) => rollup.pageRoute),
+  ].filter((route) => route !== ''))];
+
+  const productContextResult = routes.length === 0
+    ? { rows: [] as Array<{
+        pattern: string; name: string; purpose: string; tier: string; actions: string[];
+        client_refs: string[]; server_refs: string[]; observed_requests: string[];
+        audience: string; confidence: number; commit_sha: string | null;
+        prompt_version: number | null; model: string | null; source: string;
+      }> }
+    : await pool.query<{
+        pattern: string; name: string; purpose: string; tier: string; actions: string[];
+        client_refs: string[]; server_refs: string[]; observed_requests: string[];
+        audience: string; confidence: number; commit_sha: string | null;
+        prompt_version: number | null; model: string | null; source: string;
+      }>(
+        `SELECT pattern, name, purpose, tier, actions, client_refs, server_refs,
+                observed_requests, audience, confidence, commit_sha,
+                prompt_version, model, source
+           FROM route_map
+          WHERE project_id=$1
+            AND COALESCE(NULLIF(regexp_replace(pattern, '^https?://[^/]*', '', 'i'), ''), '/')
+                =ANY($2::text[])
+          ORDER BY pattern`,
+        [projectId, routes],
+      );
+  const productContext = productContextResult.rows.map((row): ProductContextEvidence => ({
+    route: row.pattern,
+    name: row.name,
+    purpose: row.purpose,
+    tier: row.tier,
+    actions: row.actions,
+    clientRefs: row.client_refs,
+    serverRefs: row.server_refs,
+    observedRequests: row.observed_requests,
+    audience: row.audience,
+    confidence: row.confidence,
+    commitSha: row.commit_sha,
+    promptVersion: row.prompt_version,
+    model: row.model,
+    source: row.source,
+  }));
+
+  const affectedResult = await pool.query<{ affected_units: string | number }>(
+    `WITH episode_events AS (
+       SELECT e.end_user_id, e.session_id
+         FROM error_events e
+         JOIN error_event_identities i
+           ON i.event_id=e.id AND i.project_id=e.project_id
+        WHERE i.project_id=$1 AND i.episode_id=$2
+          AND e.created_at > now() - interval '7 days'
+     ), anonymous_sessions AS (
+       SELECT session_id FROM episode_events
+        WHERE session_id IS NOT NULL
+        GROUP BY session_id
+       HAVING bool_and(end_user_id IS NULL)
+     )
+     SELECT
+       (SELECT count(DISTINCT end_user_id) FROM episode_events WHERE end_user_id IS NOT NULL)
+       + (SELECT count(*) FROM anonymous_sessions) AS affected_units`,
+    [projectId, episodeId],
+  );
+  const affectedUnits = Number(affectedResult.rows[0]?.affected_units ?? 0);
+
+  const currentIssueResult = await pool.query<{ canonical_issue_id: string }>(
+    `SELECT canonical_issue_id FROM issue_episodes WHERE project_id=$1 AND id=$2`,
+    [projectId, episodeId],
+  );
+  const currentIssueId = currentIssueResult.rows[0]?.canonical_issue_id;
+  if (!currentIssueId) throw new Error(`episode ${episodeId} not found in project ${projectId}`);
+
+  const relatedResult = routes.length === 0
+    ? { rows: [] as Array<{ issue_id: string; title: string; route: string }> }
+    : await pool.query<{ issue_id: string; title: string; route: string }>(
+        `SELECT g.id AS issue_id, g.title,
+                COALESCE(NULLIF(regexp_replace(g.page_url_normalized, '^https?://[^/]*', '', 'i'), ''), '/') AS route
+           FROM error_groups g
+          WHERE g.project_id=$1 AND g.id<>$2
+            AND g.status NOT IN ('resolved','merged','archived')
+            AND COALESCE(NULLIF(regexp_replace(g.page_url_normalized, '^https?://[^/]*', '', 'i'), ''), '/')
+                =ANY($3::text[])
+          ORDER BY g.last_seen DESC, g.id
+          LIMIT $4`,
+        [projectId, currentIssueId, routes, MAX_RELATED_CANDIDATES],
+      );
+
+  const status = threshold.resolution_status ?? 'missing';
+  return {
+    frames: {
+      sourceEventId: threshold.event_id,
+      status,
+      resolverVersion: threshold.resolver_version,
+      envelope: envelopeV2(threshold.envelope),
+      commitSha: threshold.commit_sha,
+    },
+    failedRequests,
+    writeRollups,
+    productContext,
+    replayPointers: anchors
+      .filter((anchor): anchor is AnchorRow & { session_id: string; retained_session_id: string } => (
+        anchor.session_id !== null && anchor.retained_session_id !== null
+      ))
+      .map((anchor) => ({
+        anchorKind: anchor.anchor_kind,
+        eventId: anchor.event_id,
+        sessionId: anchor.session_id,
+        anchorMs: new Date(anchor.event_at).getTime(),
+      })),
+    availability: {
+      recording: recordingAvailability(anchors),
+      sourceMap: status,
+    },
+    affectedUnits,
+    relatedCandidates: relatedResult.rows.map((row) => ({
+      issueId: row.issue_id,
+      title: row.title,
+      route: row.route,
+    })),
+  };
+}

--- a/packages/worker/src/facts/persist.ts
+++ b/packages/worker/src/facts/persist.ts
@@ -1,0 +1,89 @@
+import { getPool } from '../db.js';
+import type { SessionFacts } from '../friction/facts.js';
+import { normalizePageUrl } from '../friction/urlnorm.js';
+
+export type VersionedSessionFacts = SessionFacts & { ruleVersion: number };
+
+/**
+ * One session's facts are whole-session truth at a rule version. A late chunk
+ * produces a replacement truth, so the old set is deleted and rewritten in a
+ * single transaction.
+ */
+export async function replaceSessionFacts(
+  projectId: string,
+  sessionId: string,
+  facts: VersionedSessionFacts,
+): Promise<void> {
+  const client = await getPool().connect();
+  try {
+    await client.query('BEGIN');
+    const session = await client.query(
+      `SELECT 1 FROM sessions WHERE project_id=$1 AND id=$2 FOR KEY SHARE`,
+      [projectId, sessionId],
+    );
+    if (session.rowCount === 0) {
+      throw new Error(`session ${sessionId} not found in project ${projectId}`);
+    }
+
+    await client.query(
+      `DELETE FROM session_request_failures
+       WHERE project_id=$1 AND session_id=$2 AND rule_version=$3`,
+      [projectId, sessionId, facts.ruleVersion],
+    );
+    await client.query(
+      `DELETE FROM session_write_rollups
+       WHERE project_id=$1 AND session_id=$2 AND rule_version=$3`,
+      [projectId, sessionId, facts.ruleVersion],
+    );
+
+    for (const failure of facts.failures) {
+      await client.query(
+        `INSERT INTO session_request_failures
+           (project_id, session_id, request_id_hash, page_route, method,
+            endpoint_pattern, status, action_kind, action_selector, action_link,
+            occurred_at, rule_version)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+        [
+          projectId,
+          sessionId,
+          failure.requestIdHash,
+          normalizePageUrl(failure.pageRoute),
+          failure.method,
+          normalizePageUrl(failure.endpointPattern),
+          failure.status,
+          failure.actionKind,
+          failure.actionSelector,
+          failure.actionLink,
+          failure.occurredAt,
+          facts.ruleVersion,
+        ],
+      );
+    }
+
+    for (const rollup of facts.successes) {
+      await client.query(
+        `INSERT INTO session_write_rollups
+           (project_id, session_id, page_route, method, endpoint_pattern,
+            status_class, occurrence_count, rule_version)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+        [
+          projectId,
+          sessionId,
+          normalizePageUrl(rollup.pageRoute),
+          rollup.method,
+          normalizePageUrl(rollup.endpointPattern),
+          rollup.statusClass,
+          rollup.count,
+          facts.ruleVersion,
+        ],
+      );
+    }
+
+    await client.query('COMMIT');
+  } catch (error: unknown) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/packages/worker/src/facts/persist.ts
+++ b/packages/worker/src/facts/persist.ts
@@ -1,19 +1,37 @@
 import { getPool } from '../db.js';
 import type { SessionFacts } from '../friction/facts.js';
-import { normalizePageUrl } from '../friction/urlnorm.js';
 
 export type VersionedSessionFacts = SessionFacts & { ruleVersion: number };
 
 /**
  * One session's facts are whole-session truth at a rule version. A late chunk
- * produces a replacement truth, so the old set is deleted and rewritten in a
- * single transaction.
+ * or a rule-version bump produces a replacement truth, so every stored row for
+ * the session is deleted and rewritten in a single transaction: rows from an
+ * older rule version must not linger beside the current set.
+ *
+ * Routes and endpoint patterns arrive already normalized by the extractor.
+ * Normalizing again here is not idempotent for every input and can collapse
+ * two distinct extractor keys onto one primary key, so un-normalized input is
+ * rejected instead: hosts and query strings do not belong in either table.
  */
+function assertNormalized(value: string, field: string): void {
+  if (value.includes('://') || value.includes('?')) {
+    throw new Error(`${field} must be a normalized path, got a host or query string`);
+  }
+}
 export async function replaceSessionFacts(
   projectId: string,
   sessionId: string,
   facts: VersionedSessionFacts,
 ): Promise<void> {
+  for (const f of facts.failures) {
+    assertNormalized(f.pageRoute, 'failure page_route');
+    assertNormalized(f.endpointPattern, 'failure endpoint_pattern');
+  }
+  for (const r of facts.successes) {
+    assertNormalized(r.pageRoute, 'rollup page_route');
+    assertNormalized(r.endpointPattern, 'rollup endpoint_pattern');
+  }
   const client = await getPool().connect();
   try {
     await client.query('BEGIN');
@@ -26,55 +44,65 @@ export async function replaceSessionFacts(
     }
 
     await client.query(
-      `DELETE FROM session_request_failures
-       WHERE project_id=$1 AND session_id=$2 AND rule_version=$3`,
-      [projectId, sessionId, facts.ruleVersion],
+      `DELETE FROM session_request_failures WHERE project_id=$1 AND session_id=$2`,
+      [projectId, sessionId],
     );
     await client.query(
-      `DELETE FROM session_write_rollups
-       WHERE project_id=$1 AND session_id=$2 AND rule_version=$3`,
-      [projectId, sessionId, facts.ruleVersion],
+      `DELETE FROM session_write_rollups WHERE project_id=$1 AND session_id=$2`,
+      [projectId, sessionId],
     );
 
-    for (const failure of facts.failures) {
+    if (facts.failures.length > 0) {
       await client.query(
         `INSERT INTO session_request_failures
            (project_id, session_id, request_id_hash, page_route, method,
             endpoint_pattern, status, action_kind, action_selector, action_link,
             occurred_at, rule_version)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+         SELECT $1, $2, f.request_id_hash, f.page_route, f.method,
+                f.endpoint_pattern, f.status, f.action_kind, f.action_selector,
+                f.action_link, f.occurred_at, $3
+           FROM unnest($4::text[], $5::text[], $6::text[], $7::text[],
+                       $8::integer[], $9::text[], $10::text[], $11::text[],
+                       $12::timestamptz[])
+             AS f(request_id_hash, page_route, method, endpoint_pattern,
+                  status, action_kind, action_selector, action_link, occurred_at)`,
         [
           projectId,
           sessionId,
-          failure.requestIdHash,
-          normalizePageUrl(failure.pageRoute),
-          failure.method,
-          normalizePageUrl(failure.endpointPattern),
-          failure.status,
-          failure.actionKind,
-          failure.actionSelector,
-          failure.actionLink,
-          failure.occurredAt,
           facts.ruleVersion,
+          facts.failures.map((f) => f.requestIdHash),
+          facts.failures.map((f) => f.pageRoute),
+          facts.failures.map((f) => f.method),
+          facts.failures.map((f) => f.endpointPattern),
+          facts.failures.map((f) => f.status),
+          facts.failures.map((f) => f.actionKind),
+          facts.failures.map((f) => f.actionSelector),
+          facts.failures.map((f) => f.actionLink),
+          facts.failures.map((f) => f.occurredAt),
         ],
       );
     }
 
-    for (const rollup of facts.successes) {
+    if (facts.successes.length > 0) {
       await client.query(
         `INSERT INTO session_write_rollups
            (project_id, session_id, page_route, method, endpoint_pattern,
             status_class, occurrence_count, rule_version)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+         SELECT $1, $2, r.page_route, r.method, r.endpoint_pattern,
+                r.status_class, r.occurrence_count, $3
+           FROM unnest($4::text[], $5::text[], $6::text[], $7::integer[],
+                       $8::integer[])
+             AS r(page_route, method, endpoint_pattern, status_class,
+                  occurrence_count)`,
         [
           projectId,
           sessionId,
-          normalizePageUrl(rollup.pageRoute),
-          rollup.method,
-          normalizePageUrl(rollup.endpointPattern),
-          rollup.statusClass,
-          rollup.count,
           facts.ruleVersion,
+          facts.successes.map((r) => r.pageRoute),
+          facts.successes.map((r) => r.method),
+          facts.successes.map((r) => r.endpointPattern),
+          facts.successes.map((r) => r.statusClass),
+          facts.successes.map((r) => r.count),
         ],
       );
     }

--- a/packages/worker/src/friction/__tests__/analyzer.test.ts
+++ b/packages/worker/src/friction/__tests__/analyzer.test.ts
@@ -190,8 +190,10 @@ describe('friction analyzer trust-boundary bounds', () => {
 });
 
 describe('friction fingerprinting', () => {
-  it('uses rule version 4 for the host-free identity contract', () => {
-    expect(RULE_VERSION).toBe(4);
+  it('uses rule version 5 for the detailed-fact counting rules', () => {
+    // v4 was the host-free identity contract; v5 adds DELETE as a write
+    // method, status 0 as a failure, and strict same-origin matching.
+    expect(RULE_VERSION).toBe(5);
   });
 
   it('normalizes variable URL portions without retaining query or hash', () => {

--- a/packages/worker/src/friction/__tests__/facts.test.ts
+++ b/packages/worker/src/friction/__tests__/facts.test.ts
@@ -100,17 +100,21 @@ describe('session facts', () => {
     expect(facts.failures).toHaveLength(0);
   });
 
-  it('does not treat an unparseable URL as same-origin', () => {
+  it('excludes a request it cannot resolve when the session has no page origin', () => {
+    // With a page origin present, odd strings resolve exactly as the browser
+    // resolved them and count as same-origin. Without any page event there is
+    // no base to resolve against, so a slash-less string stays unjudgeable
+    // and must not count.
     const facts = extractSessionFacts([envelope([
-      page(T0, 'https://app.example.com/assets'),
       telemetry(T0 + 1, {
         kind: 'request_start', requestId: 'bad-url-1', clickId: null,
-        method: 'POST', url: '::::not-a-url',
+        method: 'POST', url: 'api/assets',
       }),
       telemetry(T0 + 2, { kind: 'request_end', requestId: 'bad-url-1', status: 500 }),
     ])]);
 
     expect(facts.failedWriteCount).toBe(0);
+    expect(facts.failures).toHaveLength(0);
   });
 
   it('extracts privacy-bounded request facts with only explicit click links', () => {

--- a/packages/worker/src/friction/__tests__/facts.test.ts
+++ b/packages/worker/src/friction/__tests__/facts.test.ts
@@ -56,6 +56,50 @@ describe('session facts', () => {
     expect(facts.failedWriteCount).toBe(1);
   });
 
+  it('counts a slash-less document-relative request the way the browser resolves it', () => {
+    // The SDK records the raw string handed to fetch, so fetch('api/assets')
+    // arrives without a leading slash and still belongs to the page origin.
+    const facts = extractSessionFacts([envelope([
+      page(T0, 'https://app.example.com/assets'),
+      telemetry(T0 + 1, {
+        kind: 'request_start', requestId: 'rel-1', clickId: null,
+        method: 'POST', url: 'api/assets',
+      }),
+      telemetry(T0 + 2, { kind: 'request_end', requestId: 'rel-1', status: 500 }),
+    ])]);
+
+    expect(facts.failedWriteCount).toBe(1);
+    expect(facts.failures[0]?.endpointPattern).toBe('/api/assets');
+  });
+
+  it('resolves a protocol-relative URL to its host instead of counting it blindly', () => {
+    const facts = extractSessionFacts([envelope([
+      page(T0, 'https://app.example.com/assets'),
+      telemetry(T0 + 1, {
+        kind: 'request_start', requestId: 'proto-1', clickId: null,
+        method: 'POST', url: '//evil.example/api/steal',
+      }),
+      telemetry(T0 + 2, { kind: 'request_end', requestId: 'proto-1', status: 500 }),
+    ])]);
+
+    expect(facts.failedWriteCount).toBe(0);
+    expect(facts.failures).toHaveLength(0);
+  });
+
+  it('excludes nonstandard statuses past 599 as the pre-fact gate did', () => {
+    const facts = extractSessionFacts([envelope([
+      page(T0, 'https://app.example.com/assets'),
+      telemetry(T0 + 1, {
+        kind: 'request_start', requestId: 'junk-1', clickId: null,
+        method: 'PUT', url: '/api/assets/1',
+      }),
+      telemetry(T0 + 2, { kind: 'request_end', requestId: 'junk-1', status: 999 }),
+    ])]);
+
+    expect(facts.failedWriteCount).toBe(0);
+    expect(facts.failures).toHaveLength(0);
+  });
+
   it('does not treat an unparseable URL as same-origin', () => {
     const facts = extractSessionFacts([envelope([
       page(T0, 'https://app.example.com/assets'),

--- a/packages/worker/src/friction/__tests__/facts.test.ts
+++ b/packages/worker/src/friction/__tests__/facts.test.ts
@@ -30,6 +30,123 @@ describe('session facts', () => {
     expect(facts.unattributedFailedRequestCount).toBe(1);
   });
 
+  it('counts a refused DELETE as a failed write', () => {
+    const facts = extractSessionFacts([envelope([
+      page(T0, 'https://app.example.com/assets/1'),
+      telemetry(T0 + 1, {
+        kind: 'request_start', requestId: 'delete-1', clickId: null,
+        method: 'DELETE', url: '/api/assets/1',
+      }),
+      telemetry(T0 + 2, { kind: 'request_end', requestId: 'delete-1', status: 400 }),
+    ])]);
+
+    expect(facts.failedWriteCount).toBe(1);
+  });
+
+  it('counts a status-zero transport refusal as a failed write', () => {
+    const facts = extractSessionFacts([envelope([
+      page(T0, 'https://app.example.com/assets'),
+      telemetry(T0 + 1, {
+        kind: 'request_start', requestId: 'create-1', clickId: null,
+        method: 'POST', url: '/api/assets',
+      }),
+      telemetry(T0 + 2, { kind: 'request_end', requestId: 'create-1', status: 0 }),
+    ])]);
+
+    expect(facts.failedWriteCount).toBe(1);
+  });
+
+  it('does not treat an unparseable URL as same-origin', () => {
+    const facts = extractSessionFacts([envelope([
+      page(T0, 'https://app.example.com/assets'),
+      telemetry(T0 + 1, {
+        kind: 'request_start', requestId: 'bad-url-1', clickId: null,
+        method: 'POST', url: '::::not-a-url',
+      }),
+      telemetry(T0 + 2, { kind: 'request_end', requestId: 'bad-url-1', status: 500 }),
+    ])]);
+
+    expect(facts.failedWriteCount).toBe(0);
+  });
+
+  it('extracts privacy-bounded request facts with only explicit click links', () => {
+    const facts = extractSessionFacts([envelope([
+      page(T0, 'https://app.example.com/assets/42/edit?tab=details'),
+      telemetry(T0 + 1, {
+        kind: 'click', clickId: 'click-1', selector: '[data-testid="save"]', cursor: 'pointer',
+      }),
+      telemetry(T0 + 2, {
+        kind: 'request_start', requestId: 'failure-1', clickId: 'click-1',
+        method: 'PUT', url: 'https://app.example.com/api/assets/42?token=secret',
+      }),
+      telemetry(T0 + 3, { kind: 'request_end', requestId: 'failure-1', status: 400 }),
+      telemetry(T0 + 4, {
+        kind: 'request_start', requestId: 'failure-2', clickId: null,
+        method: 'DELETE', url: '/api/assets/43?token=secret',
+      }),
+      telemetry(T0 + 5, { kind: 'request_end', requestId: 'failure-2', status: 0 }),
+      telemetry(T0 + 6, {
+        kind: 'request_start', requestId: 'success-1', clickId: null,
+        method: 'POST', url: '/api/assets?source=form',
+      }),
+      telemetry(T0 + 7, { kind: 'request_end', requestId: 'success-1', status: 201 }),
+      telemetry(T0 + 8, {
+        kind: 'request_start', requestId: 'success-2', clickId: null,
+        method: 'POST', url: '/api/assets?source=retry',
+      }),
+      telemetry(T0 + 9, { kind: 'request_end', requestId: 'success-2', status: 204 }),
+    ])]);
+
+    expect(facts.failures).toHaveLength(2);
+    expect(facts.failures[0]).toMatchObject({
+      pageRoute: '/assets/:id/edit',
+      method: 'PUT',
+      endpointPattern: '/api/assets/:id',
+      status: 400,
+      actionKind: 'click',
+      actionSelector: '[data-testid="save"]',
+      actionLink: 'direct',
+    });
+    expect(facts.failures[0]?.requestIdHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(facts.failures[1]).toMatchObject({
+      method: 'DELETE',
+      endpointPattern: '/api/assets/:id',
+      status: 0,
+      actionKind: null,
+      actionSelector: null,
+      actionLink: 'none',
+    });
+    expect(JSON.stringify(facts.failures)).not.toContain('app.example.com');
+    expect(JSON.stringify(facts.failures)).not.toContain('token');
+    expect(facts.successes).toEqual([{
+      pageRoute: '/assets/:id/edit',
+      method: 'POST',
+      endpointPattern: '/api/assets',
+      statusClass: 2,
+      count: 2,
+    }]);
+  });
+
+  it('keeps repeated SDK request ids distinct across page reloads', () => {
+    const facts = extractSessionFacts([envelope([
+      page(T0, 'https://app.example.com/assets'),
+      telemetry(T0 + 1, {
+        kind: 'request_start', requestId: 'f_1', clickId: null,
+        method: 'POST', url: '/api/assets',
+      }),
+      telemetry(T0 + 2, { kind: 'request_end', requestId: 'f_1', status: 400 }),
+      page(T0 + 10_000, 'https://app.example.com/assets'),
+      telemetry(T0 + 10_001, {
+        kind: 'request_start', requestId: 'f_1', clickId: null,
+        method: 'POST', url: '/api/assets',
+      }),
+      telemetry(T0 + 10_002, { kind: 'request_end', requestId: 'f_1', status: 400 }),
+    ])]);
+
+    expect(facts.failures).toHaveLength(2);
+    expect(new Set(facts.failures.map((failure) => failure.requestIdHash)).size).toBe(2);
+  });
+
   it('uses the earliest normalized entry path', () => {
     const facts = extractSessionFacts([envelope([
       page(T0 + 10, 'https://x.test/other'),

--- a/packages/worker/src/friction/__tests__/facts.test.ts
+++ b/packages/worker/src/friction/__tests__/facts.test.ts
@@ -147,6 +147,25 @@ describe('session facts', () => {
     expect(new Set(facts.failures.map((failure) => failure.requestIdHash)).size).toBe(2);
   });
 
+  it('ignores a duplicate request_end instead of emitting a colliding fact row', () => {
+    // Telemetry is browser-controlled: a repeated end for one start must not
+    // double-count or produce two failure rows with one request hash, which
+    // would poison the persistence transaction on its primary key.
+    const facts = extractSessionFacts([envelope([
+      page(T0, 'https://app.example.com/assets'),
+      telemetry(T0 + 1, {
+        kind: 'request_start', requestId: 'dup-1', clickId: null,
+        method: 'POST', url: '/api/assets',
+      }),
+      telemetry(T0 + 2, { kind: 'request_end', requestId: 'dup-1', status: 500 }),
+      telemetry(T0 + 3, { kind: 'request_end', requestId: 'dup-1', status: 500 }),
+    ])]);
+
+    expect(facts.failures).toHaveLength(1);
+    expect(facts.failedWriteCount).toBe(1);
+    expect(facts.unattributedFailedRequestCount).toBe(0);
+  });
+
   it('uses the earliest normalized entry path', () => {
     const facts = extractSessionFacts([envelope([
       page(T0 + 10, 'https://x.test/other'),

--- a/packages/worker/src/friction/analyzer.ts
+++ b/packages/worker/src/friction/analyzer.ts
@@ -5,7 +5,7 @@ import type {
 } from '@opslane/shared';
 import { frictionFingerprint, normalizePageUrl } from './fingerprint.js';
 
-export const RULE_VERSION = 4;
+export const RULE_VERSION = 5;
 
 const CLICK_CLUSTER_GAP_MS = 1_000;
 const RAGE_MIN_CLICKS = 3;

--- a/packages/worker/src/friction/facts.ts
+++ b/packages/worker/src/friction/facts.ts
@@ -66,8 +66,16 @@ function originOf(url: string): string | null {
 const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
 function isFailure(status: number): boolean {
-  return status === 0 || status >= 400;
+  // 0 is a transport-level refusal. Statuses past 599 are nonstandard junk
+  // (proxy 999 and friends) and stay excluded, as the pre-fact gate did.
+  return status === 0 || (status >= 400 && status < 600);
 }
+
+// Detailed failure facts are derived from browser-controlled telemetry, so a
+// hostile or broken client could otherwise write unbounded rows per session.
+// Counters stay exact past the cap; only the detailed rows are bounded, most
+// recent kept to match the read side's recency order.
+const MAX_STORED_FAILURE_FACTS = 1000;
 
 export function extractSessionFacts(chunks: SessionChunkEnvelope[]): SessionFacts {
   const facts: SessionFacts = {
@@ -116,10 +124,23 @@ export function extractSessionFacts(chunks: SessionChunkEnvelope[]): SessionFact
   }
   if (entryPageHref !== null) facts.entryPath = normalizeEntryPath(entryPageHref);
 
-  const sameOrigin = (url: string): boolean => {
-    if (url.startsWith('/') && !url.startsWith('//')) return true;
-    const origin = originOf(url);
-    return origin !== null && pageOrigins.has(origin);
+  // The SDK records the raw string handed to fetch, so requests arrive as
+  // absolute URLs, root-relative paths, slash-less document-relative paths
+  // ('api/assets'), or protocol-relative '//host/path'. Resolving against the
+  // page origin judges all of them the way the browser did; only a URL that
+  // cannot be resolved at all falls back to the root-relative check.
+  const basePageOrigin = (entryPageHref !== null ? originOf(entryPageHref) : null)
+    ?? pageOrigins.values().next().value ?? null;
+  const resolveRequestUrl = (url: string): URL | null => {
+    try { return new URL(url); } catch { /* not absolute */ }
+    if (basePageOrigin !== null) {
+      try { return new URL(url, basePageOrigin); } catch { /* unresolvable */ }
+    }
+    return null;
+  };
+  const sameOrigin = (resolved: URL | null, rawUrl: string): boolean => {
+    if (resolved !== null) return pageOrigins.has(resolved.origin);
+    return rawUrl.startsWith('/') && !rawUrl.startsWith('//');
   };
   pages.sort((left, right) => left.at - right.at);
   const routeAt = (at: number): string => {
@@ -168,9 +189,10 @@ export function extractSessionFacts(chunks: SessionChunkEnvelope[]): SessionFact
       }
       consumedRequests.add(event.requestId);
       startById.delete(event.requestId);
-      if (!sameOrigin(start.url)) continue;
+      const resolved = resolveRequestUrl(start.url);
+      if (!sameOrigin(resolved, start.url)) continue;
       const isWrite = WRITE_METHODS.has(start.method);
-      const endpointPattern = normalizePageUrl(start.url);
+      const endpointPattern = normalizePageUrl(resolved !== null ? resolved.href : start.url);
       if (event.status >= 200 && event.status < 300 && isWrite) {
         facts.successfulWriteCount += 1;
         const statusClass = Math.floor(event.status / 100);
@@ -209,6 +231,9 @@ export function extractSessionFacts(chunks: SessionChunkEnvelope[]): SessionFact
     }
   }
   facts.successes = [...successRollups.values()];
+  if (facts.failures.length > MAX_STORED_FAILURE_FACTS) {
+    facts.failures = facts.failures.slice(-MAX_STORED_FAILURE_FACTS);
+  }
   return facts;
 }
 

--- a/packages/worker/src/friction/facts.ts
+++ b/packages/worker/src/friction/facts.ts
@@ -139,6 +139,7 @@ export function extractSessionFacts(chunks: SessionChunkEnvelope[]): SessionFact
     startedAt: number;
   }>();
   const successRollups = new Map<string, SuccessfulWriteRollup>();
+  const consumedRequests = new Set<string>();
   for (const { event } of extractTelemetryEvents(chunks)) {
     if (event.kind === 'click') {
       facts.clickCount += 1;
@@ -156,9 +157,17 @@ export function extractSessionFacts(chunks: SessionChunkEnvelope[]): SessionFact
     if (event.kind === 'request_end') {
       const start = startById.get(event.requestId);
       if (!start) {
-        if (isFailure(event.status)) facts.unattributedFailedRequestCount += 1;
+        // Either the start never arrived or a duplicate end already consumed
+        // it. Only the never-started case is a countable unattributed failure;
+        // a duplicate end is telemetry noise and must not double-count or
+        // produce a second fact row with the same request hash.
+        if (!consumedRequests.has(event.requestId) && isFailure(event.status)) {
+          facts.unattributedFailedRequestCount += 1;
+        }
         continue;
       }
+      consumedRequests.add(event.requestId);
+      startById.delete(event.requestId);
       if (!sameOrigin(start.url)) continue;
       const isWrite = WRITE_METHODS.has(start.method);
       const endpointPattern = normalizePageUrl(start.url);

--- a/packages/worker/src/friction/facts.ts
+++ b/packages/worker/src/friction/facts.ts
@@ -1,9 +1,30 @@
+import { createHash } from 'node:crypto';
 import type { SessionChunkEnvelope } from '@opslane/shared';
 import { extractTelemetryEvents } from './analyzer.js';
-import { normalizeEntryPath } from './fingerprint.js';
+import { normalizeEntryPath, normalizePageUrl } from './fingerprint.js';
 
 export type Coverage = 'complete' | 'partial' | 'no_replay';
 export type ActivityClass = 'active' | 'light_touch' | 'zero_interaction' | 'idle_tab' | 'unknown';
+
+export interface FailedRequestFact {
+  requestIdHash: string;
+  pageRoute: string;
+  method: string;
+  endpointPattern: string;
+  status: number;
+  actionKind: 'click' | 'form_submit' | null;
+  actionSelector: string | null;
+  actionLink: 'direct' | 'none';
+  occurredAt: string;
+}
+
+export interface SuccessfulWriteRollup {
+  pageRoute: string;
+  method: string;
+  endpointPattern: string;
+  statusClass: number;
+  count: number;
+}
 
 export interface SessionFacts {
   entryPath: string | null;
@@ -17,6 +38,8 @@ export interface SessionFacts {
   failedWriteCount: number;
   firstEventMs: number | null;
   lastEventMs: number | null;
+  failures: FailedRequestFact[];
+  successes: SuccessfulWriteRollup[];
 }
 
 export interface SessionContextInput {
@@ -40,7 +63,11 @@ function originOf(url: string): string | null {
   }
 }
 
-const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH']);
+const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function isFailure(status: number): boolean {
+  return status === 0 || status >= 400;
+}
 
 export function extractSessionFacts(chunks: SessionChunkEnvelope[]): SessionFacts {
   const facts: SessionFacts = {
@@ -55,8 +82,11 @@ export function extractSessionFacts(chunks: SessionChunkEnvelope[]): SessionFact
     failedWriteCount: 0,
     firstEventMs: null,
     lastEventMs: null,
+    failures: [],
+    successes: [],
   };
   const pageOrigins = new Set<string>();
+  const pages: Array<{ at: number; route: string }> = [];
   let entryPageHref: string | null = null;
   let entryPageTs = Number.POSITIVE_INFINITY;
   for (const chunk of chunks) {
@@ -73,6 +103,7 @@ export function extractSessionFacts(chunks: SessionChunkEnvelope[]): SessionFact
         facts.pageEventCount += 1;
         const origin = originOf(data['href']);
         if (origin) pageOrigins.add(origin);
+        pages.push({ at: ts, route: normalizePageUrl(data['href']) });
         if (ts < entryPageTs) {
           entryPageTs = ts;
           entryPageHref = data['href'];
@@ -86,31 +117,89 @@ export function extractSessionFacts(chunks: SessionChunkEnvelope[]): SessionFact
   if (entryPageHref !== null) facts.entryPath = normalizeEntryPath(entryPageHref);
 
   const sameOrigin = (url: string): boolean => {
+    if (url.startsWith('/') && !url.startsWith('//')) return true;
     const origin = originOf(url);
-    return origin === null || pageOrigins.has(origin);
+    return origin !== null && pageOrigins.has(origin);
   };
-  const startById = new Map<string, { method: string; url: string }>();
+  pages.sort((left, right) => left.at - right.at);
+  const routeAt = (at: number): string => {
+    let route = '';
+    for (const page of pages) {
+      if (page.at > at) break;
+      route = page.route;
+    }
+    return route;
+  };
+  const clicksById = new Map<string, string>();
+  const startById = new Map<string, {
+    method: string;
+    url: string;
+    clickId: string | null;
+    route: string;
+    startedAt: number;
+  }>();
+  const successRollups = new Map<string, SuccessfulWriteRollup>();
   for (const { event } of extractTelemetryEvents(chunks)) {
-    if (event.kind === 'click') facts.clickCount += 1;
+    if (event.kind === 'click') {
+      facts.clickCount += 1;
+      clicksById.set(event.clickId, event.selector);
+    }
     if (event.kind === 'request_start') {
-      startById.set(event.requestId, { method: event.method.toUpperCase(), url: event.url });
+      startById.set(event.requestId, {
+        method: event.method.toUpperCase(),
+        url: event.url,
+        clickId: event.clickId,
+        route: routeAt(event.at),
+        startedAt: event.at,
+      });
     }
     if (event.kind === 'request_end') {
       const start = startById.get(event.requestId);
       if (!start) {
-        if (event.status >= 400) facts.unattributedFailedRequestCount += 1;
+        if (isFailure(event.status)) facts.unattributedFailedRequestCount += 1;
         continue;
       }
       if (!sameOrigin(start.url)) continue;
       const isWrite = WRITE_METHODS.has(start.method);
-      if (event.status >= 200 && event.status < 300 && isWrite) facts.successfulWriteCount += 1;
-      if (event.status >= 400 && event.status < 600) {
+      const endpointPattern = normalizePageUrl(start.url);
+      if (event.status >= 200 && event.status < 300 && isWrite) {
+        facts.successfulWriteCount += 1;
+        const statusClass = Math.floor(event.status / 100);
+        const key = JSON.stringify([start.route, start.method, endpointPattern, statusClass]);
+        const current = successRollups.get(key);
+        if (current) current.count += 1;
+        else {
+          successRollups.set(key, {
+            pageRoute: start.route,
+            method: start.method,
+            endpointPattern,
+            statusClass,
+            count: 1,
+          });
+        }
+      }
+      if (isFailure(event.status)) {
         if (isWrite) facts.failedWriteCount += 1;
-        if (event.status < 500) facts.failedRequest4xxCount += 1;
-        else facts.failedRequest5xxCount += 1;
+        if (event.status >= 400 && event.status < 500) facts.failedRequest4xxCount += 1;
+        if (event.status >= 500 && event.status < 600) facts.failedRequest5xxCount += 1;
+        const actionSelector = start.clickId === null ? null : clicksById.get(start.clickId) ?? null;
+        facts.failures.push({
+          requestIdHash: createHash('sha256')
+            .update(`${event.requestId}:${start.startedAt}`)
+            .digest('hex'),
+          pageRoute: start.route,
+          method: start.method,
+          endpointPattern,
+          status: event.status,
+          actionKind: actionSelector === null ? null : 'click',
+          actionSelector,
+          actionLink: actionSelector === null ? 'none' : 'direct',
+          occurredAt: new Date(event.at).toISOString(),
+        });
       }
     }
   }
+  facts.successes = [...successRollups.values()];
   return facts;
 }
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -45,6 +45,7 @@ import { FRICTION_INVESTIGATION_MODEL, investigateFriction } from './friction/in
 import { readChunksBounded } from './friction/chunk-reader.js';
 import { analyzeSession, RULE_VERSION } from './friction/analyzer.js';
 import { classifyActivity, deriveCoverage, extractSessionFacts, formatSessionContext } from './friction/facts.js';
+import { replaceSessionFacts } from './facts/persist.js';
 import { writeFrictionSignals } from './friction/persist.js';
 import { processFrictionOutcomes } from './friction/promotion.js';
 import {
@@ -1037,6 +1038,10 @@ export async function processSessionAnalysisJob(
       totalChunkCount: session.chunk_count,
       envelopeCount: read.envelopes.length,
       truncated: read.truncated,
+    });
+    await replaceSessionFacts(session.project_id, session.id, {
+      ...facts,
+      ruleVersion: RULE_VERSION,
     });
     await db.upsertSessionAnalysis({
       sessionId: session.id,


### PR DESCRIPTION
Implements Slice 5 of the pipeline rewrite (docs/superpowers/specs/2026-08-16-pipeline-implementation-plan.md): compact session facts and the work-round evidence reader.

## What changed
- Session analysis now stores detailed failed-request rows and successful-write rollups (`session_request_failures`, `session_write_rollups` in migration 054), replacing one session's fact set transactionally after late chunks. Facts cascade with recording expiry.
- Click-to-request links persist only when the recording establishes them; timing proximity and dangling click ids do not become causation.
- `loadEvidence` returns the durable evidence for one work round from its frozen anchors: resolved frames with commit, failed requests, rollups, product understanding, replay pointers, and explicit availability — without decoding recordings and without reading the mutable `sample_event_id`.

## Review fixes folded in (`/code-review medium`, findings verified)
- A duplicate `request_end` no longer emits a colliding fact row that would poison the persistence transaction on its PK.
- Persist validates instead of re-normalizing (`normalizePageUrl` is not idempotent and could collapse two distinct keys); replacement deletes every stored rule version; inserts are batched via `unnest`.
- Request URLs resolve against the page origin, so slash-less document-relative paths count and protocol-relative URLs resolve to their real host. Statuses past 599 stay excluded. Detailed failure facts cap at 1000 most-recent per session (counters stay exact).
- `RULE_VERSION` bumped to 5 for the changed counting semantics; the reader's `route_map` lookup uses plain equality (patterns are host-free by the migration-052 CHECK).

## Verification
Black-box acceptance run against a live stack (14 criteria, `.verify/runs/20260818-142016`, untracked): 13 pass. The production check replayed 479 retained window recordings through the new extractor: 5xx reproduced exactly (45/36); failed writes came back 112/63 vs the spec's 97/62 — the delta traces to six sessions prod analyzed at rule_version 3 with partial coverage (the spec's numbers were undercounts) plus one DELETE-write from the new rule. Spec follow-up: amend the Slice 5 production-check totals or note the provenance.

Local gate: `pnpm -r build`, `pnpm test`, and `go test ./...` (zero skips) green on a disposable database. Sole local red is `packages/sdk` `debug-id-browser.test.ts`, which cannot launch WebKit on this devbox (missing host libraries; package untouched by this change).