### PR TITLE
fix(worker): hand rejected diagnosis submissions back for correction

### DIFF
--- a/docs/architecture/life-of-an-error.md
+++ b/docs/architecture/life-of-an-error.md
@@ -32,7 +32,7 @@ A fast model call classifies the error: fixable in application code, or not? Hig
 
 ## 6. Investigate and fix
 
-For fixable errors, the worker clones the repository (GitHub token or App installation token) to the commit from the frozen evidence bundle and runs an agentic fix loop inside an **E2B sandbox**: read the referenced source, form a root cause, edit, install dependencies, and collect build/test evidence. The verdict is validated: candidate citations are verified against repository files (quoted code must appear within ±5 lines), evidence must cite files the investigation actually read, and filler text is rejected. Failed attempts escalate through model tiers before giving up.
+For fixable errors, the worker clones the repository (GitHub token or App installation token) to the commit from the frozen evidence bundle and runs an agentic fix loop inside an **E2B sandbox**: read the referenced source, form a root cause, edit, install dependencies, and collect build/test evidence. The verdict is validated in two stages: during the run, correctable defects (missing citations, unread evidence) are rejected with feedback allowing up to two resubmits; post-run validation is authoritative. Candidate citations are verified against repository files (quoted code must appear within ±5 lines), evidence must cite files the investigation actually read, and filler text is rejected. Failed attempts escalate through model tiers before giving up.
 
 ## 7. Route by confidence — two stages
 

--- a/packages/worker/src/__tests__/investigate.test.ts
+++ b/packages/worker/src/__tests__/investigate.test.ts
@@ -77,11 +77,16 @@ function diagnosisResponse(overrides: Record<string, unknown> = {}) {
   };
 }
 
