### PR TITLE
fix(test): FK-safe digest fixture cleanup under parallel package runs

### DIFF
--- a/packages/ingestion/digest/build_test.go
+++ b/packages/ingestion/digest/build_test.go
@@ -163,6 +163,15 @@ func seedDigestFixtureWithSessionAge(t *testing.T, pool *pgxpool.Pool, now time.
 			`DELETE FROM sessions WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 			`DELETE FROM end_users WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 			`DELETE FROM error_groups WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
+			// Jobs are not only created by digest tests: the priority sweeper's
+			// pass (priority/sweeper.go) inserts error_group_jobs for every
+			// project it scans, and under `go test ./...` its package runs in
+			// parallel against this shared database. Without these two deletes,
+			// DELETE FROM projects races that sweep and fails on
+			// error_group_jobs_project_id_fkey (observed on main pushes
+			// 33015197337 and 33016532031).
+			`DELETE FROM job_usage WHERE job_id IN (SELECT id FROM error_group_jobs WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1))`,
+			`DELETE FROM error_group_jobs WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 			`UPDATE projects SET default_environment_id = NULL WHERE org_id = $1`,
 			`DELETE FROM environments WHERE project_id IN (SELECT id FROM projects WHERE org_id = $1)`,
 			`DELETE FROM projects WHERE org_id = $1`,


### PR DESCRIPTION
Main went red on the last two merge pushes (runs 33015197337, 33016532031) with digest tests failing only in fixture cleanup: `DELETE FROM projects` hit `error_group_jobs_project_id_fkey`. Root cause: `go test ./...` runs package binaries in parallel against one shared database, and the priority sweeper's pass (`priority/sweeper.go`) inserts `error_group_jobs` rows for every project it scans — including digest fixture projects created by a concurrently running test. The digest fixture cleanup never deleted jobs, so losing the race failed tests whose assertions all passed.

Fix: delete `job_usage` (via job ids) and `error_group_jobs` for the org's projects before deleting projects. Cleanup is now FK-safe regardless of who inserted jobs.

Verified: digest package green locally on a migrated DB. Also re-ran main's failed run to confirm the flake reads green on retry.