### PR TITLE
fix: hosted events + MCP were pointed at api.opslane.com, which serves a Cloudflare 403

### DIFF
--- a/.changeset/hosted-default-endpoint.md
+++ b/.changeset/hosted-default-endpoint.md
@@ -1,0 +1,10 @@
+---
+"@opslane/sdk": patch
+---
+
+The default `endpoint` now points at `https://app.opslane.com`, the host that
+actually serves the hosted Opslane API. The previous default,
+`https://api.opslane.com`, was never wired to an origin and answered every
+request with a Cloudflare 403 block page, so any `init()` that omitted
+`endpoint` on hosted Opslane failed CORS preflight and sent nothing.
+Integrations that pass `endpoint` explicitly are unaffected.

--- a/docs/design/2026-08-26-onboarding-v2.md
+++ b/docs/design/2026-08-26-onboarding-v2.md
@@ -87,7 +87,7 @@ The server owns step derivation: `GET /api/v1/onboarding/state` returns the fact
 
 ### 5.2 Snippet step (dashboard) — the one hard gate
 
-Framework tabs (Vue / React / Next.js / Other), key inline, `environment: 'development'`, and an endpoint rule with a deterministic source of truth: the dashboard is served by the ingestion service, so `window.location.origin` *is* the ingest endpoint. Include `endpoint: origin` unless the origin equals the compile-time hosted constant `https://app.opslane.com`.
+Framework tabs (Vue / React / Next.js / Other), key inline, `environment: 'development'`, and an endpoint rule with a deterministic source of truth: the dashboard is served by the ingestion service, so `window.location.origin` *is* the ingest endpoint. The snippet always includes `endpoint: origin`; no hosted special case (omission left hosted users on the SDK's default endpoint, which pointed at an unwired hostname).
 
 **Why the key is inline** (killing the show-once ceremony): it's `ScopeIngest` (`opslane_pk_`), write-only, ships in the browser bundle by design, and `docs/install.md:111` already documents it as safe to expose. The honest cost, stated in the same doc: a committed key is slow to rotate. Accepted for activation speed; the success screen nudges "move it to an env var before you commit".
 
@@ -195,7 +195,7 @@ v1 chooses completion over enforcement, and the cost is stated flat: a user can 
 **M2 — Wizard rewrite**
 
 1. New order renders; project creation is name-only with an idempotency token; no setup-PR call remains in the wizard.
-2. Snippet shows a real working `opslane_pk_` key on first load and after a full browser reset (mint-on-resume), correct per tab; self-hosted origin gets `endpoint`; hosted omits it.
+2. Snippet shows a real working `opslane_pk_` key on first load and after a full browser reset (mint-on-resume), correct per tab; the snippet always includes `endpoint` set to the dashboard origin (the SDK's baked-in default proved wrong for hosted, so omission is no longer a case).
 3. Following snippet + test button in `test-fixtures/vue-app` against a live stack flips the listener green within one poll interval; success links `latest_error_group_id`.
 4. Reload/cleared-browser at every step resumes at the correct step from server facts; an org with `onboarded_at` never sees the wizard; a projectless legacy org does.
 5. Cannot advance past step 2 without `has_events`; GitHub and Slack steps each advance via success or "do this later"; finishing calls `/onboarding/complete`, which succeeds with both integrations deferred and refuses without events.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -10,7 +10,7 @@ description: Connect Claude Code or Codex to Opslane and work on issues from you
 
 Opslane has a remote Model Context Protocol (MCP) server. It lets a coding agent read your latest daily summary, open an issue with its evidence, and link the pull request that fixes it.
 
-The server accepts `POST /mcp` at your Opslane address. For hosted Opslane, that is `https://api.opslane.com/mcp`. It provides three tools:
+The server accepts `POST /mcp` at your Opslane address. For hosted Opslane, that is `https://app.opslane.com/mcp`. It provides three tools:
 
 | Tool | What it does |
 | --- | --- |
@@ -33,7 +33,7 @@ export OPSLANE_API_KEY=opslane_ak_...
 For Claude Code, add the server from the terminal:
 
 ```bash
-claude mcp add --transport http opslane https://api.opslane.com/mcp \
+claude mcp add --transport http opslane https://app.opslane.com/mcp \
   --header "Authorization: Bearer ${OPSLANE_API_KEY}"
 ```
 
@@ -44,7 +44,7 @@ To share the server address with your team, commit this `.mcp.json`. Each person
   "mcpServers": {
     "opslane": {
       "type": "http",
-      "url": "https://api.opslane.com/mcp",
+      "url": "https://app.opslane.com/mcp",
       "headers": { "Authorization": "Bearer ${OPSLANE_API_KEY}" }
     }
   }
@@ -55,11 +55,11 @@ For Codex, add the server to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.opslane]
-url = "https://api.opslane.com/mcp"
+url = "https://app.opslane.com/mcp"
 bearer_token_env_var = "OPSLANE_API_KEY"
 ```
 
-For a self-host, replace `https://api.opslane.com` with your own address.
+For a self-host, replace `https://app.opslane.com` with your own address.
 
 Ask the agent to call `opslane_digest` to test the connection. A missing, invalid, expired, or revoked key returns `401`. An ingest or source-map key returns `403 insufficient_scope`.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -42,7 +42,7 @@ import App from './App';
 init({
   apiKey: 'opslane_pk_...',
   environment: 'development',
-  endpoint: 'https://your-opslane-instance.example.com', // omit for hosted Opslane
+  endpoint: 'https://your-opslane-instance.example.com', // https://app.opslane.com for hosted Opslane
 });
 
 // After sign-in.
@@ -67,7 +67,7 @@ import App from './App.vue';
 init({
   apiKey: 'opslane_pk_...',
   environment: 'development',
-  endpoint: 'https://your-opslane-instance.example.com', // omit for hosted Opslane
+  endpoint: 'https://your-opslane-instance.example.com', // https://app.opslane.com for hosted Opslane
 });
 
 setUser({ id: currentUser.id, email: currentUser.email });
@@ -91,7 +91,7 @@ export function OpslaneProvider({ children }: { children: React.ReactNode }) {
     init({
       apiKey: 'opslane_pk_...',
       environment: 'development',
-      endpoint: 'https://your-opslane-instance.example.com', // omit for hosted Opslane
+      endpoint: 'https://your-opslane-instance.example.com', // https://app.opslane.com for hosted Opslane
     });
   }, []);
   return <>{children}</>;
