### PR TITLE
Pipeline rewrite Slice 11: cut over production

### DIFF
--- a/packages/ingestion/db/migration_060_test.go
+++ b/packages/ingestion/db/migration_060_test.go
@@ -1,0 +1,242 @@
+package db_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMigration060AdoptsThePreRewriteWorld applies every migration except the
+// cutover backfill, seeds the pre-rewrite shape, then applies the backfill and
+// checks what the pipeline needs afterwards.
+func TestMigration060AdoptsThePreRewriteWorld(t *testing.T) {
+	admin := testPool(t)
+	psql := findPsql(t)
+	pool, dsn := disposableDB(t, admin)
+	ctx := context.Background()
+
+	var backfill string
+	for _, file := range migrationFiles(t) {
+		if strings.HasPrefix(filepath.Base(file), "060_") {
+			backfill = file
+			continue
+		}
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("apply %s: %v", file, err)
+		}
+	}
+	if backfill == "" {
+		t.Fatal("060 cutover backfill migration not found")
+	}
+
+	// Pre-rewrite state: three issues and their observations, no identities.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO orgs (id, name) VALUES ('11111111-1111-1111-1111-111111111111', 'cutover');
+		INSERT INTO projects (id, org_id, name, github_repo)
+		  VALUES ('22222222-2222-2222-2222-222222222222',
+		          '11111111-1111-1111-1111-111111111111', 'app', 'owner/repo');
+		INSERT INTO environments (id, project_id, name)
+		  VALUES ('33333333-3333-3333-3333-333333333333',
+		          '22222222-2222-2222-2222-222222222222', 'production');
+
+		INSERT INTO error_groups
+		  (id, project_id, fingerprint, title, kind, status, first_seen, last_seen, resolved_at)
+		VALUES
+		  ('aaaaaaaa-0000-0000-0000-000000000001',
+		   '22222222-2222-2222-2222-222222222222', 'fp-active', 'Active issue',
+		   'error', 'new', now() - interval '20 days', now(), NULL),
+		  ('aaaaaaaa-0000-0000-0000-000000000002',
+		   '22222222-2222-2222-2222-222222222222', 'fp-resolved', 'Resolved issue',
+		   'error', 'resolved', now() - interval '40 days', now() - interval '30 days',
+		   now() - interval '29 days'),
+		  ('aaaaaaaa-0000-0000-0000-000000000003',
+		   '22222222-2222-2222-2222-222222222222', 'fp-friction', 'Dead click',
+		   'friction', 'new', now() - interval '10 days', now(), NULL);
+
+		INSERT INTO error_events
+		  (id, project_id, environment_id, error_group_id, timestamp,
+		   error_type, error_message, stack_trace_raw, created_at)
+		VALUES
+		  ('bbbbbbbb-0000-0000-0000-000000000001',
+		   '22222222-2222-2222-2222-222222222222', '33333333-3333-3333-3333-333333333333',
+		   'aaaaaaaa-0000-0000-0000-000000000001', now(), 'TypeError', 'boom', 'at x',
+		   now() - interval '2 days'),
+		  ('bbbbbbbb-0000-0000-0000-000000000002',
+		   '22222222-2222-2222-2222-222222222222', '33333333-3333-3333-3333-333333333333',
+		   'aaaaaaaa-0000-0000-0000-000000000001', now(), 'TypeError', 'boom', 'at x',
+		   now() - interval '1 day'),
+		  ('bbbbbbbb-0000-0000-0000-000000000003',
+		   '22222222-2222-2222-2222-222222222222', '33333333-3333-3333-3333-333333333333',
+		   'aaaaaaaa-0000-0000-0000-000000000002', now(), 'TypeError', 'old', 'at y',
+		   now() - interval '35 days');
+	`); err != nil {
+		t.Fatalf("seed pre-cutover world: %v", err)
+	}
+
+	if err := applyMigration(t, psql, dsn, backfill); err != nil {
+		t.Fatalf("apply backfill: %v", err)
+	}
+
+	// Every issue gets exactly one episode, and only unresolved issues get an
+	// open one. A resolved issue with an open round would look live on day one.
+	var episodes, openEpisodes int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*), count(*) FILTER (WHERE closed_at IS NULL)
+		  FROM issue_episodes`).Scan(&episodes, &openEpisodes); err != nil {
+		t.Fatal(err)
+	}
+	if episodes != 3 {
+		t.Errorf("episodes = %d, want 3 (one per adopted issue)", episodes)
+	}
+	if openEpisodes != 2 {
+		t.Errorf("open episodes = %d, want 2 (the resolved issue's round is closed)", openEpisodes)
+	}
+
+	// Each issue's own fingerprint becomes its alias, typed by the issue's kind.
+	var aliasKind string
+	if err := pool.QueryRow(ctx, `
+		SELECT fingerprint_kind FROM canonical_issue_fingerprints
+		 WHERE fingerprint = 'fp-friction'`).Scan(&aliasKind); err != nil {
+		t.Fatal(err)
+	}
+	if aliasKind != "friction" {
+		t.Errorf("friction alias kind = %q, want friction", aliasKind)
+	}
+	var aliases int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM canonical_issue_fingerprints
+		 WHERE confirmed_by = 'exact' AND identity_version = 2`).Scan(&aliases); err != nil {
+		t.Fatal(err)
+	}
+	if aliases != 3 {
+		t.Errorf("aliases = %d, want 3", aliases)
+	}
+
+	// The backfill merges nothing: three issues in, three issues out.
+	var merges int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM issue_merges`).Scan(&merges); err != nil {
+		t.Fatal(err)
+	}
+	if merges != 0 {
+		t.Errorf("merges = %d, want 0; the backfill must not combine issues", merges)
+	}
+
+	// Every observation settles onto the issue it already belonged to, carrying
+	// that issue's episode. identity.ConfirmMerge refuses to merge an issue
+	// holding events without settled identity, so a gap here would make every
+	// adopted issue permanently unmergeable.
+	var unsettled int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*)
+		  FROM error_events e
+		  LEFT JOIN error_event_identities i
+		    ON i.project_id = e.project_id AND i.event_id = e.id
+		 WHERE e.error_group_id IS NOT NULL
+		   AND (i.event_id IS NULL OR i.status <> 'settled')`).Scan(&unsettled); err != nil {
+		t.Fatal(err)
+	}
+	if unsettled != 0 {
+		t.Errorf("%d observations have no settled identity; ConfirmMerge would refuse forever", unsettled)
+	}
+
+	var mismatched int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*)
+		  FROM error_event_identities i
+		  JOIN error_events e
+		    ON e.project_id = i.project_id AND e.id = i.event_id
+		  JOIN issue_episodes ep ON ep.id = i.episode_id
+		 WHERE i.canonical_issue_id <> e.error_group_id
+		    OR ep.canonical_issue_id <> e.error_group_id
+		    OR i.resolved_fingerprint IS NOT NULL`).Scan(&mismatched); err != nil {
+		t.Fatal(err)
+	}
+	if mismatched != 0 {
+		t.Errorf("%d identities point at the wrong issue, wrong episode, or claim a resolved fingerprint", mismatched)
+	}
+
+	// Adopted rounds are already published on the digest channel, so the first
+	// message after cutover cannot introduce them as new.
+	var unpublished int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*)
+		  FROM issue_episodes ep
+		  LEFT JOIN issue_publications p
+		    ON p.project_id = ep.project_id AND p.episode_id = ep.id AND p.channel = 'digest'
+		 WHERE ep.sequence = 1 AND p.episode_id IS NULL`).Scan(&unpublished); err != nil {
+		t.Fatal(err)
+	}
+	if unpublished != 0 {
+		t.Errorf("%d adopted rounds have no digest receipt; they would announce themselves as new", unpublished)
+	}
+}
+
+// TestMigration060IsReapplySafeWithData re-runs the backfill over a world it has
+// already adopted. run-migrations.sh replays every file on every start, so a
+// second pass must not open a second round, rebind an alias, or duplicate a
+// receipt.
+func TestMigration060IsReapplySafeWithData(t *testing.T) {
+	admin := testPool(t)
+	psql := findPsql(t)
+	pool, dsn := disposableDB(t, admin)
+	ctx := context.Background()
+
+	files := migrationFiles(t)
+	for _, file := range files {
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("apply %s: %v", file, err)
+		}
+	}
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO orgs (id, name) VALUES ('44444444-4444-4444-4444-444444444444', 'replay');
+		INSERT INTO projects (id, org_id, name, github_repo)
+		  VALUES ('55555555-5555-5555-5555-555555555555',
+		          '44444444-4444-4444-4444-444444444444', 'app', 'owner/repo');
+		INSERT INTO environments (id, project_id, name)
+		  VALUES ('66666666-6666-6666-6666-666666666666',
+		          '55555555-5555-5555-5555-555555555555', 'production');
+		INSERT INTO error_groups
+		  (id, project_id, fingerprint, title, kind, status, first_seen, last_seen)
+		VALUES ('cccccccc-0000-0000-0000-000000000001',
+		        '55555555-5555-5555-5555-555555555555', 'fp-replay', 'Replay issue',
+		        'error', 'new', now() - interval '5 days', now());
+		INSERT INTO error_events
+		  (id, project_id, environment_id, error_group_id, timestamp,
+		   error_type, error_message, stack_trace_raw)
+		VALUES ('dddddddd-0000-0000-0000-000000000001',
+		        '55555555-5555-5555-5555-555555555555',
+		        '66666666-6666-6666-6666-666666666666',
+		        'cccccccc-0000-0000-0000-000000000001', now(),
+		        'TypeError', 'boom', 'at x');
+	`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	backfill := ""
+	for _, file := range files {
+		if strings.HasPrefix(filepath.Base(file), "060_") {
+			backfill = file
+		}
+	}
+	for pass := 1; pass <= 2; pass++ {
+		if err := applyMigration(t, psql, dsn, backfill); err != nil {
+			t.Fatalf("backfill pass %d: %v", pass, err)
+		}
+	}
+
+	var episodes, aliases, identities, receipts int
+	if err := pool.QueryRow(ctx, `
+		SELECT (SELECT count(*) FROM issue_episodes),
+		       (SELECT count(*) FROM canonical_issue_fingerprints),
+		       (SELECT count(*) FROM error_event_identities),
+		       (SELECT count(*) FROM issue_publications)`,
+	).Scan(&episodes, &aliases, &identities, &receipts); err != nil {
+		t.Fatal(err)
+	}
+	if episodes != 1 || aliases != 1 || identities != 1 || receipts != 1 {
+		t.Errorf("after two passes: episodes=%d aliases=%d identities=%d receipts=%d, want 1 each",
+			episodes, aliases, identities, receipts)
+	}
+}

