### PR TITLE
fix(mcp): allow public Host behind Service Connect loopback hop

### DIFF
--- a/docs/superpowers/plans/2026-08-27-mcp-loopback-403.md
+++ b/docs/superpowers/plans/2026-08-27-mcp-loopback-403.md
@@ -15,7 +15,7 @@
 - Ingestion package rules apply: handlers stay in `handler/`, run `go build ./... && go test ./...` from `packages/ingestion` (repo `AGENTS.md`).
 - DB-gated tests need `DATABASE_URL` with all migrations applied; a green run with skips is not proof. Verify skips executably: `go test ./... -json | jq -rs '[.[] | select(.Action=="skip" and .Test != null) | .Test] | unique'`. With storage env (`MINIO_*`/`REPLAY_STORE_*`) exported the list must be empty; without it, every listed name must be a storage suite (repo `AGENTS.md`).
 - Keep the diff small; no drive-by refactors. One atomic commit for fix + tests.
-- Do not weaken MCP bearer auth: `RequireBearerToken` wraps the transport (`mcp.go:81-84`), so the Host check being disabled sits strictly behind auth. Tests below prove missing/invalid tokens still fail in the loopback-proxy shape. `/mcp` is mounted exactly once (`routes.go:78`); the loopback-shape negative-auth tests below are the enforcement that no request reaches the transport unauthenticated.
+- Do not weaken MCP bearer auth: `RequireBearerToken` wraps the transport (in `MCPHandler()`, `mcp.go`), so the Host check being disabled sits strictly behind auth. Tests below prove missing/invalid tokens still fail in the loopback-proxy shape. `/mcp` is mounted exactly once (`routes.go:78`); the loopback-shape negative-auth tests below are the enforcement that no request reaches the transport unauthenticated.
 
 ---
 
@@ -50,7 +50,7 @@
 ### Task 1: Regression tests (written first) + fix in the MCP handler
 
 **Files:**
-- Modify: `packages/ingestion/handler/mcp.go:33-38` (StreamableHTTPOptions)
+- Modify: `packages/ingestion/handler/mcp.go` (the `StreamableHTTPOptions` literal in `MCPHandler()`)
 - Test: `packages/ingestion/handler/mcp_auth_test.go`
 
 **Interfaces:**

