### PR TITLE
ci: make the npm release publish again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
+    ignore:
+      # changesets/action v2 requires Changesets CLI v3; bump both together by hand.
+      - dependency-name: changesets/action
+        update-types: ['version-update:semver-major']
   - package-ecosystem: docker
     directories:
       - '/packages/ingestion'

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build publishable packages
         run: pnpm --filter @opslane/sdk... build
       - name: Version PR or publish
-        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0 (v2 requires Changesets CLI v3; we run v2)
         with:
           publish: pnpm changeset publish
         env:

--- a/scripts/check-packed-packages.mjs
+++ b/scripts/check-packed-packages.mjs
@@ -4,8 +4,9 @@
  *
  * For each publishable package (@opslane/sdk):
  *   1. `pnpm pack` the exact tarball npm would ship
- *   2. Assert the tarball contains ONLY allowlisted paths (dist/, package.json,
- *      README*, LICENSE*) — no stray env files, sources, or maps
+ *   2. Assert the tarball contains ONLY allowlisted paths (dist/, bin/*.mjs,
+ *      package.json, README*, LICENSE*, THIRD_PARTY_NOTICES.md) — no stray env
+ *      files, sources, or maps
  *   3. Install the tarball into a fresh, empty consumer project (no workspace)
  *   4. SDK: typecheck real imports with tsc — catches unresolvable type-only
  *      imports from the private @opslane/shared package
@@ -18,7 +19,9 @@ import { mkdtempSync, writeFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
-const ALLOWED_TARBALL_PATH = /^package\/(dist\/|package\.json$|README[^/]*$|LICENSE[^/]*$)/;
+// bin/ carries the opslane-sourcemaps CLI entry; THIRD_PARTY_NOTICES.md carries
+// the licenses of the build-time dependencies bundled into dist/.
+const ALLOWED_TARBALL_PATH = /^package\/(dist\/|bin\/[^/]+\.mjs$|package\.json$|README[^/]*$|LICENSE[^/]*$|THIRD_PARTY_NOTICES\.md$)/;
 
 const TARGETS = [
   {


### PR DESCRIPTION
The Version Packages PR for #476 never appeared because the npm release workflow has been failing on every push to main since 2026-08-26.

- Dependabot #416 bumped `changesets/action` to v2.1.1, which exits with "designed to work with Changesets CLI v3" against our CLI v2. Pinned back to v1.9.0 and added a Dependabot ignore for the major so it does not come back; upgrading CLI and action together is a separate change.
- #476 added `bin/opslane-sourcemaps.mjs` and `THIRD_PARTY_NOTICES.md` to the `@opslane/sdk` tarball (both listed in `package.json` `files`), and `scripts/check-packed-packages.mjs` rejected them. Allowlisted `bin/*.mjs` and the notices file. `node scripts/check-packed-packages.mjs` passes locally against the built SDK.

Once this merges, the next main run should open the Version Packages PR that publishes `@opslane/sdk` 4.2.0 (npm is still at 4.1.0; 4.1.1 was never published for the same reason).

https://claude.ai/code/session_01NH1xAULqRNKBh4oNBptCXv