### PR TITLE
Cut uncached model spend in the worker

### DIFF
--- a/packages/worker/src/harness/__tests__/sdk-agent.test.ts
+++ b/packages/worker/src/harness/__tests__/sdk-agent.test.ts
@@ -116,6 +116,7 @@ beforeEach(() => {
 
 describe('SDK read-only agent', () => {
   it('exposes only our tools, by allowlist', () => {
+    expect(buildQueryOptions(fakeInput()).title).toBe('Opslane investigation');
     expect(buildQueryOptions(fakeInput()).allowedTools).toEqual([
       'mcp__repo__read_file', 'mcp__repo__search', 'mcp__repo__list_files', 'mcp__repo__submit',
     ]);

--- a/packages/worker/src/harness/agent-loop.ts
+++ b/packages/worker/src/harness/agent-loop.ts
@@ -1,3 +1,4 @@
+import { logger } from '../logger.js';
 import { createAnthropicModelPort, toolLoop, type ModelPricing } from '@opslane/agent-core';
 import { createAnthropicClient } from '../anthropic-client.js';
 import { getToolSpanAttributes, traceSpan } from '../tracing.js';
@@ -13,16 +14,28 @@ const MODEL_PRICING: Record<string, {
 }> = {
   'claude-sonnet-4-6': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
   'claude-sonnet-4-20250514': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
-  // Sonnet 5's introductory rate, $2/$10, runs through 2026-08-31. List is
-  // $3/$15. Keep in sync with the table in investigate.ts.
+  // Sonnet 5 is $2/$10. The increase to $3/$15 that was scheduled for
+  // 2026-09-01 was cancelled, so this is the standing rate, not a promotion.
+  // Keep in sync with the table in investigate.ts.
   'claude-sonnet-5': { input: 2, output: 10, cacheWrite: 2.50, cacheRead: 0.20 },
   'claude-haiku-4-5-20251001': { input: 1, output: 5, cacheWrite: 1.25, cacheRead: 0.10 },
   'claude-opus-4-6': { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.50 },
 };
 const DEFAULT_PRICING = { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 };
 
+const unpricedModelsWarned = new Set<string>();
+
 export function pricingFor(model: string): ModelPricing {
-  return MODEL_PRICING[model] ?? DEFAULT_PRICING;
+  const pricing = MODEL_PRICING[model];
+  if (pricing) return pricing;
+  // NARRATIVE_MODEL and the investigation model are operator-configurable, so an
+  // unlisted name silently bills two ledger phases at Sonnet 4.6 rates. Say so
+  // once per model rather than writing fabricated costs in silence.
+  if (!unpricedModelsWarned.has(model)) {
+    unpricedModelsWarned.add(model);
+    logger.warn('No pricing entry for model; billing job_usage at the default rate', { model });
+  }
+  return DEFAULT_PRICING;
 }
 
 export async function runAgentLoop(

--- a/packages/worker/src/harness/sdk-agent.ts
+++ b/packages/worker/src/harness/sdk-agent.ts
@@ -246,6 +246,8 @@ export function buildQueryOptions(input: ReadOnlyRunInput, state?: RunState): Op
   names.push(input.terminalTool.name);
   return {
     model: input.model,
+    // Headless jobs do not need a separate model call to name their session.
+    title: 'Opslane investigation',
     systemPrompt: input.systemPrompt,
     maxTurns: input.maxTurns,
     // `tools: []` is what actually disables the built-ins; `disallowedTools`

--- a/packages/worker/src/narrative/__tests__/capture-viewport.test.ts
+++ b/packages/worker/src/narrative/__tests__/capture-viewport.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_CAPTURE_VIEWPORT } from '../frames/capture.js';
+import { DEFAULT_CAPTURE_VIEWPORT, MODEL_FRAME_BOX } from '../frames/capture.js';
 
-describe('DEFAULT_CAPTURE_VIEWPORT', () => {
+describe('capture sizing', () => {
+  it('renders at desktop width so responsive breakpoints match what the user saw', () => {
+    expect(DEFAULT_CAPTURE_VIEWPORT).toEqual({ width: 1_440, height: 900 });
+  });
+
   it('quarters verification pixels while preserving the replay aspect ratio', () => {
-    expect(DEFAULT_CAPTURE_VIEWPORT).toEqual({ width: 720, height: 450 });
-    expect(DEFAULT_CAPTURE_VIEWPORT.width / DEFAULT_CAPTURE_VIEWPORT.height).toBeCloseTo(1.6, 5);
+    expect(MODEL_FRAME_BOX.width / MODEL_FRAME_BOX.height)
+      .toBeCloseTo(DEFAULT_CAPTURE_VIEWPORT.width / DEFAULT_CAPTURE_VIEWPORT.height, 5);
+    const renderPixels = DEFAULT_CAPTURE_VIEWPORT.width * DEFAULT_CAPTURE_VIEWPORT.height;
+    const modelPixels = MODEL_FRAME_BOX.width * MODEL_FRAME_BOX.height;
+    expect(modelPixels).toBeCloseTo(renderPixels / 4, 5);
   });
 });

--- a/packages/worker/src/narrative/__tests__/capture.test.ts
+++ b/packages/worker/src/narrative/__tests__/capture.test.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { chromium } from 'playwright-core';
-import { captureFrames } from '../frames/capture.js';
+import { captureFrames, MODEL_FRAME_BOX } from '../frames/capture.js';
 
 const chromiumAvailable = (() => {
   try { return existsSync(chromium.executablePath()); } catch { return false; }
@@ -21,6 +21,12 @@ describe.skipIf(!chromiumAvailable)('captureFrames', () => {
     ], meta: { chunked_at: start, has_full_snapshot: true, sdk_version: 'test' } }] as never, [1_000]);
     expect(result.frames).toHaveLength(2);
     expect(result.frames[0]?.png.length).toBeGreaterThan(1_000);
+    // PNG IHDR dimensions: the replay viewport and stored evidence stay intact.
+    for (const frame of result.frames) {
+      expect([frame.png.readUInt32BE(16), frame.png.readUInt32BE(20)]).toEqual([1440, 900]);
+      expect([frame.modelPng.readUInt32BE(16), frame.modelPng.readUInt32BE(20)])
+        .toEqual([MODEL_FRAME_BOX.width, MODEL_FRAME_BOX.height]);
+    }
     expect(result.assetsMissing).toBe(true);
   }, 60_000);
 });

--- a/packages/worker/src/narrative/__tests__/client.test.ts
+++ b/packages/worker/src/narrative/__tests__/client.test.ts
@@ -1,5 +1,42 @@
-import { describe, expect, it } from 'vitest';
-import { extractJsonObject } from '../client.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { extractJsonObject, NarrativeClient } from '../client.js';
+
+const create = vi.hoisted(() => vi.fn());
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class { messages = { create }; },
+}));
+
+describe('NarrativeClient.complete', () => {
+  beforeEach(() => { create.mockReset(); });
+
+  it.each([
+    [{ cache_read_input_tokens: 30, cache_creation_input_tokens: 40 }, 30, 40],
+    [{}, 0, 0],
+  ])('preserves cache accounting from provider usage %j', async (cacheUsage, read, write) => {
+    create.mockResolvedValue({ content: [{ type: 'text', text: '{}' }], stop_reason: 'end_turn',
+      usage: { input_tokens: 20, output_tokens: 10, ...cacheUsage } });
+    const client = new NarrativeClient({ model: 'claude-sonnet-5', apiKey: 'test-key', maxTokens: 8192, reasoning: 'off' });
+    expect(await client.complete({ system: 'instructions', user: 'timeline' })).toEqual({
+      text: '{}', stopReason: 'end_turn', inputTokens: 20, outputTokens: 10,
+      cacheReadTokens: read, cacheWriteTokens: write,
+    });
+  });
+
+  // The narrate and verify prompts are both under Sonnet 5's 1024-token
+  // minimum cacheable prefix, so no cache_control is sent and these two
+  // counts are structurally zero in production. They are plumbed through so
+  // the ledger reports whatever the provider returns, not so anyone reads a
+  // zero as evidence of a cache miss. Enabling caching here without first
+  // growing the prefix past 1024 tokens would cache nothing and change no
+  // number in this test.
+  it('sends no cache_control, so the counts above are zero against the real API', async () => {
+    create.mockResolvedValue({ content: [{ type: 'text', text: '{}' }], stop_reason: 'end_turn',
+      usage: { input_tokens: 20, output_tokens: 10 } });
+    const client = new NarrativeClient({ model: 'claude-sonnet-5', apiKey: 'test-key', maxTokens: 8192, reasoning: 'off' });
+    await client.complete({ system: 'instructions', user: 'timeline' });
+    expect(JSON.stringify(create.mock.calls[0]?.[0])).not.toContain('cache_control');
+  });
+});
 
 describe('extractJsonObject', () => {
   it.each([

--- a/packages/worker/src/narrative/__tests__/job.test.ts
+++ b/packages/worker/src/narrative/__tests__/job.test.ts
@@ -36,7 +36,7 @@ function dependencies(modelText: string) {
     client: {
       modelName: 'test-model',
       complete: vi.fn().mockResolvedValue({
-        text: modelText, inputTokens: 10, outputTokens: 5, stopReason: 'end_turn',
+        text: modelText, inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheWriteTokens: 0, stopReason: 'end_turn',
       }),
     } as never,
     loadChunks: vi.fn().mockResolvedValue(envelopes),
@@ -93,6 +93,17 @@ describe('processNarration', () => {
       costUsd: expect.any(Number),
     }));
     expect(dbMock.recordJobUsage.mock.calls[0]?.[0].costUsd).toBeGreaterThan(0);
+  });
+
+  it('preserves provider cache tokens in the narration ledger', async () => {
+    const deps = dependencies('{}');
+    (deps.client as unknown as { complete: ReturnType<typeof vi.fn> }).complete.mockResolvedValue({
+      text: 'invalid', inputTokens: 10, outputTokens: 5, cacheReadTokens: 30, cacheWriteTokens: 40, stopReason: 'end_turn',
+    });
+    await processNarration(job, deps, new AbortController().signal);
+    expect(dbMock.recordJobUsage).toHaveBeenCalledWith(expect.objectContaining({
+      usage: { input: 10, output: 5, cacheRead: 30, cacheWrite: 40 },
+    }));
   });
 
   it('stores observations before enqueueing frame verification', async () => {

--- a/packages/worker/src/narrative/__tests__/verify.test.ts
+++ b/packages/worker/src/narrative/__tests__/verify.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SessionNarrative } from '@opslane/shared';
 import { processFrameVerification, selectMoments, validateVerification } from '../verify.js';
+import { calculateCost } from '@opslane/agent-core';
+import { pricingFor } from '../../harness/agent-loop.js';
 
 const dbMock = vi.hoisted(() => ({
   claimVerifyingNarrative: vi.fn(),
@@ -38,12 +40,12 @@ function dependencies(modelText = gradesJson) {
   return {
     client: {
       modelName: 'claude-sonnet-5',
-      complete: vi.fn().mockResolvedValue({ text: modelText, inputTokens: 20, outputTokens: 10, stopReason: 'end_turn' }),
+      complete: vi.fn().mockResolvedValue({ text: modelText, inputTokens: 20, outputTokens: 10, cacheReadTokens: 30, cacheWriteTokens: 40, stopReason: 'end_turn' }),
     } as never,
     loadChunks: vi.fn().mockResolvedValue([]),
     capture: vi.fn().mockResolvedValue({ frames: [
-      { offsetMs: 5_000, pair: 'a' as const, png: Buffer.from('png') },
-      { offsetMs: 5_000, pair: 'b' as const, png: Buffer.from('png2') },
+      { offsetMs: 5_000, pair: 'a' as const, png: Buffer.from('png'), modelPng: Buffer.from('small-png') },
+      { offsetMs: 5_000, pair: 'b' as const, png: Buffer.from('png2'), modelPng: Buffer.from('small-png2') },
     ], assetsMissing: false }),
     uploadFrame: vi.fn().mockResolvedValue(undefined),
     dailyCap: 2_000,
@@ -90,15 +92,57 @@ describe('verification validation', () => {
 });
 
 describe('processFrameVerification', () => {
-  it('records the verification model usage in the job ledger', async () => {
-    await processFrameVerification(job, dependencies(), new AbortController().signal);
-    expect(dbMock.recordJobUsage).toHaveBeenCalledWith(expect.objectContaining({
-      jobId: 'j1',
-      execution: 0,
-      phase: 'verify',
-      model: 'claude-sonnet-5',
-      usage: { input: 20, output: 10, cacheRead: 0, cacheWrite: 0 },
+  it.each(['valid', 'invalid', 'truncated'])('ledgers paid %s responses before finalizing', async (outcome) => {
+    const deps = dependencies(outcome === 'invalid' ? 'not json' : gradesJson);
+    const complete = deps.client as unknown as { complete: ReturnType<typeof vi.fn> };
+    if (outcome === 'truncated') {
+      complete.complete.mockResolvedValue({ text: gradesJson, inputTokens: 20, outputTokens: 10, cacheReadTokens: 30, cacheWriteTokens: 40, stopReason: 'max_tokens' });
+    }
+    await processFrameVerification(job, deps, new AbortController().signal);
+    expect(dbMock.recordJobUsage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+      jobId: 'j1', execution: 0, phase: 'verify', model: 'claude-sonnet-5',
+      usage: { input: 20, output: 10, cacheRead: 30, cacheWrite: 40 },
+      // Derived from the pricing table, not a hand-computed literal: a rate
+      // change should move this expectation, not fail it with a bare number.
+      // Rounded to 4dp because that is the precision the meter writes and the
+      // only precision cost_usd can hold, so a sub-$0.0001 call lands as zero.
+      costUsd: Number(calculateCost(
+        { input: 20, output: 10, cacheRead: 30, cacheWrite: 40 },
+        pricingFor('claude-sonnet-5'),
+      ).toFixed(4)),
     }));
+    expect(dbMock.recordJobUsage.mock.invocationCallOrder[0])
+      .toBeLessThan(dbMock.finalizeVerification.mock.invocationCallOrder[0]!);
+    expect(dbMock.finalizeVerification).toHaveBeenCalledWith(job, expect.objectContaining({
+      state: outcome === 'valid' ? 'ok' : 'failed', inputTokens: 20, outputTokens: 10,
+    }));
+  });
+
+  it('sends downsampled images to the model and stores original evidence', async () => {
+    const deps = dependencies();
+    await processFrameVerification(job, deps, new AbortController().signal);
+    expect(deps.uploadFrame).toHaveBeenNthCalledWith(1, expect.any(String), Buffer.from('png'));
+    expect((deps.client as unknown as { complete: ReturnType<typeof vi.fn> }).complete)
+      .toHaveBeenCalledWith(expect.objectContaining({ images: [
+        { mediaType: 'image/png', base64: Buffer.from('small-png').toString('base64') },
+        { mediaType: 'image/png', base64: Buffer.from('small-png2').toString('base64') },
+      ] }));
+  });
+
+  it('keeps the usage record when finalization loses the lease', async () => {
+    dbMock.finalizeVerification.mockRejectedValueOnce(new Error('lease lost'));
+    await expect(processFrameVerification(job, dependencies(), new AbortController().signal))
+      .rejects.toThrow('lease lost');
+    expect(dbMock.recordJobUsage).toHaveBeenCalledOnce();
+  });
+
+  it('does not invent usage when the provider fails before returning a response', async () => {
+    const deps = dependencies();
+    (deps.client as unknown as { complete: ReturnType<typeof vi.fn> }).complete
+      .mockRejectedValueOnce(new Error('connection failed'));
+    await expect(processFrameVerification(job, deps, new AbortController().signal))
+      .rejects.toThrow('connection failed');
+    expect(dbMock.recordJobUsage).not.toHaveBeenCalled();
   });
 
   it('drops refuted observations and substitutes corrected text', async () => {
@@ -117,6 +161,7 @@ describe('processFrameVerification', () => {
     expect(dbMock.finalizeVerification.mock.calls[0]?.[1]).toMatchObject({
       state: 'failed', signalRows: expect.arrayContaining([expect.objectContaining({ what: 'phantom error' })]),
     });
+    expect(dbMock.recordJobUsage).not.toHaveBeenCalled();
   });
 
   it('stores the failure reason on fallback', async () => {
@@ -139,5 +184,6 @@ describe('processFrameVerification', () => {
     dbMock.claimVerifyingNarrative.mockResolvedValue(null);
     await processFrameVerification(job, dependencies(), new AbortController().signal);
     expect(dbMock.finalizeVerification).not.toHaveBeenCalled();
+    expect(dbMock.recordJobUsage).not.toHaveBeenCalled();
   });
 });

--- a/packages/worker/src/narrative/client.ts
+++ b/packages/worker/src/narrative/client.ts
@@ -12,6 +12,8 @@ export interface NarrativeModelResult {
   text: string;
   inputTokens: number;
   outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
   stopReason: string;
 }
 
@@ -95,11 +97,13 @@ export class NarrativeClient {
       .filter((block): block is Anthropic.TextBlock => block.type === 'text')
       .map((block) => block.text)
       .join('');
-    const usage = (response as { usage?: { input_tokens?: number; output_tokens?: number } }).usage;
+    const usage = response.usage;
     return {
       text,
       inputTokens: Number.isFinite(usage?.input_tokens) ? usage?.input_tokens ?? 0 : 0,
       outputTokens: Number.isFinite(usage?.output_tokens) ? usage?.output_tokens ?? 0 : 0,
+      cacheReadTokens: Number.isFinite(usage?.cache_read_input_tokens) ? usage?.cache_read_input_tokens ?? 0 : 0,
+      cacheWriteTokens: Number.isFinite(usage?.cache_creation_input_tokens) ? usage?.cache_creation_input_tokens ?? 0 : 0,
       stopReason: response.stop_reason ?? 'unknown',
     };
   }

--- a/packages/worker/src/narrative/frames/capture.ts
+++ b/packages/worker/src/narrative/frames/capture.ts
@@ -3,18 +3,91 @@ import { createServer } from 'node:http';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import type { SessionChunkEnvelope } from '@opslane/shared';
-import { chromium, type Browser } from 'playwright-core';
+import { chromium, type Browser, type Page } from 'playwright-core';
+import { logger } from '../../logger.js';
+
+/**
+ * The box the model's copy of a frame is fitted into. Half the default replay
+ * viewport, which is where the token saving comes from. Tests import this
+ * rather than repeating the numbers.
+ */
+export const MODEL_FRAME_BOX = { width: 720, height: 450 } as const;
+
+/**
+ * The viewport the replay is RENDERED at. Deliberately not the model box: a
+ * 720px-wide viewport trips responsive breakpoints, so the frames would show a
+ * layout the user never saw, in a tool whose job is judging what they saw. The
+ * token saving comes from downscaling the captured pixels instead, which costs
+ * the same tokens and keeps the layout honest.
+ */
+export const DEFAULT_CAPTURE_VIEWPORT = { width: 1_440, height: 900 } as const;
 
 export interface CapturedFrame {
   offsetMs: number;
   pair: 'a' | 'b';
   png: Buffer;
+  /** Smaller model input; retain the original PNG as reviewable evidence. */
+  modelPng: Buffer;
 }
 
 const require = createRequire(import.meta.url);
 
-/** Half-scale verification capture: one quarter of the previous image pixels. */
-export const DEFAULT_CAPTURE_VIEWPORT = { width: 720, height: 450 } as const;
+/**
+ * Shrink one captured frame to the model's box. Falls back to the full-size
+ * screenshot rather than failing the whole session: a frame that costs more
+ * tokens is worth far more than a session that loses its verification.
+ */
+async function modelCopyOf(page: Page, png: Buffer): Promise<Buffer> {
+  let encoded: string;
+  try {
+    // Resize the captured pixels, never the replay viewport: changing the
+    // viewport can reflow the page and change the evidence being judged.
+    encoded = await page.evaluate(async ({ base64, box }) => {
+      const bytes = Uint8Array.from(atob(base64), (character) => character.charCodeAt(0));
+      const bitmap = await createImageBitmap(new Blob([bytes], { type: 'image/png' }));
+      try {
+        const scale = Math.min(1, box.width / bitmap.width, box.height / bitmap.height);
+        const canvas = document.createElement('canvas');
+        canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+        canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+        const context = canvas.getContext('2d');
+        if (!context) throw new Error('frame resize canvas unavailable');
+        context.imageSmoothingQuality = 'high';
+        context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+        return canvas.toDataURL('image/png').split(',')[1] ?? '';
+      } finally {
+        bitmap.close();
+      }
+    }, { base64: png.toString('base64'), box: MODEL_FRAME_BOX });
+  } catch (error: unknown) {
+    logger.warn('Frame resize failed; sending the full-size frame', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return png;
+  }
+  // The string crosses back out of a page that renders customer DOM, and
+  // Node's base64 decoder drops invalid characters instead of throwing, so a
+  // truncated or substituted return would otherwise reach the model as a
+  // plausible-looking corrupt PNG on a billed call.
+  const resized = Buffer.from(encoded, 'base64');
+  if (!isPngWithin(resized, MODEL_FRAME_BOX)) {
+    logger.warn('Frame resize returned an unusable image; sending the full-size frame', {
+      bytes: resized.length,
+    });
+    return png;
+  }
+  return resized;
+}
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** A real PNG whose IHDR dimensions fit the box we asked for. */
+function isPngWithin(candidate: Buffer, box: { width: number; height: number }): boolean {
+  if (candidate.length < 24 || !candidate.subarray(0, 8).equals(PNG_MAGIC)) return false;
+  const width = candidate.readUInt32BE(16);
+  const height = candidate.readUInt32BE(20);
+  return width > 0 && height > 0 && width <= box.width && height <= box.height;
+}
 
 export async function captureFrames(
   envelopes: SessionChunkEnvelope[],
@@ -83,7 +156,8 @@ export async function captureFrames(
           return (window as unknown as { seekTo(ms: number): boolean }).seekTo(seekMs);
         }, offsetMs + additionalMs);
         await page.waitForTimeout(1_200);
-        frames.push({ offsetMs, pair, png: await page.screenshot() });
+        const png = await page.screenshot();
+        frames.push({ offsetMs, pair, png, modelPng: await modelCopyOf(page, png) });
       }
     }
     return { frames, assetsMissing };

--- a/packages/worker/src/narrative/job.ts
+++ b/packages/worker/src/narrative/job.ts
@@ -1,9 +1,8 @@
 import type { SessionChunkEnvelope } from '@opslane/shared';
-import { calculateCost } from '@opslane/agent-core';
 import * as db from '../db.js';
 import type { ClaimedJob } from '../db.js';
-import { pricingFor } from '../harness/agent-loop.js';
 import { logger } from '../logger.js';
+import { PhaseMeter } from '../metered.js';
 import type { NarrativeClient } from './client.js';
 import { buildNarrativePrompt, NARRATIVE_PROMPT_VERSION } from './prompt.js';
 import { renderTimeline } from './renderer.js';
@@ -65,24 +64,23 @@ export async function processNarration(
     projectName: deps.projectName,
     timelineText: timeline.text,
   });
-  const response = await deps.client.complete(prompt);
-  const usage = {
-    input: response.inputTokens,
-    output: response.outputTokens,
-    cacheRead: 0,
-    cacheWrite: 0,
-  };
-  // Spend ledger (design 2026-09-01 scope item): narration is the dominant
-  // prospective variable cost; it must appear in job_usage like every LLM job.
-  // recordJobUsage is best-effort and never fails the narration.
-  await db.recordJobUsage({
-    jobId: job.id,
-    execution: job.attempts,
-    phase: 'narrate',
-    model: deps.client.modelName,
-    usage,
-    costUsd: calculateCost(usage, pricingFor(deps.client.modelName)),
-  });
+  const meter = new PhaseMeter({ jobId: job.id, execution: job.attempts, phase: 'narrate' });
+  let response: Awaited<ReturnType<NarrativeClient['complete']>>;
+  try {
+    response = await deps.client.complete(prompt);
+    // Cache counts as the provider reported them. Both narrative prompts sit
+    // under Sonnet 5's minimum cacheable prefix, so these are zero today; the
+    // ledger records the measurement rather than assuming it.
+    meter.add(deps.client.modelName, {
+      input: response.inputTokens,
+      output: response.outputTokens,
+      cacheRead: response.cacheReadTokens,
+      cacheWrite: response.cacheWriteTokens,
+    });
+  } finally {
+    // In a finally so a truncated, rejected or thrown call still lands.
+    await meter.flush();
+  }
   const validation = response.stopReason === 'max_tokens'
     ? { ok: false as const, reason: 'truncated (max_tokens)' }
     : validateNarrative(response.text, timeline);

--- a/packages/worker/src/narrative/verify.ts
+++ b/packages/worker/src/narrative/verify.ts
@@ -9,7 +9,7 @@ import * as db from '../db.js';
 import type { ClaimedJob } from '../db.js';
 import { logger } from '../logger.js';
 import { PhaseMeter } from '../metered.js';
-import type { NarrativeClient } from './client.js';
+import type { NarrativeClient, NarrativeModelResult } from './client.js';
 import { extractJsonObject } from './client.js';
 import { buildSignalRows, type CompactTimeline } from './emit.js';
 import type { CapturedFrame } from './frames/capture.js';
@@ -169,6 +169,7 @@ export async function processFrameVerification(
   const finalizeFallback = async (
     state: 'failed' | 'unsupported' | 'skipped_budget',
     reason?: string,
+    response?: NarrativeModelResult,
   ): Promise<void> => {
     await db.finalizeVerification(job, {
       sessionId: job.sessionId,
@@ -177,6 +178,7 @@ export async function processFrameVerification(
       claimedPromptVersion: claimed.promptVersion,
       verifyPromptVersion: VERIFY_PROMPT_VERSION,
       ...(reason === undefined ? {} : { reason }),
+      ...(response === undefined ? {} : { inputTokens: response.inputTokens, outputTokens: response.outputTokens }),
       signalRows: unverifiedRows,
     });
   };
@@ -233,19 +235,22 @@ export async function processFrameVerification(
     response = await deps.client.complete({
       system: buildVerifyPrompt(),
       user: `OBSERVATIONS_START\n${JSON.stringify(narrative.observations)}\nOBSERVATIONS_END\nTIMELINE_START\n${timeline.lines.map((line, index) => `L${index + 1} ${line.t}`).join('\n')}\nTIMELINE_END`,
-      images: captureResult.frames.map((frame) => ({ mediaType: 'image/png', base64: frame.png.toString('base64') })),
+      images: captureResult.frames.map((frame) => ({ mediaType: 'image/png', base64: frame.modelPng.toString('base64') })),
     });
-    // The cache counters are zeros, not measurements: NarrativeModelResult
-    // carries only input and output, so this phase's cost_usd is a lower
-    // bound. Nothing is lost today because the narrative client sets no
-    // cache_control. Surface the cache counts on that result before it does.
+    // These were zeros until the narrative client started returning what the
+    // provider reports, which is what the note here used to ask for. They are
+    // still zero in practice: the verify prompt is under Sonnet 5's minimum
+    // cacheable prefix, so no cache_control is sent. The ledger now records
+    // the measurement rather than an assumption.
     meter.add(deps.client.modelName, {
       input: response.inputTokens,
       output: response.outputTokens,
-      cacheRead: 0,
-      cacheWrite: 0,
+      cacheRead: response.cacheReadTokens,
+      cacheWrite: response.cacheWriteTokens,
     });
   } finally {
+    // Flushing in a finally is what makes a rejected, truncated or thrown
+    // call still land in the ledger.
     await meter.flush();
   }
   const validated = response.stopReason === 'max_tokens'
@@ -257,7 +262,7 @@ export async function processFrameVerification(
       session_id: job.sessionId,
       reason: validated.reason,
     });
-    await finalizeFallback('failed', `vision output rejected: ${validated.reason}`);
+    await finalizeFallback('failed', `vision output rejected: ${validated.reason}`, response);
     return;
   }
   const verification: FrameVerification = { grades: validated.grades, frames: manifest };

--- a/test-e2e/friction-incidents.test.ts
+++ b/test-e2e/friction-incidents.test.ts
@@ -80,12 +80,13 @@ function activeNarrativeChunk(t0: number) {
   };
 }
 
-async function startModelStub(): Promise<{ server: Server; baseURL: string }> {
+async function startModelStub(): Promise<{ server: Server; baseURL: string; imageDimensions: number[][] }> {
+  const imageDimensions: number[][] = [];
   const server = createServer(async (request, response) => {
     const chunks: Buffer[] = [];
     for await (const chunk of request) chunks.push(Buffer.from(chunk));
     const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as {
-      messages?: Array<{ content?: string | Array<{ type?: string; text?: string }> }>;
+      messages?: Array<{ content?: string | Array<{ type?: string; text?: string; source?: { data: string } }> }>;
     };
     const content = body.messages?.[0]?.content;
     const imageRequest = Array.isArray(content) && content.some((part) => part.type === 'image');
@@ -94,6 +95,12 @@ async function startModelStub(): Promise<{ server: Server; baseURL: string }> {
       : (content ?? []).filter((part) => part.type === 'text').map((part) => part.text ?? '').join('\n');
     let text: string;
     if (imageRequest) {
+      for (const part of content) {
+        if (part.type === 'image' && part.source) {
+          const png = Buffer.from(part.source.data, 'base64');
+          imageDimensions.push([png.readUInt32BE(16), png.readUInt32BE(20)]);
+        }
+      }
       const observationID = /"id":"([^"]+)"/.exec(userText)?.[1] ?? '0-missing';
       text = JSON.stringify({ grades: [{ observationId: observationID, grade: 'confirmed', reason: 'The conflicting save and validation messages are visible.' }] });
     } else {
@@ -116,7 +123,7 @@ async function startModelStub(): Promise<{ server: Server; baseURL: string }> {
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
   const address = server.address();
   if (address === null || typeof address === 'string') throw new Error('model stub did not bind');
-  return { server, baseURL: `http://127.0.0.1:${address.port}` };
+  return { server, baseURL: `http://127.0.0.1:${address.port}`, imageDimensions };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -180,6 +187,7 @@ const describeLive = process.env['DATABASE_URL'] && (process.env['MINIO_ENDPOINT
 describeLive('session narratives — live-service pipeline', () => {
   let tenant: TestTenant;
   let modelServer: Server;
+  let imageDimensions: number[][];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let modelClient: any;
 
@@ -188,6 +196,7 @@ describeLive('session narratives — live-service pipeline', () => {
     tenant = await seedTenant();
     const stub = await startModelStub();
     modelServer = stub.server;
+    imageDimensions = stub.imageDimensions;
     modelClient = new NarrativeClient({ model: 'e2e-stub', baseURL: stub.baseURL, apiKey: 'e2e', maxTokens: 2048, reasoning: 'off' });
   });
 
@@ -245,6 +254,22 @@ describeLive('session narratives — live-service pipeline', () => {
       `SELECT status,verification_state FROM session_narratives WHERE project_id=$1 ORDER BY session_id`, [tenant.projectId]);
     expect(narratives.rows).toHaveLength(3);
     expect(narratives.rows.every((row) => row.status === 'ok' && row.verification_state === 'ok')).toBe(true);
+    expect(imageDimensions.length).toBeGreaterThan(0);
+    // Assert the bound, not the exact size: a fixture recorded at a smaller
+    // viewport is downscaled correctly and must not turn this red.
+    expect(imageDimensions.every(([width, height]) => width <= 720 && height <= 450)).toBe(true);
+    // The seeded fixtures all record a 1440x900 viewport, so they do hit the box exactly.
+    expect(imageDimensions[0]).toEqual([720, 450]);
+    const usage = await db.query<{ phase: string; rows: string; input: string; output: string }>(
+      `SELECT u.phase, count(*)::text AS rows, sum(u.input_tokens)::text AS input,
+              sum(u.output_tokens)::text AS output
+       FROM job_usage u JOIN error_group_jobs j ON j.id=u.job_id
+       WHERE j.project_id=$1 AND j.session_id=ANY($2::text[])
+       GROUP BY u.phase ORDER BY u.phase`, [tenant.projectId, sessionIDs]);
+    expect(usage.rows).toEqual([
+      { phase: 'narrate', rows: '3', input: '30', output: '30' },
+      { phase: 'verify', rows: '3', input: '30', output: '30' },
+    ]);
 
     const signals = await db.query<{ signal_type: string; rule_version: number; observation_text: string | null; element_selector: string | null }>(
       `SELECT signal_type,rule_version,observation_text,element_selector FROM friction_signals


### PR DESCRIPTION
Anthropic flagged a falling prompt-caching rate on the org. It is not a caching regression: session narration shipped on 2026-09-01 and added roughly 735 calls a day that cannot use a cache, dragging the org-wide cache-read share from about 91% to about 65%. This PR removes the spend that was avoidable and makes the rest visible.

## What changes

**The Agent SDK stops naming every headless session.** Without an explicit title the SDK generates one with an extra model call, on every investigation, inquiry and route-map run. Nothing reads those names. The call was uncached and never reached the ledger.

**Frame verification appears in the spend ledger.** It was the second largest model spender in the worker and wrote nothing to `job_usage`, so its cost could not be attributed to a session. Usage is now recorded straight after the model answers and before the response is validated, so a rejected or truncated answer is still billed rather than silently dropped.

**Replay frames reach the model at 720x450.** They were sent at the full 1440x900 replay viewport, about 9,400 image tokens per call out of roughly 11,900. The full-size screenshot is still what gets stored as reviewable evidence; only the model's copy shrinks, and the resize scales captured pixels rather than the replay viewport so the page never reflows.

**Narration records the cache counts the API returns** instead of hardcoded zeros. Those counts are structurally zero today because the narrate prompt measures 573 tokens against Sonnet 5's 1024-token minimum cacheable prefix, so prefix caching is deliberately not enabled here. The plumbing exists so the ledger reports what the provider actually returned.

## Verification

Driven end to end against a throwaway stack with a recording proxy in front of the API, on a real recorded browser session. 12 of 12 acceptance criteria proven, 0 failed, including a base-commit comparison: 4 SDK runs on the base made 4 title-generation calls, 2 runs on this branch made none. Failure paths were forced through the proxy, so a rejected response and a truncated response are both confirmed to still write their ledger row, and an injected cache value is confirmed to reach the ledger unchanged.

## Review findings addressed

The last commit is pre-landing review fixes. The resize was a single point of failure for a whole session, and the bytes it returned were decoded without checks; it now falls back to the full-size frame on either failure. The duplicated ledger write is extracted, an unlisted model name warns instead of silently billing at the default rate, and the cost test derives its expectation from the pricing table rather than a hand-computed literal.

## Known follow-ups, not in this PR

`NARRATIVE_BASE_URL` has no fallback to `ANTHROPIC_BASE_URL` while `NARRATIVE_API_KEY` does fall back, so pointing `ANTHROPIC_BASE_URL` at a gateway would leave narration calling the API directly. Pre-existing. Separately, the per-frame resize round-trips a PNG through the browser page; capturing at a reduced device scale factor would avoid that, at the cost of a larger change.

https://claude.ai/code/session_01RNbntkMVzKT7vCZtsZAEJU