--- a/docs/superpowers/plans/2026-08-27-mcp-loopback-403.md
+++ b/docs/superpowers/plans/2026-08-27-mcp-loopback-403.md
@@ -1,0 +1,291 @@
+# MCP Prod Loopback 403 Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `https://app.opslane.com/mcp` accept authenticated MCP connections in prod by disabling the SDK's DNS-rebinding localhost protection, which misfires behind ECS Service Connect.
+
+**Architecture:** One option on the existing `StreamableHTTPHandler` construction in the ingestion Go service, plus regression tests that reproduce the prod topology (loopback local address + public `Host` header) and prove the auth boundary is unchanged. Rollout is a standard ingestion image deploy with an explicit rollback path; live verification asserts the JSON-RPC result and re-probes negative auth.
+
+**Tech Stack:** Go 1.24, `github.com/modelcontextprotocol/go-sdk v1.7.0`, ECS Fargate + Service Connect, `~/deploy/scripts/deploy.sh`.
+
+**Spec:** This document doubles as the spec — the root-cause analysis below is the requirement source. Related feature plan: `docs/superpowers/plans/2026-08-22-remote-mcp-bearer-token.md`.
+
+## Global Constraints
+
+- Ingestion package rules apply: handlers stay in `handler/`, run `go build ./... && go test ./...` from `packages/ingestion` (repo `AGENTS.md`).
+- DB-gated tests need `DATABASE_URL` with all migrations applied; a green run with skips is not proof. Verify skips executably: `go test ./... -json | jq -rs '[.[] | select(.Action=="skip" and .Test != null) | .Test] | unique'`. With storage env (`MINIO_*`/`REPLAY_STORE_*`) exported the list must be empty; without it, every listed name must be a storage suite (repo `AGENTS.md`).
+- Keep the diff small; no drive-by refactors. One atomic commit for fix + tests.
+- Do not weaken MCP bearer auth: `RequireBearerToken` wraps the transport (`mcp.go:81-84`), so the Host check being disabled sits strictly behind auth. Tests below prove missing/invalid tokens still fail in the loopback-proxy shape. `/mcp` is mounted exactly once (`routes.go:78`); the loopback-shape negative-auth tests below are the enforcement that no request reaches the transport unauthenticated.
+
+---
+
+## Root cause (evidence)
+
+1. Prod error is `403 Forbidden: invalid Host header "app.opslane.com"`, emitted by the SDK at `mcp/streamable.go:330` (v1.7.0), **not** by our auth. Server logs in the repro show `mcp bearer authentication outcome=ok` immediately before the 403 — Claude Code merely labels every 403 as an auth rejection.
+2. The SDK check fires when the accepted TCP connection's *local* address is loopback while `Host` is not loopback. SDK documentation for the option (`streamable.go:174-182`): "By default, requests arriving via a localhost address (127.0.0.1, [::1]) that have a non-localhost Host header are rejected with 403 Forbidden. This protects against DNS rebinding attacks…"
+3. Prod topology trips it: the ingestion ECS service enables Service Connect (`~/deploy/terraform/ecs.tf`, `service_connect_configuration`). The injected Envoy agent receives ALB traffic and re-delivers it to the Go server over `127.0.0.1` with `Host: app.opslane.com` preserved. Every MCP request 403s.
+4. Nothing caught it because unit tests use `httptest.NewRequest` (no `http.LocalAddrContextKey` in context, check never runs) and local dev connects with a loopback `Host`.
+
+**Topology confirmation:** the loopback hop is inferred from Service Connect's documented ingress interception plus the observed prod 403; it is confirmed two ways in Task 2: (a) pre-deploy, our own probe must return the SDK's distinctive body `Forbidden: invalid Host header "app.opslane.com"` — that string is emitted only by the Host check, so it self-correlates without log access; (b) post-deploy, the live probe returning a JSON-RPC `result` proves the Host check was the failing gate. If the post-deploy probe still 403s, the diagnosis is wrong — roll back and re-investigate rather than layering more changes.
+
+**Spike results (run in this worktree, 2026-08-27, against a disposable migrated DB):** Task 1's exact tests are validated. Without the fix, both tests fail with the literal prod body `Forbidden: invalid Host header "app.opslane.com"`; with `DisableLocalhostProtection: true`, both pass — the JSON-RPC decode asserts `result.serverInfo.name == "opslane"` with no `error`, and missing/invalid tokens still return 401 in the loopback shape. The ingestion package gate (`go build ./... && go test ./...`) is green with zero failures, and the Global Constraints skip-check command runs as written: 33 skips, all storage-gated suites (storage env unset), matching policy.
+
+## Alternatives considered
+
+- **`DisableLocalhostProtection: true` in code (chosen):** explicit, colocated with the transport config, regression-testable, survives SDK upgrades. Safe because this is a remote, bearer-authenticated server behind an ALB — the protection targets unauthenticated *local* MCP servers attacked via DNS rebinding from a browser, and the auth middleware in front of the transport is unchanged (proven by tests below).
+- **`MCPGODEBUG=disablelocalhostprotection=1` env var in terraform:** works today, but MCPGODEBUG keys are documented as temporary compatibility parameters slated for removal in upcoming SDK minors; also invisible from the code.
+- **Disable Service Connect on the ingestion service:** removes the loopback hop but breaks worker→ingestion service discovery (`client_alias ingestion:8080`) and is a far larger blast radius for a one-line problem.
+- **Rewrite `Host` at the ALB/Envoy:** ALB cannot rewrite Host; Service Connect's Envoy is not user-configurable.
+
+## Codex review notes
+
+**Iteration 1 — adopted:** JSON-RPC body assertions instead of bare 200 checks; negative-auth coverage in the loopback shape; tests written before the fix (no "temporarily revert" step); dedicated HTTP client with timeout; single atomic commit; rollback procedure; negative live probes; `mktemp` for probe output; explicit skip-count policy; single-mount route check; SDK option semantics quoted.
+**Iteration 1 — rejected:** removing the agentic-worker header (required plan-template boilerplate for this repo's tooling, not plan content; re-flagged in iteration 2, same disposition). Kept the real-socket test despite the redundancy flag — it is the prod-shape spike the requester asked for, and it is the only test where `net/http` itself populates `LocalAddrContextKey`; cost is one extra sub-second DB-backed test.
+
+**Iteration 2 — adopted:** working rollback-point capture (read the deployed image tag from the live ECS task definition; the previous version was a broken shell line); executable skip-count verification via `go test -json`; self-correlating pre-deploy evidence (the 403 *body text* is emitted only by the SDK's Host check, so capturing it from our own probe needs no log correlation); environment prechecks before the live probes so probe-environment failures are not misread as deploy regressions; `io.LimitReader` in the socket test; "ingestion package gate" naming; documented the option's complete v1.7.0 scope (below).
+**Iteration 2 — resolved by inspection, not plan change:** the single-mount grep was dropped — `/mcp` is mounted exactly once at `routes.go:78` and the router-level negative-auth tests are the real enforcement. `DisableLocalhostProtection` in v1.7.0 gates only the Host-check block (`streamable.go:327-333`; the `sse.go:195` twin is on a transport we do not use). `CrossOriginProtection` is a separate option, nil for us before and after this change — origin handling is untouched. The handler emits no CORS headers, so browsers cannot read `/mcp` responses cross-origin; clients are non-browser CLIs holding bearer keys.
+
+---
+
+### Task 1: Regression tests (written first) + fix in the MCP handler
+
+**Files:**
+- Modify: `packages/ingestion/handler/mcp.go:33-38` (StreamableHTTPOptions)
+- Test: `packages/ingestion/handler/mcp_auth_test.go`
+
+**Interfaces:**
+- Consumes: existing `testDeps`, `seedTenant`, `cleanupTenantHandler`, `handler.NewRouterWithPool` test helpers; `Queries.CreateProjectKey(ctx, projectID, db.ScopeAPI, name, nil, "")`.
+- Produces: nothing new — behavior-only change.
+
+- [ ] **Step 1: Write both failing tests** (append to `mcp_auth_test.go`; add `"io"`, `"net"`, and `"encoding/json"` to imports)
+
+```go
+// decodeInitializeResult asserts the body is a successful JSON-RPC initialize
+// response for the opslane server, not merely HTTP 200 (JSON-RPC errors also
+// ride on 200).
+func decodeInitializeResult(t *testing.T, body []byte) {
+	t.Helper()
+	var response struct {
+		Error  *struct{ Message string } `json:"error"`
+		Result *struct {
+			ServerInfo struct {
+				Name string `json:"name"`
+			} `json:"serverInfo"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatalf("decode initialize response: %v, body = %s", err, body)
+	}
+	if response.Error != nil {
+		t.Fatalf("initialize returned JSON-RPC error: %+v, body = %s", response.Error, body)
+	}
+	if response.Result == nil || response.Result.ServerInfo.Name != "opslane" {
+		t.Fatalf("initialize result missing serverInfo.name=opslane, body = %s", body)
+	}
+}
+
+const mcpInitializeBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`
+
+// Prod delivers ALB traffic to the container through the ECS Service Connect
+// Envoy agent, so the server accepts the connection on 127.0.0.1 while Host
+// stays the public domain. The SDK's DNS-rebinding localhost protection must
+// not reject that combination — and the bearer gate in front of it must be
+// unaffected by disabling it.
+func TestMCPBehindLoopbackProxy(t *testing.T) {
+	deps, pool := testDeps(t)
+	ctx := context.Background()
+	orgID, projectID, _, _ := seedTenant(t, deps.Queries)
+	t.Cleanup(func() { cleanupTenantHandler(t, pool, orgID) })
+
+	apiKey, err := deps.Queries.CreateProjectKey(ctx, projectID, db.ScopeAPI, "mcp", nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router := handler.NewRouterWithPool(deps, pool)
+	request := func(token string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(mcpInitializeBody))
+		req.Host = "app.opslane.com"
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		req = req.WithContext(context.WithValue(req.Context(), http.LocalAddrContextKey,
+			&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 8080}))
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec
+	}
+
+	if rec := request(apiKey.Raw); rec.Code != http.StatusOK {
+		t.Fatalf("valid key: status = %d, want 200, body = %s", rec.Code, rec.Body.String())
+	} else {
+		decodeInitializeResult(t, rec.Body.Bytes())
+	}
+	// Disabling the Host check must not loosen the bearer gate in this shape.
+	if rec := request(""); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing token: status = %d, want 401, body = %s", rec.Code, rec.Body.String())
+	}
+	if rec := request("sk_invalid_token"); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("invalid token: status = %d, want 401, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Same scenario over a real loopback socket, so net/http populates
+// LocalAddrContextKey exactly as prod does.
+func TestMCPBehindLoopbackProxyRealSocket(t *testing.T) {
+	deps, pool := testDeps(t)
+	ctx := context.Background()
+	orgID, projectID, _, _ := seedTenant(t, deps.Queries)
+	t.Cleanup(func() { cleanupTenantHandler(t, pool, orgID) })
+
+	apiKey, err := deps.Queries.CreateProjectKey(ctx, projectID, db.ScopeAPI, "mcp", nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(handler.NewRouterWithPool(deps, pool))
+	t.Cleanup(server.Close)
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/mcp", strings.NewReader(mcpInitializeBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = "app.opslane.com"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer "+apiKey.Raw)
+
+	response, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body = %s", response.StatusCode, body)
+	}
+	decodeInitializeResult(t, body)
+}
+```
+
+- [ ] **Step 2: Run tests to verify both fail with the prod signature**
+
+Run (from `packages/ingestion`, against a migrated disposable DB):
+`DATABASE_URL=... go test ./handler -run TestMCPBehindLoopbackProxy -count=1`
+Expected: both FAIL with `status = 403 ... Forbidden: invalid Host header "app.opslane.com"` on the valid-key path, each preceded by an `outcome=ok` auth log line (proves auth is not the failure point). The negative-auth sub-asserts are unreachable until the fix lands.
+
+- [ ] **Step 3: Apply the fix** (in `MCPHandler()`, `mcp.go`)
+
+```go
+&mcpsdk.StreamableHTTPOptions{
+	Stateless:           true,
+	JSONResponse:        true,
+	MaxRequestBodyBytes: 1 << 20,
+	// This is a remote server behind bearer auth, but ECS Service
+	// Connect's Envoy agent hands ALB traffic to the container over
+	// 127.0.0.1 with the public Host intact, which the SDK's
+	// DNS-rebinding localhost protection would reject with a 403.
+	DisableLocalhostProtection: true,
+},
+```
+
+- [ ] **Step 4: Run tests to verify they pass, then the ingestion package gate**
+
+Run: `DATABASE_URL=... go test ./handler -run 'TestMCP' -count=1`, then the ingestion package gate `go build ./... && go test ./...`, then the skip check from Global Constraints (`go test ./... -json | jq ...`).
+Expected: PASS; the skip list is empty (storage env exported) or contains only storage suites.
+
+- [ ] **Step 5: Commit (one atomic commit)**
+
+```bash
+git add packages/ingestion/handler/mcp.go packages/ingestion/handler/mcp_auth_test.go
+git commit -m "fix(mcp): allow public Host behind Service Connect loopback hop"
+```
+
+### Task 2: Ship and verify in prod
+
+**Files:** none in this repo — PR merge + `~/deploy` rollout.
+
+**Interfaces:**
+- Consumes: merged main containing Task 1; `~/deploy/scripts/deploy.sh vYY.M.PATCH` (builds/pins ingestion+worker images, runs terraform, waits for services-stable). The script deploys both images by design; the worker image is rebuilt from the same merged main and carries no behavior change, which is the accepted blast radius of the standard rollout path.
+- Produces: working `https://app.opslane.com/mcp`.
+
+- [ ] **Step 1: Pre-deploy topology check (self-correlating)**
+
+Send one probe and capture the body — the string below is emitted only by the SDK's Host check (`streamable.go:330`), so matching it on our own request proves the failing gate without log correlation:
+
+```bash
+initialize='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"prefix-probe","version":"1"}}}'
+body=$(curl -sS -X POST https://app.opslane.com/mcp \
+  -H "Authorization: Bearer $OPSLANE_API_KEY" \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d "$initialize")
+echo "$body" | grep -F 'Forbidden: invalid Host header "app.opslane.com"' \
+  || { echo "STOP: prod does not show the SDK Host-check 403 — diagnosis does not match"; exit 1; }
+```
+
+If the grep does not match (e.g. the body is a JSON-RPC auth error instead), STOP — this plan does not apply.
+
+- [ ] **Step 2: Open PR, merge on green CI**
+
+```bash
+gh pr create --title "fix(mcp): allow public Host behind Service Connect loopback hop" --body "Prod /mcp returned 403 'Forbidden: invalid Host header' on every request: the go-sdk's DNS-rebinding localhost protection fires because Service Connect's Envoy agent delivers ALB traffic to the container over 127.0.0.1 with Host: app.opslane.com intact. Auth was never the problem (bearer verification logs outcome=ok before the 403). Fix: DisableLocalhostProtection on the streamable transport — safe for a remote bearer-authenticated server; regression tests prove the bearer gate is unchanged in the loopback-hop shape (valid key succeeds with a real initialize result; missing/invalid tokens still 401)."
+```
+
+- [ ] **Step 3: Record the rollback point, then deploy**
+
+```bash
+cd ~/deploy && export AWS_PROFILE=opslane
+# Rollback point: the tag of the ingestion image running RIGHT NOW.
+TD=$(aws ecs describe-services --cluster opslane --services ingestion \
+  --query 'services[0].taskDefinition' --output text)
+PREV_IMAGE=$(aws ecs describe-task-definition --task-definition "$TD" \
+  --query 'taskDefinition.containerDefinitions[0].image' --output text)
+echo "rollback image: $PREV_IMAGE"   # tag (vYY.M.PATCH) is the deploy.sh argument for rollback
+[ -n "$PREV_IMAGE" ] || { echo "STOP: could not capture rollback point"; exit 1; }
+
+./scripts/deploy.sh v26.8.X   # next patch tag
+```
+
+Rollback procedure — only for an actual deploy regression (see Step 4's precheck/probe split): re-run `./scripts/deploy.sh <tag from PREV_IMAGE>` — the script pins images by digest from that release's manifest, restoring the exact previous ingestion and worker images.
+
+- [ ] **Step 4: Live verification — prechecks, then positive and negative probes**
+
+Prechecks separate probe-environment failures from deploy regressions; a precheck failure means fix the environment and re-probe, never roll back.
+
+```bash
+command -v curl >/dev/null && command -v jq >/dev/null || { echo "PRECHECK FAIL: need curl+jq"; exit 2; }
+[ -n "$OPSLANE_API_KEY" ] || { echo "PRECHECK FAIL: OPSLANE_API_KEY unset"; exit 2; }
+curl -sS -o /dev/null -w '%{http_code}' https://app.opslane.com/health | grep -q 200 \
+  || { echo "PRECHECK FAIL: /health unreachable — environment or service-wide issue, not this change"; exit 2; }
+
+PROBE_OUT=$(mktemp)
+trap 'rm -f "$PROBE_OUT"' EXIT
+initialize='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}'
+
+# Positive: valid key must return 200 AND a JSON-RPC result naming the server.
+code=$(curl -sS -o "$PROBE_OUT" -w '%{http_code}' -X POST https://app.opslane.com/mcp \
+  -H "Authorization: Bearer $OPSLANE_API_KEY" \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d "$initialize")
+[ "$code" = "200" ] || { echo "FAIL: expected 200, got $code"; cat "$PROBE_OUT"; exit 1; }
+jq -e '.error == null and .result.serverInfo.name == "opslane"' "$PROBE_OUT" || { echo "FAIL: bad initialize result"; cat "$PROBE_OUT"; exit 1; }
+
+# Negative: missing and invalid tokens must stay rejected (401).
+for auth in "" "Authorization: Bearer sk_invalid_probe_token"; do
+  code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST https://app.opslane.com/mcp \
+    ${auth:+-H "$auth"} \
+    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+    -d "$initialize")
+  [ "$code" = "401" ] || { echo "FAIL: expected 401 for '${auth:-no auth}', got $code"; exit 1; }
+done
+echo "PASS: positive and negative probes"
+```
+
+Then reconnect the failing client: `claude mcp` → Opslane → Reconnect → status `connected`.

--- a/packages/ingestion/handler/mcp.go
+++ b/packages/ingestion/handler/mcp.go
@@ -34,6 +34,11 @@ func (d *Dependencies) MCPHandler() http.Handler {
 			Stateless:           true,
 			JSONResponse:        true,
 			MaxRequestBodyBytes: 1 << 20,
+			// This is a remote server behind bearer auth, but ECS Service
+			// Connect's Envoy agent hands ALB traffic to the container over
+			// 127.0.0.1 with the public Host intact, which the SDK's
+			// DNS-rebinding localhost protection would reject with a 403.
+			DisableLocalhostProtection: true,
 		},
 	)
 

