### PR TITLE
fix(dashboard): scale session replay to recorded viewport so click positions stay aligned

### DIFF
--- a/packages/dashboard/src/components/ReplayPlayer.vue
+++ b/packages/dashboard/src/components/ReplayPlayer.vue
@@ -3,7 +3,7 @@ import { onMounted, onUnmounted, ref, watch } from 'vue';
 import { Replayer } from 'rrweb';
 import type { eventWithTime } from '@rrweb/types';
 import 'rrweb/dist/style.css';
-import { crashSeekMs, ensureReplayMeta, formatTime, replayDurationMs, sortedReplayEvents } from './replay-utils';
+import { crashSeekMs, ensureReplayMeta, formatTime, replayDurationMs, replayViewport, sortedReplayEvents } from './replay-utils';
 
 const props = defineProps<{
   events: eventWithTime[];
@@ -21,6 +21,29 @@ const speed = ref(1);
 const showSpeedMenu = ref(false);
 let timer: ReturnType<typeof setInterval> | null = null;
 
+// rrweb renders the replay at the recorded viewport size and draws the cursor in
+// recorded coordinates. We scale the whole `.replayer-wrapper` (iframe + cursor
+// together) to fit the container instead of stretching the iframe, so a wider
+// recording does not reflow and drift the click positions. See replay-utils.
+let recordedWidth = 1280;
+let recordedHeight = 720;
+let resizeObserver: ResizeObserver | null = null;
+let appliedSignature = '';
+
+function applyScale() {
+  const el = containerRef.value;
+  if (!el || recordedWidth <= 0) return;
+  const available = el.clientWidth;
+  if (available <= 0) return;
+  const scale = Math.min(1, available / recordedWidth);
+  const height = Math.round(recordedHeight * scale);
+  const signature = `${scale}:${height}`;
+  if (signature === appliedSignature) return;
+  appliedSignature = signature;
+  el.style.setProperty('--replay-scale', String(scale));
+  el.style.height = `${height}px`;
+}
+
 function buildPlayer() {
   if (!containerRef.value || !props.events || props.events.length === 0) return;
   containerRef.value.innerHTML = '';
@@ -36,6 +59,22 @@ function buildPlayer() {
   });
 
   replayer.value = r;
+
+  const viewport = replayViewport(events);
+  recordedWidth = viewport.width;
+  recordedHeight = viewport.height;
+  appliedSignature = '';
+  applyScale();
+  // The recorded viewport can change mid-session (e.g. a browser resize); rrweb
+  // re-lays-out and emits 'resize', so rescale to the new dimensions.
+  r.on('resize', (payload) => {
+    const dims = payload as { width?: number; height?: number };
+    if (dims?.width && dims.width > 0) recordedWidth = dims.width;
+    if (dims?.height && dims.height > 0) recordedHeight = dims.height;
+    applyScale();
+  });
+  resizeObserver = new ResizeObserver(() => applyScale());
+  resizeObserver.observe(containerRef.value);
   const metaTotal = r.getMetaData().totalTime;
   duration.value = Math.max(0, (metaTotal > 0 ? metaTotal : replayDurationMs(events)) / 1000);
 
@@ -57,6 +96,15 @@ function destroyPlayer() {
   if (timer) {
     clearInterval(timer);
     timer = null;
+  }
+  if (resizeObserver) {
+    resizeObserver.disconnect();
+    resizeObserver = null;
+  }
+  appliedSignature = '';
+  if (containerRef.value) {
+    containerRef.value.style.removeProperty('--replay-scale');
+    containerRef.value.style.removeProperty('height');
   }
   if (replayer.value) {
     try {
@@ -162,10 +210,18 @@ watch(
 <style scoped>
 .replay-container {
   min-height: 360px;
+  overflow: hidden;
+}
+
+/* Scale the whole rrweb wrapper (iframe + cursor overlay) to fit the container
+   at the recorded viewport's coordinate space. Do NOT stretch the iframe on its
+   own: that reflows a responsive recording and drifts the replayed clicks. */
+.replay-container :deep(.replayer-wrapper) {
+  transform: scale(var(--replay-scale, 1));
+  transform-origin: top left;
 }
 
 .replay-container :deep(iframe) {
-  width: 100%;
   border: 0;
 }
 </style>

--- a/packages/dashboard/src/components/ReplayPlayer.vue
+++ b/packages/dashboard/src/components/ReplayPlayer.vue
@@ -29,6 +29,7 @@ let recordedWidth = 1280;
 let recordedHeight = 720;
 let resizeObserver: ResizeObserver | null = null;
 let appliedSignature = '';
+let pendingFrame: number | null = null;
 
 function applyScale() {
   const el = containerRef.value;
@@ -42,6 +43,17 @@ function applyScale() {
   appliedSignature = signature;
   el.style.setProperty('--replay-scale', String(scale));
   el.style.height = `${height}px`;
+}
+
+// applyScale writes height on the element the ResizeObserver watches. Deferring
+// to the next frame keeps that write out of the observer's own callback, which
+// avoids the benign "ResizeObserver loop" console warning on every real resize.
+function scheduleScale() {
+  if (pendingFrame !== null) return;
+  pendingFrame = requestAnimationFrame(() => {
+    pendingFrame = null;
+    applyScale();
+  });
 }
 
 function buildPlayer() {
@@ -73,7 +85,7 @@ function buildPlayer() {
     if (dims?.height && dims.height > 0) recordedHeight = dims.height;
     applyScale();
   });
-  resizeObserver = new ResizeObserver(() => applyScale());
+  resizeObserver = new ResizeObserver(() => scheduleScale());
   resizeObserver.observe(containerRef.value);
   const metaTotal = r.getMetaData().totalTime;
   duration.value = Math.max(0, (metaTotal > 0 ? metaTotal : replayDurationMs(events)) / 1000);
@@ -100,6 +112,10 @@ function destroyPlayer() {
   if (resizeObserver) {
     resizeObserver.disconnect();
     resizeObserver = null;
+  }
+  if (pendingFrame !== null) {
+    cancelAnimationFrame(pendingFrame);
+    pendingFrame = null;
   }
   appliedSignature = '';
   if (containerRef.value) {
@@ -208,11 +224,10 @@ watch(
 </template>
 
 <style scoped>
-.replay-container {
-  min-height: 360px;
-  overflow: hidden;
-}
-
+/* Height is set to recordedHeight * scale from JS (a CSS transform does not
+   affect layout), so no min-height here: a fixed floor would leave dead space
+   under a short replay. The template element carries `overflow-hidden`, which
+   clips the scaled wrapper. */
 /* Scale the whole rrweb wrapper (iframe + cursor overlay) to fit the container
    at the recorded viewport's coordinate space. Do NOT stretch the iframe on its
    own: that reflows a responsive recording and drifts the replayed clicks. */

--- a/packages/dashboard/src/components/replay-utils.test.ts
+++ b/packages/dashboard/src/components/replay-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { eventWithTime } from '@rrweb/types';
-import { crashSeekMs, ensureReplayMeta, formatTime, isActiveEvent, replayDurationMs, sortedReplayEvents } from './replay-utils';
+import { crashSeekMs, ensureReplayMeta, formatTime, isActiveEvent, replayDurationMs, replayViewport, sortedReplayEvents } from './replay-utils';
 
 const ev = (timestamp: number, type: number, source?: number): eventWithTime =>
   ({ timestamp, type, data: source === undefined ? {} : { source } } as unknown as eventWithTime);
@@ -72,5 +72,22 @@ describe('ensureReplayMeta', () => {
   it('leaves a stream with Meta untouched', () => {
     const events = [ev(1000, 4), ev(1000, 2)];
     expect(ensureReplayMeta(events)).toBe(events);
+  });
+});
+
+describe('replayViewport', () => {
+  const meta = (width: number, height: number): eventWithTime =>
+    ({ timestamp: 1000, type: 4, data: { width, height } } as unknown as eventWithTime);
+
+  it('reads the recorded viewport from the first Meta event', () => {
+    expect(replayViewport([meta(1050, 820), ev(1000, 2)])).toEqual({ width: 1050, height: 820 });
+  });
+
+  it('falls back to 1280x720 when no Meta event is present', () => {
+    expect(replayViewport([ev(1000, 2), ev(2000, 3, 1)])).toEqual({ width: 1280, height: 720 });
+  });
+
+  it('falls back to defaults for a zero or missing dimension', () => {
+    expect(replayViewport([meta(0, 0)])).toEqual({ width: 1280, height: 720 });
   });
 });

--- a/packages/dashboard/src/components/replay-utils.test.ts
+++ b/packages/dashboard/src/components/replay-utils.test.ts
@@ -90,4 +90,9 @@ describe('replayViewport', () => {
   it('falls back to defaults for a zero or missing dimension', () => {
     expect(replayViewport([meta(0, 0)])).toEqual({ width: 1280, height: 720 });
   });
+
+  it('falls back to a coherent pair when only one dimension is valid', () => {
+    expect(replayViewport([meta(1050, 0)])).toEqual({ width: 1280, height: 720 });
+    expect(replayViewport([meta(0, 820)])).toEqual({ width: 1280, height: 720 });
+  });
 });

--- a/packages/dashboard/src/components/replay-utils.ts
+++ b/packages/dashboard/src/components/replay-utils.ts
@@ -28,6 +28,21 @@ export function ensureReplayMeta(events: eventWithTime[]): eventWithTime[] {
   return [synthetic, ...events];
 }
 
+/**
+ * The recorded viewport, taken from rrweb's first Meta event. The player scales
+ * the replay to fit its container using this as the source coordinate space, so
+ * that the replayed cursor (drawn in recorded coordinates) stays aligned with
+ * the reflowed page. Falls back to the same 1280x720 default ensureReplayMeta
+ * injects for recordings that never carried a Meta event.
+ */
+export function replayViewport(events: eventWithTime[]): { width: number; height: number } {
+  const meta = events.find((event) => event.type === 4);
+  const data = meta?.data as { width?: number; height?: number } | undefined;
+  const width = data?.width && data.width > 0 ? data.width : 1280;
+  const height = data?.height && data.height > 0 ? data.height : 720;
+  return { width, height };
+}
+
 export function replayDurationMs(events: eventWithTime[]): number {
   if (!events || events.length < 2) return 0;
   return Math.max(0, events[events.length - 1].timestamp - events[0].timestamp);

--- a/packages/dashboard/src/components/replay-utils.ts
+++ b/packages/dashboard/src/components/replay-utils.ts
@@ -38,9 +38,13 @@ export function ensureReplayMeta(events: eventWithTime[]): eventWithTime[] {
 export function replayViewport(events: eventWithTime[]): { width: number; height: number } {
   const meta = events.find((event) => event.type === 4);
   const data = meta?.data as { width?: number; height?: number } | undefined;
-  const width = data?.width && data.width > 0 ? data.width : 1280;
-  const height = data?.height && data.height > 0 ? data.height : 720;
-  return { width, height };
+  // All-or-nothing: a Meta event missing either dimension is not a usable
+  // viewport, so fall back to a coherent default pair rather than mixing a real
+  // width with a default height (which would distort the aspect ratio).
+  if (data && data.width && data.width > 0 && data.height && data.height > 0) {
+    return { width: data.width, height: data.height };
+  }
+  return { width: 1280, height: 720 };
 }
 
 export function replayDurationMs(events: eventWithTime[]): number {


### PR DESCRIPTION
## What

Session replays showed the cursor/clicks on the wrong element whenever the recorded viewport was wider than the player's container.

`ReplayPlayer.vue` forced the rrweb iframe to `width: 100%`, shrinking it to the container width. rrweb renders at the recorded viewport and draws the cursor overlay in recorded coordinates, so a wider recording reflowed the responsive page to the narrow iframe while the cursor stayed at its recorded position — landing it on a different element.

## Fix

Scale the whole `.replayer-wrapper` (iframe **and** cursor together) to fit the container, keeping the replay in its recorded coordinate space instead of reflowing it:
- `replayViewport()` reads the recorded width/height from rrweb's Meta event (coherent all-or-nothing fallback to 1280x720).
- `applyScale()` sets `--replay-scale = min(1, containerWidth / recordedWidth)` and the container height to `recordedHeight × scale` (a transform doesn't affect layout).
- Rescale on container resize (ResizeObserver, deferred a frame to avoid the RO-loop warning) and on rrweb's mid-session `resize` event.
- Observer/frame are torn down on unmount and session change.

## Verification

Real rrweb record→replay of a 1200px session in a 600px container:
- **Before:** recorded click at x=900 ("Right") → page reflowed to 604px → `elementFromPoint` hit nothing; cursor clipped off-screen.
- **After:** same click → hits "Right"; cursor renders on the button.

Both programmatic (`elementFromPoint`) and visual (screenshots) confirmed.

Dashboard build + 359 unit tests pass (new `replayViewport` cases included).
