### PR TITLE
test(notify): scope dispatcher claim tests to their own seeded rows

### DIFF
--- a/packages/ingestion/notify/dispatcher_db_test.go
+++ b/packages/ingestion/notify/dispatcher_db_test.go
@@ -30,14 +30,22 @@ func TestDispatcherClaimLeaseAndFencing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(claims) != 1 || claims[0].ID != seed.DeliveryID || claims[0].Attempts != 1 || claims[0].LeaseGeneration != 1 {
-		t.Fatalf("claims = %+v", claims)
+	claim, ok := claimFor(claims, seed.DeliveryID)
+	if !ok {
+		t.Fatalf("seeded delivery not claimed; batch = %+v", claims)
 	}
-	if again, err := d.claim(context.Background()); err != nil || len(again) != 0 {
-		t.Fatalf("second claim = %+v, %v", again, err)
+	if claim.Attempts != 1 || claim.LeaseGeneration != 1 {
+		t.Fatalf("claim = %+v", claim)
+	}
+	again, err := d.claim(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, reclaimed := claimFor(again, seed.DeliveryID); reclaimed {
+		t.Fatalf("leased delivery was claimed again; batch = %+v", again)
 	}
 
-	stale := claims[0]
+	stale := claim
 	stale.LeaseGeneration++
 	updated, err := d.complete(context.Background(), stale, Outcome{Class: "delivered"})
 	if err != nil || updated {
@@ -68,8 +76,8 @@ func TestDispatcherClaimSkipsExhaustedRows(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(claims) != 0 {
-		t.Fatalf("exhausted row was claimed: %+v", claims)
+	if claim, ok := claimFor(claims, seed.DeliveryID); ok {
+		t.Fatalf("exhausted row was claimed: %+v", claim)
 	}
 }
 
@@ -90,9 +98,11 @@ func TestDispatcherReapsExpiredAndExhaustedClaims(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	count, err := New(pool, cipher, Options{}).reapExpired(ctx)
-	if err != nil || count != 2 {
-		t.Fatalf("reap count=%d err=%v", count, err)
+	// reapExpired sweeps the whole table, so its count includes rows other
+	// packages seeded. The contract this test owns is the state each of its two
+	// rows lands in, asserted below.
+	if _, err := New(pool, cipher, Options{}).reapExpired(ctx); err != nil {
+		t.Fatalf("reap: %v", err)
 	}
 	var retryStatus string
 	var retryAt time.Time
@@ -133,10 +143,14 @@ func TestDispatcherHTTPOutcomesPersistExpectedState(t *testing.T) {
 			seed := seedDelivery(t, pool, cipher, server.URL+"/hook")
 			d := New(pool, cipher, Options{ExtraHosts: []string{serverHost(server)}})
 			claims, err := d.claim(context.Background())
-			if err != nil || len(claims) != 1 {
-				t.Fatalf("claim=%+v err=%v", claims, err)
+			if err != nil {
+				t.Fatal(err)
 			}
-			d.deliverClaim(context.Background(), claims[0])
+			claim, ok := claimFor(claims, seed.DeliveryID)
+			if !ok {
+				t.Fatalf("seeded delivery not claimed; batch = %+v", claims)
+			}
+			d.deliverClaim(context.Background(), claim)
 
 			var status string
 			var nextAttempt time.Time

--- a/packages/ingestion/notify/testhelper_test.go
+++ b/packages/ingestion/notify/testhelper_test.go
@@ -97,10 +97,27 @@ func seedDelivery(t *testing.T, pool *pgxpool.Pool, cipher *ConfigCipher, webhoo
 		VALUES ($1, $2, 'issue.created', $3, $4)`, seed.EventID, seed.ProjectID, "test:"+seed.EventID, payload); err != nil {
 		t.Fatalf("insert outbound event: %v", err)
 	}
+	// Backdate next_attempt_at. claim() orders by it and takes a limited batch,
+	// and `go test ./...` runs packages concurrently against one database, so
+	// another package's freshly inserted delivery can crowd this row out of the
+	// batch. An hour in the past sorts ahead of anything a concurrent test
+	// creates while this one runs.
 	if _, err := pool.Exec(ctx, `
-		INSERT INTO outbound_deliveries (id, event_id, destination_id)
-		VALUES ($1, $2, $3)`, seed.DeliveryID, seed.EventID, seed.DestinationID); err != nil {
+		INSERT INTO outbound_deliveries (id, event_id, destination_id, next_attempt_at)
+		VALUES ($1, $2, $3, now() - interval '1 hour')`, seed.DeliveryID, seed.EventID, seed.DestinationID); err != nil {
 		t.Fatalf("insert outbound delivery: %v", err)
 	}
 	return seed
+}
+
+// claimFor finds one seeded delivery inside a claim batch. The dispatcher
+// claims across every tenant, so a batch can carry rows a concurrently running
+// package seeded. Assert on the row the test owns, never on the batch size.
+func claimFor(claims []deliveryClaim, deliveryID string) (deliveryClaim, bool) {
+	for _, claim := range claims {
+		if claim.ID == deliveryID {
+			return claim, true
+		}
+	}
+	return deliveryClaim{}, false
 }


### PR DESCRIPTION
## Why

Main has been red since fbfa231 (Slice 10) on `TestDispatcherClaimSkipsExhaustedRows`. It is not re-run flake.

`claim()` sweeps `outbound_deliveries` across every tenant with `LIMIT 10` (`packages/ingestion/notify/dispatcher.go:314`). Four tests in `dispatcher_db_test.go` asserted on the size of the returned batch, which is only correct when nothing else in the database is claimable. `go test ./...` runs packages concurrently against one database, and Slice 10 gave the digest package a delivery path that seeds pending rows (`packages/ingestion/digest/validate.go:219`), so a latent assumption started losing the race.

The CI failure shows the test claiming a row with `Attempts:1 MaxAttempts:5`, which is not the exhausted row it seeded.

## What changed

Assert on the seeded delivery rather than on batch size, via a small `claimFor` helper, and backdate the seed's `next_attempt_at` by an hour so it sorts ahead of rows a concurrent package creates mid-test.

The contracts are unchanged: an exhausted row is still never claimed, a leased row is still never re-claimed, and both reaped rows are still checked for their exact terminal state. The only assertion dropped is the database-wide `reapExpired` count, whose per-row state checks directly underneath it are the real contract.

## Verification

Reproduced first, rather than assumed. Seeded one foreign claimable delivery into a scratch database and ran the original tests: failed with two rows in the batch, matching CI. Applied the fix, re-ran against the same pollution: all six dispatcher tests pass.

Full suite with `DATABASE_URL` and storage configured, using the gate CI runs:

```
go test ./... -v -count=1   # exit 0
scripts/check-go-skips.mjs  # Go OK: 1388 passed, 0 allowlisted skip(s), no failures, no unexpected skips
```