@@ -109,7 +109,7 @@ import { init, setUser } from '@opslane/sdk';
 init({
   apiKey: 'opslane_pk_...',
   environment: 'development',
-  endpoint: 'https://your-opslane-instance.example.com', // omit for hosted Opslane
+  endpoint: 'https://your-opslane-instance.example.com', // https://app.opslane.com for hosted Opslane
 });
 
 setUser({ id: 'user-123' });

--- a/docs/reference/sdk-options.md
+++ b/docs/reference/sdk-options.md
@@ -8,7 +8,7 @@ All options accepted by `init()` from `@opslane/sdk`, mirrored from `SdkInitOpti
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `apiKey` | `string` | *(required)* | Project-scoped public ingest key. It must start with `opslane_pk_`; `init` refuses to start without it. |
-| `endpoint` | `string` | `https://api.opslane.com` | Your Opslane instance; validated as an http(s) URL. |
+| `endpoint` | `string` | `https://app.opslane.com` | Your Opslane instance; validated as an http(s) URL. |
 | `release` | `string` | `''` | Optional immutable deployment identifier; source maps match by debug ID. |
 | `environment` | `string` | `''` | Optional deployment name sent with events and session initialization. The server uses it only when payload overrides are enabled for the project; existing session environment assignment takes precedence. |
 | `maxBreadcrumbs` | `number` | `50` | Ring-buffer size for breadcrumbs attached to each event. |

--- a/packages/dashboard/src/views/SetupWizard.vue
+++ b/packages/dashboard/src/views/SetupWizard.vue
@@ -133,9 +133,13 @@ const pollTimer = ref<ReturnType<typeof setInterval>>();
 const keyError = ref('');
 const keyLoading = ref(false);
 