--- a/packages/ingestion/db/migration_060_test.go
+++ b/packages/ingestion/db/migration_060_test.go
@@ -52,7 +52,13 @@ func TestMigration060AdoptsThePreRewriteWorld(t *testing.T) {
 		   now() - interval '29 days'),
 		  ('aaaaaaaa-0000-0000-0000-000000000003',
 		   '22222222-2222-2222-2222-222222222222', 'fp-friction', 'Dead click',
-		   'friction', 'new', now() - interval '10 days', now(), NULL);
+		   'friction', 'new', now() - interval '10 days', now(), NULL),
+		  ('aaaaaaaa-0000-0000-0000-000000000004',
+		   '22222222-2222-2222-2222-222222222222', 'fp-archived', 'Archived issue',
+		   'error', 'archived', now() - interval '60 days', now() - interval '50 days', NULL),
+		  ('aaaaaaaa-0000-0000-0000-000000000005',
+		   '22222222-2222-2222-2222-222222222222', 'fp-merged', 'Merged issue',
+		   'error', 'merged', now() - interval '70 days', now() - interval '60 days', NULL);
 
 		INSERT INTO error_events
 		  (id, project_id, environment_id, error_group_id, timestamp,
@@ -86,11 +92,24 @@ func TestMigration060AdoptsThePreRewriteWorld(t *testing.T) {
 		  FROM issue_episodes`).Scan(&episodes, &openEpisodes); err != nil {
 		t.Fatal(err)
 	}
-	if episodes != 3 {
-		t.Errorf("episodes = %d, want 3 (one per adopted issue)", episodes)
+	if episodes != 5 {
+		t.Errorf("episodes = %d, want 5 (one per adopted issue)", episodes)
 	}
+	// Only the active error issue and the friction issue stay open. The
+	// dispatcher treats resolved, merged, and archived alike as terminal, so an
+	// archived issue with an open round would read as live on day one.
 	if openEpisodes != 2 {
-		t.Errorf("open episodes = %d, want 2 (the resolved issue's round is closed)", openEpisodes)
+		t.Errorf("open episodes = %d, want 2 (resolved, merged and archived rounds are closed)", openEpisodes)
+	}
+	var terminalOpen int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM issue_episodes ep
+		  JOIN error_groups g ON g.id = ep.canonical_issue_id
+		 WHERE g.status IN ('resolved','merged','archived') AND ep.closed_at IS NULL`).Scan(&terminalOpen); err != nil {
+		t.Fatal(err)
+	}
+	if terminalOpen != 0 {
+		t.Errorf("%d terminal issues have an open round", terminalOpen)
 	}
 
 	// Each issue's own fingerprint becomes its alias, typed by the issue's kind.
@@ -109,8 +128,20 @@ func TestMigration060AdoptsThePreRewriteWorld(t *testing.T) {
 		 WHERE confirmed_by = 'exact' AND identity_version = 2`).Scan(&aliases); err != nil {
 		t.Fatal(err)
 	}
-	if aliases != 3 {
-		t.Errorf("aliases = %d, want 3", aliases)
+	// Four, not five: a merged group's fingerprint is deliberately left unbound.
+	// Settlement aborts when it locks an issue whose status is 'merged', so
+	// binding it would stall every future observation that matches it.
+	if aliases != 4 {
+		t.Errorf("aliases = %d, want 4 (every issue except the merged one)", aliases)
+	}
+	var mergedBound int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM canonical_issue_fingerprints
+		 WHERE fingerprint = 'fp-merged'`).Scan(&mergedBound); err != nil {
+		t.Fatal(err)
+	}
+	if mergedBound != 0 {
+		t.Errorf("merged issue's fingerprint was bound; settlement would stall on it")
 	}
 
 	// The backfill merges nothing: three issues in, three issues out.
@@ -238,5 +269,130 @@ func TestMigration060IsReapplySafeWithData(t *testing.T) {
 	if episodes != 1 || aliases != 1 || identities != 1 || receipts != 1 {
 		t.Errorf("after two passes: episodes=%d aliases=%d identities=%d receipts=%d, want 1 each",
 			episodes, aliases, identities, receipts)
+	}
+}
+
+// TestMigration060DoesNotPublishRoundsItDidNotAdopt is the regression for the
+// worst defect the review found. run-migrations.sh replays every file on every
+// service start. An earlier draft stamped a digest receipt on every sequence-1
+// episode, so a restart would mark a genuinely new issue as already published,
+// and digest.FreezeCandidates skips any episode that already carries a
+// publication row. The issue would never reach the daily message.
+func TestMigration060DoesNotPublishRoundsItDidNotAdopt(t *testing.T) {
+	admin := testPool(t)
+	psql := findPsql(t)
+	pool, dsn := disposableDB(t, admin)
+	ctx := context.Background()
+
+	files := migrationFiles(t)
+	backfill := ""
+	for _, file := range files {
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("apply %s: %v", file, err)
+		}
+		if strings.HasPrefix(filepath.Base(file), "060_") {
+			backfill = file
+		}
+	}
+
+	// A new issue born after cutover, with its first round open and unpublished.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO orgs (id, name) VALUES ('77777777-7777-7777-7777-777777777777', 'post-cutover');
+		INSERT INTO projects (id, org_id, name, github_repo)
+		  VALUES ('88888888-8888-8888-8888-888888888888',
+		          '77777777-7777-7777-7777-777777777777', 'app', 'owner/repo');
+		INSERT INTO error_groups
+		  (id, project_id, fingerprint, title, kind, status, first_seen, last_seen)
+		VALUES ('eeeeeeee-0000-0000-0000-000000000001',
+		        '88888888-8888-8888-8888-888888888888', 'canonical:new-issue',
+		        'Born after cutover', 'error', 'new', now(), now());
+		INSERT INTO issue_episodes (id, project_id, canonical_issue_id, sequence)
+		  VALUES ('ffffffff-0000-0000-0000-000000000001',
+		          '88888888-8888-8888-8888-888888888888',
+		          'eeeeeeee-0000-0000-0000-000000000001', 1);
+	`); err != nil {
+		t.Fatalf("seed post-cutover issue: %v", err)
+	}
+
+	// The restart.
+	if err := applyMigration(t, psql, dsn, backfill); err != nil {
+		t.Fatalf("replay backfill: %v", err)
+	}
+
+	var published int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM issue_publications
+		 WHERE episode_id = 'ffffffff-0000-0000-0000-000000000001'`).Scan(&published); err != nil {
+		t.Fatal(err)
+	}
+	if published != 0 {
+		t.Errorf("a replay published a round the backfill never adopted; that issue would be "+
+			"suppressed from the digest permanently (receipts = %d)", published)
+	}
+}
+
+// TestMigration060DoesNotSettleAcrossProjects covers the tenant-scoping gap the
+// review found. error_event_identities has independent foreign keys onto the
+// project and the event, so neither rejects an identity whose event belongs to
+// one project and whose canonical issue belongs to another.
+func TestMigration060DoesNotSettleAcrossProjects(t *testing.T) {
+	admin := testPool(t)
+	psql := findPsql(t)
+	pool, dsn := disposableDB(t, admin)
+	ctx := context.Background()
+
+	files := migrationFiles(t)
+	backfill := ""
+	for _, file := range files {
+		if strings.HasPrefix(filepath.Base(file), "060_") {
+			backfill = file
+			continue
+		}
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("apply %s: %v", file, err)
+		}
+	}
+
+	// A legacy event in project A pointing at project B's group.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO orgs (id, name) VALUES ('99999999-9999-9999-9999-999999999999', 'two-tenants');
+		INSERT INTO projects (id, org_id, name, github_repo) VALUES
+		  ('aaaaaaaa-1111-1111-1111-111111111111',
+		   '99999999-9999-9999-9999-999999999999', 'project-a', 'owner/a'),
+		  ('bbbbbbbb-1111-1111-1111-111111111111',
+		   '99999999-9999-9999-9999-999999999999', 'project-b', 'owner/b');
+		INSERT INTO environments (id, project_id, name) VALUES
+		  ('cccccccc-1111-1111-1111-111111111111',
+		   'aaaaaaaa-1111-1111-1111-111111111111', 'production');
+		INSERT INTO error_groups
+		  (id, project_id, fingerprint, title, kind, status, first_seen, last_seen)
+		VALUES ('dddddddd-1111-1111-1111-111111111111',
+		        'bbbbbbbb-1111-1111-1111-111111111111', 'fp-project-b', 'B issue',
+		        'error', 'new', now(), now());
+		INSERT INTO error_events
+		  (id, project_id, environment_id, error_group_id, timestamp,
+		   error_type, error_message, stack_trace_raw)
+		VALUES ('eeeeeeee-1111-1111-1111-111111111111',
+		        'aaaaaaaa-1111-1111-1111-111111111111',
+		        'cccccccc-1111-1111-1111-111111111111',
+		        'dddddddd-1111-1111-1111-111111111111', now(),
+		        'TypeError', 'boom', 'at x');
+	`); err != nil {
+		t.Fatalf("seed cross-project event: %v", err)
+	}
+
+	if err := applyMigration(t, psql, dsn, backfill); err != nil {
+		t.Fatalf("apply backfill: %v", err)
+	}
+
+	var straddling int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM error_event_identities i
+		  JOIN error_groups g ON g.id = i.canonical_issue_id
+		 WHERE g.project_id <> i.project_id`).Scan(&straddling); err != nil {
+		t.Fatal(err)
+	}
+	if straddling != 0 {
+		t.Errorf("%d identities point at another project's canonical issue", straddling)
 	}
 }

