### PR TITLE
ci: log the npm OIDC exchange while trusted publishing is failing

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -78,3 +78,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
+          # Trusted publishing has failed with a bare ENEEDAUTH since the repo
+          # rename; verbose shows the OIDC exchange request and its status.
+          NPM_CONFIG_LOGLEVEL: verbose


### PR DESCRIPTION
Four reruns of the 4.2.0 publish fail with a bare `ENEEDAUTH` under trusted publishing, after the trusted publisher on npmjs.com was recreated for `opslane/opslane`. npm only reports why the OIDC exchange was refused at verbose level. This sets `NPM_CONFIG_LOGLEVEL=verbose` on the publish step so the next main push shows the exchange request and its HTTP status. Revert once 4.2.0 is out.

https://claude.ai/code/session_01NH1xAULqRNKBh4oNBptCXv