### PR TITLE
fix(db): stop the boot replay from reinstalling 033's retired unique index

### DIFF
--- a/packages/ingestion/db/migration_037_test.go
+++ b/packages/ingestion/db/migration_037_test.go
@@ -1,0 +1,85 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+)
+
+// The migration runner replays every file on every boot, and 037 retires
+// 033's unique index so a retried job can append one decision row per
+// attempt. The first production database that actually held two decisions
+// for one job made 033's replay — and with it every deploy — fail at
+// CREATE UNIQUE INDEX. 033 is now guarded on the marker index 037 leaves
+// behind; this test holds the replay to that contract.
+func TestMigration033ReplaysOverADatabaseCarryingPerAttemptDecisions(t *testing.T) {
+	admin := testPool(t)
+	psql := findPsql(t)
+	pool, dsn := disposableDB(t, admin)
+	for _, file := range migrationFiles(t) {
+		if err := applyMigration(t, psql, dsn, file); err != nil {
+			t.Fatalf("migration %s failed: %v", file, err)
+		}
+	}
+
+	ctx := context.Background()
+	var orgID, projectID, groupID, jobID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO orgs (name) VALUES ('migration-037') RETURNING id`,
+	).Scan(&orgID); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO projects (org_id, name, github_repo)
+		 VALUES ($1, 'migration-037', 'opslane/migration-037') RETURNING id`, orgID,
+	).Scan(&projectID); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO error_groups
+		   (project_id, fingerprint, title, first_seen, last_seen)
+		 VALUES ($1, 'migration-037-group', 'Migration 037 group', now(), now())
+		 RETURNING id`, projectID,
+	).Scan(&groupID); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO error_group_jobs (error_group_id, project_id, triggered_by)
+		 VALUES ($1, $2, 'auto') RETURNING id`, groupID, projectID,
+	).Scan(&jobID); err != nil {
+		t.Fatal(err)
+	}
+
+	// One decision per attempt for the same job: exactly the shape 037
+	// legalized and the shape that broke 033's unguarded replay.
+	for _, outcome := range []string{"not_actionable", "code_fix"} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO diagnosis_decisions
+			   (error_group_id, project_id, job_id, outcome, decision_reason,
+			    model, prompt_version)
+			 VALUES ($1, $2, $3, $4, 'migration-037 replay fixture', 'test', 'v0')`,
+			groupID, projectID, jobID, outcome); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := applyMigration(t, psql, dsn, "migrations/033_diagnosis_decisions.sql"); err != nil {
+		t.Fatalf("replay 033 over per-attempt decisions: %v", err)
+	}
+
+	indexExists := func(name string) bool {
+		var exists bool
+		if err := pool.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM pg_indexes
+			  WHERE schemaname = 'public' AND indexname = $1)`, name,
+		).Scan(&exists); err != nil {
+			t.Fatal(err)
+		}
+		return exists
+	}
+	if indexExists("uq_diagnosis_decisions_job") {
+		t.Fatal("replaying 033 reinstalled the retired unique index")
+	}
+	if !indexExists("idx_diagnosis_decisions_job") {
+		t.Fatal("037's per-job lookup index is missing after the replay")
+	}
+}

--- a/packages/ingestion/db/migrations/033_diagnosis_decisions.sql
+++ b/packages/ingestion/db/migrations/033_diagnosis_decisions.sql
@@ -15,8 +15,26 @@ CREATE TABLE IF NOT EXISTS diagnosis_decisions (
   decided_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS uq_diagnosis_decisions_job
-  ON diagnosis_decisions(job_id) WHERE job_id IS NOT NULL;
+-- Create-if-not-superseded, per 072's precedent: 037 retires this index in
+-- favor of one decision row per attempt, and the boot replay runs this file
+-- again on every deploy. Once a retried job has written its second decision —
+-- exactly what 037 legalizes — an unguarded CREATE UNIQUE INDEX can never
+-- succeed again, and the replay (and with it every deploy) fails here. 037
+-- leaves idx_diagnosis_decisions_job behind as its marker: when that index
+-- exists, the unique index must stay retired and the replay is a no-op. A
+-- fresh database carries neither index at this point, so it still gets 033's
+-- version first and 037 retires it moments later in the same run.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+     WHERE schemaname = 'public'
+       AND indexname = 'idx_diagnosis_decisions_job'
+  ) THEN
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_diagnosis_decisions_job
+      ON diagnosis_decisions(job_id) WHERE job_id IS NOT NULL;
+  END IF;
+END $$;
 CREATE INDEX IF NOT EXISTS idx_diagnosis_decisions_group
   ON diagnosis_decisions(error_group_id, decided_at DESC);
 CREATE INDEX IF NOT EXISTS idx_diagnosis_decisions_project


### PR DESCRIPTION
## What broke

The v26.8.18 deploy failed at the predeploy migration task (exit 3; services were not rolled). The runner replays every migration file on every deploy: 033 recreated `uq_diagnosis_decisions_job` each time for 037 to drop again moments later. That round trip was harmless until the table actually held what 037 legalizes — one decision row per attempt of the same job. The first retried job that recorded two decisions (job `cdfa0c72…`) made 033's `CREATE UNIQUE INDEX` fail with a duplicate key. Every deploy is blocked at this step until this lands.

## The fix

Per 072's precedent (`0fdc6c0`), the creation is now guarded: 037 leaves `idx_diagnosis_decisions_job` behind as its marker, and when that index exists the replay is a no-op. A fresh database carries neither index at 033's turn, so it still gets the unique index first and 037 retires it in the same run.

## Verification

- New test replays 033 over a fully migrated database seeded with two decisions for one job: replay succeeds, the unique index stays retired, 037's lookup index survives. Passes locally.
- Full disposable-DB migration suite passes locally (the handful of other db tests that need a seeded persistent dev database fail identically on unmodified main in my environment).

https://claude.ai/code/session_015E4ZPr8fryDB8F1Z6R2fYt