--- a/packages/ingestion/db/migrations/060_cutover_backfill.sql
+++ b/packages/ingestion/db/migrations/060_cutover_backfill.sql
@@ -13,51 +13,53 @@
 --
 -- Deliberately merges nothing. Each group keeps its own identity, which is the
 -- plan's "uncertain clusters stay split" default taken all the way. Where two
--- adopted issues later turn out to be one problem, settlement records an
+-- adopted error issues later turn out to be one problem, settlement records an
 -- issue_alias_conflicts row and identity.ConfirmMerge resolves it under audit.
 -- That path refuses to merge an issue carrying observations without settled
--- identity, which is why step 3 settles every historical event and not just
--- recent ones.
+-- identity, which is why step 2 settles every historical event and not just
+-- recent ones. (ConfirmMerge also refuses any group with kind <> 'error', so
+-- adopted friction issues cannot be merged by anyone; nothing here changes
+-- that.)
 --
 -- Reapply-safe: run-migrations.sh replays every file on every start, so each
 -- statement is guarded and re-running changes nothing.
 
--- 1. One episode per existing issue.
+-- 1. One episode per existing issue, plus a digest receipt for the rounds this
+--    statement actually adopts.
 --
--- Resolved groups get an episode that is opened and immediately closed, so
--- their history exists and their observations have an episode to hang from,
--- while idx_one_open_episode still sees no open round for them. A recurrence
--- after cutover opens sequence 2, which is what makes the card read as returned
--- rather than new.
-INSERT INTO issue_episodes (project_id, canonical_issue_id, sequence, opened_at, closed_at)
-SELECT g.project_id,
-       g.id,
-       1,
-       g.first_seen,
-       CASE WHEN g.status = 'resolved'
-            THEN COALESCE(g.resolved_at, g.updated_at)
-       END
-  FROM error_groups g
-ON CONFLICT (project_id, canonical_issue_id, sequence) DO NOTHING;
-
--- 2. Bind each issue's fingerprint as its own alias.
+-- The receipt has to be tied to the episodes inserted *by this run*, which is
+-- why it is a data-modifying CTE rather than a second statement. A standalone
+-- INSERT over "every sequence-1 episode" would restamp on every service start,
+-- and since digest.FreezeCandidates skips any episode that already has a
+-- publication row, a genuinely new issue whose first round had not yet been
+-- published would be suppressed from the daily message permanently. On reapply
+-- the ON CONFLICT below inserts nothing, RETURNING yields nothing, and no
+-- receipt is written.
 --
