### PR TITLE
fix(github): resolve the app installation by repo, not the org's newest

### DIFF
--- a/packages/ingestion/db/queries.go
+++ b/packages/ingestion/db/queries.go
@@ -2434,7 +2434,17 @@ func loadDraftBranchCleanup(ctx context.Context, tx pgx.Tx, groupID string) (str
 	var branch string
 	var installationID *int64
 	err := tx.QueryRow(ctx,
-		`SELECT r.branch_name, o.github_installation_id
+		`SELECT r.branch_name,
+		        COALESCE(
+		          (SELECT i.installation_id
+		             FROM github_app_installations i
+		            WHERE i.org_id = p.org_id
+		              AND NOT i.suspended
+		              AND i.repos ? p.github_repo
+		            ORDER BY i.created_at DESC
+		            LIMIT 1),
+		          o.github_installation_id
+		        ) AS github_installation_id
 		 FROM delivery_reservations r
 		 JOIN projects p ON p.id = r.project_id
 		 JOIN orgs o ON o.id = p.org_id
@@ -2501,7 +2511,17 @@ func (q *Queries) ProcessPRWebhook(ctx context.Context, githubRepo string, prNum
 	var installationID *int64
 	err = tx.QueryRow(ctx,
 		`SELECT eg.id, eg.project_id, eg.kind, eg.status, eg.pr_fix_job_id,
-		        r.branch_name, o.github_installation_id
+		        r.branch_name,
+		        COALESCE(
+		          (SELECT i.installation_id
+		             FROM github_app_installations i
+		            WHERE i.org_id = p.org_id
+		              AND NOT i.suspended
+		              AND i.repos ? p.github_repo
+		            ORDER BY i.created_at DESC
+		            LIMIT 1),
+		          o.github_installation_id
+		        ) AS github_installation_id
 		 FROM error_groups eg
 		 JOIN projects p ON eg.project_id = p.id
 		 JOIN orgs o ON o.id = p.org_id

--- a/packages/ingestion/db/queries_test.go
+++ b/packages/ingestion/db/queries_test.go
@@ -952,6 +952,70 @@ func TestProcessPRWebhook_DraftCloseRestoresNeedsHumanAndClosesDelivery(t *testi
 	}
 }
 
+// An org can hold several app installations, and orgs.github_installation_id
+// remembers only the newest. A token minted from that column for a repo the
+// newest installation cannot see turns every clone into "Repository not
+// found" (seen in prod 2026-09-12: an importcsv install overwrote the column
+// and every conelike inquiry dead-lettered). The webhook cleanup path must
+// resolve the installation that actually covers the project's repo.
+func TestProcessPRWebhook_DraftCleanupResolvesInstallationByRepo(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	orgID, projectID, _, groupID := seedGroup(t, pool, q, "two-installs")
+
+	const (
+		coveringInstallation = int64(111000111)
+		newestInstallation   = int64(222000222)
+	)
+	// The newest installation covers a different repo, and the org column
+	// points at it — the exact state a second GitHub org connection leaves.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO github_app_installations
+		   (installation_id, github_org_name, github_org_id, org_id, repos, created_at)
+		 VALUES ($1, 'org', 1, $3, '["org/two-installs"]'::jsonb, now() - interval '1 day'),
+		        ($2, 'other', 2, $3, '["other/marketing"]'::jsonb, now())`,
+		coveringInstallation, newestInstallation, orgID,
+	); err != nil {
+		t.Fatalf("seed installations: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE orgs SET github_installation_id = $2 WHERE id = $1`,
+		orgID, newestInstallation,
+	); err != nil {
+		t.Fatalf("point org at newest installation: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx,
+		`UPDATE error_groups SET status = 'pr_draft', pr_number = 9,
+		     pr_url = 'https://github.com/org/two-installs/pull/9'
+		 WHERE id = $1`, groupID,
+	); err != nil {
+		t.Fatalf("seed draft group: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO delivery_reservations
+		   (error_group_id, project_id, operation_key, branch_name, posture,
+		    diff_hash, candidate_diff, state, pr_url, pr_number)
+		 VALUES ($1, $2, $3, 'opslane/fix-two-installs', 'draft',
+		         'hash', 'diff', 'open', 'https://github.com/org/two-installs/pull/9', 9)`,
+		groupID, projectID, "fix:"+groupID,
+	); err != nil {
+		t.Fatalf("seed delivery reservation: %v", err)
+	}
+
+	result, err := q.ProcessPRWebhook(
+		ctx, "org/two-installs", 9, false, "delivery-two-installs", time.Now(),
+	)
+	if err != nil || result.GroupID != groupID || result.CleanupBranch != "opslane/fix-two-installs" {
+		t.Fatalf("ProcessPRWebhook = (%+v, %v), want cleanup for group %s", result, err, groupID)
+	}
+	if result.InstallationID == nil || *result.InstallationID != coveringInstallation {
+		t.Fatalf("cleanup installation = %v, want the one covering the repo (%d), not the org's newest (%d)",
+			result.InstallationID, coveringInstallation, newestInstallation)
+	}
+}
+
 func TestProcessPRWebhook_ConcurrentRedeliveryReportsDuplicate(t *testing.T) {
 	pool := testPool(t)
 	ctx := context.Background()

--- a/packages/worker/src/__tests__/db-queries.test.ts
+++ b/packages/worker/src/__tests__/db-queries.test.ts
@@ -27,6 +27,7 @@ import {
   setSessionAnalysisStatus,
   claimJob,
   resolveEvidenceEventId,
+  getProjectGitHubInstallation,
   listUnmappedPatterns,
   listProductContextPatterns,
   MAX_ROUTE_PATTERN_BYTES,
@@ -583,6 +584,27 @@ describe('getProject', () => {
     const project = await getProject('p1');
     expect(project?.github_repo).toBe('org/repo');
     expect(mockQuery.mock.calls[0][0]).toContain('friction_autonomy');
+  });
+});
+
+describe('getProjectGitHubInstallation', () => {
+  beforeEach(() => mockQuery.mockReset());
+
+  it('resolves the installation covering the repo, not the org column alone', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ github_installation_id: 111, github_repo: 'org/repo' }],
+    });
+    const install = await getProjectGitHubInstallation('p1');
+    expect(install).toEqual({ installationId: 111, githubRepo: 'org/repo' });
+    const sql = mockQuery.mock.calls[0][0] as string;
+    // The org column remembers only the newest installation; a token minted
+    // from it for a repo that installation cannot see clones as "Repository
+    // not found". Repo membership must decide, with the column as fallback.
+    expect(sql).toContain('github_app_installations');
+    expect(sql).toContain('i.repos ? p.github_repo');
+    expect(sql).toContain('NOT i.suspended');
+    expect(sql).toContain('COALESCE');
+    expect(mockQuery.mock.calls[0][1]).toEqual(['p1']);
   });
 });
 

--- a/packages/worker/src/db.ts
+++ b/packages/worker/src/db.ts
@@ -2026,11 +2026,27 @@ export async function getProjectGitHubInstallation(projectId: string): Promise<{
   githubRepo: string | null;
 } | null> {
   const pool = getPool();
+  // An org can hold several app installations (one per GitHub org it
+  // connects), but orgs.github_installation_id remembers only the newest.
+  // Minting a token from that column for a repo the newest installation
+  // cannot see turns every clone into "Repository not found". Resolve by
+  // repo membership first; the org column remains the fallback for rows
+  // that predate per-installation repo lists.
   const { rows } = await pool.query<{
     github_installation_id: number | null;
     github_repo: string | null;
   }>(
-    `SELECT o.github_installation_id, p.github_repo
+    `SELECT COALESCE(
+              (SELECT i.installation_id
+                 FROM github_app_installations i
+                WHERE i.org_id = p.org_id
+                  AND NOT i.suspended
+                  AND i.repos ? p.github_repo
+                ORDER BY i.created_at DESC
+                LIMIT 1),
+              o.github_installation_id
+            ) AS github_installation_id,
+            p.github_repo
      FROM projects p
      JOIN orgs o ON o.id = p.org_id
      WHERE p.id = $1`,


### PR DESCRIPTION
## What broke

An org can hold several GitHub App installations, but `orgs.github_installation_id` remembers only the newest. Connecting the importcsv GitHub org on 2026-09-11 overwrote the column, so every AMFJ worker job minted an importcsv token, cloned the private `conelike/asset-management-jira` as "Repository not found", and dead-lettered after 3 attempts (smoke stage 5 died on this during the v26.8.20 verification).

## The fix

`github_app_installations.repos` already records which repos each installation covers. The three project/repo-scoped readers — the worker's `getProjectGitHubInstallation` (inquiry, ci-watch, fix, product-context) and ingestion's draft-branch cleanup and PR-webhook lookups — now pick the unsuspended installation whose repo list contains the project's repo, keeping the org column as fallback for rows predating per-installation repo lists. Org-scoped onboarding/settings reads intentionally keep the column: they describe the org's connection state, not a repo's credentials.

## Verification

- New Go test: one org, two installations, org column pointed at the wrong one — the draft-cleanup path must return the covering installation. Verified red on the old query, green with the fix; all existing ProcessPRWebhook tests pass against a migrated Postgres.
- New worker test pins the membership clause + fallback into the query shape; all 38 db-queries tests pass; worker typecheck clean.
- Codex independent review: no actionable regressions (gate PASS).

https://claude.ai/code/session_015E4ZPr8fryDB8F1Z6R2fYt