--- a/packages/ingestion/handler/mcp_auth_test.go
+++ b/packages/ingestion/handler/mcp_auth_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/opslane/opslane/packages/ingestion/handler"
 )
 
+const mcpInitializeBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`
+
 func TestMCPBearerAuth(t *testing.T) {
 	var logs bytes.Buffer
 	previousLogger := slog.Default()
@@ -55,8 +57,7 @@ func TestMCPBearerAuth(t *testing.T) {
 	router := handler.NewRouterWithPool(deps, pool)
 	request := func(token string, cancelled bool) *httptest.ResponseRecorder {
 		t.Helper()
-		req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(
-			`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`))
+		req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(mcpInitializeBody))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json, text/event-stream")
 		if token != "" {
@@ -150,8 +151,6 @@ func decodeInitializeResult(t *testing.T, body []byte) {
 	}
 }
 
-const mcpInitializeBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`
-
 // Prod delivers ALB traffic to the container through the ECS Service Connect
 // Envoy agent, so the server accepts the connection on 127.0.0.1 while Host
 // stays the public domain. The SDK's DNS-rebinding localhost protection must
@@ -189,8 +188,15 @@ func TestMCPBehindLoopbackProxy(t *testing.T) {
 		t.Fatalf("valid key: status = %d, want 200, body = %s", rec.Code, rec.Body.String())
 	} else {
 		decodeInitializeResult(t, rec.Body.Bytes())
+		// With the SDK's Host backstop disabled, browser-side safety of /mcp
+		// rests on no CORS grant ever being emitted for it. Pin that.
+		if origin := rec.Header().Get("Access-Control-Allow-Origin"); origin != "" {
+			t.Fatalf("/mcp response grants CORS origin %q; browser access must stay blocked", origin)
+		}
 	}