--- confirmed_by = 'exact' because this is not a judgement call: the fingerprint
--- is the key the group was already stored under. identity_version must track
--- identity.IdentityVersion in packages/ingestion/identity/canonical.go; bump
--- both together or settled observations stop matching their aliases.
-INSERT INTO canonical_issue_fingerprints
-  (project_id, fingerprint, fingerprint_kind, canonical_issue_id, identity_version, confirmed_by)
-SELECT g.project_id,
-       g.fingerprint,
-       CASE WHEN g.kind = 'error' THEN 'raw' ELSE 'friction' END,
-       g.id,
-       2,
-       'exact'
-  FROM error_groups g
-ON CONFLICT (project_id, identity_version, fingerprint) DO NOTHING;
+-- Terminal issues get a round that is opened and closed at once, so their
+-- history exists and their observations have an episode to hang from, while
+-- idx_one_open_episode still sees no open round for them. 'resolved', 'merged',
+-- and 'archived' are all terminal to the dispatcher; closing only 'resolved'
+-- would leave archived issues looking live. A recurrence after cutover opens
+-- sequence 2, which is what makes the card read as returned rather than new.
+WITH adopted AS (
+  INSERT INTO issue_episodes (project_id, canonical_issue_id, sequence, opened_at, closed_at)
+  SELECT g.project_id,
+         g.id,
+         1,
+         g.first_seen,
+         CASE WHEN g.status IN ('resolved', 'merged', 'archived')
+              THEN COALESCE(g.resolved_at, g.updated_at)
+         END
+    FROM error_groups g
+  ON CONFLICT (project_id, canonical_issue_id, sequence) DO NOTHING
+  RETURNING project_id, id
+)
+INSERT INTO issue_publications (project_id, episode_id, channel)
+SELECT project_id, id, 'digest' FROM adopted
+ON CONFLICT (project_id, episode_id, channel) DO NOTHING;
 
--- 3. Settle every historical observation onto the issue it already belongs to.
+-- 2. Settle every historical observation onto the issue it already belongs to.
 --
 -- resolved_fingerprint stays NULL: these events were captured before stack
 -- resolution existed and were never source-mapped. Recording a resolved
@@ -66,6 +68,10 @@ ON CONFLICT (project_id, identity_version, fingerprint) DO NOTHING;
 -- Status 'settled' keeps the settler's pending sweep away from them. The filter
 -- counts affected units over a seven-day window, so adopting full history does
 -- not inflate reach; it only lets an issue's real recent activity be seen.
+--
+-- The join carries project_id on both sides. The two foreign keys are checked
+-- independently, so a legacy event pointing at another project's group would
+-- otherwise write an identity that straddles two tenants.
 INSERT INTO error_event_identities
   (project_id, event_id, status, canonical_issue_id, raw_fingerprint,
    identity_version, episode_id, settled_at)
@@ -80,6 +86,7 @@ SELECT e.project_id,
   FROM error_events e
   JOIN error_groups g
     ON g.id = e.error_group_id
+   AND g.project_id = e.project_id
   JOIN issue_episodes ep
     ON ep.project_id = g.project_id
    AND ep.canonical_issue_id = g.id
@@ -87,15 +94,28 @@ SELECT e.project_id,
  WHERE e.error_group_id IS NOT NULL
 ON CONFLICT (project_id, event_id) DO NOTHING;
 
--- 4. Receipts, so adopted issues are not introduced as new.
+-- 3. Bind each issue's fingerprint as its own alias.
 --
--- The digest publishes an episode once per channel. Marking every adopted
--- episode as already published on the digest channel means the first daily
--- message after cutover reports new and returned work only. When an adopted
--- issue recurs after being resolved, sequence 2 opens with no receipt and the
--- customer hears about it again, correctly labelled as returned.
-INSERT INTO issue_publications (project_id, episode_id, channel)
-SELECT ep.project_id, ep.id, 'digest'
-  FROM issue_episodes ep
- WHERE ep.sequence = 1
-ON CONFLICT (project_id, episode_id, channel) DO NOTHING;
+-- confirmed_by = 'exact' because this is not a judgement call: the fingerprint
+-- is the key the group was already stored under.
+--
+-- Merged groups are skipped. Settlement locks the canonical issue and aborts
+-- when it finds status 'merged', so binding a merged loser's fingerprint would
+-- stall every future observation that matches it. The old world carries no
+-- pointer to the winner, so the honest outcome is to leave the fingerprint
+-- unbound and let a recurrence open a fresh issue.
+--
+-- identity_version is pinned at 2 to match identity.IdentityVersion at the time
+-- of cutover. Do not edit this literal later: a version change needs its own
+-- migration, or already-adopted aliases would silently stop matching.
+INSERT INTO canonical_issue_fingerprints
+  (project_id, fingerprint, fingerprint_kind, canonical_issue_id, identity_version, confirmed_by)
+SELECT g.project_id,
+       g.fingerprint,
+       CASE WHEN g.kind = 'error' THEN 'raw' ELSE 'friction' END,
+       g.id,
+       2,
+       'exact'
+  FROM error_groups g
+ WHERE g.status <> 'merged'
+ON CONFLICT (project_id, identity_version, fingerprint) DO NOTHING;