-/** The single agent reads what it needs and submits once. */
+/**
+ * The single agent reads what it needs and submits. The diagnosis response
+ * repeats for the whole run: a submission the pre-acceptance validator rejects
+ * is asked for again, so an unchanged bad answer models the agent that cannot
+ * correct itself and exhausts the resubmit budget.
+ */
 function happyPath(overrides: Record<string, unknown> = {}): void {
   mockMessagesCreate
     .mockResolvedValueOnce(toolUseResponse([{ name: 'read_file', input: { path: 'src/App.vue' } }]))
-    .mockResolvedValueOnce(diagnosisResponse(overrides));
+    .mockResolvedValue(diagnosisResponse(overrides));
 }
 
 beforeEach(async () => {
@@ -298,6 +303,62 @@ describe('the agent never names an outcome', () => {
 
     expect(result.outcome).toBe('incomplete');
     expect(result.decisionReason).toMatch(/^filler_verdict:/);
+  });
+});
+
+describe('a rejected submission is handed back for correction', () => {
+  it('recovers a diagnosis whose first submission missed one citation', async () => {
+    const missingCitation = {
+      candidates_considered: [
+        { statement: 'items defaults to null and is mapped during render', kind: 'local_code', id: 'c1',
+          citation: { path: 'src/App.vue', line: 1, quote: 'items.map(i => i.name)' } },
+        // The auxiliary local candidate the agent forgot to ground — the c6 shape.
+        { statement: 'A watcher clears items during navigation', kind: 'local_code', id: 'c2', citation: null },
+      ],
+      rejected_candidates: [],
+    };
+    mockMessagesCreate
+      .mockResolvedValueOnce(toolUseResponse([{ name: 'read_file', input: { path: 'src/App.vue' } }]))
+      .mockResolvedValueOnce(diagnosisResponse(missingCitation))
+      .mockResolvedValueOnce(diagnosisResponse({
+        candidates_considered: [
+          { statement: 'items defaults to null and is mapped during render', kind: 'local_code', id: 'c1',
+            citation: { path: 'src/App.vue', line: 1, quote: 'items.map(i => i.name)' } },
+          { statement: 'A watcher clears items during navigation', kind: 'local_code', id: 'c2',
+            citation: { path: 'src/App.vue', line: 1, quote: 'items.map(i => i.name)' } },
+        ],
+        rejected_candidates: [],
+      }));
+
+    const result = await investigateError('key', makeInput(), tempDir);
+
+    expect(result.outcome).toBe('code_fix');
+    expect(result.decisionBasis).toBe('local_defect');
+
+    // The correction request reached the model as an error tool result naming
+    // the defect, not as a silent retry. (The messages array is shared and
+    // mutated across turns, so assert on the conversation, not on position.)
+    const resubmitRequest = mockMessagesCreate.mock.calls[2]![0] as { messages: unknown };
+    const conversation = JSON.stringify(resubmitRequest.messages);
+    expect(conversation).toContain('candidate_missing_citation: c2');
+    expect(conversation).toContain('"is_error":true');
+  });
+
+  it('stops asking after the resubmit budget and terminalizes as before', async () => {
+    happyPath({
+      candidates_considered: [
+        { statement: 'Ungrounded local claim', kind: 'local_code', id: 'c1', citation: null },
+      ],
+      rejected_candidates: [],
+    });
+
+    const result = await investigateError('key', makeInput(), tempDir);
+
+    expect(result.outcome).toBe('incomplete');
+    expect(result.decisionBasis).toBe('invalid_verdict');
+    expect(result.decisionReason).toMatch(/^candidate_missing_citation:/);
+    // One read turn, the initial submission, and exactly two resubmit attempts.
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/packages/worker/src/__tests__/investigate.test.ts
+++ b/packages/worker/src/__tests__/investigate.test.ts
@@ -344,6 +344,27 @@ describe('a rejected submission is handed back for correction', () => {
     expect(conversation).toContain('"is_error":true');
   });
 
+  it('counts a read_file batched with the submission before validating it', async () => {
+    // The read and the submit arrive in ONE assistant turn. The sibling read
+    // must execute (and land in filesRead) before the submission is validated,
+    // or the citation of the just-read file is rejected as citation_not_read —
+    // a rejection the mechanism itself would have manufactured.
+    const submission = diagnosisResponse();
+    mockMessagesCreate.mockResolvedValueOnce({
+      content: [
+        { type: 'tool_use', id: 'read-1', name: 'read_file', input: { path: 'src/App.vue' } },
+        ...submission.content,
+      ],
+      usage: USAGE,
+    });
+
+    const result = await investigateError('key', makeInput(), tempDir);
+
+    expect(result.outcome).toBe('code_fix');
+    expect(result.filesRead).toContain('src/App.vue');
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
+  });
+
   it('stops asking after the resubmit budget and terminalizes as before', async () => {
     happyPath({
       candidates_considered: [

--- a/packages/worker/src/investigate.ts
+++ b/packages/worker/src/investigate.ts
@@ -324,7 +324,7 @@ export async function investigateError(
     }
     const shape = validateAdjudicationShape(submitted, { requireStructuralShape: true });
     if (shape.status === 'incomplete') {
-      return { ok: false, feedback: resubmitGuidance(shape.reason) };
+      return { ok: false, feedback: resubmitGuidance(shape.code, shape.reason) };
     }
     const derived = deriveOutcome(submitted, resolveCited, quoteAt);
     // Mechanically repairable derivation failures also go back for correction.
@@ -343,9 +343,20 @@ export async function investigateError(
       };
     }
     if (derived.basis === 'unrejected_local_candidates') {
+      // Name the actual defect per candidate: "ungrounded" means the model DID
+      // reject the candidate but the rejection's quote failed the verbatim
+      // check — telling it only to "reject by id" would ask for the thing it
+      // already did.
+      const rejectedIds = new Set((submitted.rejected_candidates ?? []).map((rejection) => rejection.id));
+      const perCandidate = (derived.dispositions ?? [])
+        .filter((entry) => entry.disposition !== 'rejected')
+        .map((entry) => rejectedIds.has(entry.id)
+          ? `${entry.id}: its rejection citation did not check out — the quote must be 8-300 characters copied verbatim from within a few lines of the cited line, in a file you read`
+          : `${entry.id}: not rejected in rejected_candidates`)
+        .join('; ');
       return {
         ok: false,
-        feedback: `${derived.reason}. Either reject each of those candidates by id in rejected_candidates with a grounded citation {path, line, quote} from a file you read, or change your conclusion to the local cause the evidence supports.`,
+        feedback: `${derived.reason}. ${perCandidate}. Fix each rejection's grounded citation {path, line, quote}, or — only if the evidence genuinely supports it — change your conclusion to a local cause.`,
       };
     }
     const verdict = validateVerdict({
@@ -356,7 +367,7 @@ export async function investigateError(
       filesRead: context.filesRead,
     }, resolveCited);
     if (verdict.status === 'incomplete') {
-      return { ok: false, feedback: resubmitGuidance(verdict.reason) };
+      return { ok: false, feedback: resubmitGuidance(verdict.code, verdict.reason) };
     }
     return { ok: true };
   };
@@ -404,6 +415,10 @@ export async function investigateError(
     });
   }
 
+  // The authoritative acceptance pipeline. validateSubmission above is its
+  // pre-acceptance mirror — a rule added here without a matching (or
+  // deliberately omitted) counterpart there silently exempts that rule from
+  // the correction loop. Keep the two in step.
   let decision = deriveOutcome(adjudication, resolveCited, quoteAt);
   if (adjudication) {
     const shape = validateAdjudicationShape(adjudication, { requireStructuralShape: true });

--- a/packages/worker/src/investigate.ts
+++ b/packages/worker/src/investigate.ts
@@ -13,7 +13,7 @@ import type { RuntimeInfo } from './runtime-info.js';
 import { traceSpan } from './tracing.js';
 import type { TriageResult } from './agent-fix.js';
 import { calculateCost } from '@opslane/agent-core';
-import { validateAdjudicationShape, validateVerdict } from './verdict-validation.js';
+import { resubmitGuidance, validateAdjudicationShape, validateVerdict } from './verdict-validation.js';
 import { quoteWithinWindow } from './quote-at.js';
 
 /**
@@ -284,6 +284,83 @@ export async function investigateError(
     ? `\n\nFiles named by the stack trace, as a starting point only: ${stackFiles.slice(0, 5).join(', ')}`
     : '';
 
+  // One read per cited file per adjudication: a submission citing the same
+  // file across several candidates and rejections must not re-read it each
+  // time in the process that also owns lease heartbeats.
+  const quoteFileCache = new Map<string, string | null>();
+  const resolveCited = (cited: string): string | null => resolveInsideRepo(repoPath, cited);
+  const quoteAt = (resolved: string, line: number, quote: string): boolean => {
+    if (!quoteFileCache.has(resolved)) {
+      try {
+        // The model picks the path, so bound the read the same way
+        // executeReadFile does: a citation into a multi-megabyte vendored or
+        // minified file is not groundable evidence, and slurping it whole
+        // per candidate check would buy nothing but memory pressure.
+        const target = join(repoPath, resolved);
+        quoteFileCache.set(
+          resolved,
+          statSync(target).size > QUOTE_CHECK_MAX_FILE_BYTES ? null : readFileSync(target, 'utf8'),
+        );
+      } catch {
+        quoteFileCache.set(resolved, null);
+      }
+    }
+    const text = quoteFileCache.get(resolved);
+    return text !== null && text !== undefined && quoteWithinWindow(text, line, quote);
+  };
+
+  // Pre-acceptance mirror of the post-run checks below. A defect the model can
+  // repair in one turn — a candidate missing its citation, an unread file in
+  // the evidence — goes back as feedback instead of voiding the whole paid run.
+  // The post-run validation stays authoritative: a submission still broken
+  // after the resubmit budget lands there and terminalizes exactly as before.
+  const validateSubmission = (
+    raw: Record<string, unknown>,
+    context: { filesRead: string[] },
+  ): { ok: true } | { ok: false; feedback: string } => {
+    const submitted = parseAdjudication(raw);
+    if (!submitted) {
+      return { ok: false, feedback: 'best_supported was empty — state the cause in one sentence.' };
+    }
+    const shape = validateAdjudicationShape(submitted, { requireStructuralShape: true });
+    if (shape.status === 'incomplete') {
+      return { ok: false, feedback: resubmitGuidance(shape.reason) };
+    }
+    const derived = deriveOutcome(submitted, resolveCited, quoteAt);
+    // Mechanically repairable derivation failures also go back for correction.
+    // Substantive judgments (insufficient evidence, an unplaced cause) do not:
+    // those are the model's honest answer, not a format defect.
+    if (derived.basis === 'citation_unresolvable') {
+      return {
+        ok: false,
+        feedback: `${derived.reason}. cause_locations[0].path must be the bare repository-relative path of a file that exists in the checkout.`,
+      };
+    }
+    if (derived.basis === 'uncitable_local_claim') {
+      return {
+        ok: false,
+        feedback: `${derived.reason}. A local cause requires at least one cause_locations entry naming the file.`,
+      };
+    }
+    if (derived.basis === 'unrejected_local_candidates') {
+      return {
+        ok: false,
+        feedback: `${derived.reason}. Either reject each of those candidates by id in rejected_candidates with a grounded citation {path, line, quote} from a file you read, or change your conclusion to the local cause the evidence supports.`,
+      };
+    }
+    const verdict = validateVerdict({
+      causeText: submitted.best_supported,
+      claimsCodeCause: derived.outcome === 'code_fix',
+      evidence: submitted.evidence ?? [],
+      agentTaskBrief: submitted.agent_task_brief ?? null,
+      filesRead: context.filesRead,
+    }, resolveCited);
+    if (verdict.status === 'incomplete') {
+      return { ok: false, feedback: resubmitGuidance(verdict.reason) };
+    }
+    return { ok: true };
+  };
+
   const run = await traceSpan('investigation.diagnose', { 'investigation.stage': 'diagnose' }, () =>
     runReadOnlyAgent({
       apiKey,
@@ -299,6 +376,7 @@ export async function investigateError(
       terminalTool: submitDiagnosisTool(),
       repoPath,
       classification: { minFilesRead: 1 },
+      validateTerminal: validateSubmission,
     }));
 
   const filesRead = run.filesRead;
@@ -326,33 +404,7 @@ export async function investigateError(
     });
   }
 
-  // One read per cited file per adjudication: a submission citing the same
-  // file across several candidates and rejections must not re-read it each
-  // time in the process that also owns lease heartbeats.
-  const quoteFileCache = new Map<string, string | null>();
-  let decision = deriveOutcome(
-    adjudication,
-    (cited) => resolveInsideRepo(repoPath, cited),
-    (resolved, line, quote) => {
-      if (!quoteFileCache.has(resolved)) {
-        try {
-          // The model picks the path, so bound the read the same way
-          // executeReadFile does: a citation into a multi-megabyte vendored or
-          // minified file is not groundable evidence, and slurping it whole
-          // per candidate check would buy nothing but memory pressure.
-          const target = join(repoPath, resolved);
-          quoteFileCache.set(
-            resolved,
-            statSync(target).size > QUOTE_CHECK_MAX_FILE_BYTES ? null : readFileSync(target, 'utf8'),
-          );
-        } catch {
-          quoteFileCache.set(resolved, null);
-        }
-      }
-      const text = quoteFileCache.get(resolved);
-      return text !== null && text !== undefined && quoteWithinWindow(text, line, quote);
-    },
-  );
+  let decision = deriveOutcome(adjudication, resolveCited, quoteAt);
   if (adjudication) {
     const shape = validateAdjudicationShape(adjudication, { requireStructuralShape: true });
     if (shape.status === 'incomplete') {
@@ -369,7 +421,7 @@ export async function investigateError(
         evidence: adjudication.evidence ?? [],
         agentTaskBrief: adjudication.agent_task_brief ?? null,
         filesRead,
-      }, (cited) => resolveInsideRepo(repoPath, cited));
+      }, resolveCited);
       if (validation.status === 'incomplete') {
         decision = {
           outcome: 'incomplete',

--- a/packages/worker/src/readonly-agent.ts
+++ b/packages/worker/src/readonly-agent.ts
@@ -177,6 +177,23 @@ export async function runReadOnlyAgent(input: ReadOnlyRunInput): Promise<ReadOnl
     : 2;
   /** Rejected submissions returned for correction, counted across both paths. */
   let resubmitsUsed = 0;
+  /**
+   * The most recent rejected terminal submission. If the run then fails before
+   * a corrected resubmit arrives (truncation, prose, exhausted turns), this is
+   * returned as the terminal input rather than dropping an already-paid,
+   * parseable submission — the caller's post-run validation judges it and
+   * records its real defect. Deliberately NOT applied to api_error, whose stop
+   * value drives job-level retry semantics.
+   */
+  let rejectedSubmission: Record<string, unknown> | null = null;
+  const fallbackOr = (result: ReadOnlyRunResult): ReadOnlyRunResult =>
+    rejectedSubmission === null ? result : { ...result, terminalInput: rejectedSubmission, stop: 'terminal' };
+
+  /** The forced-verdict stage makes a call only when this holds — the same
+   * predicate gates both the stage entry and the last-turn retry decision so
+   * the two cannot drift apart. */
+  const forcedStageWillRun = (): boolean =>
+    input.classification !== undefined && filesRead.size >= input.classification.minFilesRead;
 
   /**
    * Rejection feedback for the terminal call, or null to accept. Consults the
@@ -311,7 +328,7 @@ export async function runReadOnlyAgent(input: ReadOnlyRunInput): Promise<ReadOnl
       // call the tool burn the whole budget on prose.
       if (nudged) {
         logger.warn(`${SPAN_PREFIX}: ended without calling ${input.terminalTool.name}`, { turn });
-        return { terminalInput: null, stop: 'no_tool_call', filesRead: [...filesRead], lastModelText, costUsd, usage };
+        return fallbackOr({ terminalInput: null, stop: 'no_tool_call', filesRead: [...filesRead], lastModelText, costUsd, usage });
       }
       nudged = true;
       messages.push({
@@ -328,40 +345,15 @@ export async function runReadOnlyAgent(input: ReadOnlyRunInput): Promise<ReadOnl
       continue;
     }
 
-    if (terminal) {
-      // On the loop's final turn, a rejection has somewhere to send the
-      // correction only if the forced-verdict stage will actually run — which
-      // requires classification AND its evidence gate already met (the stage
-      // returns no_evidence before making a call otherwise). Rejecting with no
-      // retry ahead would drop the submission the post-run validator should
-      // have judged. Accept it instead.
-      const forcedStageWillRun =
-        input.classification !== undefined && filesRead.size >= input.classification.minFilesRead;
-      const retryPossible = forcedStageWillRun || turn < input.maxTurns - 1;
-      const feedback = retryPossible ? rejectTerminal(terminal.input) : null;
-      if (feedback === null) {
-        return { terminalInput: terminal.input, stop: 'terminal', filesRead: [...filesRead], lastModelText, costUsd, usage };
-      }
-      // Every tool_use block needs a tool_result; sibling calls in the rejected
-      // turn are deliberately not executed so the correction happens first.
-      messages.push({
-        role: 'user',
-        content: toolCalls.map((call): Anthropic.ToolResultBlockParam => call.id === terminal.id
-          ? { type: 'tool_result', tool_use_id: call.id, is_error: true, content: feedback }
-          : {
-            type: 'tool_result',
-            tool_use_id: call.id,
-            content: `Not executed: correct and resubmit ${input.terminalTool.name} first.`,
-          }),
-      });
-      continue;
-    }
-
     // The calls in a turn are independent I/O — a grep subprocess and disk
     // reads — so they run together. Promise.all preserves the order the model
-    // asked in, which the tool_result blocks have to match.
+    // asked in, which the tool_result blocks have to match. Terminal calls are
+    // excluded and handled after: siblings execute FIRST so a read_file
+    // batched with the submission counts as read before the submission is
+    // validated — validating on the pre-turn snapshot manufactured a
+    // self-inflicted citation_not_read rejection for exactly that batching.
     const executed = await Promise.all(
-      toolCalls.map(async (call) => {
+      toolCalls.filter((call) => call.name !== input.terminalTool.name).map(async (call) => {
         const attrs: Record<string, string | number | boolean> = {
           'tool.name': call.name,
           [`${SPAN_PREFIX}.turn`]: turn,
@@ -390,17 +382,60 @@ export async function runReadOnlyAgent(input: ReadOnlyRunInput): Promise<ReadOnl
 
     // Recorded after the fan-out, in the order the model asked, so concurrency
     // cannot reorder what the caller reports as the files the agent opened.
-    const results: Anthropic.ToolResultBlockParam[] = [];
+    const outputs = new Map<string, { output: string; read: string | null }>();
     for (const { id, output, read } of executed) {
       if (read) filesRead.add(read);
-      results.push({ type: 'tool_result', tool_use_id: id, content: output });
+      outputs.set(id, { output, read });
     }
+
+    if (terminal) {
+      // On the loop's final turn, a rejection has somewhere to send the
+      // correction only if the forced-verdict stage will actually run.
+      // Rejecting with no retry ahead would drop the submission the post-run
+      // validator should have judged. Accept it instead.
+      const retryPossible = forcedStageWillRun() || turn < input.maxTurns - 1;
+      const feedback = retryPossible ? rejectTerminal(terminal.input) : null;
+      if (feedback === null) {
+        return { terminalInput: terminal.input, stop: 'terminal', filesRead: [...filesRead], lastModelText, costUsd, usage };
+      }
+      rejectedSubmission = terminal.input;
+      // Every tool_use block needs a tool_result, in the model's order:
+      // executed siblings carry their real output, the rejected submission its
+      // feedback, and any duplicate terminal call a stub.
+      messages.push({
+        role: 'user',
+        content: toolCalls.map((call): Anthropic.ToolResultBlockParam => {
+          if (call.id === terminal.id) {
+            return { type: 'tool_result', tool_use_id: call.id, is_error: true, content: feedback };
+          }
+          const result = outputs.get(call.id);
+          if (result !== undefined) {
+            return { type: 'tool_result', tool_use_id: call.id, content: result.output };
+          }
+          return {
+            type: 'tool_result',
+            tool_use_id: call.id,
+            content: `Not executed: a rejected ${input.terminalTool.name} submission is already being corrected.`,
+          };
+        }),
+      });
+      continue;
+    }
+
+    const results: Anthropic.ToolResultBlockParam[] = toolCalls.map((call): Anthropic.ToolResultBlockParam => {
+      const result = outputs.get(call.id);
+      return {
+        type: 'tool_result',
+        tool_use_id: call.id,
+        content: result?.output ?? `Error: Unknown tool "${call.name}"`,
+      };
+    });
     messages.push({ role: 'user', content: results });
   }
 
   if (input.classification) {
-    if (filesRead.size < input.classification.minFilesRead) {
-      return { terminalInput: null, stop: 'no_evidence', filesRead: [...filesRead], lastModelText, costUsd, usage };
+    if (!forcedStageWillRun()) {
+      return fallbackOr({ terminalInput: null, stop: 'no_evidence', filesRead: [...filesRead], lastModelText, costUsd, usage });
     }
 
     messages.push({
@@ -441,7 +476,7 @@ export async function runReadOnlyAgent(input: ReadOnlyRunInput): Promise<ReadOnl
 
       recordUsage(response);
       if (response.stop_reason === 'max_tokens') {
-        return { terminalInput: null, stop: 'truncated', filesRead: [...filesRead], lastModelText, costUsd, usage };
+        return fallbackOr({ terminalInput: null, stop: 'truncated', filesRead: [...filesRead], lastModelText, costUsd, usage });
       }
       const verdictCalls: { id: string; name: string; input: Record<string, unknown> }[] = [];
       for (const block of response.content) {
@@ -452,7 +487,7 @@ export async function runReadOnlyAgent(input: ReadOnlyRunInput): Promise<ReadOnl
       }
       const terminalBlock = verdictCalls.find((call) => call.name === input.terminalTool.name);
       if (!terminalBlock) {
-        return { terminalInput: null, stop: 'no_tool_call', filesRead: [...filesRead], lastModelText, costUsd, usage };
+        return fallbackOr({ terminalInput: null, stop: 'no_tool_call', filesRead: [...filesRead], lastModelText, costUsd, usage });
       }
       const feedback = rejectTerminal(terminalBlock.input);
       if (feedback === null) {
@@ -465,6 +500,7 @@ export async function runReadOnlyAgent(input: ReadOnlyRunInput): Promise<ReadOnl
           usage,
         };
       }
+      rejectedSubmission = terminalBlock.input;
       // Every tool_use block needs a matching tool_result — an unpaired
       // sibling call (or a duplicate terminal call) would fail the next
       // request instead of delivering the correction.
@@ -482,5 +518,5 @@ export async function runReadOnlyAgent(input: ReadOnlyRunInput): Promise<ReadOnl
     }
   }
 
-  return { terminalInput: null, stop: 'turns_exhausted', filesRead: [...filesRead], lastModelText, costUsd, usage };
+  return fallbackOr({ terminalInput: null, stop: 'turns_exhausted', filesRead: [...filesRead], lastModelText, costUsd, usage });
 }

--- a/packages/worker/src/readonly-agent.ts
+++ b/packages/worker/src/readonly-agent.ts
@@ -61,6 +61,20 @@ export interface ReadOnlyRunInput {
   repoPath: string;
   /** Optional evidence gate followed by one dedicated verdict-only turn. */
   classification?: { minFilesRead: number };
+  /**
+   * Pre-acceptance check on a terminal submission. On failure the feedback goes
+   * back to the model as the rejected call's tool result and the model may
+   * resubmit, up to maxResubmits times across the whole run. Without this hook
+   * the first terminal call ends the run whatever it contains — a one-field
+   * defect the model could fix in a single turn instead discards the entire
+   * paid investigation.
+   */
+  validateTerminal?: (
+    raw: Record<string, unknown>,
+    context: { filesRead: string[] },
+  ) => { ok: true } | { ok: false; feedback: string };
+  /** Resubmissions validateTerminal may trigger. Defaults to 2. */
+  maxResubmits?: number;
 }
 
 /** Prefixes trace span and log names, e.g. "diagnose.read_file". */
@@ -155,6 +169,36 @@ export async function runReadOnlyAgent(input: ReadOnlyRunInput): Promise<ReadOnl
   let costUsd = 0;
   /** Whether the prose-instead-of-tool-call nudge has already been spent. */
   let nudged = false;
+  // Clamped: Infinity or NaN here would make the resubmit budget check
+  // permanently false and turn a consistently rejected verdict into an
+  // unlimited paid loop.
+  const maxResubmits = Number.isFinite(input.maxResubmits ?? 2)
+    ? Math.min(Math.max(Math.trunc(input.maxResubmits ?? 2), 0), 5)
+    : 2;
+  /** Rejected submissions returned for correction, counted across both paths. */
+  let resubmitsUsed = 0;
+
+  /**
+   * Rejection feedback for the terminal call, or null to accept. Consults the
+   * resubmit and spend budgets so an exhausted budget accepts the submission
+   * as-is — the caller's own post-run validation still gets the final word,
+   * and a rejected-but-unaffordable submission reaches it instead of being
+   * dropped.
+   */
+  const rejectTerminal = (raw: Record<string, unknown>): string | null => {
+    if (!input.validateTerminal || resubmitsUsed >= maxResubmits || costUsd > input.budgetUsd) return null;
+    const verdict = input.validateTerminal(raw, { filesRead: [...filesRead] });
+    if (verdict.ok) return null;
+    resubmitsUsed++;
+    logger.info(`${SPAN_PREFIX}: terminal submission rejected, asking for a corrected resubmit`, {
+      resubmit: resubmitsUsed,
+      feedback: verdict.feedback.slice(0, 500),
+    });
+    return (
+      `Your submission was NOT recorded. ${verdict.feedback} ` +
+      `Correct this and call ${input.terminalTool.name} again with the complete submission.`
+    );
+  };
 
   const systemMessages: Anthropic.TextBlockParam[] = [
     { type: 'text', text: input.systemPrompt, cache_control: { type: 'ephemeral' } },
@@ -285,7 +329,32 @@ export async function runReadOnlyAgent(input: ReadOnlyRunInput): Promise<ReadOnl
     }
 
     if (terminal) {
-      return { terminalInput: terminal.input, stop: 'terminal', filesRead: [...filesRead], lastModelText, costUsd, usage };
+      // On the loop's final turn, a rejection has somewhere to send the
+      // correction only if the forced-verdict stage will actually run — which
+      // requires classification AND its evidence gate already met (the stage
+      // returns no_evidence before making a call otherwise). Rejecting with no
+      // retry ahead would drop the submission the post-run validator should
+      // have judged. Accept it instead.
+      const forcedStageWillRun =
+        input.classification !== undefined && filesRead.size >= input.classification.minFilesRead;
+      const retryPossible = forcedStageWillRun || turn < input.maxTurns - 1;
+      const feedback = retryPossible ? rejectTerminal(terminal.input) : null;
+      if (feedback === null) {
+        return { terminalInput: terminal.input, stop: 'terminal', filesRead: [...filesRead], lastModelText, costUsd, usage };
+      }
+      // Every tool_use block needs a tool_result; sibling calls in the rejected
+      // turn are deliberately not executed so the correction happens first.
+      messages.push({
+        role: 'user',
+        content: toolCalls.map((call): Anthropic.ToolResultBlockParam => call.id === terminal.id
+          ? { type: 'tool_result', tool_use_id: call.id, is_error: true, content: feedback }
+          : {
+            type: 'tool_result',
+            tool_use_id: call.id,
+            content: `Not executed: correct and resubmit ${input.terminalTool.name} first.`,
+          }),
+      });
+      continue;
     }
 
     // The calls in a turn are independent I/O — a grep subprocess and disk
@@ -338,43 +407,57 @@ export async function runReadOnlyAgent(input: ReadOnlyRunInput): Promise<ReadOnl
       role: 'user',
       content: 'Exploration is over. Submit your verdict now using only evidence you actually gathered.',
     });
-    markLastUserMessageForCaching(messages);
 
-    let response: Anthropic.Message;
-    try {
-      response = await client.messages.create({
-        model: input.model,
-        max_tokens: 16000,
-        system: systemMessages,
-        messages,
-        tools,
-        tool_choice: { type: 'tool', name: input.terminalTool.name },
-      });
-    } catch (error: unknown) {
-      const detail = error instanceof Error ? error.message : String(error);
-      const status = (error as { status?: unknown }).status;
-      logger.warn(`${SPAN_PREFIX}: classification call failed`, { error: detail, status });
-      return {
-        terminalInput: null,
-        stop: 'api_error',
-        ...(typeof status === 'number' ? { apiErrorStatus: status } : {}),
-        apiErrorDetail: detail,
-        filesRead: [...filesRead],
-        lastModelText,
-        costUsd,
-        usage,
-      };
-    }
+    // Bounded by the shared resubmit budget: each rejected verdict consumes one
+    // resubmit, so this loop runs at most 1 + maxResubmits times.
+    for (;;) {
+      markLastUserMessageForCaching(messages);
 
-    recordUsage(response);
-    if (response.stop_reason === 'max_tokens') {
-      return { terminalInput: null, stop: 'truncated', filesRead: [...filesRead], lastModelText, costUsd, usage };
-    }
-    for (const block of response.content) {
-      if (block.type === 'text') lastModelText = block.text;
-      if (block.type === 'tool_use' && block.name === input.terminalTool.name) {
+      let response: Anthropic.Message;
+      try {
+        response = await client.messages.create({
+          model: input.model,
+          max_tokens: 16000,
+          system: systemMessages,
+          messages,
+          tools,
+          tool_choice: { type: 'tool', name: input.terminalTool.name },
+        });
+      } catch (error: unknown) {
+        const detail = error instanceof Error ? error.message : String(error);
+        const status = (error as { status?: unknown }).status;
+        logger.warn(`${SPAN_PREFIX}: classification call failed`, { error: detail, status });
         return {
-          terminalInput: block.input as Record<string, unknown>,
+          terminalInput: null,
+          stop: 'api_error',
+          ...(typeof status === 'number' ? { apiErrorStatus: status } : {}),
+          apiErrorDetail: detail,
+          filesRead: [...filesRead],
+          lastModelText,
+          costUsd,
+          usage,
+        };
+      }
+
+      recordUsage(response);
+      if (response.stop_reason === 'max_tokens') {
+        return { terminalInput: null, stop: 'truncated', filesRead: [...filesRead], lastModelText, costUsd, usage };
+      }
+      const verdictCalls: { id: string; name: string; input: Record<string, unknown> }[] = [];
+      for (const block of response.content) {
+        if (block.type === 'text') lastModelText = block.text;
+        if (block.type === 'tool_use') {
+          verdictCalls.push({ id: block.id, name: block.name, input: block.input as Record<string, unknown> });
+        }
+      }
+      const terminalBlock = verdictCalls.find((call) => call.name === input.terminalTool.name);
+      if (!terminalBlock) {
+        return { terminalInput: null, stop: 'no_tool_call', filesRead: [...filesRead], lastModelText, costUsd, usage };
+      }
+      const feedback = rejectTerminal(terminalBlock.input);
+      if (feedback === null) {
+        return {
+          terminalInput: terminalBlock.input,
           stop: 'terminal',
           filesRead: [...filesRead],
           lastModelText,
@@ -382,8 +465,21 @@ export async function runReadOnlyAgent(input: ReadOnlyRunInput): Promise<ReadOnl
           usage,
         };
       }
+      // Every tool_use block needs a matching tool_result — an unpaired
+      // sibling call (or a duplicate terminal call) would fail the next
+      // request instead of delivering the correction.
+      messages.push({ role: 'assistant', content: response.content });
+      messages.push({
+        role: 'user',
+        content: verdictCalls.map((call): Anthropic.ToolResultBlockParam => call.id === terminalBlock.id
+          ? { type: 'tool_result', tool_use_id: call.id, is_error: true, content: feedback }
+          : {
+            type: 'tool_result',
+            tool_use_id: call.id,
+            content: `Not executed: correct and resubmit ${input.terminalTool.name} first.`,
+          }),
+      });
     }
-    return { terminalInput: null, stop: 'no_tool_call', filesRead: [...filesRead], lastModelText, costUsd, usage };
   }
 
   return { terminalInput: null, stop: 'turns_exhausted', filesRead: [...filesRead], lastModelText, costUsd, usage };

--- a/packages/worker/src/verdict-validation.ts
+++ b/packages/worker/src/verdict-validation.ts
@@ -8,9 +8,36 @@ import { CANDIDATE_ID, isMalformedRejection } from './diagnose-schema.js';
 // unanchored form.
 export const FILLER_VERDICT = /^\s*(placeholder|tbd|to be determined)\b/i;
 
+/**
+ * Machine codes for every way a submission can be incomplete. Typed so the
+ * guidance map below is compile-time exhaustive — recovering the code by
+ * splitting the prose reason is the substring-matching mistake this repo has
+ * already paid for twice (see reason-codes.ts and classify.ts).
+ */
+export type IncompleteCode =
+  | 'legacy_shape'
+  | 'candidate_missing_id'
+  | 'duplicate_candidate_id'
+  | 'candidate_missing_citation'
+  | 'rejection_malformed'
+  | 'rejection_unknown_id'
+  | 'duplicate_rejection_id'
+  | 'empty_rejection_evidence'
+  | 'missing_rejected_candidates'
+  | 'no_files_read'
+  | 'empty_verdict'
+  | 'filler_verdict'
+  | 'no_citations'
+  | 'missing_brief'
+  | 'filler_brief'
+  | 'citation_malformed'
+  | 'citation_missing_link'
+  | 'citation_unresolvable'
+  | 'citation_not_read';
+
 export type VerdictValidation =
   | { status: 'valid' }
-  | { status: 'incomplete'; reason: string };
+  | { status: 'incomplete'; code: IncompleteCode; reason: string };
 
 export interface VerdictForValidation {
   causeText: string;
@@ -20,8 +47,8 @@ export interface VerdictForValidation {
   filesRead: string[];
 }
 
-function incomplete(reason: string): VerdictValidation {
-  return { status: 'incomplete', reason };
+function incomplete(code: IncompleteCode, detail: string): VerdictValidation {
+  return { status: 'incomplete', code, reason: `${code}: ${detail}` };
 }
 
 /**
@@ -49,7 +76,7 @@ export function validateAdjudicationShape(
       candidate.id !== undefined || candidate.citation !== undefined);
   if (!isNewShape) {
     if (options?.requireStructuralShape) {
-      return incomplete('legacy_shape: submission omitted rejected_candidates and candidate ids');
+      return incomplete('legacy_shape', 'submission omitted rejected_candidates and candidate ids');
     }
     return { status: 'valid' };
   }
@@ -57,29 +84,29 @@ export function validateAdjudicationShape(
   const ids = new Set<string>();
   for (const candidate of adjudication.candidates_considered) {
     if (!candidate.id || !CANDIDATE_ID.test(candidate.id)) {
-      return incomplete(`candidate_missing_id: ${candidate.statement.slice(0, 80)}`);
+      return incomplete('candidate_missing_id', `${candidate.statement.slice(0, 80)}`);
     }
-    if (ids.has(candidate.id)) return incomplete(`duplicate_candidate_id: ${candidate.id}`);
+    if (ids.has(candidate.id)) return incomplete('duplicate_candidate_id', `${candidate.id}`);
     ids.add(candidate.id);
 
     const local = candidate.kind === 'local_code' || candidate.kind === 'configuration';
     if (local && !candidate.citation) {
-      return incomplete(`candidate_missing_citation: ${candidate.id}`);
+      return incomplete('candidate_missing_citation', `${candidate.id}`);
     }
   }
 
   const seenRejections = new Set<string>();
   for (const rejection of adjudication.rejected_candidates ?? []) {
     if (isMalformedRejection(rejection)) {
-      return incomplete('rejection_malformed: entry with empty id or citation');
+      return incomplete('rejection_malformed', 'entry with empty id or citation');
     }
-    if (!ids.has(rejection.id)) return incomplete(`rejection_unknown_id: ${rejection.id}`);
+    if (!ids.has(rejection.id)) return incomplete('rejection_unknown_id', `${rejection.id}`);
     if (seenRejections.has(rejection.id)) {
-      return incomplete(`duplicate_rejection_id: ${rejection.id}`);
+      return incomplete('duplicate_rejection_id', `${rejection.id}`);
     }
     seenRejections.add(rejection.id);
     if (!rejection.evidence.trim()) {
-      return incomplete(`empty_rejection_evidence: ${rejection.id}`);
+      return incomplete('empty_rejection_evidence', `${rejection.id}`);
     }
   }
 
@@ -89,55 +116,63 @@ export function validateAdjudicationShape(
   // substring path — quietly erasing the grounding gate. Half a new shape is
   // not a shape.
   if (adjudication.rejected_candidates === undefined) {
-    return incomplete('missing_rejected_candidates: structural candidates require a rejected_candidates array');
+    return incomplete('missing_rejected_candidates', 'structural candidates require a rejected_candidates array');
   }
 
   return { status: 'valid' };
 }
 
+const CITATION_SHAPE =
+  'a citation is {path, line, quote} where quote is 8-300 characters copied verbatim from near that line ' +
+  'in a file you actually read';
+
+const CANDIDATE_ID_GUIDANCE =
+  'give every candidate a unique id matching "c1", "c2", … and reference those ids in rejected_candidates.';
+const REJECTION_GUIDANCE =
+  `each rejection must name an existing candidate id exactly once, with non-empty evidence and a valid citation (${CITATION_SHAPE}).`;
+const EVIDENCE_GUIDANCE =
+  'the evidence array must cite at least one file you read with read_file, using its exact repository path, ' +
+  'and each entry needs a non-empty detail and symptomLink.';
+const FILLER_GUIDANCE = 'state the actual cause; placeholder text is rejected.';
+
 /**
- * Turn a validator reason code into an instruction the model can act on when
- * the submission is handed back for correction. The reason strings above are
- * forensic labels; alone they tell the model what failed but not what a
- * passing submission looks like.
+ * Per-code instruction the model can act on when its submission is handed back
+ * for correction. The reason strings are forensic labels; alone they tell the
+ * model what failed but not what a passing submission looks like. A Record so
+ * adding an IncompleteCode without guidance is a compile error, not a silent
+ * fall-through to an instruction the model cannot follow.
  */
-export function resubmitGuidance(reason: string): string {
-  const code = reason.split(':')[0]?.trim() ?? '';
-  const citationShape =
-    'a citation is {path, line, quote} where quote is 8-300 characters copied verbatim from near that line ' +
-    'in a file you actually read';
-  switch (code) {
-    case 'candidate_missing_citation':
-      return `${reason} — every local_code or configuration candidate must carry a valid citation (${citationShape}). ` +
-        'A citation whose quote is too short, too long, or not verbatim is dropped and counts as missing. ' +
-        'Add a real citation to that candidate, or change its kind if it does not point at local code.';
-    case 'candidate_missing_id':
-    case 'duplicate_candidate_id':
-      return `${reason} — give every candidate a unique id matching "c1", "c2", … and reference those ids in rejected_candidates.`;
-    case 'missing_rejected_candidates':
-      return `${reason} — include a rejected_candidates array; pass [] if you reject nothing.`;
-    case 'rejection_malformed':
-    case 'rejection_unknown_id':
-    case 'duplicate_rejection_id':
-    case 'empty_rejection_evidence':
-      return `${reason} — each rejection must name an existing candidate id exactly once, with non-empty evidence and a valid citation (${citationShape}).`;
-    case 'legacy_shape':
-      return `${reason} — resubmit with candidate ids and a rejected_candidates array.`;
-    case 'no_citations':
-    case 'citation_malformed':
-    case 'citation_missing_link':
-    case 'citation_unresolvable':
-    case 'citation_not_read':
-      return `${reason} — the evidence array must cite at least one file you read with read_file, using its exact repository path, and each entry needs a non-empty detail and symptomLink.`;
-    case 'missing_brief':
-      return `${reason} — a local code cause needs agent_task_brief: a self-contained markdown brief (symptom, files, cause, change, verification).`;
-    case 'empty_verdict':
-    case 'filler_verdict':
-    case 'filler_brief':
-      return `${reason} — state the actual cause; placeholder text is rejected.`;
-    default:
-      return reason;
-  }
+const RESUBMIT_GUIDANCE: Record<IncompleteCode, string> = {
+  candidate_missing_citation:
+    `every local_code or configuration candidate must carry a valid citation (${CITATION_SHAPE}). ` +
+    'A citation whose quote is too short, too long, or not verbatim is dropped and counts as missing. ' +
+    'Add a real citation to that candidate, or change its kind if it does not point at local code.',
+  candidate_missing_id: CANDIDATE_ID_GUIDANCE,
+  duplicate_candidate_id: CANDIDATE_ID_GUIDANCE,
+  missing_rejected_candidates: 'include a rejected_candidates array; pass [] if you reject nothing.',
+  rejection_malformed: REJECTION_GUIDANCE,
+  rejection_unknown_id: REJECTION_GUIDANCE,
+  duplicate_rejection_id: REJECTION_GUIDANCE,
+  empty_rejection_evidence: REJECTION_GUIDANCE,
+  legacy_shape: 'resubmit with candidate ids and a rejected_candidates array.',
+  no_files_read:
+    'read the files that support your conclusion with read_file first — only files opened with read_file ' +
+    'count as read — then resubmit citing them.',
+  no_citations: EVIDENCE_GUIDANCE,
+  citation_malformed: EVIDENCE_GUIDANCE,
+  citation_missing_link: EVIDENCE_GUIDANCE,
+  citation_unresolvable: EVIDENCE_GUIDANCE,
+  citation_not_read: EVIDENCE_GUIDANCE,
+  missing_brief:
+    'a local code cause needs agent_task_brief: a self-contained markdown brief (symptom, files, cause, change, verification).',
+  empty_verdict: FILLER_GUIDANCE,
+  filler_verdict: FILLER_GUIDANCE,
+  filler_brief: FILLER_GUIDANCE,
+};
+
+/** The full corrective message for one rejected-submission defect. */
+export function resubmitGuidance(code: IncompleteCode, reason: string): string {
+  return `${reason} — ${RESUBMIT_GUIDANCE[code]}`;
 }
 
 export function validateVerdict(
@@ -145,22 +180,22 @@ export function validateVerdict(
   resolvePath: (path: string) => string | null,
 ): VerdictValidation {
   if (verdict.filesRead.length < 1) {
-    return incomplete('no_files_read: the investigation read no repository files');
+    return incomplete('no_files_read', 'the investigation read no repository files');
   }
   if (!verdict.causeText.trim()) {
-    return incomplete('empty_verdict: cause text is empty');
+    return incomplete('empty_verdict', 'cause text is empty');
   }
   if (FILLER_VERDICT.test(verdict.causeText)) {
-    return incomplete('filler_verdict: cause text matches a placeholder pattern');
+    return incomplete('filler_verdict', 'cause text matches a placeholder pattern');
   }
   if (verdict.evidence.length === 0) {
-    return incomplete('no_citations: the verdict contains no evidence citations');
+    return incomplete('no_citations', 'the verdict contains no evidence citations');
   }
   if (verdict.claimsCodeCause && !verdict.agentTaskBrief?.trim()) {
-    return incomplete('missing_brief: a code cause requires an agent task brief');
+    return incomplete('missing_brief', 'a code cause requires an agent task brief');
   }
   if (verdict.agentTaskBrief && FILLER_VERDICT.test(verdict.agentTaskBrief)) {
-    return incomplete('filler_brief: the agent task brief matches a placeholder pattern');
+    return incomplete('filler_brief', 'the agent task brief matches a placeholder pattern');
   }
 
   const resolvedReads = new Set(
@@ -171,17 +206,17 @@ export function validateVerdict(
   for (const citation of verdict.evidence) {
     const path = citation.path.trim();
     if (!path) {
-      return incomplete('citation_malformed: citation path is empty');
+      return incomplete('citation_malformed', 'citation path is empty');
     }
     if (!citation.detail.trim() || !citation.symptomLink.trim()) {
-      return incomplete(`citation_missing_link: ${path} must include detail and symptom link`);
+      return incomplete('citation_missing_link', `${path} must include detail and symptom link`);
     }
     const resolved = resolvePath(path);
     if (resolved === null) {
-      return incomplete(`citation_unresolvable: ${path} does not resolve to a repository file`);
+      return incomplete('citation_unresolvable', `${path} does not resolve to a repository file`);
     }
     if (!resolvedReads.has(resolved)) {
-      return incomplete(`citation_not_read: ${path} was not read during the investigation`);
+      return incomplete('citation_not_read', `${path} was not read during the investigation`);
     }
   }
 

--- a/packages/worker/src/verdict-validation.ts
+++ b/packages/worker/src/verdict-validation.ts
@@ -95,6 +95,51 @@ export function validateAdjudicationShape(
   return { status: 'valid' };
 }
 
+/**
+ * Turn a validator reason code into an instruction the model can act on when
+ * the submission is handed back for correction. The reason strings above are
+ * forensic labels; alone they tell the model what failed but not what a
+ * passing submission looks like.
+ */
+export function resubmitGuidance(reason: string): string {
+  const code = reason.split(':')[0]?.trim() ?? '';
+  const citationShape =
+    'a citation is {path, line, quote} where quote is 8-300 characters copied verbatim from near that line ' +
+    'in a file you actually read';
+  switch (code) {
+    case 'candidate_missing_citation':
+      return `${reason} — every local_code or configuration candidate must carry a valid citation (${citationShape}). ` +
+        'A citation whose quote is too short, too long, or not verbatim is dropped and counts as missing. ' +
+        'Add a real citation to that candidate, or change its kind if it does not point at local code.';
+    case 'candidate_missing_id':
+    case 'duplicate_candidate_id':
+      return `${reason} — give every candidate a unique id matching "c1", "c2", … and reference those ids in rejected_candidates.`;
+    case 'missing_rejected_candidates':
+      return `${reason} — include a rejected_candidates array; pass [] if you reject nothing.`;
+    case 'rejection_malformed':
+    case 'rejection_unknown_id':
+    case 'duplicate_rejection_id':
+    case 'empty_rejection_evidence':
+      return `${reason} — each rejection must name an existing candidate id exactly once, with non-empty evidence and a valid citation (${citationShape}).`;
+    case 'legacy_shape':
+      return `${reason} — resubmit with candidate ids and a rejected_candidates array.`;
+    case 'no_citations':
+    case 'citation_malformed':
+    case 'citation_missing_link':
+    case 'citation_unresolvable':
+    case 'citation_not_read':
+      return `${reason} — the evidence array must cite at least one file you read with read_file, using its exact repository path, and each entry needs a non-empty detail and symptomLink.`;
+    case 'missing_brief':
+      return `${reason} — a local code cause needs agent_task_brief: a self-contained markdown brief (symptom, files, cause, change, verification).`;
+    case 'empty_verdict':
+    case 'filler_verdict':
+    case 'filler_brief':
+      return `${reason} — state the actual cause; placeholder text is rejected.`;
+    default:
+      return reason;
+  }
+}
+
 export function validateVerdict(
   verdict: VerdictForValidation,
   resolvePath: (path: string) => string | null,


### PR DESCRIPTION
## Why

A terminal `submit_diagnosis` call that failed cross-field validation voided the entire paid investigation as `incomplete`. Prod discarded a correct window-title diagnosis — three verbatim-checked citations, right root cause — because one *auxiliary* candidate (c6) lacked a citation (`candidate_missing_citation: c6`). Combined with the digest only surfacing `verified_fix`/`needs_human` outcomes, defects like this quietly starve the daily digest.

## What

**Correction loop (commit 1).** `runReadOnlyAgent` gains a `validateTerminal` hook: a terminal submission is validated *before* acceptance, and a failing one is returned to the model as an error `tool_result` carrying the specific defect and how to fix it. Bounded by 2 resubmits (clamped) and the existing spend budget, in both the in-loop and forced-verdict paths. The conversation is cached, so a correction costs one turn instead of a discarded run. The post-run validation is unchanged and remains the final gate: a submission still broken after retries terminalizes exactly as before.

`investigate.ts` wires the full validator stack (parse → shape → derive → verdict) into the hook, including mechanically repairable derivation failures (unresolvable cause location, local claim without a location, external conclusion with unrejected local candidates). Substantive judgments — insufficient evidence, an unplaced cause — are never bounced.

**Review hardening (commit 2).** Codex review (2 rounds) plus /code-review with adversarial verification surfaced seven findings; six fixed:

- Sibling `read_file` calls batched with a submission now execute **before** validation, so a same-turn read counts as read (previously the mechanism manufactured a false `citation_not_read` rejection).
- A rejected submission is retained and returned for post-run judgment when the resubmit path fails (truncation, prose, exhausted turns) instead of losing its forensics. `api_error` deliberately keeps its stop value for job-level retry semantics.
- Resubmit guidance is a compile-time-exhaustive `Record<IncompleteCode, string>` instead of string-splitting prose reasons (the substring-matching mistake this repo documents twice), which also closes the missing `no_files_read` case.
- `unrejected_local_candidates` feedback names the per-candidate defect (rejection quote failed verbatim grounding vs never rejected) instead of telling the model to redo what it already did.
- The last-turn retry gate and the forced-stage entry check share one predicate; the rejected-turn `tool_result` construction pairs every `tool_use` block.
- Deferred: structurally unifying the pre/post validation pipelines (mirror is documented at both sites).

## Verification

- 1353 worker tests pass with `DATABASE_URL` (11 env skips), including 3 new tests: rejected-then-corrected recovers to `code_fix`; same-turn batched read counts before validation; budget exhaustion terminalizes as before after exactly 2 retries.
- Full local gates: `pnpm -r build`, `pnpm test:repo`, `pnpm test:unit` (sdk excluded — known host env failure of `debug-id-browser`; test-e2e excluded — needs the live-stack CI job), `go build/vet/test ./...` against a disposable migrated Postgres, `docker compose config --quiet`.
- Live trial against the real prod window-title error on the actual AMFJ checkout: `not_actionable` / `cause_outside_codebase` (medium), correctly identifying the Atlassian Connect bridge as the origin — the verdict prod's voided run never delivered.