-	// Disabling the Host check must not loosen the bearer gate in this shape.
+	// These pin the auth-before-transport ordering: the bearer gate runs ahead
+	// of the transport (and its disabled Host check), so a future middleware
+	// reordering that exposed the transport unauthenticated would fail here.
 	if rec := request(""); rec.Code != http.StatusUnauthorized {
 		t.Fatalf("missing token: status = %d, want 401, body = %s", rec.Code, rec.Body.String())
 	}

--- a/packages/ingestion/handler/mcp_auth_test.go
+++ b/packages/ingestion/handler/mcp_auth_test.go
@@ -3,7 +3,10 @@ package handler_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -121,4 +124,118 @@ func TestMCPBearerAuth(t *testing.T) {
 			t.Fatal("structured auth logs leaked a bearer token")
 		}
 	}
+}
+
+// decodeInitializeResult asserts the body is a successful JSON-RPC initialize
+// response for the opslane server, not merely HTTP 200 (JSON-RPC errors also
+// ride on 200).
+func decodeInitializeResult(t *testing.T, body []byte) {
+	t.Helper()
+	var response struct {
+		Error  *struct{ Message string } `json:"error"`
+		Result *struct {
+			ServerInfo struct {
+				Name string `json:"name"`
+			} `json:"serverInfo"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatalf("decode initialize response: %v, body = %s", err, body)
+	}
+	if response.Error != nil {
+		t.Fatalf("initialize returned JSON-RPC error: %+v, body = %s", response.Error, body)
+	}
+	if response.Result == nil || response.Result.ServerInfo.Name != "opslane" {
+		t.Fatalf("initialize result missing serverInfo.name=opslane, body = %s", body)
+	}
+}
+
+const mcpInitializeBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`
+
+// Prod delivers ALB traffic to the container through the ECS Service Connect
+// Envoy agent, so the server accepts the connection on 127.0.0.1 while Host
+// stays the public domain. The SDK's DNS-rebinding localhost protection must
+// not reject that combination — and the bearer gate in front of it must be
+// unaffected by disabling it.
+func TestMCPBehindLoopbackProxy(t *testing.T) {
+	deps, pool := testDeps(t)
+	ctx := context.Background()
+	orgID, projectID, _, _ := seedTenant(t, deps.Queries)
+	t.Cleanup(func() { cleanupTenantHandler(t, pool, orgID) })
+
+	apiKey, err := deps.Queries.CreateProjectKey(ctx, projectID, db.ScopeAPI, "mcp", nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router := handler.NewRouterWithPool(deps, pool)
+	request := func(token string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(mcpInitializeBody))
+		req.Host = "app.opslane.com"
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		req = req.WithContext(context.WithValue(req.Context(), http.LocalAddrContextKey,
+			&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 8080}))
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec
+	}
+
+	if rec := request(apiKey.Raw); rec.Code != http.StatusOK {
+		t.Fatalf("valid key: status = %d, want 200, body = %s", rec.Code, rec.Body.String())
+	} else {
+		decodeInitializeResult(t, rec.Body.Bytes())
+	}
+	// Disabling the Host check must not loosen the bearer gate in this shape.
+	if rec := request(""); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing token: status = %d, want 401, body = %s", rec.Code, rec.Body.String())
+	}
+	if rec := request("sk_invalid_token"); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("invalid token: status = %d, want 401, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Same scenario over a real loopback socket, so net/http populates
+// LocalAddrContextKey exactly as prod does.
+func TestMCPBehindLoopbackProxyRealSocket(t *testing.T) {
+	deps, pool := testDeps(t)
+	ctx := context.Background()
+	orgID, projectID, _, _ := seedTenant(t, deps.Queries)
+	t.Cleanup(func() { cleanupTenantHandler(t, pool, orgID) })
+
+	apiKey, err := deps.Queries.CreateProjectKey(ctx, projectID, db.ScopeAPI, "mcp", nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(handler.NewRouterWithPool(deps, pool))
+	t.Cleanup(server.Close)
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/mcp", strings.NewReader(mcpInitializeBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = "app.opslane.com"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer "+apiKey.Raw)
+
+	response, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body = %s", response.StatusCode, body)
+	}
+	decodeInitializeResult(t, body)
 }


### PR DESCRIPTION
## Problem

Prod `https://app.opslane.com/mcp` returned **403 on every request**, surfacing in Claude Code as "Server rejected the configured Authorization header." The token was never the problem: the truncated error detail is `Forbidden: invalid Host header "app.opslane.com"`, emitted by the MCP go-sdk (v1.7.0, `mcp/streamable.go:330`), and server logs show `mcp bearer authentication outcome=ok` immediately before the 403.

## Root cause

The SDK ships DNS-rebinding "localhost protection": a request accepted on a loopback local address with a non-loopback `Host` gets 403. The ingestion ECS service runs Service Connect, whose Envoy agent delivers ALB traffic to the container over **127.0.0.1** with `Host: app.opslane.com` intact — so every MCP request matches the attack fingerprint. Unit tests never caught it because `httptest.NewRequest` carries no local-addr in context, and local dev uses a loopback Host.

## Fix

`DisableLocalhostProtection: true` on the streamable transport. Safe because `RequireBearerToken` wraps the transport, so the disabled check sat strictly *behind* auth — it was never a live barrier for unauthenticated requests. In v1.7.0 the option gates only the Host-check block; `CrossOriginProtection` (nil, unchanged) is separate.

## Tests

- `TestMCPBehindLoopbackProxy`: injected loopback `LocalAddrContextKey` + public Host — valid key gets a real `initialize` result (`serverInfo.name == "opslane"`), missing/invalid keys still 401, and `/mcp` grants no `Access-Control-Allow-Origin` (browser-side safety pinned).
- `TestMCPBehindLoopbackProxyRealSocket`: same over a real 127.0.0.1 socket so `net/http` populates the local addr itself.
- Both fail with the exact prod 403 body when the option is reverted.

## Verification

Black-box verified by driving base and fixed binaries against the same DB/env/port: base 403s with the prod signature (for `app.opslane.com` and `example.com`), fixed serves initialize + tools/list; missing/invalid/wrong-scope keys and Origin handling identical to base. Reviewed by specialist + adversarial passes (0 critical). One cross-model dissent, for the record: Codex recommended keeping the protection for self-hosters, but its premise ("the only rebinding barrier") is wrong on middleware ordering — auth precedes the transport, pinned by the loopback-shape 401 tests.

Plan with full evidence: `docs/superpowers/plans/2026-08-27-mcp-loopback-403.md`. Prod still needs an ingestion deploy after merge.