--- a/packages/ingestion/db/migrations/060_cutover_backfill.sql
+++ b/packages/ingestion/db/migrations/060_cutover_backfill.sql
@@ -1,0 +1,101 @@
+-- Cutover backfill: adopt the pre-rewrite world into the pipeline's tables.
+--
+-- Before this runs, every issue in the product is an error_groups row keyed on
+-- a raw fingerprint, and no observation has an identity. The new pipeline reads
+-- issues through issue_episodes, canonical_issue_fingerprints, and
+-- error_event_identities. Without this file the settler would mint a second,
+-- parallel canonical issue for every problem that already exists, and the daily
+-- message would introduce months-old issues to the customer as new.
+--
+-- canonical_issue_id is a foreign key onto error_groups(id), so adoption is not
+-- a copy: an existing group already *is* its canonical issue. This file only
+-- builds the rows that point at it.
+--
+-- Deliberately merges nothing. Each group keeps its own identity, which is the
+-- plan's "uncertain clusters stay split" default taken all the way. Where two
+-- adopted issues later turn out to be one problem, settlement records an
+-- issue_alias_conflicts row and identity.ConfirmMerge resolves it under audit.
+-- That path refuses to merge an issue carrying observations without settled
+-- identity, which is why step 3 settles every historical event and not just
+-- recent ones.
+--
+-- Reapply-safe: run-migrations.sh replays every file on every start, so each
+-- statement is guarded and re-running changes nothing.
+
+-- 1. One episode per existing issue.
+--
+-- Resolved groups get an episode that is opened and immediately closed, so
+-- their history exists and their observations have an episode to hang from,
+-- while idx_one_open_episode still sees no open round for them. A recurrence
+-- after cutover opens sequence 2, which is what makes the card read as returned
+-- rather than new.
+INSERT INTO issue_episodes (project_id, canonical_issue_id, sequence, opened_at, closed_at)
+SELECT g.project_id,
+       g.id,
+       1,
+       g.first_seen,
+       CASE WHEN g.status = 'resolved'
+            THEN COALESCE(g.resolved_at, g.updated_at)
+       END
+  FROM error_groups g
+ON CONFLICT (project_id, canonical_issue_id, sequence) DO NOTHING;
+
+-- 2. Bind each issue's fingerprint as its own alias.
+--
+-- confirmed_by = 'exact' because this is not a judgement call: the fingerprint
+-- is the key the group was already stored under. identity_version must track
+-- identity.IdentityVersion in packages/ingestion/identity/canonical.go; bump
+-- both together or settled observations stop matching their aliases.
+INSERT INTO canonical_issue_fingerprints
+  (project_id, fingerprint, fingerprint_kind, canonical_issue_id, identity_version, confirmed_by)
+SELECT g.project_id,
+       g.fingerprint,
+       CASE WHEN g.kind = 'error' THEN 'raw' ELSE 'friction' END,
+       g.id,
+       2,
+       'exact'
+  FROM error_groups g
+ON CONFLICT (project_id, identity_version, fingerprint) DO NOTHING;
+
+-- 3. Settle every historical observation onto the issue it already belongs to.
+--
+-- resolved_fingerprint stays NULL: these events were captured before stack
+-- resolution existed and were never source-mapped. Recording a resolved
+-- fingerprint we never computed would bind an alias on a guess.
+--
+-- Status 'settled' keeps the settler's pending sweep away from them. The filter
+-- counts affected units over a seven-day window, so adopting full history does
+-- not inflate reach; it only lets an issue's real recent activity be seen.
+INSERT INTO error_event_identities
+  (project_id, event_id, status, canonical_issue_id, raw_fingerprint,
+   identity_version, episode_id, settled_at)
+SELECT e.project_id,
+       e.id,
+       'settled',
+       g.id,
+       g.fingerprint,
+       2,
+       ep.id,
+       e.created_at
+  FROM error_events e
+  JOIN error_groups g
+    ON g.id = e.error_group_id
+  JOIN issue_episodes ep
+    ON ep.project_id = g.project_id
+   AND ep.canonical_issue_id = g.id
+   AND ep.sequence = 1
+ WHERE e.error_group_id IS NOT NULL
+ON CONFLICT (project_id, event_id) DO NOTHING;
+
+-- 4. Receipts, so adopted issues are not introduced as new.
+--
+-- The digest publishes an episode once per channel. Marking every adopted
+-- episode as already published on the digest channel means the first daily
+-- message after cutover reports new and returned work only. When an adopted
+-- issue recurs after being resolved, sequence 2 opens with no receipt and the
+-- customer hears about it again, correctly labelled as returned.
+INSERT INTO issue_publications (project_id, episode_id, channel)
+SELECT ep.project_id, ep.id, 'digest'
+  FROM issue_episodes ep
+ WHERE ep.sequence = 1
+ON CONFLICT (project_id, episode_id, channel) DO NOTHING;

--- a/scripts/cutover-smoke.sh
+++ b/scripts/cutover-smoke.sh
@@ -18,6 +18,9 @@
 #
 # Optional:
 #   SMOKE_TIMEOUT      seconds to wait per stage (default 180)
+#   SMOKE_QUERY_TIMEOUT       seconds before one read is abandoned (default 30)
+#   SMOKE_ALLOW_DECLINED_INQUIRY=1  pass even if the inquiry declines, leaving
+#                                   the investigator handoff unproven
 #   DIGEST_REPLAY_CMD  how to invoke cmd/digest-replay (default: go run ...)
 #
 # Exit 0 only when every stage passed.
@@ -29,6 +32,11 @@ readonly DATABASE_URL="${DATABASE_URL:?DATABASE_URL is required}"
 readonly SMOKE_API_KEY="${SMOKE_API_KEY:?SMOKE_API_KEY is required}"
 readonly SMOKE_PROJECT_ID="${SMOKE_PROJECT_ID:?SMOKE_PROJECT_ID is required}"
 readonly SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-180}"
+readonly SMOKE_QUERY_TIMEOUT="${SMOKE_QUERY_TIMEOUT:-30}"
+# A model declining a synthetic error is a legitimate answer, but then stage 6
+# never exercises the handoff to the investigator. Set this to accept that and
+# still exit 0, knowing the accepted path went unproven.
+readonly SMOKE_ALLOW_DECLINED_INQUIRY="${SMOKE_ALLOW_DECLINED_INQUIRY:-0}"
 readonly DIGEST_REPLAY_CMD="${DIGEST_REPLAY_CMD:-go run ./packages/ingestion/cmd/digest-replay}"
 
 for command_name in curl jq psql; do
@@ -48,9 +56,11 @@ fail() {
   exit 1
 }
 
-# query runs one read and returns a single value with no decoration.
+# query runs one read and returns a single value with no decoration. The outer
+# timeout is what makes SMOKE_TIMEOUT real: without it a wedged connection blocks
+# inside psql and the deadline below is never even evaluated.
 query() {
-  psql "$DATABASE_URL" -X -q -t -A -v ON_ERROR_STOP=1 -c "$1"
+  timeout "$SMOKE_QUERY_TIMEOUT" psql "$DATABASE_URL" -X -q -t -A -v ON_ERROR_STOP=1 -c "$1"
 }
 
 # await polls one scalar query until it equals the expected value.
