### PR TITLE
fix(cutover): run digest-replay from inside the Go module

### DIFF
--- a/scripts/cutover-smoke.sh
+++ b/scripts/cutover-smoke.sh
@@ -10,6 +10,15 @@
 # reaches a terminal worker state because the filter admits at two affected
 # units. Run this instead, with SKIP_SMOKE=1 on the deploy.
 #
+# What the target stack needs, learned by running this against a fresh rig:
+#   - a project with a connected repository. The inquiry clones it, preferring
+#     the GitHub App installation token and falling back to GITHUB_TOKEN. With
+#     neither, issue_inquiry dead-letters on "GITHUB_TOKEN is not set" and
+#     stage 5 stalls with no decision ever written.
+#   - an enabled notification destination carrying 'digest.daily' in its
+#     event_types. Without one, publishing fails with "digest has no enabled
+#     destination", the run is marked failed, and stage 7 cannot pass.
+#
 # Required:
 #   INGESTION_URL     e.g. https://app.opslane.com
 #   DATABASE_URL      a DSN that can read the pipeline tables
@@ -37,7 +46,10 @@ readonly SMOKE_QUERY_TIMEOUT="${SMOKE_QUERY_TIMEOUT:-30}"
 # never exercises the handoff to the investigator. Set this to accept that and
 # still exit 0, knowing the accepted path went unproven.
 readonly SMOKE_ALLOW_DECLINED_INQUIRY="${SMOKE_ALLOW_DECLINED_INQUIRY:-0}"
-readonly DIGEST_REPLAY_CMD="${DIGEST_REPLAY_CMD:-go run ./packages/ingestion/cmd/digest-replay}"
+# `go run` resolves its package path against the module root, and there is no
+# go.mod at the repository root, so this has to enter packages/ingestion. In a
+# deployed image the binary already exists; override this with its path.
+readonly DIGEST_REPLAY_CMD="${DIGEST_REPLAY_CMD:-go -C packages/ingestion run ./cmd/digest-replay}"
 
 for command_name in curl jq psql; do
   command -v "$command_name" >/dev/null 2>&1 || {


### PR DESCRIPTION
Found by running `scripts/cutover-smoke.sh` end to end for the first time, on a full stack built from main.

## The defect

The default `DIGEST_REPLAY_CMD` was `go run ./packages/ingestion/cmd/digest-replay`. `go run` resolves its package path against the module root, and there is no `go.mod` at the repository root, so stage 7 died immediately:

```
[7/7] a digest run freezes, validates, and delivers
go: go.mod file not found in current directory or any parent directory
FAIL at stage 7: freezing a digest run failed
```

Now `go -C packages/ingestion run ./cmd/digest-replay`. A deployed image already has the binary and should override the variable.

This matters more than a normal typo: the cutover deploys with `SKIP_SMOKE=1`, so this script is the only gate. A stage 7 that cannot start would have surfaced during the window.

## Also recorded

Two stack prerequisites that each cost a failed run to find, now documented in the script header:

- The project needs a connected repository. The inquiry clones it, preferring the GitHub App installation token and falling back to `GITHUB_TOKEN`. With neither, `issue_inquiry` dead-letters on `GITHUB_TOKEN is not set` and stage 5 stalls with no decision ever written. Production has the App configured, so this is a rig concern.
- The project needs an enabled notification destination carrying `digest.daily`. Without one, publishing fails with `digest has no enabled destination`, the run is marked `failed`, and stage 7 cannot pass.

## Verification

Full stack from main (ingestion, worker, postgres, minio), migrations through 060 applied, real Anthropic key. All seven stages pass, exit 0:

```
[4/7] filter: open_inquiry (2 affected units in seven days)
[5/7] ok: an inquiry decision exists
[7/7] ok: run ... at status written
      ok: the writer produced a payload
      ok: the run is delivered
cutover smoke passed: all 7 stages
```

The two-observation design works as intended: both settle onto one canonical issue and the filter admits them at exactly the two-unit threshold.

## Still unproven

Stage 6's accepted path. The inquiry declined the synthetic error on both runs, once as `do_not_pursue` and once as `wait_for_more_evidence`, each with a substantive reason about the empty evidence bundle. That is a correct answer, so the run used `SMOKE_ALLOW_DECLINED_INQUIRY=1`. Nothing here demonstrates that an accepted episode reaches the investigator.