### PR TITLE
fix(worker): mark every long silence in the session timeline, not only click-ended ones

### DIFF
--- a/packages/worker/src/narrative/__tests__/renderer.test.ts
+++ b/packages/worker/src/narrative/__tests__/renderer.test.ts
@@ -32,6 +32,11 @@ const requestEnd = (requestId: string, status: number, at: number) => ({
   timestamp: at,
   data: { tag: 'opslane.telemetry', payload: { kind: 'request_end', requestId, status, at } },
 });
+let nextFeedbackNodeId = 900; // above the snapshot's ids so feedback nodes never collide
+const feedback = (text: string, timestamp: number) => ({
+  type: 3, timestamp,
+  data: { source: 0, adds: [{ parentId: 1, node: { id: nextFeedbackNodeId++, type: 3, textContent: text } }], removes: [], texts: [], attributes: [] },
+});
 const rawInput = (id: number, timestamp: number) => ({
   type: 3,
   timestamp,
@@ -114,7 +119,7 @@ describe('idle markers', () => {
     expect(rendered.lines.filter((line) => line.kind === 'idle')).toHaveLength(2);
   });
 
-  it('stays chronological when system lines land inside the gap', () => {
+  it('does not call a wait on an in-flight request idle, before the response or the click after it', () => {
     const rendered = renderTimeline([envelope([
       meta('https://app.example.com/assets', t0),
       snapshot(t0),
@@ -123,11 +128,119 @@ describe('idle markers', () => {
       requestEnd('r1', 500, t0 + 90_000),
       click('button.save-btn', t0 + 122_000),
     ])]);
-    const texts = rendered.lines.map((line) => line.text);
-    const responseIndex = texts.findIndex((text) => text.includes('POST'));
+    expect(rendered.lines.some((line) => line.kind === 'idle')).toBe(false);
+    expect(rendered.lines.find((line) => line.text.includes('POST'))?.text).toContain('SLOW 88.9s');
+  });
+
+  it('marks the stretch after a waited-on response once the user goes quiet again', () => {
+    const rendered = renderTimeline([envelope([
+      meta('https://app.example.com/assets', t0),
+      snapshot(t0),
+      click('button.save-btn', t0 + 1_000),
+      requestStart('r1', 'POST', '/api/save', t0 + 1_100),
+      requestEnd('r1', 500, t0 + 90_000),
+      click('button.save-btn', t0 + 400_000),
+    ])]);
+    const markers = rendered.lines.filter((line) => line.kind === 'idle');
+    expect(markers).toHaveLength(1);
+    expect(markers[0]!.text).toContain('[user idle 5m 10s — away from the app]');
+    expect(rendered.lines[rendered.lines.indexOf(markers[0]!) + 1]!.text).toContain('CLICK');
+  });
+
+  it('marks a silence that ends with the page updating itself', () => {
+    const rendered = renderTimeline([envelope([
+      meta('https://app.example.com/assets', t0),
+      snapshot(t0),
+      click('button.save-btn', t0 + 1_000),
+      feedback('2 out of 10 assets match your filter criteria', t0 + 1_000 + 32 * 60_000),
+    ])]);
     const markerIndex = rendered.lines.findIndex((line) => line.kind === 'idle');
-    expect(markerIndex).toBeGreaterThan(responseIndex);
+    expect(markerIndex).toBeGreaterThan(-1);
+    expect(rendered.lines[markerIndex]!.text).toContain('[user idle 32m 0s — away from the app]');
+    expect(rendered.lines[markerIndex + 1]!.text).toContain('UI TEXT APPEARED');
+  });
+
+  it('does not mark a silence at or under the threshold before a self-update', () => {
+    const rendered = renderTimeline([envelope([
+      meta('https://app.example.com/assets', t0),
+      snapshot(t0),
+      click('button.save-btn', t0 + 1_000),
+      feedback('2 out of 10 assets match your filter criteria', t0 + 1_000 + IDLE_THRESHOLD_MS),
+    ])]);
+    expect(rendered.lines.some((line) => line.kind === 'idle')).toBe(false);
+  });
+
+  it('marks every long quiet stretch inside one silence', () => {
+    const rendered = renderTimeline([envelope([
+      meta('https://app.example.com/assets', t0),
+      snapshot(t0),
+      click('button.save-btn', t0 + 1_000),
+      feedback('Save failed', t0 + 62_000),
+      feedback('Save failed again', t0 + 1_921_000),
+    ])]);
+    const markers = rendered.lines.filter((line) => line.kind === 'idle').map((line) => line.text);
+    expect(markers).toHaveLength(2);
+    expect(markers[0]).toContain('[user idle 1m 1s — away from the app]');
+    expect(markers[1]).toContain('[user idle 30m 59s — away from the app]');
+  });
+
+  it('still marks an activity gap when a system line lands early in it', () => {
+    const rendered = renderTimeline([envelope([
+      meta('https://app.example.com/assets', t0),
+      snapshot(t0),
+      click('button.save-btn', t0 + 1_000),
+      requestStart('r1', 'POST', '/api/save', t0 + 1_100),
+      requestEnd('r1', 500, t0 + 2_000),
+      click('button.save-btn', t0 + 122_000),
+    ])]);
+    const markerIndex = rendered.lines.findIndex((line) => line.kind === 'idle');
+    expect(markerIndex).toBeGreaterThan(-1);
+    expect(rendered.lines[markerIndex]!.text).toContain('[user idle 2m 1s — away from the app]');
     expect(rendered.lines[markerIndex + 1]!.text).toContain('CLICK');
+  });
+
+  it('marks an absence between two clicks that frequent background updates would otherwise hide', () => {
+    const rendered = renderTimeline([envelope([
+      meta('https://app.example.com/assets', t0),
+      snapshot(t0),
+      click('button.refresh', t0),
+      ...Array.from({ length: 19 }, (_, i) => feedback(`${i} out of 10 assets match`, t0 + (i + 1) * 30_000)),
+      click('button.refresh', t0 + 600_000),
+    ])]);
+    const markers = rendered.lines.filter((line) => line.kind === 'idle');
+    expect(markers).toHaveLength(1);
+    expect(markers[0]!.text).toContain('[user idle 10m 0s — away from the app]');
+    expect(rendered.lines[rendered.lines.indexOf(markers[0]!) + 1]!.text).toContain('CLICK');
+  });
+
+  it('emits no marker before the first user action', () => {
+    const rendered = renderTimeline([envelope([
+      meta('https://app.example.com/assets', t0),
+      snapshot(t0),
+      requestStart('r1', 'GET', '/api/list', t0 + 100),
+      requestEnd('r1', 200, t0 + 90_000),
+      feedback('Save failed', t0 + 200_000),
+    ])]);
+    expect(rendered.lines.some((line) => line.kind === 'idle')).toBe(false);
+  });
+
+  it('orders late-flushed typed lines chronologically so a marker can sit between them and later feedback', () => {
+    const rendered = renderTimeline([envelope([
+      meta('https://app.example.com/assets', t0),
+      snapshot(t0),
+      rawInput(2, t0 + 2_000),
+      rawInput(2, t0 + 3_000),
+      feedback('Save failed', t0 + 122_000),
+    ])]);
+    const texts = rendered.lines.map((line) => line.text);
+    const typedIndex = texts.findIndex((text) => text.includes('typed in'));
+    const feedbackIndex = texts.findIndex((text) => text.includes('Save failed'));
+    const markerIndex = rendered.lines.findIndex((line) => line.kind === 'idle');
+    expect(typedIndex).toBeGreaterThan(-1);
+    expect(typedIndex).toBeLessThan(markerIndex);
+    expect(markerIndex).toBeLessThan(feedbackIndex);
+    const stamps = rendered.lines.map((line) => line.atMs).filter((at): at is number => at !== null && Number.isFinite(at));
+    expect([...stamps].sort((a, b) => a - b)).toEqual(stamps);
   });
 
   it('emits no marker when the gap-ending activity renders no line', () => {
@@ -155,17 +268,79 @@ describe('idle marker hardening', () => {
     expect(rendered.text).not.toContain('[user idle');
   });
 
-  it('skips the marker when the gap-ending activity rendered no line', () => {
-    // a lone keystroke ends the gap but stays below the aggregation display
-    // threshold; asserting absence up to the later feedback line would lie
+  it('marks the silence after a lone keystroke, before the feedback that ends it', () => {
+    // the keystroke at t+122s is a user action: the 1s→122s silence has no line
+    // to attach a marker to, while the 122s→400s silence gets one
     const rendered = renderTimeline([envelope([
       meta('https://app.example.com/assets', t0), snapshot(t0),
       click('button.save-btn', t0 + 1_000),
       rawInput(2, t0 + 122_000),
-      { type: 3, timestamp: t0 + 400_000, data: { source: 0, adds: [
-        { parentId: 1, node: { id: 9, type: 3, textContent: 'Save failed' } }], removes: [], texts: [], attributes: [] } },
+      feedback('Save failed', t0 + 400_000),
     ])]);
-    expect(rendered.text).not.toContain('[user idle');
+    const markers = rendered.lines.filter((line) => line.kind === 'idle');
+    expect(markers).toHaveLength(1);
+    expect(markers[0]!.text).toContain('[user idle 4m 38s — away from the app]');
+    expect(rendered.lines[rendered.lines.indexOf(markers[0]!) + 1]!.text).toContain('Save failed');
+  });
+
+  it('keeps a non-finite line in its slot while reordering typed lines around it', () => {
+    // the click has no payload stamp, so its line is inert; the keystrokes that
+    // follow it are flushed last with their first stamp and must sort back
+    // before the feedback without disturbing the click's slot
+    const badClick = { type: 5, timestamp: t0 + 1_500, data: { tag: 'opslane.telemetry',
+      payload: { kind: 'click', clickId: 'cx', selector: 'button.save-btn', cursor: 'pointer' } } };
+    const rendered = renderTimeline([envelope([
+      meta('https://app.example.com/assets', t0), snapshot(t0),
+      badClick,
+      rawInput(2, t0 + 2_000), rawInput(2, t0 + 3_000),
+      feedback('Save failed', t0 + 10_000),
+    ])]);
+    const texts = rendered.lines.map((line) => line.text);
+    expect(texts.findIndex((text) => text.includes('CLICK'))).toBe(1);
+    expect(texts.findIndex((text) => text.includes('typed in'))).toBeLessThan(texts.findIndex((text) => text.includes('Save failed')));
+  });
+
+  it('leaves a payload stamp outside the session window in place and gives it no marker', () => {
+    const forged = { type: 5, timestamp: t0 + 4_000, data: { tag: 'opslane.telemetry',
+      payload: { kind: 'click', at: -5, clickId: 'cx', selector: 'button.evil', cursor: 'pointer' } } };
+    const nullAt = { type: 5, timestamp: t0 + 5_000, data: { tag: 'opslane.telemetry',
+      payload: { kind: 'click', at: null, clickId: 'cy', selector: 'button.null', cursor: 'pointer' } } };
+    const rendered = renderTimeline([envelope([
+      meta('https://app.example.com/assets', t0), snapshot(t0),
+      click('button.save-btn', t0 + 1_000),
+      forged,
+      nullAt,
+      feedback('Save failed', t0 + 122_000),
+    ])]);
+    const texts = rendered.lines.map((line) => line.text);
+    expect(texts[1]).toContain('button.save-btn');
+    expect(texts.findIndex((text) => text.includes('button.evil'))).toBe(2);
+    expect(texts.findIndex((text) => text.includes('button.null'))).toBe(3);
+    expect(rendered.text).not.toContain('[user idle 29');
+    expect(rendered.lines.filter((line) => line.kind === 'idle').map((line) => line.text)).toEqual([
+      expect.stringContaining('[user idle 2m 1s — away from the app]'),
+    ]);
+  });
+
+  it('drops an event with a non-numeric outer timestamp instead of letting it poison startTs', () => {
+    const rendered = renderTimeline([envelope([
+      { type: 4, timestamp: 'abc', data: { href: 'https://app.example.com/assets' } },
+      meta('https://app.example.com/assets', t0), snapshot(t0),
+      click('button.save-btn', t0 + 1_000),
+    ])]);
+    expect(rendered.startTs).toBe(t0);
+    expect(rendered.text).not.toContain('NaN');
+  });
+
+  it('gives up markers before evidence at the byte budget', () => {
+    const rendered = renderTimeline([envelope([
+      meta('https://app.example.com/assets', t0), snapshot(t0),
+      click('button.save-btn', t0 + 1_000),
+      ...Array.from({ length: 6 }, (_, i) => feedback(`Save failed ${i}`, t0 + 1_000 + (i + 1) * 61_000)),
+    ])], { maxBytes: 420 });
+    expect(rendered.lines.some((line) => line.kind === 'idle')).toBe(false);
+    expect(rendered.lines.filter((line) => line.text.includes('Save failed'))).toHaveLength(6);
+    expect(rendered.truncated).toBe(false);
   });
 
   it('markers do not displace trailing real lines at the maxLines budget', () => {

--- a/packages/worker/src/narrative/renderer.ts
+++ b/packages/worker/src/narrative/renderer.ts
@@ -6,6 +6,8 @@ export interface TimelineLine {
   route: string;
   atMs: number | null;
   kind?: 'idle';
+  /** For a request line: when the request went out. A stretch the user spent waiting on it is not idle time. */
+  waitingSince?: number;
 }
 
 /** No user interaction for longer than this is the user being away, not the
@@ -60,8 +62,13 @@ export function renderTimeline(
     events = events.slice(0, options.maxInputEvents);
     truncated = true;
   }
-  events.sort((a, b) => Number(a['timestamp'] ?? 0) - Number(b['timestamp'] ?? 0));
+  // A non-numeric outer timestamp would make the sort comparator return NaN
+  // and the order implementation-defined; such an event cannot be placed, so
+  // it is dropped rather than allowed to poison startTs and every relative stamp.
+  events = events.filter((event) => Number.isFinite(Number(event['timestamp'])));
+  events.sort((a, b) => Number(a['timestamp']) - Number(b['timestamp']));
   const startTs = Number(events[0]?.['timestamp'] ?? 0);
+  const endTs = Number(events[events.length - 1]?.['timestamp'] ?? startTs);
   const relative = (timestamp: number): string => `t+${((timestamp - startTs) / 1_000).toFixed(1)}s`;
 
   const nodes = new Map<number, MirrorNode>();
@@ -110,8 +117,8 @@ export function renderTimeline(
 
   const lines: TimelineLine[] = [];
   let route = '';
-  const push = (text: string, selector: string | null, atMs: number | null): void => {
-    lines.push({ text: sanitize(text), selector, route, atMs });
+  const push = (text: string, selector: string | null, atMs: number | null, extra: Pick<TimelineLine, 'waitingSince'> = {}): void => {
+    lines.push({ text: sanitize(text), selector, route, atMs, ...extra });
   };
   let lastUrl = '';
   const openRequests = new Map<string, { method: string; url: string; at: number }>();
@@ -182,7 +189,7 @@ export function renderTimeline(
           const status = Number(item['status']);
           const slow = at - request.at > 1_000 ? ` SLOW ${((at - request.at) / 1_000).toFixed(1)}s` : '';
           if (request.method !== 'GET' || status >= 400 || slow) {
-            push(`${relative(at)} ${request.method} ${shortUrl(request.url)} -> ${status}${slow}`, null, at);
+            push(`${relative(at)} ${request.method} ${shortUrl(request.url)} -> ${status}${slow}`, null, at, { waitingSince: request.at });
           }
         }
       } else if (kind === 'form_submit') {
@@ -264,30 +271,86 @@ export function renderTimeline(
   }
   flushInputs();
 
-  const withIdleMarkers = (batch: TimelineLine[]): TimelineLine[] => {
-    const sortedActivity = [...userActivityMs].sort((a, b) => a - b);
+  // A line's own stamp comes from the SDK payload, which the client controls.
+  // Only a finite stamp inside the session's event window may reorder lines
+  // or measure a silence; anything else keeps its slot and is inert. The
+  // slack covers a payload stamped a moment after its carrying event.
+  const PLAUSIBLE_SLACK_MS = 5_000;
+  const plausibleAt = (line: TimelineLine): line is TimelineLine & { atMs: number } =>
+    line.atMs !== null && Number.isFinite(line.atMs)
+    && line.atMs >= startTs - PLAUSIBLE_SLACK_MS && line.atMs <= endTs + PLAUSIBLE_SLACK_MS;
+
+  // Lines are pushed in event order except typed-input aggregates, which are
+  // flushed later with their first timestamp. Order plausible stamps by time;
+  // every other line keeps its slot. The comparator only ever compares two
+  // finite numbers, so it stays transitive.
+  const chronological = (batch: TimelineLine[]): TimelineLine[] => {
+    const entries = batch.map((line, index) => ({ line, index })).filter((entry) => plausibleAt(entry.line));
+    const sorted = [...entries].sort((a, b) => (a.line.atMs! - b.line.atMs!) || (a.index - b.index));
     const out = [...batch];
-    for (let i = 1; i < sortedActivity.length; i++) {
-      const gapStart = sortedActivity[i - 1]!;
-      const gapEnd = sortedActivity[i]!;
-      if (gapEnd - gapStart <= IDLE_THRESHOLD_MS) continue;
-      const successor = out.findIndex((line) => line.atMs !== null && line.atMs >= gapEnd);
-      if (successor === -1) continue;
-      // Only assert absence when the line after the marker is the activity
-      // that ended the gap. Attaching the marker to an arbitrarily later line
-      // would tell the model the user was away across a span in which they
-      // were active but rendered nothing (a lone keystroke, a small scroll).
-      if (out[successor]!.atMs! - gapEnd > 1_000) continue;
-      const gapSeconds = Math.round((gapEnd - gapStart) / 1_000);
-      const minutes = Math.floor(gapSeconds / 60);
-      const seconds = gapSeconds % 60;
-      out.splice(successor, 0, {
-        text: sanitize(`${relative(gapStart)} [user idle ${minutes}m ${seconds}s — away from the app]`),
+    entries.forEach((entry, position) => { out[entry.index] = sorted[position]!.line; });
+    return out;
+  };
+
+  // A silence starts at a user action. Inside it, every rendered line that
+  // lands more than the threshold after the previous line or action gets a
+  // marker for that quiet stretch, whatever kind of line it is: a page that
+  // refreshes itself half an hour after the last click is still a user who
+  // walked away. Two exceptions keep the marker honest. A response to a
+  // request that was already in flight when the stretch began is time the
+  // user spent waiting, not away, so it gets no marker and counts as attended.
+  // And the action that ends a silence still gets a marker for the whole
+  // unattended span when nothing inside it earned one, so frequent background
+  // updates cannot hide a long absence.
+  const withIdleMarkers = (batch: TimelineLine[]): TimelineLine[] => {
+    const activity = [...new Set(userActivityMs)]
+      .filter((at) => at >= startTs - PLAUSIBLE_SLACK_MS && at <= endTs + PLAUSIBLE_SLACK_MS)
+      .sort((a, b) => a - b);
+    const out: TimelineLine[] = [];
+    let activityIndex = 0;
+    let lastActivity: number | null = null;
+    let attended: number | null = null;
+    let previousLine: number | null = null;
+    let markedSinceActivity = false;
+    const marker = (from: number, to: number): TimelineLine => {
+      const gapSeconds = Math.round((to - from) / 1_000);
+      return {
+        text: sanitize(`${relative(from)} [user idle ${Math.floor(gapSeconds / 60)}m ${gapSeconds % 60}s — away from the app]`),
         selector: null,
-        route: out[successor - 1]?.route ?? out[successor]!.route,
-        atMs: gapStart,
+        route: out[out.length - 1]?.route ?? '',
+        atMs: from,
         kind: 'idle',
-      });
+      };
+    };
+    for (const line of batch) {
+      if (!plausibleAt(line)) {
+        out.push(line);
+        continue;
+      }
+      const at = line.atMs;
+      while (activityIndex < activity.length && activity[activityIndex]! < at) {
+        lastActivity = activity[activityIndex]!;
+        markedSinceActivity = false;
+        activityIndex++;
+      }
+      if (lastActivity !== null) {
+        const stretchStart = Math.max(lastActivity, previousLine ?? lastActivity);
+        const endsSilence = activity[activityIndex] === at;
+        const unattendedSince = Math.max(lastActivity, attended ?? lastActivity);
+        if (endsSilence && !markedSinceActivity && at - unattendedSince > IDLE_THRESHOLD_MS) {
+          out.push(marker(unattendedSince, at));
+          markedSinceActivity = true;
+        } else if (!endsSilence && at - stretchStart > IDLE_THRESHOLD_MS) {
+          if (line.waitingSince !== undefined && line.waitingSince <= stretchStart + PLAUSIBLE_SLACK_MS) {
+            attended = at;
+          } else {
+            out.push(marker(stretchStart, at));
+            markedSinceActivity = true;
+          }
+        }
+      }
+      previousLine = at;
+      out.push(line);
     }
     return out;
   };
@@ -295,23 +358,24 @@ export function renderTimeline(
   // Markers are inserted after the line-count cut so they never displace real
   // trailing evidence; long gap-riddled sessions are exactly where late-session
   // abandonment lines live. A marker whose successor was cut simply drops.
-  let output = lines;
+  let output = chronological(lines);
   if (output.length > options.maxLines) {
     output = output.slice(0, options.maxLines);
     truncated = true;
   }
   output = withIdleMarkers(output);
-  while (output.length > 0 && output[output.length - 1]!.kind === 'idle') {
-    output = output.slice(0, -1);
+  const render = (batch: TimelineLine[]): string => batch.map((line, index) => `L${index + 1} ${line.text}`).join('\n');
+  let text = render(output);
+  // Markers are narration aids and can be regenerated; evidence cannot. When
+  // the byte budget is exceeded, markers go first, then real lines from the end.
+  if (Buffer.byteLength(text, 'utf8') > options.maxBytes && output.some((line) => line.kind === 'idle')) {
+    output = output.filter((line) => line.kind !== 'idle');
+    text = render(output);
   }
-  let text = output.map((line, index) => `L${index + 1} ${line.text}`).join('\n');
   while (Buffer.byteLength(text, 'utf8') > options.maxBytes && output.length > 1) {
     truncated = true;
     output = output.slice(0, Math.max(1, output.length - 50));
-    while (output.length > 0 && output[output.length - 1]!.kind === 'idle') {
-      output = output.slice(0, -1);
-    }
-    text = output.map((line, index) => `L${index + 1} ${line.text}`).join('\n');
+    text = render(output);
   }
   return { lines: output, text, truncated, startTs };
 }


### PR DESCRIPTION
## Problem

A digest card ("Inline edits and searches hang with no loading feedback", 2026-09-04) was built on a `slow_response` friction group whose observations included "the next UI update took about 32 minutes". The user had clicked and walked away; the page refreshed itself half an hour later. The timeline the narrator read had no idle marker between the two, because `withIdleMarkers` only marked a gap between two user actions when the rendered line after the gap was the action that ended it. Re-narrating the stored timeline with the shipped prompt reproduced the 32-minute `slow_response` 2/2 runs; with a marker present the same model produced 0/3.

## Change

- Timed lines are ordered chronologically before the line cap. Typed-input aggregates were flushed late with their first timestamp and could land after later lines (visible in stored prod timelines).
- A marker is inserted before every rendered line that lands more than the threshold after the previous line or user action, whatever kind of line it is, with two exceptions: a response to a request already in flight when the stretch began is time spent waiting (no marker, counts as attended), and the action ending a silence still gets a marker for the whole unattended span when nothing inside it earned one, so polling cannot hide an absence. No marker before the first user action.
- Hardening from review: a payload stamp only reorders or measures when finite and inside the session's event window; events with a non-numeric outer timestamp are dropped before sorting; markers are removed before real lines when the byte budget is exceeded.

Two existing tests changed contract on purpose (a waited-on slow response no longer gets a marker in front of it; a silence after a lone keystroke is now marked before the feedback that ends it). Seven review-driven tests added; 23/23 in the renderer suite, full worker suite 1432 passed / 154 database-gated skipped.

## Verification

- Before/after narration on 7 stored prod sessions from the affected group, 3 runs each with the live model: `slow_response` observations 8 → 3; the 32-minute one went 3 → 0. The 3 survivors are sub-threshold pauses (48 to 49 seconds), a separate narrator-prompt problem tracked with #465.
- `/review`: testing and maintainability specialists, Claude adversarial, Codex adversarial. All findings fixed in this commit.

## Not in this PR

- Requiring a measured request for a `slow_response` observation (validator rule), and the absence-claim check for the friction investigator: follow-up PRs.
- SDK request-timing hook for apps whose API calls bypass fetch/XHR: #465.

https://claude.ai/code/session_014yKbkxdYv5kjdNVnvcqMDj