@@ -58,7 +68,9 @@ await() {
   local description="$1" sql="$2" want="$3" deadline got
   deadline=$(( $(date +%s) + SMOKE_TIMEOUT ))
   while :; do
-    got="$(query "$sql")"
+    # A failed read must not trip `set -e`: that would kill the script without
+    # naming the stage. Keep polling and let the deadline report it.
+    got="$(query "$sql" || true)"
     if [[ "$got" == "$want" ]]; then
       echo "  ok: $description"
       return 0
@@ -166,14 +178,14 @@ await "a filter decision exists" \
     WHERE project_id='${SMOKE_PROJECT_ID}' AND episode_id='${EPISODE_ID}'" \
   "t"
 
-FILTER_DECISION="$(query "SELECT decision FROM issue_decisions
-                           WHERE project_id='${SMOKE_PROJECT_ID}'
-                             AND episode_id='${EPISODE_ID}'
-                           ORDER BY decided_at DESC, id DESC LIMIT 1")"
-FILTER_REASON="$(query "SELECT reason FROM issue_decisions
-                         WHERE project_id='${SMOKE_PROJECT_ID}'
-                           AND episode_id='${EPISODE_ID}'
-                         ORDER BY decided_at DESC, id DESC LIMIT 1")"
+# One row, one round trip. Reading decision and reason separately could pair a
+# decision with a different row's reason if another lands between the two reads.
+FILTER_ROW="$(query "SELECT decision || '|' || reason FROM issue_decisions
+                      WHERE project_id='${SMOKE_PROJECT_ID}'
+                        AND episode_id='${EPISODE_ID}'
+                      ORDER BY decided_at DESC, id DESC LIMIT 1")"
+FILTER_DECISION="${FILTER_ROW%%|*}"
+FILTER_REASON="${FILTER_ROW#*|}"
 echo "  filter: ${FILTER_DECISION} (${FILTER_REASON})"
 
 # Two distinct users in scope must clear the bar. Anything else means the filter
@@ -191,14 +203,12 @@ await "an inquiry decision exists" \
     WHERE project_id='${SMOKE_PROJECT_ID}' AND episode_id='${EPISODE_ID}'" \
   "t"
 
-INQUIRY_DECISION="$(query "SELECT decision FROM issue_inquiry_decisions
-                            WHERE project_id='${SMOKE_PROJECT_ID}'
-                              AND episode_id='${EPISODE_ID}'
-                            ORDER BY decided_at DESC, id DESC LIMIT 1")"
-INQUIRY_REASON="$(query "SELECT reason FROM issue_inquiry_decisions
-                          WHERE project_id='${SMOKE_PROJECT_ID}'
-                            AND episode_id='${EPISODE_ID}'
-                          ORDER BY decided_at DESC, id DESC LIMIT 1")"
+INQUIRY_ROW="$(query "SELECT decision || '|' || reason FROM issue_inquiry_decisions
+                       WHERE project_id='${SMOKE_PROJECT_ID}'
+                         AND episode_id='${EPISODE_ID}'
+                       ORDER BY decided_at DESC, id DESC LIMIT 1")"
+INQUIRY_DECISION="${INQUIRY_ROW%%|*}"
+INQUIRY_REASON="${INQUIRY_ROW#*|}"
 echo "  inquiry: ${INQUIRY_DECISION} (${INQUIRY_REASON})"
 
 # The verdict itself is not asserted. The inquiry asks a model whether this is a
@@ -222,6 +232,16 @@ else
   [[ "$(query "$INVESTIGATIONS")" == "0" ]] ||
     fail "inquiry returned '${INQUIRY_DECISION}' but an investigation was created anyway"
   echo "  ok: declined episode created no investigation"
+
+  # Passing here would be a false pass. The negative half held, but the handoff
+  # to the investigator, which is what the window actually needs proven, was
+  # never exercised. Say so rather than printing a green line.
+  if [[ "$SMOKE_ALLOW_DECLINED_INQUIRY" != "1" ]]; then
+    fail "the inquiry declined this observation, so the accepted path was never run.
+  Nothing here proves an accepted episode reaches the investigator. Re-run, or set
+  SMOKE_ALLOW_DECLINED_INQUIRY=1 to accept the gate with that path unproven."
+  fi
+  echo "  WARNING: accepted path unproven (SMOKE_ALLOW_DECLINED_INQUIRY=1)" >&2
 fi
 
 # ---------------------------------------------------------------------------
@@ -231,17 +251,34 @@ stage "a digest run freezes, validates, and delivers"
 # The sweeper runs on the daily boundary, which the window cannot wait for, so
 # drive one run directly. Same code path, explicit timestamp.
 BOUNDARY="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-$DIGEST_REPLAY_CMD -project "$SMOKE_PROJECT_ID" -freeze -at "$BOUNDARY" ||
+FREEZE_OUTPUT="$($DIGEST_REPLAY_CMD -project "$SMOKE_PROJECT_ID" -freeze -at "$BOUNDARY")" ||
   fail "freezing a digest run failed"
 
-RUN_ID="$(query "SELECT id FROM digest_runs
-                  WHERE project_id='${SMOKE_PROJECT_ID}'
-                  ORDER BY created_at DESC LIMIT 1")"
-[[ -n "$RUN_ID" ]] || fail "no digest run was frozen"
-echo "  ok: run ${RUN_ID} frozen"
+# Take the id the freezer reports, not the newest row. digest_runs is unique per
+# project and local date, so the freezer may hand back a run that already
+# existed; picking "latest" could just as easily land on an unrelated project's
+# newer run and assert against it.
+RUN_ID="$(sed -n 's/^run=\([0-9a-f-]*\).*/\1/p' <<<"$FREEZE_OUTPUT")"
+[[ -n "$RUN_ID" ]] || fail "could not read a run id from the freezer: ${FREEZE_OUTPUT}"
 
-await "the run is written" \
-  "SELECT status IN ('written','validated','delivered') FROM digest_runs WHERE id='${RUN_ID}'" \
+# If today's run was already delivered, both freeze and publish short-circuit and
+# every assertion below passes without a single new write. That is the digest
+# equivalent of a green light on a dead wire.
+FROZEN_STATUS="$(query "SELECT status FROM digest_runs WHERE id='${RUN_ID}'")"
+if [[ "$FROZEN_STATUS" == "delivered" ]]; then
+  fail "today's digest run (${RUN_ID}) was already delivered before this smoke ran.
+  Freezing and publishing are both no-ops now, so stage 7 would pass without
+  writing or validating anything. Re-run after the next daily boundary."
+fi
+echo "  ok: run ${RUN_ID} at status ${FROZEN_STATUS}"
+
+# Assert on the payload, not on the exact status. The daily sweeper runs in
+# production and may validate or deliver this run between the freeze above and
+# this read; demanding status='written' would then time out on a run that in fact
+# succeeded. A non-null payload is the part that proves the writer ran.
+await "the writer produced a payload" \
+  "SELECT payload IS NOT NULL AND status IN ('written','validated','delivered')
+     FROM digest_runs WHERE id='${RUN_ID}'" \
   "t"
 
 $DIGEST_REPLAY_CMD -project "$SMOKE_PROJECT_ID" -publish -run "$RUN_ID" ||

--- a/scripts/cutover-smoke.sh
+++ b/scripts/cutover-smoke.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+#
+# Cutover smoke: drive one observation through every stage of the pipeline and
+# assert each one in order.
+#
+# This is the gate before traffic resumes in the maintenance window. The deploy
+# script's own smoke cannot serve that purpose: it reads `.group_id` from the
+# ingest response and polls it as an incident id, but that field now carries the
+# capture handle (a raw fingerprint, not a UUID), and a single event never
+# reaches a terminal worker state because the filter admits at two affected
+# units. Run this instead, with SKIP_SMOKE=1 on the deploy.
+#
+# Required:
+#   INGESTION_URL     e.g. https://app.opslane.com
+#   DATABASE_URL      a DSN that can read the pipeline tables
+#   SMOKE_API_KEY     ingest key for SMOKE_PROJECT_ID
+#   SMOKE_PROJECT_ID  project UUID
+#
+# Optional:
+#   SMOKE_TIMEOUT      seconds to wait per stage (default 180)
+#   DIGEST_REPLAY_CMD  how to invoke cmd/digest-replay (default: go run ...)
+#
+# Exit 0 only when every stage passed.
+
+set -euo pipefail
+
+readonly INGESTION_URL="${INGESTION_URL:?INGESTION_URL is required}"
+readonly DATABASE_URL="${DATABASE_URL:?DATABASE_URL is required}"
+readonly SMOKE_API_KEY="${SMOKE_API_KEY:?SMOKE_API_KEY is required}"
+readonly SMOKE_PROJECT_ID="${SMOKE_PROJECT_ID:?SMOKE_PROJECT_ID is required}"
+readonly SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-180}"
+readonly DIGEST_REPLAY_CMD="${DIGEST_REPLAY_CMD:-go run ./packages/ingestion/cmd/digest-replay}"
+
+for command_name in curl jq psql; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "required command not found: $command_name" >&2
+    exit 1
+  }
+done
+
+STAGE=0
+stage() {
+  STAGE=$((STAGE + 1))
+  printf '\n[%d/7] %s\n' "$STAGE" "$1"
+}
+fail() {
+  printf 'FAIL at stage %d: %s\n' "$STAGE" "$1" >&2
+  exit 1
+}
+
+# query runs one read and returns a single value with no decoration.
+query() {
+  psql "$DATABASE_URL" -X -q -t -A -v ON_ERROR_STOP=1 -c "$1"
+}
+
+# await polls one scalar query until it equals the expected value.
+await() {
+  local description="$1" sql="$2" want="$3" deadline got
+  deadline=$(( $(date +%s) + SMOKE_TIMEOUT ))
+  while :; do
+    got="$(query "$sql")"
+    if [[ "$got" == "$want" ]]; then
+      echo "  ok: $description"
+      return 0
+    fi
+    if (( $(date +%s) >= deadline )); then
+      fail "$description (last value: '${got}', wanted '${want}')"
+    fi
+    sleep 3
+  done
+}
+
+MARKER="cutover-smoke-$(date +%s)-$$"
+readonly MARKER
+
+# ---------------------------------------------------------------------------
+
+stage "an event is accepted and returns a capture handle"
+
+# Two distinct users on purpose. The cheap filter admits at two affected units
+# in seven days (admitUnits in packages/ingestion/filter/evaluate.go), so a
+# single observation parks at 'watch' and stages four onward never run. This is
+# the smallest input that exercises the whole pipeline.
+post_event() {
+  local user_id="$1" session_id="$2"
+  jq -n \
+    --arg marker "$MARKER" \
+    --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg user "$user_id" \
+    --arg session "$session_id" \
+    '{
+      timestamp: $timestamp,
+      session_id: $session,
+      error: {
+        type: "CutoverSmokeError",
+        message: $marker,
+        stack: ("CutoverSmokeError: " + $marker + "\n    at cutoverSmoke (cutover-smoke.sh:1:1)")
+      },
+      breadcrumbs: [],
+      context: {source: "cutover-smoke", user: {id: $user}},
+      sdk_version: "cutover-smoke"
+    }' |
+    curl -fsS -X POST "${INGESTION_URL}/api/v1/events" \
+      -H "X-API-Key: ${SMOKE_API_KEY}" \
+      -H "Content-Type: application/json" \
+      --data @-
+}
+
+FIRST_RESPONSE="$(post_event "cutover-smoke-user-1" "cutover-smoke-session-1")"
+post_event "cutover-smoke-user-2" "cutover-smoke-session-2" >/dev/null
+
+CAPTURE_HANDLE="$(jq -er '.group_id' <<<"$FIRST_RESPONSE")"
+[[ -n "$CAPTURE_HANDLE" && "$CAPTURE_HANDLE" != "null" ]] ||
+  fail "ingest returned no capture handle: $FIRST_RESPONSE"
+echo "  ok: capture handle ${CAPTURE_HANDLE}"
+
+await "both observations are stored" \
+  "SELECT count(*) FROM error_events
+    WHERE project_id='${SMOKE_PROJECT_ID}' AND error_message='${MARKER}'" \
+  "2"
+
+EVENT_IDS="SELECT id FROM error_events
+             WHERE project_id='${SMOKE_PROJECT_ID}' AND error_message='${MARKER}'"
+
+# ---------------------------------------------------------------------------
+
+stage "its resolution row reaches a terminal status"
+
+# Settlement only proceeds from 'resolved' or 'no_map'. 'failed' is terminal for
+# the resolver but would strand identity, so it is not accepted here.
+await "resolution is settleable" \
+  "SELECT count(*) FROM error_event_resolutions
+    WHERE project_id='${SMOKE_PROJECT_ID}'
+      AND event_id IN (${EVENT_IDS})
+      AND status IN ('resolved','no_map')" \
+  "2"
+
+# ---------------------------------------------------------------------------
+
+stage "its identity settles to a canonical issue"
+
+await "identities are settled" \
+  "SELECT count(*) FROM error_event_identities
+    WHERE project_id='${SMOKE_PROJECT_ID}'
+      AND event_id IN (${EVENT_IDS})
+      AND status='settled' AND canonical_issue_id IS NOT NULL" \
+  "2"
+
+await "both observations settled onto one issue" \
+  "SELECT count(DISTINCT canonical_issue_id) FROM error_event_identities
+    WHERE project_id='${SMOKE_PROJECT_ID}' AND event_id IN (${EVENT_IDS})" \
+  "1"
+
+EPISODE_ID="$(query "SELECT DISTINCT episode_id FROM error_event_identities
+                      WHERE project_id='${SMOKE_PROJECT_ID}'
+                        AND event_id IN (${EVENT_IDS})")"
+[[ -n "$EPISODE_ID" ]] || fail "settled identity carries no episode"
+echo "  ok: episode ${EPISODE_ID}"
+
+# ---------------------------------------------------------------------------
+
+stage "the filter writes a decision"
+
+await "a filter decision exists" \
+  "SELECT count(*) > 0 FROM issue_decisions
+    WHERE project_id='${SMOKE_PROJECT_ID}' AND episode_id='${EPISODE_ID}'" \
+  "t"
+
+FILTER_DECISION="$(query "SELECT decision FROM issue_decisions
+                           WHERE project_id='${SMOKE_PROJECT_ID}'
+                             AND episode_id='${EPISODE_ID}'
+                           ORDER BY decided_at DESC, id DESC LIMIT 1")"
+FILTER_REASON="$(query "SELECT reason FROM issue_decisions
+                         WHERE project_id='${SMOKE_PROJECT_ID}'
+                           AND episode_id='${EPISODE_ID}'
+                         ORDER BY decided_at DESC, id DESC LIMIT 1")"
+echo "  filter: ${FILTER_DECISION} (${FILTER_REASON})"
+
+# Two distinct users in scope must clear the bar. Anything else means the filter
+# or the project's action scope is misconfigured, and the pipeline would stall
+# here for real traffic too.
+[[ "$FILTER_DECISION" == "open_inquiry" ]] ||
+  fail "filter did not admit two affected users: ${FILTER_DECISION} (${FILTER_REASON})"
+
+# ---------------------------------------------------------------------------
+
+stage "a qualified episode reaches an inquiry decision"
+
+await "an inquiry decision exists" \
+  "SELECT count(*) > 0 FROM issue_inquiry_decisions
+    WHERE project_id='${SMOKE_PROJECT_ID}' AND episode_id='${EPISODE_ID}'" \
+  "t"
+
+INQUIRY_DECISION="$(query "SELECT decision FROM issue_inquiry_decisions
+                            WHERE project_id='${SMOKE_PROJECT_ID}'
+                              AND episode_id='${EPISODE_ID}'
+                            ORDER BY decided_at DESC, id DESC LIMIT 1")"
+INQUIRY_REASON="$(query "SELECT reason FROM issue_inquiry_decisions
+                          WHERE project_id='${SMOKE_PROJECT_ID}'
+                            AND episode_id='${EPISODE_ID}'
+                          ORDER BY decided_at DESC, id DESC LIMIT 1")"
+echo "  inquiry: ${INQUIRY_DECISION} (${INQUIRY_REASON})"
+
+# The verdict itself is not asserted. The inquiry asks a model whether this is a
+# real product problem, and declining a synthetic error is a correct answer. What
+# the gate proves is that the stage ran and committed a decision.
+
+# ---------------------------------------------------------------------------
+
+stage "an accepted episode creates exactly one investigation"
+
+INVESTIGATIONS="SELECT count(*) FROM error_group_jobs
+                 WHERE project_id='${SMOKE_PROJECT_ID}'
+                   AND episode_id='${EPISODE_ID}'
+                   AND job_type='investigate'"
+
+if [[ "$INQUIRY_DECISION" == "investigate" ]]; then
+  await "exactly one investigation was created" "$INVESTIGATIONS" "1"
+else
+  # A declined episode must create none. Handing work to the investigator
+  # without an accepted inquiry is the failure this half guards against.
+  [[ "$(query "$INVESTIGATIONS")" == "0" ]] ||
+    fail "inquiry returned '${INQUIRY_DECISION}' but an investigation was created anyway"
+  echo "  ok: declined episode created no investigation"
+fi
+
+# ---------------------------------------------------------------------------
+
+stage "a digest run freezes, validates, and delivers"
+
+# The sweeper runs on the daily boundary, which the window cannot wait for, so
+# drive one run directly. Same code path, explicit timestamp.
+BOUNDARY="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+$DIGEST_REPLAY_CMD -project "$SMOKE_PROJECT_ID" -freeze -at "$BOUNDARY" ||
+  fail "freezing a digest run failed"
+
+RUN_ID="$(query "SELECT id FROM digest_runs
+                  WHERE project_id='${SMOKE_PROJECT_ID}'
+                  ORDER BY created_at DESC LIMIT 1")"
+[[ -n "$RUN_ID" ]] || fail "no digest run was frozen"
+echo "  ok: run ${RUN_ID} frozen"
+
+await "the run is written" \
+  "SELECT status IN ('written','validated','delivered') FROM digest_runs WHERE id='${RUN_ID}'" \
+  "t"
+
+$DIGEST_REPLAY_CMD -project "$SMOKE_PROJECT_ID" -publish -run "$RUN_ID" ||
+  fail "validating and publishing the digest run failed"
+
+await "the run is delivered" \
+  "SELECT status FROM digest_runs WHERE id='${RUN_ID}'" \
+  "delivered"
+
+printf '\ncutover smoke passed: all 7 stages\n'