-const hostedOrigin = 'https://app.opslane.com';
+// Always emit the endpoint. The dashboard is served by the ingestion service,
+// so window.location.origin is the correct ingest endpoint everywhere --
+// including hosted. Omitting it on hosted left users on the SDK's baked-in
+// default, which pointed at a hostname that was never wired up (the CORS
+// failure every hosted onboarding hit).
 const endpointLine = computed(() => (
-  window.location.origin === hostedOrigin ? '' : `\n  endpoint: '${window.location.origin}',`
+  `\n  endpoint: '${window.location.origin}',`
 ));
 const initSnippet = computed(() => {
   const common = `init({\n  apiKey: '${apiKey.value}',\n  environment: 'development',${endpointLine.value}\n});`;

--- a/packages/dashboard/src/views/SetupWizard.vue
+++ b/packages/dashboard/src/views/SetupWizard.vue
@@ -136,7 +136,7 @@ const keyLoading = ref(false);
 // Always emit the endpoint. The dashboard is served by the ingestion service,
 // so window.location.origin is the correct ingest endpoint everywhere --
 // including hosted. Omitting it on hosted left users on the SDK's baked-in
-// default, which pointed at a hostname that was never wired up (the CORS
+// default, which pointed at a hostname never wired to an origin (the CORS
 // failure every hosted onboarding hit).
 const endpointLine = computed(() => (
   `\n  endpoint: '${window.location.origin}',`

--- a/packages/dashboard/src/views/__tests__/setup-wizard.test.ts
+++ b/packages/dashboard/src/views/__tests__/setup-wizard.test.ts
@@ -70,6 +70,8 @@ describe('SetupWizard', () => {
       label: 'onboarding', expires_at: null, scope: 'ingest',
     });
     expect(wrapper.text()).toContain('opslane_pk_resume');
+    // The snippet always carries an explicit endpoint (the SDK default is not trusted).
+    expect(wrapper.text()).toContain(`endpoint: '${window.location.origin}'`);
     expect(localStorage.getItem('opslane_project_id')).toBe('p1');
     expect(api.onboardingSetup).not.toHaveBeenCalled();
     wrapper.unmount();

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -19,7 +19,7 @@ import { init } from '@opslane/sdk';
 
 init({
   apiKey: import.meta.env.VITE_OPSLANE_API_KEY,
-  endpoint: 'https://your-opslane-instance.example.com', // omit for hosted Opslane
+  endpoint: 'https://your-opslane-instance.example.com', // https://app.opslane.com for hosted Opslane
   release: import.meta.env.VITE_OPSLANE_RELEASE,          // e.g. your git SHA
 });
 ```

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -99,7 +99,7 @@ All `init` options, from the SDK's `SdkInitOptions` type:
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `apiKey` | `string` | *(required)* | Project ingest key. `init` is a no-op without it. |
-| `endpoint` | `string` | `https://api.opslane.com` | Your Opslane instance. Must be a valid http(s) URL. |
+| `endpoint` | `string` | `https://app.opslane.com` | Your Opslane instance. Must be a valid http(s) URL. |
 | `release` | `string` | `''` | Immutable build identifier; must match uploaded source maps. |
 | `maxBreadcrumbs` | `number` | `50` | Maximum breadcrumbs kept in the ring buffer. |
 | `breadcrumbMaxAge` | `number` | `30000` | Milliseconds a breadcrumb stays relevant before being dropped. |

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -44,7 +44,7 @@ export interface SdkInitOptions {
   beforeSend?: BeforeSendHook;
 }
 
-const DEFAULT_ENDPOINT = 'https://api.opslane.com';
+const DEFAULT_ENDPOINT = 'https://app.opslane.com';
 const PUBLIC_KEY_PREFIX = 'opslane_pk_';
 
 export class InvalidApiKeyError extends Error {


### PR DESCRIPTION
## Problem

First hosted onboarding attempt failed at the test-event step: the browser preflight to `https://api.opslane.com/api/v1/events` gets a Cloudflare 403 block page (no CORS headers), so every SDK event from a hosted user's app dies. `api.opslane.com` has no record in the deploy terraform and 403s on every path (`/health` included). `app.opslane.com` is the real API: health 200, `/api/v1/events` preflight answers 204 with `access-control-allow-origin` echoed for any origin, `/mcp` answers 401.

Two of our surfaces sent people to the dead host:
- the SDK's `DEFAULT_ENDPOINT` (`config.ts:47`) — which the v2 wizard exposed by omitting `endpoint` on hosted
- the remote MCP guide + SDK docs

## Fix

- SDK `DEFAULT_ENDPOINT` → `https://app.opslane.com`
- Wizard snippet always emits `endpoint: window.location.origin` (correct everywhere, hosted included — the dashboard is served by ingestion); no reliance on the SDK default
- `docs/guides/mcp.md`, `docs/reference/sdk-options.md`, `packages/sdk/README.md` → live host
- Design doc updated (no hosted-omission case)

## Verified

- `app.opslane.com` preflight/health/mcp probed live (see commit message)
- SDK 350/350 (excluding the known host-env `debug-id-browser` failure), dashboard 372/372, docs drift clean

## Note

If `api.opslane.com` should exist as the canonical API host, that's a deploy-repo change (DNS + cert + Cloudflare rules) — this PR makes the code match what production actually serves today. Requires an SDK npm release for the default to reach users.