### PR TITLE
fix(dashboard): wizard UX — drop the error link and the default Check again button

### DIFF
--- a/docs/design/2026-08-26-onboarding-v2.md
+++ b/docs/design/2026-08-26-onboarding-v2.md
@@ -97,7 +97,7 @@ Framework tabs (Vue / React / Next.js / Other), key inline, `environment: 'devel
 <button onClick={() => { throw new Error('opslane-test'); }}>Test Opslane</button>
 ```
 
-The listener polls `event-count` (which gains `latest_error_group_id`; today it returns only `has_events`, `read_api.go:1184`) and links the latest captured group. Copy says "the latest error Opslane captured": if the app was already erroring, that group may not be `opslane-test`, and v1 does not do marker matching (follow-up issue). There is no way to advance past this screen without an event; Vue and React tab content follows `docs/install.md`, and the Next.js tab is new content shipped with a matching install.md section in the same PR.
+The listener polls `event-count` until `has_events` flips. The success panel confirms the capture in place and deliberately does NOT link the captured error: it is a throwaway test error, and a mid-wizard link invites navigation away from the flow. The dashboard shows the issues list right after completion. There is no way to advance past this screen without an event; Vue and React tab content follows `docs/install.md`, and the Next.js tab is new content shipped with a matching install.md section in the same PR.
 
 ### 5.3 GitHub step (deferable)
 

--- a/packages/dashboard/src/views/SetupWizard.vue
+++ b/packages/dashboard/src/views/SetupWizard.vue
@@ -230,11 +230,16 @@ const installHref = computed(() => safeUrl(
   githubAppStatus.value?.install_url ?? '', GITHUB_PR_URL_OPTIONS,
 ));
 
+const githubStatusFailed = ref(false);
 async function loadGitHubStatus(): Promise<void> {
   try {
     githubAppStatus.value = await getGitHubAppStatus();
+    githubStatusFailed.value = false;
   } catch {
-    githubAppStatus.value = null;
+    // Keep the last known status so a transient failure mid-poll doesn't
+    // blank the Install link; flag a failure only when we have nothing to
+    // show, which renders the retry affordance instead of a dead end.
+    githubStatusFailed.value = !githubAppStatus.value;
   }
 }
 