### PR DESCRIPTION
Slices 1 through 10 are merged but have never been deployed. Production still runs pre-rewrite code, and I confirmed against the prod database that none of the eight new pipeline tables exist there. This is the switchover.

## What is here

**`060_cutover_backfill.sql`** teaches the new pipeline about the issues that already exist. Without it the settler mints a second, parallel canonical issue for every problem in the database, and the daily message introduces months-old issues as new.

`canonical_issue_id` is a foreign key onto `error_groups(id)`, so an existing group already *is* its canonical issue. The migration only builds the rows that point at it: one episode per issue, each issue's own fingerprint bound back to it as an alias, every historical observation settled onto the issue it already belonged to, and a digest receipt so adopted rounds cannot announce themselves as new.

It merges nothing. That is the plan's "uncertain clusters stay split" default taken all the way; later merges go through the audited `ConfirmMerge` path.

Numbered 060, not the plan's 055. Main is already at 059.

**`scripts/cutover-smoke.sh`** walks one observation through all seven stages. The deploy script's own smoke cannot pass under the new pipeline: it reads `.group_id` as an incident id, but that field now carries the capture handle, which is a raw fingerprint rather than a UUID, and a single event is one affected unit, below the filter's `admitUnits = 2`. Deploy with `SKIP_SMOKE=1` and run this instead.

