### PR TITLE
build(deps): bump cryptography to 50.0.0 in the flask-app fixture

### DIFF
--- a/test-fixtures/flask-app/requirements.txt
+++ b/test-fixtures/flask-app/requirements.txt
@@ -3,6 +3,6 @@ flask-sqlalchemy==3.1.1
 sqlalchemy==2.0.30
 psycopg2==2.9.9
 gunicorn==22.0.0
-cryptography==48.0.1
+cryptography==50.0.0
 alembic==1.13.1
 python-dotenv==1.2.2


### PR DESCRIPTION
Clears the last open Dependabot alert (PKCS#7 Bleichenbacher oracle,
patched in 50.0.0). Fixture-only dependency.