@@ -243,15 +248,25 @@ async function loadGitHubStatus(): Promise<void> {
 // installation lands (or the step is left). No manual "check again" needed.
 const installStarted = ref(false);
 const githubStatusTimer = ref<ReturnType<typeof setInterval>>();
+const githubPollInFlight = ref(false);
+async function pollGitHubStatusOnce(): Promise<void> {
+  // The in-flight guard keeps slow responses from overlapping, which also
+  // prevents an out-of-order stale result overwriting an installed:true.
+  if (githubPollInFlight.value) return;
+  githubPollInFlight.value = true;
+  try {
+    await loadGitHubStatus();
+  } finally {
+    githubPollInFlight.value = false;
+  }
+  if (githubAppStatus.value?.installed) stopGitHubStatusPolling();
+}
 function startGitHubStatusPolling(): void {
   installStarted.value = true;
   if (githubStatusTimer.value) clearInterval(githubStatusTimer.value);
-  githubStatusTimer.value = setInterval(async () => {
-    await loadGitHubStatus();
-    if (githubAppStatus.value?.installed && githubStatusTimer.value) {
-      clearInterval(githubStatusTimer.value);
-      githubStatusTimer.value = undefined;
-    }
+  void pollGitHubStatusOnce();
+  githubStatusTimer.value = setInterval(() => {
+    void pollGitHubStatusOnce();
   }, 4000);
 }
 function stopGitHubStatusPolling(): void {
@@ -506,6 +521,10 @@ onUnmounted(() => {
                 <RepoSelector v-model="selectedRepo" :disabled="githubBusy" />
                 <Button variant="primary" class="w-full" :busy="githubBusy" :disabled="!selectedRepo" @click="attachRepo(selectedRepo)">Connect repository</Button>
               </div>
+              <p v-else-if="githubStatusFailed" class="text-sm text-danger">
+                Couldn't reach GitHub status.
+                <button data-testid="github-status-retry" type="button" class="underline" @click="loadGitHubStatus">Try again</button>
+              </p>
               <p v-else-if="installStarted" class="flex items-center gap-2 text-xs text-muted">
                 <span class="h-3 w-3 animate-spin rounded-full border-2 border-accent border-r-transparent"></span>
                 Waiting for GitHub — we'll detect the installation automatically. If your org needs an admin to approve it, you can continue for now.

--- a/packages/dashboard/src/views/SetupWizard.vue
+++ b/packages/dashboard/src/views/SetupWizard.vue
@@ -238,6 +238,29 @@ async function loadGitHubStatus(): Promise<void> {
   }
 }
 
+// The App install happens on github.com in another tab and never calls back
+// into this one, so after the user heads there we poll status until the
+// installation lands (or the step is left). No manual "check again" needed.
+const installStarted = ref(false);
+const githubStatusTimer = ref<ReturnType<typeof setInterval>>();
+function startGitHubStatusPolling(): void {
+  installStarted.value = true;
+  if (githubStatusTimer.value) clearInterval(githubStatusTimer.value);
+  githubStatusTimer.value = setInterval(async () => {
+    await loadGitHubStatus();
+    if (githubAppStatus.value?.installed && githubStatusTimer.value) {
+      clearInterval(githubStatusTimer.value);
+      githubStatusTimer.value = undefined;
+    }
+  }, 4000);
+}
+function stopGitHubStatusPolling(): void {
+  if (githubStatusTimer.value) {
+    clearInterval(githubStatusTimer.value);
+    githubStatusTimer.value = undefined;
+  }
+}
+
 async function attachRepo(repo: string): Promise<void> {
   if (!repo.trim()) return;
   githubError.value = '';
@@ -255,6 +278,7 @@ async function attachRepo(repo: string): Promise<void> {
 }
 
 function deferGitHub(): void {
+  stopGitHubStatusPolling();
   step.value = 'connect_slack';
 }
 
@@ -338,6 +362,7 @@ function goToDashboard(): void {
 
 onUnmounted(() => {
   if (pollTimer.value) clearInterval(pollTimer.value);
+  stopGitHubStatusPolling();
 });
 </script>
 
@@ -474,13 +499,17 @@ onUnmounted(() => {
                 target="_blank"
                 rel="noopener noreferrer"
                 class="flex w-full items-center justify-center rounded-md bg-accent px-4 py-3 text-sm font-medium text-on-accent"
+                data-testid="github-install"
+                @click="startGitHubStatusPolling"
               >Install GitHub App</a>
-              <Button v-if="!githubAppStatus?.installed" class="w-full" @click="loadGitHubStatus">Check again</Button>
-              <div v-else class="space-y-3">
+              <div v-if="githubAppStatus?.installed" class="space-y-3">
                 <RepoSelector v-model="selectedRepo" :disabled="githubBusy" />
                 <Button variant="primary" class="w-full" :busy="githubBusy" :disabled="!selectedRepo" @click="attachRepo(selectedRepo)">Connect repository</Button>
               </div>
-              <p v-if="!githubAppStatus?.installed" class="text-xs text-muted">Waiting for GitHub? Ask an admin to approve the installation, or continue for now.</p>
+              <p v-else-if="installStarted" class="flex items-center gap-2 text-xs text-muted">
+                <span class="h-3 w-3 animate-spin rounded-full border-2 border-accent border-r-transparent"></span>
+                Waiting for GitHub — we'll detect the installation automatically. If your org needs an admin to approve it, you can continue for now.
+              </p>
             </div>
             <button data-testid="defer-github" type="button" class="mt-6 w-full text-sm text-muted underline hover:text-text" @click="deferGitHub">
               Do this later

--- a/packages/dashboard/src/views/SetupWizard.vue
+++ b/packages/dashboard/src/views/SetupWizard.vue
@@ -128,7 +128,6 @@ async function submitProject(): Promise<void> {
 
 const framework = ref<'vue' | 'react' | 'nextjs' | 'other'>('vue');
 const hasEvents = ref(false);
-const latestGroupId = ref<string | null>(null);
 const pollTimer = ref<ReturnType<typeof setInterval>>();
 const keyError = ref('');
 const keyLoading = ref(false);
@@ -207,11 +206,7 @@ function startEventPolling(): void {
       const status = await getEventStatus(projectId.value);
       if (status.has_events) {
         hasEvents.value = true;
-        latestGroupId.value = status.latest_error_group_id;
-        // Grouping is async: has_events flips before the error group exists.
-        // Keep polling until the group id arrives so the success link points
-        // at the captured error rather than degrading to the issues list.
-        if (latestGroupId.value && pollTimer.value) clearInterval(pollTimer.value);
+        if (pollTimer.value) clearInterval(pollTimer.value);
       }
     } catch {
       // Keep polling through transient errors.
@@ -449,12 +444,11 @@ onUnmounted(() => {
                 <span class="h-4 w-4 animate-spin rounded-full border-2 border-accent border-r-transparent"></span>
                 Waiting for your first event…
               </div>
+              <!-- No link to the captured error here: it is a throwaway test
+                   error, and navigating away mid-wizard is a drop-off point.
+                   The dashboard shows their issues right after the flow ends. -->
               <div v-else class="space-y-4 rounded-md border border-success/30 bg-success/10 p-4">
-                <p class="text-sm text-success">Event received. View <a
-                  data-testid="latest-group-link"
-                  :href="latestGroupId ? '/issues/' + latestGroupId : '/'"
-                  class="underline"
-                >the latest error Opslane captured</a>.</p>
+                <p class="text-sm text-success">Event received — Opslane captured your test error.</p>
                 <p class="text-xs text-muted">You can delete the test button now. Move the key to an environment variable before committing.</p>
                 <Button data-testid="sdk-continue" variant="primary" @click="continueFromSdk">Continue</Button>
               </div>

--- a/packages/dashboard/src/views/__tests__/setup-wizard.test.ts
+++ b/packages/dashboard/src/views/__tests__/setup-wizard.test.ts
@@ -137,6 +137,22 @@ describe('SetupWizard', () => {
     wrapper.unmount();
   });
 
+  it('shows the GitHub waiting state only after the install link is clicked, then polls', async () => {
+    api.getOnboardingState.mockResolvedValue({
+      ...baseState, next_step: 'connect_github', project_id: 'p1', has_events: true,
+    });
+    const wrapper = mount(SetupWizard);
+    await flushPromises();
+    expect(wrapper.text()).not.toContain('Check again');
+    expect(wrapper.text()).not.toContain('Waiting for GitHub');
+    const initialCalls = api.getGitHubAppStatus.mock.calls.length;
+    await wrapper.get('[data-testid="github-install"]').trigger('click');
+    expect(wrapper.text()).toContain('Waiting for GitHub');
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(api.getGitHubAppStatus.mock.calls.length).toBeGreaterThan(initialCalls);
+    wrapper.unmount();
+  });
+
   it('shows completion failure instead of the done screen', async () => {
     api.getOnboardingState.mockResolvedValue({
       ...baseState, next_step: 'connect_github', project_id: 'p1', has_events: true,

--- a/packages/dashboard/src/views/__tests__/setup-wizard.test.ts
+++ b/packages/dashboard/src/views/__tests__/setup-wizard.test.ts
@@ -151,6 +151,57 @@ describe('SetupWizard', () => {
     await vi.advanceTimersByTimeAsync(4000);
     expect(api.getGitHubAppStatus.mock.calls.length).toBeGreaterThan(initialCalls);
     wrapper.unmount();
+    const callsAtUnmount = api.getGitHubAppStatus.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(12000);
+    expect(api.getGitHubAppStatus.mock.calls.length).toBe(callsAtUnmount);
+  });
+
+  it('stops polling GitHub status once the installation lands', async () => {
+    api.getOnboardingState.mockResolvedValue({
+      ...baseState, next_step: 'connect_github', project_id: 'p1', has_events: true,
+    });
+    const wrapper = mount(SetupWizard);
+    await flushPromises();
+    api.getGitHubAppStatus.mockResolvedValue({
+      installed: true, installation_id: 7, install_url: null,
+    });
+    await wrapper.get('[data-testid="github-install"]').trigger('click');
+    await flushPromises();
+    const callsAfterInstall = api.getGitHubAppStatus.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(12000);
+    expect(api.getGitHubAppStatus.mock.calls.length).toBe(callsAfterInstall);
+    expect(wrapper.text()).toContain('Connect repository');
+    wrapper.unmount();
+  });
+
+  it('keeps the Install link through a transient poll failure', async () => {
+    api.getOnboardingState.mockResolvedValue({
+      ...baseState, next_step: 'connect_github', project_id: 'p1', has_events: true,
+    });
+    const wrapper = mount(SetupWizard);
+    await flushPromises();
+    await wrapper.get('[data-testid="github-install"]').trigger('click');
+    api.getGitHubAppStatus.mockRejectedValue(new Error('network blip'));
+    await vi.advanceTimersByTimeAsync(4000);
+    await flushPromises();
+    expect(wrapper.find('[data-testid="github-install"]').exists()).toBe(true);
+    expect(wrapper.text()).not.toContain("Couldn't reach GitHub status");
+    wrapper.unmount();
+  });
+
+  it('offers a retry instead of a dead end when the first status fetch fails', async () => {
+    api.getOnboardingState.mockResolvedValue({
+      ...baseState, next_step: 'connect_github', project_id: 'p1', has_events: true,
+    });
+    api.getGitHubAppStatus.mockRejectedValueOnce(new Error('boom'));
+    const wrapper = mount(SetupWizard);
+    await flushPromises();
+    expect(wrapper.find('[data-testid="github-install"]').exists()).toBe(false);
+    expect(wrapper.text()).toContain("Couldn't reach GitHub status");
+    await wrapper.get('[data-testid="github-status-retry"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="github-install"]').exists()).toBe(true);
+    wrapper.unmount();
   });
 
   it('shows completion failure instead of the done screen', async () => {

--- a/packages/dashboard/src/views/__tests__/setup-wizard.test.ts
+++ b/packages/dashboard/src/views/__tests__/setup-wizard.test.ts
@@ -89,7 +89,10 @@ describe('SetupWizard', () => {
     expect(wrapper.find('[data-testid="sdk-continue"]').exists()).toBe(false);
     await vi.advanceTimersByTimeAsync(6001);
     await flushPromises();
-    expect(wrapper.get('[data-testid="latest-group-link"]').attributes('href')).toContain('g1');
+    // Deliberately no link to the captured error: it is a throwaway test
+    // error and navigating away mid-wizard is a drop-off point.
+    expect(wrapper.find('[data-testid="latest-group-link"]').exists()).toBe(false);
+    expect(wrapper.text()).toContain('Event received');
     await wrapper.get('[data-testid="sdk-continue"]').trigger('click');
     await flushPromises();
     expect(wrapper.text()).toContain('Connect GitHub');


### PR DESCRIPTION
Two onboarding-wizard UX fixes that were pushed to #427's branch after it was squash-merged, so they never landed. Cherry-picked onto main unchanged.

## Success panel (7d6ddf1)
The event-received panel linked to the captured test error, which navigates the user away mid-onboarding. It now confirms in place ("Event received — Opslane captured your test error.") with only a Continue button; the group-link polling and `latestGroupId` state are removed.

## Connect GitHub step (bc6e28c)
"Check again" rendered before the user had attempted an install, and the "Waiting for GitHub?" hint sat there by default. Now:
- Before any click: just **Install GitHub App** and **Do this later**.
- Clicking Install starts a 4s status poll; a spinner line explains we'll detect the installation automatically. The repo picker appears on its own when the install lands.
- Polling stops on install, defer, or unmount.

## Verification
- `pnpm --filter @opslane/dashboard test` — 373/373 (new test: waiting state hidden until the install click, then polls)
- `pnpm --filter @opslane/dashboard build` — clean