## Two decisions worth reviewing

**Every historical event is settled, not just recent ones.** `ConfirmMerge` refuses, with no human override, to merge an issue carrying events without settled identity, and its own comment points at the cutover backfill as the thing that adopts those populations first. A partial backfill would block merging until the rows were added later. Friction issues are refused regardless, on `kind <> 'error'`.

**Task 29, the pre-cutover merge report, was dropped.** It cannot run as specced: it wants a read-only production session while consuming `Settle` and `Evaluate`, but production has none of the tables it reads, identity is computed from source-mapped frames production has never computed, and both functions write. Skipping it means nothing merges at cutover, and `issue_alias_conflicts` later surfaces only the clusters that actually recur.

## Review findings, fixed

Codex reviewed the first two commits and found twelve issues, three High. The two worst were confirmed by hand before fixing.

- **Publication receipts.** The receipt insert covered every sequence-1 episode, and `run-migrations.sh` replays on every service start. A new issue whose first round had not yet been published would be marked published on the next restart, and `digest.FreezeCandidates` skips anything already published. Silently dropped forever. The receipt now rides a data-modifying CTE off the episode insert and covers only rows this run adopted.
- **Tenant scoping.** The identity backfill joined on `error_group_id` alone. The two foreign keys are checked independently, so an event in one project could get an identity pointing at another project's issue. Now joins on `project_id` too.
- **Terminal statuses.** Only `resolved` closed its round, though the dispatcher treats `resolved`, `merged`, and `archived` alike. All three close now. Merged groups are also skipped when binding aliases, since settlement aborts on a `merged` issue and would stall every observation matching that fingerprint.
- **Smoke false-passes.** Stage 6 printed green when the inquiry declined, never exercising the handoff to the investigator. Stage 7 asserted against whichever run was newest rather than the one it froze, and accepted `delivered` as proof of writing, so an already-delivered run made both freeze and publish no-ops.

## Verification

Both High fixes have regression tests, each confirmed failing against the previous version of the migration (`receipts = 1`, `1 identities point at another project's canonical issue`) and passing after.

- Four `TestMigration060` tests pass
- Full `TestMigration` suite passes
- `scripts/check-migration-reapply.sh` passes with data present
- Earlier full run: `1388 passed, 0 allowlisted skip(s), no failures, no unexpected skips`

**`scripts/cutover-smoke.sh` has never been executed.** It passes `bash -n` and nothing more. Since the deploy runs with `SKIP_SMOKE=1`, this is the only gate on the cutover, so it should be exercised on a rig before the window rather than first used against production.

## Known, not addressed here

- Day one can enqueue duplicate inquiries and investigations for legacy error groups already at `investigated` or `needs_human`. Bounded to recently active groups, but it spends model calls on work already done.
- No executable guard against `identity.IdentityVersion` drifting from the literal `2` in the migration. A version change needs its own migration; do not edit 060 after it deploys.
- The two migration tests locate 060 independently, so a rename could update one and leave the other testing a different set.